### PR TITLE
iPad対応抜け漏れ修正

### DIFF
--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -237,7 +237,6 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
           marginTop: 4,
           width: windowWidth / 10,
           flexDirection: 'row',
-          alignItems: 'center',
         },
         lineMarkWrapperDouble: {
           marginTop: 4,
@@ -252,7 +251,16 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
           fontWeight: 'bold',
           fontSize: 16,
         },
+        lineNameLong: {
+          fontWeight: 'bold',
+          fontSize: 14,
+        },
       });
+
+      const containLongLineName = !!omittedTransferLines.find(
+        (l) => getLocalizedLineName(l).length > 15
+      );
+
       return (
         <View style={padLineMarksStyle.root}>
           {lineMarks.map((lm, i) =>
@@ -271,7 +279,13 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
                   small
                 />
                 <View style={padLineMarksStyle.lineNameWrapper}>
-                  <Text style={padLineMarksStyle.lineName}>
+                  <Text
+                    style={
+                      containLongLineName
+                        ? padLineMarksStyle.lineNameLong
+                        : padLineMarksStyle.lineName
+                    }
+                  >
                     {getLocalizedLineName(omittedTransferLines[i])}
                   </Text>
                 </View>
@@ -286,11 +300,15 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
                   line={omittedTransferLines[i]}
                   small
                 />
-                {omittedTransferLines.length <= 5 ? (
-                  <Text style={padLineMarksStyle.lineName}>
-                    {getLocalizedLineName(omittedTransferLines[i])}
-                  </Text>
-                ) : null}
+                <Text
+                  style={
+                    containLongLineName
+                      ? padLineMarksStyle.lineNameLong
+                      : padLineMarksStyle.lineName
+                  }
+                >
+                  {getLocalizedLineName(omittedTransferLines[i])}
+                </Text>
               </View>
             )
           )}

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -235,7 +235,18 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
         },
         lineMarkWrapper: {
           marginTop: 4,
-          width: windowWidth / 8,
+          width: windowWidth / 10,
+          flexDirection: 'row',
+          alignItems: 'center',
+        },
+        lineMarkWrapperDouble: {
+          marginTop: 4,
+          width: windowWidth / 10,
+          flexDirection: 'column',
+        },
+        lineNameWrapper: {
+          flexDirection: 'row',
+          flexWrap: 'wrap',
         },
         lineName: {
           fontWeight: 'bold',
@@ -247,7 +258,11 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
           {lineMarks.map((lm, i) =>
             lm ? (
               <View
-                style={padLineMarksStyle.lineMarkWrapper}
+                style={
+                  lm.subSign
+                    ? padLineMarksStyle.lineMarkWrapperDouble
+                    : padLineMarksStyle.lineMarkWrapper
+                }
                 key={omittedTransferLines[i].id}
               >
                 <TransferLineMark
@@ -255,12 +270,11 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
                   mark={lm}
                   small
                 />
-                {/* 苦肉の策。他にいい方法ないかな */}
-                {omittedTransferLines.length <= 5 ? (
+                <View style={padLineMarksStyle.lineNameWrapper}>
                   <Text style={padLineMarksStyle.lineName}>
                     {getLocalizedLineName(omittedTransferLines[i])}
                   </Text>
-                ) : null}
+                </View>
               </View>
             ) : (
               <View

--- a/src/components/Transfers/index.tsx
+++ b/src/components/Transfers/index.tsx
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
     fontSize: isPad ? 32 : 24,
     color: '#333',
     fontWeight: 'bold',
-    width: '90%',
+    width: '85%',
   },
 });
 


### PR DESCRIPTION
close #72
close #71 

![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-05-23 at 16 03 59](https://user-images.githubusercontent.com/32848922/82724160-145e0e00-9d0f-11ea-8e6f-04d7b05f7ce4.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-05-23 at 16 04 08](https://user-images.githubusercontent.com/32848922/82724163-16c06800-9d0f-11ea-90c8-5c49871a0bd7.png)
