### PR TITLE
ヘッダーステート言語選択後処理の改善

### DIFF
--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -1,4 +1,8 @@
 export type AvailableLanguage = 'JA' | 'EN' | 'ZH' | 'KO';
+export type AvailableLanguageObj = {
+  code: AvailableLanguage;
+  priority: number;
+};
 
 export const ALL_AVAILABLE_LANGUAGES: AvailableLanguage[] = [
   'JA',
@@ -6,3 +10,10 @@ export const ALL_AVAILABLE_LANGUAGES: AvailableLanguage[] = [
   'ZH',
   'KO',
 ];
+
+export const ALL_AVAILABLE_LANGUAGES_WITH_PRIORITY: AvailableLanguageObj[] = ALL_AVAILABLE_LANGUAGES.map(
+  (code, priority) => ({
+    code,
+    priority,
+  })
+);

--- a/src/hooks/useTransitionHeaderState.ts
+++ b/src/hooks/useTransitionHeaderState.ts
@@ -65,6 +65,7 @@ const useTransitionHeaderState = (): void => {
                   ...prev,
                   headerState: 'CURRENT',
                 }));
+                break;
               }
               setNavigation((prev) => ({
                 ...prev,

--- a/src/screens/EnabledLanguagesSettings/index.tsx
+++ b/src/screens/EnabledLanguagesSettings/index.tsx
@@ -18,6 +18,7 @@ import FAB from '../../components/FAB';
 import { isJapanese, translate } from '../../translation';
 import {
   ALL_AVAILABLE_LANGUAGES,
+  ALL_AVAILABLE_LANGUAGES_WITH_PRIORITY,
   AvailableLanguage,
 } from '../../constants/languages';
 import navigationState from '../../store/atoms/navigation';
@@ -162,6 +163,26 @@ const EnabledLanguagesSettings: React.FC = () => {
     }
   }, [enabledLanguages, navigation]);
 
+  const languageSorter = (
+    a: AvailableLanguage,
+    b: AvailableLanguage
+  ): number => {
+    const aWithPriority = ALL_AVAILABLE_LANGUAGES_WITH_PRIORITY.find(
+      (l) => l.code === a
+    );
+    const bWithPriority = ALL_AVAILABLE_LANGUAGES_WITH_PRIORITY.find(
+      (l) => l.code === b
+    );
+    if (aWithPriority.priority < bWithPriority.priority) {
+      return -1;
+    }
+    if (aWithPriority.priority > bWithPriority.priority) {
+      return 1;
+    }
+
+    return 0;
+  };
+
   const renderItem: React.FC<
     ListRenderItemInfo<AvailableLanguage>
   > = useCallback(
@@ -176,7 +197,9 @@ const EnabledLanguagesSettings: React.FC = () => {
         } else {
           setNavigation((prev) => ({
             ...prev,
-            enabledLanguages: [...prev.enabledLanguages, item],
+            enabledLanguages: [...prev.enabledLanguages, item].sort(
+              languageSorter
+            ),
           }));
         }
       };


### PR DESCRIPTION
- ヘッダーステートがループしないバグを修正
- 言語を選んだ状態でも正しい順番でヘッダーステートがループするようにした