### PR TITLE
TTS修正

### DIFF
--- a/src/providers/SpeechProvider.tsx
+++ b/src/providers/SpeechProvider.tsx
@@ -249,9 +249,7 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
         .filter((nameR, idx, arr) => arr.indexOf(nameR) === idx)
         .filter((nameR) => nameR !== currentLine?.nameR)
         .map((nameR, i, arr) =>
-          arr.length - 1 === i
-            ? `and the <lang xml:lang="ja-JP">${nameR}</lang>`
-            : `the <lang xml:lang="ja-JP">${nameR}</lang>,`
+          arr.length - 1 === i ? `and the ${nameR}` : `the ${nameR},`
         );
 
       const belongingLines = stations.map((s) =>
@@ -515,7 +513,7 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
                 }</lang>`
               );
 
-            const ret = `${prefix} ${allStops
+            return `${prefix} ${allStops
               .slice(0, 5)
               .map((s, i, a) =>
                 a.length - 1 !== i
@@ -523,8 +521,6 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
                   : `<lang xml:lang="ja-JP">${s.nameR}</lang>`
               )
               .join('')} ${suffix}`;
-            console.log(ret);
-            return ret;
           }
           default:
             return '';


### PR DESCRIPTION
乗り換え路線の読み上げがSSMLそのまま読まれてたのでSSMLの表記を丸ごと消した（そもそも路線は変換しない仕様だったので）