### PR TITLE
React.memoを一旦消した

### DIFF
--- a/src/components/BarTerminalEast/index.tsx
+++ b/src/components/BarTerminalEast/index.tsx
@@ -97,4 +97,4 @@ const BarTerminalEast: React.FC<Props> = (props: Props) => {
   );
 };
 
-export default React.memo(BarTerminalEast);
+export default BarTerminalEast;

--- a/src/components/ErrorScreen/index.tsx
+++ b/src/components/ErrorScreen/index.tsx
@@ -67,4 +67,4 @@ const ErrorScreen: React.FC<Props> = ({ title, text, onRetryPress }: Props) => (
   </SafeAreaView>
 );
 
-export default React.memo(ErrorScreen);
+export default ErrorScreen;

--- a/src/components/HeaderJRWest/index.tsx
+++ b/src/components/HeaderJRWest/index.tsx
@@ -543,4 +543,4 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
   );
 };
 
-export default React.memo(HeaderJRWest);
+export default HeaderJRWest;

--- a/src/components/HeaderTokyoMetro/index.tsx
+++ b/src/components/HeaderTokyoMetro/index.tsx
@@ -495,4 +495,4 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
   );
 };
 
-export default React.memo(HeaderTokyoMetro);
+export default HeaderTokyoMetro;

--- a/src/components/HeaderYamanote/index.tsx
+++ b/src/components/HeaderYamanote/index.tsx
@@ -270,4 +270,4 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
   );
 };
 
-export default React.memo(HeaderYamanote);
+export default HeaderYamanote;

--- a/src/components/Layout/Permitted.tsx
+++ b/src/components/Layout/Permitted.tsx
@@ -253,4 +253,4 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   );
 };
 
-export default React.memo(PermittedLayout);
+export default PermittedLayout;

--- a/src/components/TrainTypeBox/index.tsx
+++ b/src/components/TrainTypeBox/index.tsx
@@ -266,4 +266,4 @@ TrainTypeBox.defaultProps = {
   isTY: false,
 };
 
-export default React.memo(TrainTypeBox);
+export default TrainTypeBox;

--- a/src/components/TrainTypeBoxSaikyo/index.tsx
+++ b/src/components/TrainTypeBoxSaikyo/index.tsx
@@ -264,4 +264,4 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
   );
 };
 
-export default React.memo(TrainTypeBoxSaikyo);
+export default TrainTypeBoxSaikyo;

--- a/src/components/TransferLineDot/index.tsx
+++ b/src/components/TransferLineDot/index.tsx
@@ -28,4 +28,4 @@ TransferLineDot.defaultProps = {
   small: undefined,
 };
 
-export default React.memo(TransferLineDot);
+export default TransferLineDot;

--- a/src/components/TransferLineMark/index.tsx
+++ b/src/components/TransferLineMark/index.tsx
@@ -364,4 +364,4 @@ TransferLineMark.defaultProps = {
   white: false,
 };
 
-export default React.memo(TransferLineMark);
+export default TransferLineMark;

--- a/src/screens/Main/index.tsx
+++ b/src/screens/Main/index.tsx
@@ -311,4 +311,4 @@ const MainScreen: React.FC = () => {
   }
 };
 
-export default React.memo(MainScreen);
+export default MainScreen;

--- a/src/screens/NotificationSettingsScreen/index.tsx
+++ b/src/screens/NotificationSettingsScreen/index.tsx
@@ -72,28 +72,30 @@ type ListItemProps = {
   onPress: () => void;
 };
 
-const ListItem: React.FC<ListItemProps> = React.memo(
-  ({ active, item, onPress }: ListItemProps) => (
-    <View style={styles.itemRoot}>
-      <TouchableWithoutFeedback onPress={onPress}>
-        <View style={styles.item}>
-          <View style={styles.checkbox}>
-            {active && (
-              <Svg height="100%" width="100%" viewBox="0 0 24 24">
-                <Path
-                  fill="#333"
-                  d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"
-                />
-              </Svg>
-            )}
-          </View>
-          <Text style={styles.stationName}>
-            {isJapanese ? item.name : item.nameR}
-          </Text>
+const ListItem: React.FC<ListItemProps> = ({
+  active,
+  item,
+  onPress,
+}: ListItemProps) => (
+  <View style={styles.itemRoot}>
+    <TouchableWithoutFeedback onPress={onPress}>
+      <View style={styles.item}>
+        <View style={styles.checkbox}>
+          {active && (
+            <Svg height="100%" width="100%" viewBox="0 0 24 24">
+              <Path
+                fill="#333"
+                d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"
+              />
+            </Svg>
+          )}
         </View>
-      </TouchableWithoutFeedback>
-    </View>
-  )
+        <Text style={styles.stationName}>
+          {isJapanese ? item.name : item.nameR}
+        </Text>
+      </View>
+    </TouchableWithoutFeedback>
+  </View>
 );
 
 const NotificationSettings: React.FC = () => {

--- a/src/screens/SelectLine/index.tsx
+++ b/src/screens/SelectLine/index.tsx
@@ -206,4 +206,4 @@ const SelectLineScreen: React.FC = () => {
   );
 };
 
-export default React.memo(SelectLineScreen);
+export default SelectLineScreen;


### PR DESCRIPTION
closes #612 

闇雲にReact.memoつかってたけど実際パフォーマンス図ったらJS FPSが60fpsあまり行かなくて消してみたらメモリ使用量が多少(20MBほど)減ってJSのFPSも上がった(すべて埼京線テーマで確認）