### PR TITLE
長い駅名があるときに駅名がぶれない＆刺さらないようにした

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
       "android",
       "web"
     ],
-    "version": "0.3.2",
+    "version": "0.3.3",
     "orientation": "landscape",
     "icon": "./assets/icon.png",
     "splash": {
@@ -25,7 +25,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "me.tinykitten.trainlcd",
-      "buildNumber": "17",
+      "buildNumber": "18",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。",
         "CFBundleDevelopmentRegion": "ja_JP",
@@ -42,7 +42,7 @@
         "ACCESS_COARSE_LOCATION",
         "ACCESS_FINE_LOCATION"
       ],
-      "versionCode": 21
+      "versionCode": 22
     }
   }
 }

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -86,8 +86,17 @@ const LineBoard = (props: IProps) => {
       transform: [{ rotate: '-50deg' }],
       marginBottom: 8,
     },
+    longStationName : {
+      width: 120,
+      marginLeft: -20,
+    },
+    fiveLengthStationName : {
+      width: 120,
+      marginLeft: -20,
+      marginBottom: 20,
+    },
     veryLongStationName : {
-      width: 150,
+      width: 120,
       marginLeft: -20,
       marginBottom: 20,
     },
@@ -133,12 +142,23 @@ const LineBoard = (props: IProps) => {
     </Text>
   ));
 
-  const applyVeryLongStyle = (name: string) => name.length >= 6 ? styles.veryLongStationName : null;
+  const applyLongStyle = (name: string) => {
+    if (name.length === 5) {
+      return styles.fiveLengthStationName;
+    }
+    if (name.length >= 10) {
+      return styles.veryLongStationName;
+    }
+    if (name.length > 5) {
+      return styles.longStationName;
+    }
+    return null;
+  };
 
   const renderStationNamesWrapper = (station: IStation) => {
     if (includesLongStatioName) {
       return (
-        <Text style={[styles.stationName, styles.rotatedStationName, applyVeryLongStyle(station.name)]}>
+        <Text style={[styles.stationName, styles.rotatedStationName, applyLongStyle(station.name)]}>
           {station.name}
         </Text>
       );


### PR DESCRIPTION
closes #23 

駅名の長さによってスタイルをもともと振り分けていたが、バリエーションを増やした。