### PR TITLE
JRWテーマデグレ修正

### DIFF
--- a/src/components/HeaderJRWest/index.tsx
+++ b/src/components/HeaderJRWest/index.tsx
@@ -44,13 +44,9 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
   const [stationText, setStationText] = useState(station.name);
   const [boundText, setBoundText] = useState('TrainLCD');
   const [stationNameFontSize, setStationNameFontSize] = useState(38);
-  const [boundStationNameFontSize, setBoundStationNameFontSize] = useState(21);
   const { headerState, trainType } = useRecoilValue(navigationState);
 
-  const boundStationNameLineHeight =
-    Platform.OS === 'android'
-      ? boundStationNameFontSize + 8
-      : boundStationNameFontSize;
+  const boundStationNameLineHeight = Platform.OS === 'android' ? 21 + 8 : 21;
 
   const yamanoteLine = line ? isYamanoteLine(line.id) : undefined;
   const osakaLoopLine = line ? !trainType && line.id === 11623 : undefined;
@@ -256,7 +252,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
 
   const boundLightHeight = ((): number => {
     if (Platform.OS === 'android') {
-      return boundStationNameFontSize + 8;
+      return 21 + 8;
     }
     return boundStationNameLineHeight;
   })();
@@ -287,7 +283,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
     bound: {
       color: '#fff',
       fontWeight: 'bold',
-      fontSize: RFValue(boundStationNameFontSize),
+      fontSize: RFValue(21),
       lineHeight: RFValue(boundLightHeight),
     },
     boundFor: {

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -15,13 +15,19 @@ export interface Props {
 
 const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
   const { theme } = useRecoilValue(themeState);
-  const { arrived, stations } = useRecoilValue(stationState);
+  const { arrived, stations, selectedDirection } = useRecoilValue(stationState);
   const { selectedLine } = useRecoilValue(lineState);
   const { trainType, leftStations } = useRecoilValue(navigationState);
   const joinedLineIds = trainType?.lines.map((l) => l.id);
   const slicedLeftStations = leftStations.slice(0, 8);
 
-  const notPassStations = stations.filter((s) => !s.pass);
+  const notPassStations =
+    selectedDirection === 'INBOUND'
+      ? stations.filter((s) => !s.pass)
+      : stations
+          .filter((s) => !s.pass)
+          .slice()
+          .reverse();
   const isPassing =
     notPassStations.findIndex((s) => s.id === leftStations[0]?.id) === -1;
   const nextStopStation = leftStations.filter((s) => !s.pass)[0];
@@ -31,6 +37,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
     if (arrived) {
       leftStations.filter((s) => !s.pass).slice(0, 8);
     }
+
     if (isPassing && lastStoppedStationIndex > 0) {
       return [
         notPassStations[lastStoppedStationIndex],

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -1,32 +1,51 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import LineBoardWest from '../LineBoardWest';
 import LineBoardEast from '../LineBoardEast';
 import themeState from '../../store/atoms/theme';
 import AppTheme from '../../models/Theme';
-import { APITrainType, Line, Station } from '../../models/StationAPI';
 import LineBoardSaikyo from '../LineBoardSaikyo';
+import navigationState from '../../store/atoms/navigation';
+import stationState from '../../store/atoms/station';
+import lineState from '../../store/atoms/line';
 
 export interface Props {
-  arrived: boolean;
-  selectedLine: Line;
-  stations: Station[];
-  theme?: AppTheme;
   hasTerminus: boolean;
-  trainType: APITrainType;
 }
 
-const LineBoard: React.FC<Props> = ({
-  arrived,
-  selectedLine,
-  stations,
-  hasTerminus,
-  trainType,
-}: Props) => {
+const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
   const { theme } = useRecoilValue(themeState);
+  const { arrived, stations } = useRecoilValue(stationState);
+  const { selectedLine } = useRecoilValue(lineState);
+  const { trainType, leftStations } = useRecoilValue(navigationState);
   const joinedLineIds = trainType?.lines.map((l) => l.id);
-  const slicedStations = stations.slice(0, 8);
-  const passFiltered = stations.filter((s) => !s.pass).slice(0, 8);
+  const slicedLeftStations = leftStations.slice(0, 8);
+
+  const notPassStations = stations.filter((s) => !s.pass);
+  const isPassing =
+    notPassStations.findIndex((s) => s.id === leftStations[0]?.id) === -1;
+  const nextStopStation = leftStations.filter((s) => !s.pass)[0];
+  const lastStoppedStationIndex =
+    notPassStations.findIndex((s) => s.id === nextStopStation?.id) - 1;
+  const passFiltered = useMemo(() => {
+    if (arrived) {
+      leftStations.filter((s) => !s.pass).slice(0, 8);
+    }
+    if (isPassing && lastStoppedStationIndex > 0) {
+      return [
+        notPassStations[lastStoppedStationIndex],
+        ...leftStations.filter((s) => !s.pass).slice(0, 8),
+      ];
+    }
+
+    return leftStations.filter((s) => !s.pass).slice(0, 8);
+  }, [
+    arrived,
+    isPassing,
+    lastStoppedStationIndex,
+    leftStations,
+    notPassStations,
+  ]);
 
   const belongingLines = (() => {
     if (theme === AppTheme.JRWest) {
@@ -34,7 +53,7 @@ const LineBoard: React.FC<Props> = ({
         s.lines.find((l) => joinedLineIds?.find((il) => l.id === il))
       );
     }
-    return slicedStations.map((s) =>
+    return slicedLeftStations.map((s) =>
       s.lines.find((l) => joinedLineIds?.find((il) => l.id === il))
     );
   })();
@@ -46,17 +65,17 @@ const LineBoard: React.FC<Props> = ({
       return (
         <LineBoardWest
           lineColors={lineColors}
-          arrived={arrived}
           stations={passFiltered}
           line={belongingLines[0] || selectedLine}
           lines={belongingLines}
         />
       );
+    // TODO: 加工していないprops渡しを消して子コンポーネントでstateを取るようにする
     case AppTheme.Saikyo:
       return (
         <LineBoardSaikyo
           arrived={arrived}
-          stations={slicedStations}
+          stations={slicedLeftStations}
           line={belongingLines[0] || selectedLine}
           lines={belongingLines}
           hasTerminus={hasTerminus}
@@ -67,7 +86,7 @@ const LineBoard: React.FC<Props> = ({
       return (
         <LineBoardEast
           arrived={arrived}
-          stations={slicedStations}
+          stations={slicedLeftStations}
           line={belongingLines[0] || selectedLine}
           lines={belongingLines}
           hasTerminus={hasTerminus}

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -41,7 +41,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
     if (isPassing && lastStoppedStationIndex > 0) {
       return [
         notPassStations[lastStoppedStationIndex],
-        ...leftStations.filter((s) => !s.pass).slice(0, 8),
+        ...leftStations.filter((s) => !s.pass).slice(0, 7),
       ];
     }
 

--- a/src/components/LineBoardWest/index.tsx
+++ b/src/components/LineBoardWest/index.tsx
@@ -25,7 +25,6 @@ import { heightScale } from '../../utils/scale';
 import stationState from '../../store/atoms/station';
 
 interface Props {
-  arrived: boolean;
   line: Line;
   lines: Line[];
   stations: Station[];
@@ -446,18 +445,19 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 };
 
 const LineBoardWest: React.FC<Props> = ({
-  arrived,
   stations,
   line,
   lineColors,
   lines,
 }: Props) => {
+  const { station: currentStation, arrived } = useRecoilValue(stationState);
+
   const stationNameCellForMap = (s: Station, i: number): JSX.Element => (
     <StationNameCell
       key={s.groupId}
       station={s}
       stations={stations}
-      arrived={arrived}
+      arrived={arrived && currentStation.id === s.id}
       line={line}
       lines={lines}
       index={i}

--- a/src/screens/Main/index.tsx
+++ b/src/screens/Main/index.tsx
@@ -485,13 +485,7 @@ const MainScreen: React.FC = () => {
             onPress={toTransferState}
             style={styles.touchable}
           >
-            <LineBoard
-              arrived={arrived}
-              selectedLine={selectedLine}
-              stations={leftStations}
-              hasTerminus={hasTerminus}
-              trainType={trainType}
-            />
+            <LineBoard hasTerminus={hasTerminus} />
           </TouchableWithoutFeedback>
         </View>
       );


### PR DESCRIPTION
closes #874 

#876 関係のリファクタリング含む

## 変更点
- propsバケツリレーからrecoil stateを一部使うようにした
- 次の駅に通過中に前の駅を配列に追加するようにした（これをしないと次の駅から次の次の駅に向かってるように見えるバグが起きる）
- 実際に停車している駅のIDと一致しない限り丸を赤くしないようにした（到着中フラグ && 実際の駅id === 丸dotに対応する駅id)