### PR TITLE
analyticsのイベント追加

### DIFF
--- a/ios/TrainLCD.xcodeproj/xcshareddata/xcschemes/TrainLCD.xcscheme
+++ b/ios/TrainLCD.xcodeproj/xcshareddata/xcschemes/TrainLCD.xcscheme
@@ -97,6 +97,12 @@
             ReferencedContainer = "container:TrainLCD.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled "
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/src/components/FakeStationSettings/index.tsx
+++ b/src/components/FakeStationSettings/index.tsx
@@ -20,6 +20,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useLazyQuery } from '@apollo/client';
 import { RFValue } from 'react-native-responsive-fontsize';
 import * as geolib from 'geolib';
+import analytics from '@react-native-firebase/analytics';
 import { StationsByNameData, Station } from '../../models/StationAPI';
 import { PREFS_JA, PREFS_EN } from '../../constants';
 import Heading from '../Heading';
@@ -251,7 +252,12 @@ const FakeStationSettings: React.FC = () => {
   }, [error]);
 
   const onStationPress = useCallback(
-    (station: Station) => {
+    async (station: Station) => {
+      analytics().logEvent('stationSelected', {
+        id: station.id.toString(),
+        name: station.name,
+      });
+
       setStation((prev) => ({
         ...prev,
         station,

--- a/src/components/Layout/Permitted.tsx
+++ b/src/components/Layout/Permitted.tsx
@@ -16,6 +16,7 @@ import ViewShot from 'react-native-view-shot';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LocationObject } from 'expo-location';
+import analytics from '@react-native-firebase/analytics';
 import Header from '../Header';
 import WarningPanel from '../WarningPanel';
 import DevOverlay from '../DevOverlay';
@@ -204,6 +205,11 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         type: 'image/png',
       };
       await Share.open(options);
+
+      await analytics().logEvent('userShared', {
+        id: currentLine.id,
+        name: currentLine.name,
+      });
     } catch (err) {
       if (err.message !== 'User did not share') {
         console.error(err);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,11 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import AppLoading from 'expo-app-loading';
 import { RecoilRoot } from 'recoil';
 import { StatusBar } from 'react-native';
 import * as Location from 'expo-location';
+import analytics from '@react-native-firebase/analytics';
 import { setI18nConfig } from './translation';
 import MainStack from './stacks/MainStack';
 import PrivacyScreen from './screens/Privacy';
@@ -27,6 +28,8 @@ const options = {
 const App: React.FC = () => {
   const [translationLoaded, setTranstationLoaded] = useState(false);
   const [permissionsGranted, setPermissionsGranted] = useState(false);
+  const routeNameRef = useRef(null);
+  const navigationRef = useRef(null);
 
   useEffect(() => {
     const f = async (): Promise<void> => {
@@ -55,7 +58,25 @@ const App: React.FC = () => {
   return (
     <RecoilRoot>
       <AppRootProvider>
-        <NavigationContainer>
+        <NavigationContainer
+          ref={navigationRef}
+          onReady={() => {
+            routeNameRef.current = navigationRef.current.getCurrentRoute().name;
+          }}
+          onStateChange={async () => {
+            const previousRouteName = routeNameRef.current;
+            const currentRouteName =
+              navigationRef.current.getCurrentRoute().name;
+
+            if (previousRouteName !== currentRouteName) {
+              await analytics().logScreenView({
+                screen_name: currentRouteName,
+                screen_class: currentRouteName,
+              });
+            }
+            routeNameRef.current = currentRouteName;
+          }}
+        >
           <StatusBar hidden translucent backgroundColor="transparent" />
 
           <Stack.Navigator

--- a/src/screens/AppSettings/ThemeSettings/index.tsx
+++ b/src/screens/AppSettings/ThemeSettings/index.tsx
@@ -4,8 +4,9 @@ import { Picker } from '@react-native-picker/picker';
 import { useNavigation } from '@react-navigation/native';
 import { useRecoilState } from 'recoil';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import analytics from '@react-native-firebase/analytics';
 import Heading from '../../../components/Heading';
-import getSettingsThemes from './themes';
+import settingsThemes from './themes';
 import { translate } from '../../../translation';
 import FAB from '../../../components/FAB';
 import themeState from '../../../store/atoms/theme';
@@ -41,13 +42,15 @@ const ThemeSettingsScreen: React.FC = () => {
 
   const onPressBack = useCallback(async () => {
     await AsyncStorage.setItem('@TrainLCD:previousTheme', theme.toString());
+    await analytics().logEvent('themeSelected', {
+      id: theme,
+      name: settingsThemes.find((t) => t.value === theme).label,
+    });
 
     if (navigation.canGoBack()) {
       navigation.goBack();
     }
   }, [navigation, theme]);
-
-  const settingsThemes = getSettingsThemes();
 
   return (
     <>

--- a/src/screens/AppSettings/ThemeSettings/themes.ts
+++ b/src/screens/AppSettings/ThemeSettings/themes.ts
@@ -6,7 +6,7 @@ interface SettingsTheme {
   value: AppTheme;
 }
 
-const getSettingsThemes = (): SettingsTheme[] => [
+const settingsThemes: SettingsTheme[] = (() => [
   {
     label: translate('tokyoMetroLike'),
     value: AppTheme.TokyoMetro,
@@ -27,6 +27,6 @@ const getSettingsThemes = (): SettingsTheme[] => [
     label: translate('saikyoLineLike'),
     value: AppTheme.Saikyo,
   },
-];
+])();
 
-export default getSettingsThemes;
+export default settingsThemes;

--- a/src/screens/AppSettings/index.tsx
+++ b/src/screens/AppSettings/index.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useRecoilState } from 'recoil';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { RFValue } from 'react-native-responsive-fontsize';
+import analytics from '@react-native-firebase/analytics';
 import Heading from '../../components/Heading';
 import { translate } from '../../translation';
 import FAB from '../../components/FAB';
@@ -32,7 +33,14 @@ const AppSettingsScreen: React.FC = () => {
 
   const onSpeechEnabledValueChange = useCallback(
     async (flag: boolean) => {
-      AsyncStorage.setItem('@TrainLCD:speechEnabled', flag ? 'true' : 'false');
+      await analytics().logEvent('ttsToggled', {
+        toValue: flag ? 'true' : 'false',
+      });
+
+      await AsyncStorage.setItem(
+        '@TrainLCD:speechEnabled',
+        flag ? 'true' : 'false'
+      );
       setSpeech((prev) => ({
         ...prev,
         enabled: flag,

--- a/src/screens/SelectBound/index.tsx
+++ b/src/screens/SelectBound/index.tsx
@@ -33,7 +33,6 @@ import useValueRef from '../../hooks/useValueRef';
 import getLocalType from '../../utils/localType';
 import { HeaderLangState } from '../../models/HeaderTransitionState';
 import themeState from '../../store/atoms/theme';
-import settingsThemes from '../AppSettings/ThemeSettings/themes';
 
 const styles = StyleSheet.create({
   boundLoading: {
@@ -191,7 +190,7 @@ const SelectBoundScreen: React.FC = () => {
         lineName: selectedLine.name,
         stationId: selectedStation.id.toString(),
         stationName: selectedStation.name,
-        theme: settingsThemes.find((t) => t.value === theme).label,
+        themeId: theme.toString(),
       });
 
       setStation((prev) => ({

--- a/src/screens/SelectBound/index.tsx
+++ b/src/screens/SelectBound/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useRecoilState } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
+import analytics from '@react-native-firebase/analytics';
 import Button from '../../components/Button';
 import { directionToDirectionName, LineDirection } from '../../models/Bound';
 import { Station } from '../../models/StationAPI';
@@ -171,7 +172,16 @@ const SelectBoundScreen: React.FC = () => {
   }, [navigation, setLine, setNavigation, setStation]);
 
   const handleBoundSelected = useCallback(
-    (selectedStation: Station, direction: LineDirection): void => {
+    async (
+      selectedStation: Station,
+      direction: LineDirection
+    ): Promise<void> => {
+      await analytics().logEvent('boundSelected', {
+        id: selectedStation.id.toString(),
+        name: selectedStation.name,
+        direction,
+      });
+
       setStation((prev) => ({
         ...prev,
         selectedBound: selectedStation,
@@ -233,7 +243,7 @@ const SelectBoundScreen: React.FC = () => {
       } else {
         directionText = `for ${boundStation.nameR}`;
       }
-      const boundSelectOnPress = (): void =>
+      const boundSelectOnPress = (): Promise<void> =>
         handleBoundSelected(boundStation, direction);
       return (
         <Button

--- a/src/screens/SelectBound/index.tsx
+++ b/src/screens/SelectBound/index.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
 } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
 import analytics from '@react-native-firebase/analytics';
 import Button from '../../components/Button';
@@ -32,6 +32,8 @@ import useStationListByTrainType from '../../hooks/useStationListByTrainType';
 import useValueRef from '../../hooks/useValueRef';
 import getLocalType from '../../utils/localType';
 import { HeaderLangState } from '../../models/HeaderTransitionState';
+import themeState from '../../store/atoms/theme';
+import settingsThemes from '../AppSettings/ThemeSettings/themes';
 
 const styles = StyleSheet.create({
   boundLoading: {
@@ -73,6 +75,8 @@ const SelectBoundScreen: React.FC = () => {
     { station, stations, stationsWithTrainTypes, selectedBound },
     setStation,
   ] = useRecoilState(stationState);
+  const { theme } = useRecoilValue(themeState);
+
   const currentStation = stationsWithTrainTypes.find(
     (s) => station?.name === s.name
   );
@@ -182,6 +186,14 @@ const SelectBoundScreen: React.FC = () => {
         direction,
       });
 
+      await analytics().setUserProperties({
+        lineId: selectedLine.id.toString(),
+        lineName: selectedLine.name,
+        stationId: selectedStation.id.toString(),
+        stationName: selectedStation.name,
+        theme: settingsThemes.find((t) => t.value === theme).label,
+      });
+
       setStation((prev) => ({
         ...prev,
         selectedBound: selectedStation,
@@ -189,7 +201,7 @@ const SelectBoundScreen: React.FC = () => {
       }));
       navigation.navigate('Main');
     },
-    [navigation, setStation]
+    [navigation, selectedLine.id, selectedLine.name, setStation, theme]
   );
 
   const handleNotificationButtonPress = (): void => {

--- a/src/screens/SelectLine/index.tsx
+++ b/src/screens/SelectLine/index.tsx
@@ -11,6 +11,7 @@ import {
 import * as Location from 'expo-location';
 import { useNavigation } from '@react-navigation/native';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import analytics from '@react-native-firebase/analytics';
 import Button from '../../components/Button';
 import FAB from '../../components/FAB';
 import { getLineMark } from '../../lineMark';
@@ -69,7 +70,7 @@ const SelectLineScreen: React.FC = () => {
   const navigation = useNavigation();
 
   const handleLineSelected = useCallback(
-    (line: Line): void => {
+    async (line: Line): Promise<void> => {
       if (line.lineType === LineType.Subway) {
         Alert.alert(
           translate('subwayAlertTitle'),
@@ -77,6 +78,11 @@ const SelectLineScreen: React.FC = () => {
           [{ text: 'OK' }]
         );
       }
+
+      await analytics().logEvent('lineSelected', {
+        id: line.id.toString(),
+        name: line.name,
+      });
 
       setLine((prev) => ({
         ...prev,
@@ -93,7 +99,7 @@ const SelectLineScreen: React.FC = () => {
       const buttonText = `${lineMark ? `${lineMark.sign}` : ''}${
         lineMark && lineMark.subSign ? `/${lineMark.subSign} ` : ' '
       }${isJapanese ? line.name : line.nameR}`;
-      const buttonOnPress = (): void => handleLineSelected(line);
+      const buttonOnPress = (): Promise<void> => handleLineSelected(line);
       return (
         <Button
           color={`#${line.lineColorC}`}


### PR DESCRIPTION
## なぜログを取るのか
- クラッシュ時にユーザーがどの路線で使っていたかわかるため、バグの原因を突き止めやすくなる
- 人気のテーマを調べることができるので、逆に不人気なテーマを廃止したいといったときに役立つ
- よく使われる路線を抽出することでその路線の対応改善に注力できる
## ログを取るタイミング
- テーマ選択時
- 路線選択時
- 方面選択時
- シェア完了時
- 駅検索後確定時
- TTSトグル時
## ユーザー属性を設定するタイミング
- 方面選択後、路線情報、方面情報、使用テーマをユーザー属性とする
## メンテナの方へ
**オプトアウトについては後で実装するか議論します。このPR自体が必要かどうかよりコードの品質を見てください。**