### PR TITLE
列車種別省略処理改善

### DIFF
--- a/src/components/TrainTypeBox/index.tsx
+++ b/src/components/TrainTypeBox/index.tsx
@@ -16,7 +16,7 @@ import useValueRef from '../../hooks/useValueRef';
 import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
 import { APITrainType } from '../../models/StationAPI';
 import { parenthesisRegexp } from '../../constants/regexp';
-import TRUNCATE_TRAIN_TYPE_WORD from '../../constants/truncateTrainType';
+import truncateTrainType from '../../constants/truncateTrainType';
 
 type Props = {
   trainType: APITrainType | TrainType;
@@ -86,28 +86,9 @@ const TrainTypeBox: React.FC<Props> = ({ trainType, isTY }: Props) => {
   const trainTypeName = (
     (trainType as APITrainType).name || trainTypeTextEastJa
   )?.replace(parenthesisRegexp, '');
-  const parenthsisExcludedTrainTypeNameR = (
-    (trainType as APITrainType).nameR || trainTypeTextEastEn
-  )?.replace(parenthesisRegexp, '');
-
-  const trainTypeNameR = parenthsisExcludedTrainTypeNameR
-    ?.split(' ')
-    ?.map((v, _, arr) => {
-      if (arr.length === 1) {
-        return v;
-      }
-
-      if (TRUNCATE_TRAIN_TYPE_WORD.find((w) => v.toLowerCase() === w)) {
-        const truncated = v
-          .split('')
-          .slice(0, 3)
-          .map((w, i) => (i === 0 ? w.toUpperCase() : w))
-          .join('');
-        return `${truncated}.`;
-      }
-      return v;
-    })
-    ?.join(' ');
+  const trainTypeNameR = truncateTrainType(
+    (trainType as APITrainType).nameR || translate('localEn')
+  );
 
   const isJapaneseContains = !!trainTypeName.match(
     /^[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+$/

--- a/src/components/TrainTypeBoxSaikyo/index.tsx
+++ b/src/components/TrainTypeBoxSaikyo/index.tsx
@@ -17,7 +17,7 @@ import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
 import { APITrainType } from '../../models/StationAPI';
 import { parenthesisRegexp } from '../../constants/regexp';
 import { getIsLocal, getIsRapid } from '../../utils/localType';
-import TRUNCATE_TRAIN_TYPE_WORD from '../../constants/truncateTrainType';
+import truncateTrainType from '../../constants/truncateTrainType';
 
 type Props = {
   trainType: APITrainType | TrainType;
@@ -91,28 +91,10 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
   const trainTypeName = (
     (trainType as APITrainType).name || translate('local')
   )?.replace(parenthesisRegexp, '');
-  const parenthsisExcludedTrainTypeNameR = (
+
+  const trainTypeNameR = truncateTrainType(
     (trainType as APITrainType).nameR || translate('localEn')
-  )?.replace(parenthesisRegexp, '');
-
-  const trainTypeNameR = parenthsisExcludedTrainTypeNameR
-    ?.split(' ')
-    ?.map((v, _, arr) => {
-      if (arr.length === 1) {
-        return v;
-      }
-
-      if (TRUNCATE_TRAIN_TYPE_WORD.find((w) => v.toLowerCase() === w)) {
-        const truncated = v
-          .split('')
-          .slice(0, 3)
-          .map((w, i) => (i === 0 ? w.toUpperCase() : w))
-          .join('');
-        return `${truncated}.`;
-      }
-      return v;
-    })
-    ?.join(' ');
+  );
 
   const isJapaneseContains = !!trainTypeName.match(
     /^[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+$/

--- a/src/constants/truncateTrainType.ts
+++ b/src/constants/truncateTrainType.ts
@@ -1,3 +1,29 @@
+import { parenthesisRegexp } from './regexp';
+
 const TRUNCATE_TRAIN_TYPE_WORD = ['commuter', 'limited', 'express'];
 
-export default TRUNCATE_TRAIN_TYPE_WORD;
+const truncateTrainType = (nameR: string): string => {
+  const replacedName = nameR.replace(parenthesisRegexp, '');
+
+  return replacedName
+    .split(' ')
+    .map((v, _, arr) => {
+      if (arr.length === 1) {
+        return v;
+      }
+
+      if (TRUNCATE_TRAIN_TYPE_WORD.find((w) => v.toLowerCase() === w)) {
+        const truncated = v
+          .split('')
+          .slice(0, 3)
+          .map((w) => (w === 'lim' ? 'ltd' : w))
+          .map((w, i) => (i === 0 ? w.toUpperCase() : w))
+          .join('');
+        return `${truncated !== 'Lim' ? truncated : 'Ltd'}.`;
+      }
+      return v;
+    })
+    .join(' ');
+};
+
+export default truncateTrainType;


### PR DESCRIPTION
closes #703

コードが重複していたので切り出したのと、Lim.Exp.になっているところをLtd.Exp.に直した