### PR TITLE
Androidで駅名上部が切れるバグ修正

### DIFF
--- a/src/components/HeaderDT/index.tsx
+++ b/src/components/HeaderDT/index.tsx
@@ -452,8 +452,8 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
                     styles.stationName,
                     topNameAnimatedStyles,
                     {
-                      minHeight: stationNameFontSize,
-                      lineHeight: stationNameFontSize,
+                      minHeight: stationNameFontSize + 8,
+                      lineHeight: stationNameFontSize + 8,
                       fontSize: stationNameFontSize,
                     },
                   ]}

--- a/src/components/HeaderTokyoMetro/index.tsx
+++ b/src/components/HeaderTokyoMetro/index.tsx
@@ -443,8 +443,8 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
                     topNameAnimatedStyles,
                     styles.stationName,
                     {
-                      minHeight: stationNameFontSize,
-                      lineHeight: stationNameFontSize,
+                      minHeight: stationNameFontSize + 8,
+                      lineHeight: stationNameFontSize + 8,
                       fontSize: stationNameFontSize,
                     },
                   ]}


### PR DESCRIPTION
closes #344 
