### PR TITLE
ラインマーク自力レンダリングのデザイン修正

### DIFF
--- a/src/components/TransferLineMark/index.tsx
+++ b/src/components/TransferLineMark/index.tsx
@@ -40,7 +40,7 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
       borderRadius: 1,
     },
     lineMarkRound: {
-      borderWidth: 6,
+      borderWidth: small ? 4 : 6,
       width: small ? 25.6 : 38,
       height: small ? 25.6 : 38,
       marginRight: 4,
@@ -68,6 +68,30 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
       fontWeight: 'bold',
       fontSize: small ? 14 : 24,
       color: '#333',
+    },
+    roundLineSignSingle: {
+      textAlign: 'center',
+      fontWeight: 'bold',
+      fontSize: small ? 12 : 21,
+      color: '#000',
+    },
+    roundLineSignDouble: {
+      textAlign: 'center',
+      fontWeight: 'bold',
+      fontSize: small ? 8 : 14,
+      color: '#000',
+    },
+    reversedRoundLineSignSingle: {
+      textAlign: 'center',
+      fontWeight: 'bold',
+      fontSize: small ? 18 : 28,
+      color: '#000',
+    },
+    reversedRoundLineSignDouble: {
+      textAlign: 'center',
+      fontWeight: 'bold',
+      fontSize: small ? 14 : 24,
+      color: '#000',
     },
     reversedText: {
       color: '#fff',
@@ -186,8 +210,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
               <Text
                 style={
                   mark.sign.length === 1
-                    ? styles.lineSignSingle
-                    : styles.lineSignDouble
+                    ? styles.roundLineSignSingle
+                    : styles.roundLineSignDouble
                 }
               >
                 {mark.sign}
@@ -202,8 +226,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
               <Text
                 style={
                   mark.sign.length === 1
-                    ? styles.lineSignSingle
-                    : styles.lineSignDouble
+                    ? styles.roundLineSignSingle
+                    : styles.roundLineSignDouble
                 }
               >
                 {mark.subSign}
@@ -223,8 +247,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
               <Text
                 style={[
                   mark.sign.length === 1
-                    ? styles.lineSignSingle
-                    : styles.lineSignDouble,
+                    ? styles.reversedRoundLineSignSingle
+                    : styles.reversedRoundLineSignDouble,
                   styles.reversedText,
                 ]}
               >
@@ -240,8 +264,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
               <Text
                 style={[
                   mark.sign.length === 1
-                    ? styles.lineSignSingle
-                    : styles.lineSignDouble,
+                    ? styles.roundLineSignSingle
+                    : styles.roundLineSignDouble,
                 ]}
               >
                 {mark.subSign}
@@ -301,8 +325,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
           <Text
             style={
               mark.sign.length === 1
-                ? styles.lineSignSingle
-                : styles.lineSignDouble
+                ? styles.roundLineSignSingle
+                : styles.roundLineSignDouble
             }
           >
             {mark.sign}
@@ -320,8 +344,8 @@ const TransferLineMark: React.FC<Props> = ({ line, mark, small }: Props) => {
           <Text
             style={[
               mark.sign.length === 1
-                ? styles.lineSignSingle
-                : styles.lineSignDouble,
+                ? styles.reversedRoundLineSignSingle
+                : styles.reversedRoundLineSignDouble,
               styles.reversedText,
             ]}
           >

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1547,6 +1547,31 @@ export const getLineMark = (line: Line): LineMark | null => {
         shape: MarkShape.reversedRound,
         sign: 'IY',
       };
+    case '99808': // 1系統
+      return {
+        shape: MarkShape.reversedSquare,
+        sign: '1',
+      };
+    case '99809': // 2系統
+      return {
+        shape: MarkShape.reversedSquare,
+        sign: '2',
+      };
+    case '99810': // 3系統
+      return {
+        shape: MarkShape.reversedSquare,
+        sign: '3',
+      };
+    case '99811': // 5系統
+      return {
+        shape: MarkShape.reversedSquare,
+        sign: '5',
+      };
+    case '99812': // 6系統
+      return {
+        shape: MarkShape.reversedSquare,
+        sign: '6',
+      };
     // ことでん
     case '99802': // 琴平線
       return {


### PR DESCRIPTION
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-05-25 at 20 40 50](https://user-images.githubusercontent.com/32848922/82809868-0b646c80-9ec8-11ea-8254-522d49d19ed7.png)
![Simulator Screen Shot - iPhone 11 - 2020-05-25 at 20 40 10](https://user-images.githubusercontent.com/32848922/82809864-08697c00-9ec8-11ea-9efc-0a38c2388571.png)
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-05-25 at 20 40 08](https://user-images.githubusercontent.com/32848922/82809854-030c3180-9ec8-11ea-95ac-f38b48f70c25.png)


closes #83 