### PR TITLE
Watchの中韓ステートで正しく今の駅が表示されないバグを修正

### DIFF
--- a/src/providers/AppleWatchProvider.tsx
+++ b/src/providers/AppleWatchProvider.tsx
@@ -50,6 +50,8 @@ const AppleWatchProvider: React.FC<Props> = ({ children }: Props) => {
       case 'CURRENT':
       case 'CURRENT_EN':
       case 'CURRENT_KANA':
+      case 'CURRENT_ZH':
+      case 'CURRENT_KO':
         return station;
       default:
         return nextStation;


### PR DESCRIPTION
closes #822

ブランチ名はfixだけどhotfix系のトリアージでmasterにマージする