### PR TITLE
埼京線TrainTypeBoxデザイン修正

### DIFF
--- a/src/components/TrainTypeBoxSaikyo/index.tsx
+++ b/src/components/TrainTypeBoxSaikyo/index.tsx
@@ -188,12 +188,21 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
   return (
     <View style={styles.root}>
       <LinearGradient
-        colors={['#aaa', '#000', '#000', '#aaa']}
-        locations={[0.5, 0.5, 0.5, 0.9]}
+        colors={['#000', '#000', '#fff']}
+        locations={[0.1, 0.5, 0.9]}
         style={styles.gradient}
       />
       <LinearGradient
-        colors={[`${trainTypeColor}ee`, `${trainTypeColor}aa`]}
+        colors={['#aaaaaaff', '#aaaaaabb']}
+        style={styles.gradient}
+      />
+      <LinearGradient
+        colors={['#000', '#000', '#fff']}
+        locations={[0.1, 0.5, 0.9]}
+        style={styles.gradient}
+      />
+      <LinearGradient
+        colors={[`${trainTypeColor}bb`, `${trainTypeColor}ff`]}
         style={styles.gradient}
       />
 
@@ -223,8 +232,8 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
               lineHeight: RFValue(
                 Platform.OS === 'ios' ? prevFontSize : prevFontSize + 4
               ),
-              letterSpacing: prevLetterSpacing,
               paddingLeft: prevPaddingLeft,
+              letterSpacing: prevLetterSpacing,
             },
           ]}
         >


### PR DESCRIPTION
closes #621 
![simulator_screenshot_A2891D78-395D-46AE-9F4E-3FB51D2A3C96](https://user-images.githubusercontent.com/32848922/111887325-a4e0aa00-8a17-11eb-8e57-a7d86af41f80.png)

LineBoardと上下逆だった