### PR TITLE
終点と終点の前の駅のグループIDが同じ場合終点がずれるバグを修正

### DIFF
--- a/src/hooks/useStationListByTrainType.ts
+++ b/src/hooks/useStationListByTrainType.ts
@@ -66,7 +66,7 @@ const useStationListByTrainType = (): [
       const cleanedStations = data.trainType.stations.filter(
         (s, i, arr): boolean => {
           const prv = arr[i - 1];
-          if (prv && prv.groupId === s.groupId) {
+          if (prv && prv.name === s.name) {
             return !prv;
           }
           return true;


### PR DESCRIPTION
![simulator_screenshot_157F9547-1AC8-472B-8B09-5C95D74D5060](https://user-images.githubusercontent.com/32848922/111088394-51c7ac80-856a-11eb-8e44-80b0d7d179fd.png)

closes #595 