### PR TITLE
駅検索のバグ修正

### DIFF
--- a/src/components/FakeStationSettings/index.tsx
+++ b/src/components/FakeStationSettings/index.tsx
@@ -179,8 +179,7 @@ const FakeStationSettings: React.FC = () => {
       const mapped = sorted
         .map((g, i, arr) => {
           const sameNameAndDifferentPrefStations = arr.filter(
-            (s) =>
-              s.name === g.name && s.nameR === g.nameR && s.prefId !== g.prefId
+            (s) => s.name === g.name && s.prefId !== g.prefId
           );
           if (sameNameAndDifferentPrefStations.length) {
             return {

--- a/src/components/FakeStationSettings/index.tsx
+++ b/src/components/FakeStationSettings/index.tsx
@@ -165,18 +165,7 @@ const FakeStationSettings: React.FC = () => {
 
   useEffect(() => {
     if (data) {
-      const sorted = data.stationsByName.slice().sort((a, b) => {
-        const lowerANameR = a.nameR.toLowerCase();
-        const lowerBNameR = b.nameR.toLowerCase();
-        if (lowerANameR > lowerBNameR) {
-          return 1;
-        }
-        if (lowerANameR < lowerBNameR) {
-          return -1;
-        }
-        return 0;
-      });
-      const mapped = sorted
+      const mapped = data.stationsByName
         .map((g, i, arr) => {
           const sameNameAndDifferentPrefStations = arr.filter(
             (s) => s.name === g.name && s.prefId !== g.prefId


### PR DESCRIPTION
closes #600 

駅名が同じかつ都道府県も同じ判定でローマ字を使っていたが、JR田町駅がTamachiで清輝橋線Tamatiだったので同じ名前判定にならずマージされバグっていた