### PR TITLE
西日本テーマで終点なのに「から先は〜」放送が流れるバグを修正

### DIFF
--- a/src/providers/SpeechProvider.tsx
+++ b/src/providers/SpeechProvider.tsx
@@ -379,7 +379,7 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
               )
               .say('の順に止まります。')
               .say(
-                getHasTerminus(5)
+                getHasTerminus(6)
                   ? ''
                   : `${
                       allStops
@@ -473,9 +473,9 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
                   )
                   .join('')
               )
-              .say(getHasTerminus(5) ? 'terminal.' : '.')
+              .say(getHasTerminus(6) ? 'terminal.' : '.')
               .say(
-                getHasTerminus(5)
+                getHasTerminus(6)
                   ? ''
                   : `Stops after ${
                       allStops


### PR DESCRIPTION
getHasTerminusってのは指定した数の分だけ駅があるかってのを返してくれる関数で西日本テーマだと５駅まで読み上げてくれるから５駅目は存在して、６駅目が存在しないってことは５駅目が終点