### PR TITLE
駅検索で同じ駅なのに複数駅出てしまうバグを修正

### DIFF
--- a/src/components/FakeStationSettings/index.tsx
+++ b/src/components/FakeStationSettings/index.tsx
@@ -9,7 +9,6 @@ import {
   ActivityIndicator,
   TextInputChangeEventData,
   NativeSyntheticEvent,
-  Alert,
   Platform,
   KeyboardAvoidingView,
   Keyboard,
@@ -22,12 +21,12 @@ import client from '../../api/apollo';
 import { StationsByNameData, Station } from '../../models/StationAPI';
 import { PREFS_JA, PREFS_EN } from '../../constants';
 import Heading from '../Heading';
-import useStationByCoords from '../../hooks/useStationByCoords';
 import { isJapanese, translate } from '../../translation';
 import FAB from '../FAB';
 import locationState from '../../store/atoms/location';
 import navigationState from '../../store/atoms/navigation';
 import calcHubenyDistance from '../../utils/hubeny';
+import stationState from '../../store/atoms/station';
 
 const styles = StyleSheet.create({
   rootPadding: {
@@ -112,6 +111,8 @@ const FakeStationSettings: React.FC = () => {
   const [dirty, setDirty] = useState(false);
   const navigation = useNavigation();
   const setNavigationState = useSetRecoilState(navigationState);
+  const setStation = useSetRecoilState(stationState);
+  const setNavigation = useSetRecoilState(navigationState);
   const {
     location: { coords },
   } = useRecoilValue(locationState);
@@ -157,24 +158,23 @@ const FakeStationSettings: React.FC = () => {
       });
       const data = result.data as StationsByNameData;
       const sorted = data.stationsByName.slice().sort((a, b) => {
-        if (a.groupId > b.groupId) {
+        const lowerANameR = a.nameR.toLowerCase();
+        const lowerBNameR = b.nameR.toLowerCase();
+        if (lowerANameR > lowerBNameR) {
           return 1;
         }
-        if (a.groupId < b.groupId) {
+        if (lowerANameR < lowerBNameR) {
           return -1;
         }
         return 0;
       });
-      const grouped = sorted.filter((s, i, arr) => {
-        const prev = arr[i - 1] || undefined;
-        return s.groupId !== prev?.groupId;
-      });
-      const mapped = grouped
+      const mapped = sorted
         .map((g, i, arr) => {
-          const sameNameStations = arr.filter(
-            (s) => s.name === g.name || s.nameR === g.nameR
+          const sameNameAndDifferentPrefStations = arr.filter(
+            (s) =>
+              s.name === g.name && s.nameR === g.nameR && s.prefId !== g.prefId
           );
-          if (sameNameStations.length > 1) {
+          if (sameNameAndDifferentPrefStations.length) {
             return {
               ...g,
               name: `${g.name}(${PREFS_JA[g.prefId - 1]})`,
@@ -183,6 +183,19 @@ const FakeStationSettings: React.FC = () => {
           }
           return g;
         })
+        .map((g, i, arr) => {
+          const sameNameStations = arr.filter((s) => s.name === g.name);
+          if (sameNameStations.length) {
+            return sameNameStations.reduce((acc, cur) => {
+              return {
+                ...acc,
+                lines: [...acc.lines, ...cur.lines],
+              };
+            });
+          }
+          return g;
+        })
+        .filter((g, i, arr) => arr.findIndex((s) => s.name === g.name) === i)
         .sort((a, b) => {
           const toADistance = calcHubenyDistance(
             { latitude: coords.latitude, longitude: coords.longitude },
@@ -214,45 +227,19 @@ const FakeStationSettings: React.FC = () => {
     }
   }, [coords.latitude, coords.longitude, query]);
 
-  const [
-    fetchStationFunc,
-    apiLoading,
-    fetchStationErrors,
-  ] = useStationByCoords();
-  const setLocation = useSetRecoilState(locationState);
-
-  useEffect(() => {
-    if (fetchStationErrors?.length) {
-      Alert.alert(translate('errorTitle'), translate('failedToFetchStation'), [
-        {
-          text: 'OK',
-          onPress: onPressBack,
-        },
-      ]);
-    }
-  }, [fetchStationErrors, onPressBack]);
-
   const onStationPress = useCallback(
     (station: Station) => {
-      const location = {
-        coords: {
-          latitude: station.latitude,
-          longitude: station.longitude,
-          altitude: undefined,
-          accuracy: undefined,
-          heading: undefined,
-          speed: undefined,
-          altitudeAccuracy: undefined,
-        },
-      };
-      setLocation((prev) => ({
+      setStation((prev) => ({
         ...prev,
-        location,
+        station,
       }));
-      fetchStationFunc(location);
+      setNavigation((prev) => ({
+        ...prev,
+        stationForHeader: station,
+      }));
       onPressBack();
     },
-    [fetchStationFunc, onPressBack, setLocation]
+    [onPressBack, setNavigation, setStation]
   );
 
   const renderStationNameCell = useCallback(


### PR DESCRIPTION
closes #547

同じ名前＆違う都道府県の駅をマージした
あと2度駅を取得していたので駅選択後の駅取得コードを削除