### PR TITLE
のりかえ英語フォントサイズ調整

### DIFF
--- a/src/components/Transfers/index.tsx
+++ b/src/components/Transfers/index.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   lineNameEn: {
-    fontSize: RFValue(14),
+    fontSize: RFValue(12),
     color: '#333',
     fontWeight: 'bold',
   },


### PR DESCRIPTION
英語表示がでかすぎた
![simulator_screenshot_4EEA690A-2FD5-4E56-B8E6-096AC59BC9B0](https://user-images.githubusercontent.com/32848922/111497088-2d471c80-8784-11eb-891a-010aee45991c.png)
