### PR TITLE
小さい画面で使用したときに駅が右側に食い込むバグを修正

### DIFF
--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -87,7 +87,7 @@ const LineBoard: React.FC<Props> = ({ arrived, stations, line }: Props) => {
     },
     stationNameWrapper: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
+      justifyContent: isPad ? 'space-between' : undefined,
       marginLeft: 32,
       flex: 1,
     },


### PR DESCRIPTION
iPad対応のときに出てきたバグだと思う