### PR TITLE
英語のフォントサイズ調整廃止&15文字を長大駅名に変更

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,8 +133,8 @@ android {
         applicationId 'me.tinykitten.trainlcd'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 91
-        versionName "1.9.2"
+        versionCode 92
+        versionName "1.9.3"
     }
     splits {
         abi {

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -635,12 +635,12 @@
 				CODE_SIGN_ENTITLEMENTS = TrainLCD/trainlcd.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -665,11 +665,11 @@
 				CODE_SIGN_ENTITLEMENTS = TrainLCD/trainlcd.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -811,7 +811,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_ASSET_PATHS = "\"WatchApp Extension/Preview Content\"";
@@ -820,7 +820,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.tinykitten.trainlcd.watchkitapp.watchkitextension;
@@ -848,7 +848,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"WatchApp Extension/Preview Content\"";
@@ -857,7 +857,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.tinykitten.trainlcd.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
@@ -884,14 +884,14 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.tinykitten.trainlcd.watchkitapp;
@@ -921,14 +921,14 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 1.9.6;
+				MARKETING_VERSION = 1.9.7;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.tinykitten.trainlcd.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/components/HeaderDT/index.tsx
+++ b/src/components/HeaderDT/index.tsx
@@ -138,14 +138,14 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
 
   const getFontSize = useCallback((stationName: string): number => {
     if (isPad) {
-      if (stationName.length >= 10) {
+      if (stationName.length >= 15) {
         return 48;
       }
       return 72;
     }
 
-    if (stationName.length >= 10) {
-      return 32;
+    if (stationName.length >= 15) {
+      return 38;
     }
     return 48;
   }, []);
@@ -166,8 +166,10 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
   const { top: safeAreaTop } = useSafeAreaInsets();
 
   const adjustFontSize = useCallback(
-    (stationName: string): void => {
-      setStationNameFontSize(getFontSize(stationName));
+    (stationName: string, en?: boolean): void => {
+      if (!en) {
+        setStationNameFontSize(getFontSize(stationName));
+      }
     },
     [getFontSize]
   );
@@ -300,7 +302,7 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
           fadeOut();
           setStateText(translate('soonEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
           fadeIn();
         }
         break;
@@ -328,7 +330,7 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
         }
         setStateText('');
         setStationText(station.nameR);
-        adjustFontSize(station.nameR);
+        adjustFontSize(station.nameR, true);
         fadeIn();
         break;
       case 'NEXT':
@@ -354,7 +356,7 @@ const HeaderDT: React.FC<CommonHeaderProps> = ({
           fadeOut();
           setStateText(translate('nextEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
           fadeIn();
         }
         break;

--- a/src/components/HeaderJRWest/index.tsx
+++ b/src/components/HeaderJRWest/index.tsx
@@ -51,26 +51,32 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
   const yamanoteLine = line ? isYamanoteLine(line.id) : undefined;
   const osakaLoopLine = line ? !trainType && line.id === 11623 : undefined;
 
-  const adjustFontSize = useCallback((stationName: string): void => {
-    if (isPad) {
-      if (stationName.length >= 10) {
-        setStationNameFontSize(48);
-      } else if (stationName.length >= 7) {
-        setStationNameFontSize(64);
-      } else {
-        setStationNameFontSize(72);
+  const adjustFontSize = useCallback(
+    (stationName: string, en?: boolean): void => {
+      if (en) {
+        return;
       }
-      return;
-    }
+      if (isPad) {
+        if (stationName.length >= 15) {
+          setStationNameFontSize(48);
+        } else if (stationName.length >= 7) {
+          setStationNameFontSize(64);
+        } else {
+          setStationNameFontSize(72);
+        }
+        return;
+      }
 
-    if (stationName.length >= 10) {
-      setStationNameFontSize(32);
-    } else if (stationName.length >= 7) {
-      setStationNameFontSize(48);
-    } else {
-      setStationNameFontSize(58);
-    }
-  }, []);
+      if (stationName.length >= 15) {
+        setStationNameFontSize(32);
+      } else if (stationName.length >= 7) {
+        setStationNameFontSize(48);
+      } else {
+        setStationNameFontSize(58);
+      }
+    },
+    []
+  );
   const adjustBoundFontSize = useCallback((stationName: string): void => {
     if (isPad) {
       if (stationName.length >= 5) {
@@ -141,7 +147,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
         if (nextStation) {
           setStateText(translate('arrivingAtEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
         }
         break;
       case 'CURRENT':
@@ -157,7 +163,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
       case 'CURRENT_EN':
         setStateText(translate('nowStoppingAtEn'));
         setStationText(station.nameR);
-        adjustFontSize(station.nameR);
+        adjustFontSize(station.nameR, true);
         break;
       case 'NEXT':
         if (nextStation) {
@@ -177,7 +183,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
         if (nextStation) {
           setStateText(translate('nextEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
         }
         break;
       default:

--- a/src/components/HeaderTokyoMetro/index.tsx
+++ b/src/components/HeaderTokyoMetro/index.tsx
@@ -126,14 +126,14 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
 
   const getFontSize = useCallback((stationName: string): number => {
     if (isPad) {
-      if (stationName.length >= 10) {
+      if (stationName.length >= 15) {
         return 48;
       }
       return 72;
     }
 
-    if (stationName.length >= 10) {
-      return 32;
+    if (stationName.length >= 15) {
+      return 38;
     }
     return 48;
   }, []);
@@ -144,9 +144,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
   const stateOpacityAnim = useValue<0 | 1>(0);
   const boundOpacityAnim = useValue<0 | 1>(0);
   const bottomNameRotateAnim = useValue(0);
-  const bottomNameTranslateY = useValue(
-    getFontSize(isJapanese ? station.name : station.nameR)
-  );
+  const bottomNameTranslateY = useValue<number>(0);
 
   const yamanoteLine = line ? isYamanoteLine(line.id) : undefined;
   const osakaLoopLine = line ? !trainType && line.id === 11623 : undefined;
@@ -154,8 +152,10 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
   const { top: safeAreaTop } = useSafeAreaInsets();
 
   const adjustFontSize = useCallback(
-    (stationName: string): void => {
-      setStationNameFontSize(getFontSize(stationName));
+    (stationName: string, en?: boolean): void => {
+      if (!en) {
+        setStationNameFontSize(getFontSize(stationName));
+      }
     },
     [getFontSize]
   );
@@ -289,7 +289,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
           fadeOut();
           setStateText(translate('arrivingAtEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
           fadeIn();
         }
         break;
@@ -317,7 +317,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
         }
         setStateText('');
         setStationText(station.nameR);
-        adjustFontSize(station.nameR);
+        adjustFontSize(station.nameR, true);
         fadeIn();
         break;
       case 'NEXT':
@@ -343,7 +343,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
           fadeOut();
           setStateText(translate('nextEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
           fadeIn();
         }
         break;

--- a/src/components/HeaderYamanote/index.tsx
+++ b/src/components/HeaderYamanote/index.tsx
@@ -47,26 +47,32 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
   const yamanoteLine = line ? isYamanoteLine(line.id) : undefined;
   const osakaLoopLine = line ? !trainType && line.id === 11623 : undefined;
 
-  const adjustFontSize = useCallback((stationName: string): void => {
-    if (isPad) {
-      if (stationName.length >= 10) {
-        setStationNameFontSize(48);
-      } else if (stationName.length >= 7) {
-        setStationNameFontSize(64);
-      } else {
-        setStationNameFontSize(72);
+  const adjustFontSize = useCallback(
+    (stationName: string, en?: boolean): void => {
+      if (en) {
+        return;
       }
-      return;
-    }
+      if (isPad) {
+        if (stationName.length >= 10) {
+          setStationNameFontSize(48);
+        } else if (stationName.length >= 7) {
+          setStationNameFontSize(64);
+        } else {
+          setStationNameFontSize(72);
+        }
+        return;
+      }
 
-    if (stationName.length >= 10) {
-      setStationNameFontSize(32);
-    } else if (stationName.length >= 7) {
-      setStationNameFontSize(48);
-    } else {
-      setStationNameFontSize(58);
-    }
-  }, []);
+      if (stationName.length >= 10) {
+        setStationNameFontSize(32);
+      } else if (stationName.length >= 7) {
+        setStationNameFontSize(48);
+      } else {
+        setStationNameFontSize(58);
+      }
+    },
+    []
+  );
   const adjustBoundFontSize = useCallback((stationName: string): void => {
     if (isPad) {
       if (stationName.length >= 10) {
@@ -135,7 +141,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
         if (nextStation) {
           setStateText(translate('arrivingAtEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
         }
         break;
       case 'CURRENT':
@@ -151,7 +157,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
       case 'CURRENT_EN':
         setStateText(translate('nowStoppingAtEn'));
         setStationText(station.nameR);
-        adjustFontSize(station.nameR);
+        adjustFontSize(station.nameR, true);
         break;
       case 'NEXT':
         if (nextStation) {
@@ -171,7 +177,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
         if (nextStation) {
           setStateText(translate('nextEn'));
           setStationText(nextStation.nameR);
-          adjustFontSize(nextStation.nameR);
+          adjustFontSize(nextStation.nameR, true);
         }
         break;
       default:


### PR DESCRIPTION
closes #549

山手線は駅名を表示できる幅が狭いので10文字のまま

![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 45 17](https://user-images.githubusercontent.com/32848922/110077954-6073ce00-7dca-11eb-9cee-1cf726654b4c.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 45 23](https://user-images.githubusercontent.com/32848922/110077968-62d62800-7dca-11eb-8f22-d90f09c129bc.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 46 53](https://user-images.githubusercontent.com/32848922/110077973-649feb80-7dca-11eb-9b96-a9df2dee2202.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 46 56](https://user-images.githubusercontent.com/32848922/110077978-65d11880-7dca-11eb-8094-a90095e014c1.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 47 20](https://user-images.githubusercontent.com/32848922/110077983-67024580-7dca-11eb-9265-e336e42fefc6.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 15 47 23](https://user-images.githubusercontent.com/32848922/110077991-679adc00-7dca-11eb-9d3d-b905a2edb779.png)
