### PR TITLE
環状線誤判定バグ修正

### DIFF
--- a/src/components/HeaderJRWest/index.tsx
+++ b/src/components/HeaderJRWest/index.tsx
@@ -17,7 +17,7 @@ import {
   isYamanoteLine,
   inboundStationForLoopLine,
   outboundStationForLoopLine,
-  isLoopLine,
+  getIsLoopLine,
 } from '../../utils/loopLine';
 import getCurrentStationIndex from '../../utils/currentStationIndex';
 import { getLineMark } from '../../lineMark';
@@ -90,7 +90,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
       case 'KO':
         return '행';
       default:
-        return isLoopLine(line) ? '方面' : 'ゆき';
+        return getIsLoopLine(line, trainType) ? '方面' : 'ゆき';
     }
   })();
 

--- a/src/components/HeaderSaikyo/index.tsx
+++ b/src/components/HeaderSaikyo/index.tsx
@@ -26,7 +26,7 @@ import getCurrentStationIndex from '../../utils/currentStationIndex';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
   inboundStationForLoopLine,
-  isLoopLine,
+  getIsLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
@@ -264,7 +264,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
         case 'KO':
           return ' 행';
         default:
-          return isLoopLine(line) ? ' 方面' : ' ゆき';
+          return getIsLoopLine(line, trainType) ? ' 方面' : ' ゆき';
       }
     })();
 
@@ -470,6 +470,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
     state,
     station,
     stations,
+    trainType,
     yamanoteLine,
   ]);
 

--- a/src/components/HeaderTY/index.tsx
+++ b/src/components/HeaderTY/index.tsx
@@ -26,7 +26,7 @@ import getCurrentStationIndex from '../../utils/currentStationIndex';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
   inboundStationForLoopLine,
-  isLoopLine,
+  getIsLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
@@ -244,7 +244,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
         case 'KO':
           return ' 행';
         default:
-          return isLoopLine(line) ? '方面' : 'ゆき';
+          return getIsLoopLine(line, trainType) ? '方面' : 'ゆき';
       }
     })();
 
@@ -449,6 +449,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
     state,
     station,
     stations,
+    trainType,
     yamanoteLine,
   ]);
 

--- a/src/components/HeaderTokyoMetro/index.tsx
+++ b/src/components/HeaderTokyoMetro/index.tsx
@@ -27,7 +27,7 @@ import getCurrentStationIndex from '../../utils/currentStationIndex';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
   inboundStationForLoopLine,
-  isLoopLine,
+  getIsLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
@@ -229,7 +229,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
         case 'KO':
           return ' 행';
         default:
-          return isLoopLine(line) ? '方面' : 'ゆき';
+          return getIsLoopLine(line, trainType) ? '方面' : 'ゆき';
       }
     })();
 
@@ -434,6 +434,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
     state,
     station,
     stations,
+    trainType,
     yamanoteLine,
   ]);
 

--- a/src/components/HeaderYamanote/index.tsx
+++ b/src/components/HeaderYamanote/index.tsx
@@ -21,7 +21,7 @@ import { isJapanese, translate } from '../../translation';
 import navigationState from '../../store/atoms/navigation';
 import {
   inboundStationForLoopLine,
-  isLoopLine,
+  getIsLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
@@ -310,7 +310,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
       case 'KO':
         return '행';
       default:
-        return isLoopLine(line) ? '方面' : 'ゆき';
+        return getIsLoopLine(line, trainType) ? '方面' : 'ゆき';
     }
   })();
 

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -31,6 +31,7 @@ const useUpdateBottomState = (): [() => void] => {
     isInbound,
     arrived,
     currentLine,
+    trainType,
   });
 
   const nextStopStationIndex = slicedStations.findIndex((s) => {

--- a/src/providers/AppleWatchProvider.tsx
+++ b/src/providers/AppleWatchProvider.tsx
@@ -7,7 +7,7 @@ import lineState from '../store/atoms/line';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import getCurrentLine from '../utils/currentLine';
-import { isLoopLine } from '../utils/loopLine';
+import { getIsLoopLine } from '../utils/loopLine';
 import {
   getNextInboundStopStation,
   getNextOutboundStopStation,
@@ -61,21 +61,21 @@ const AppleWatchProvider: React.FC<Props> = ({ children }: Props) => {
   const currentLine = getCurrentLine(leftStations, joinedLineIds, selectedLine);
 
   const inboundStations = useMemo(() => {
-    if (isLoopLine(currentLine)) {
+    if (getIsLoopLine(currentLine, trainType)) {
       return stations.slice().reverse();
     }
     return stations;
-  }, [currentLine, stations]).map((s) => ({
+  }, [currentLine, stations, trainType]).map((s) => ({
     ...s,
     distance: -1,
   }));
 
   const outboundStations = useMemo(() => {
-    if (isLoopLine(currentLine)) {
+    if (getIsLoopLine(currentLine, trainType)) {
       return stations;
     }
     return stations.slice().reverse();
-  }, [currentLine, stations]).map((s) => ({
+  }, [currentLine, stations, trainType]).map((s) => ({
     ...s,
     distance: -1,
   }));

--- a/src/providers/SpeechProvider.tsx
+++ b/src/providers/SpeechProvider.tsx
@@ -24,7 +24,7 @@ import AppTheme from '../models/Theme';
 import replaceSpecialChar from '../utils/replaceSpecialChar';
 import { parenthesisRegexp } from '../constants/regexp';
 import capitalizeFirstLetter from '../utils/capitalizeFirstLetter';
-import { isLoopLine } from '../utils/loopLine';
+import { getIsLoopLine } from '../utils/loopLine';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
 import speechState from '../store/atoms/speech';
 
@@ -192,6 +192,7 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
     isInbound: selectedDirection === 'INBOUND',
     arrived,
     currentLine,
+    trainType,
   });
 
   useEffect(() => {
@@ -782,7 +783,7 @@ const SpeechProvider: React.FC<Props> = ({ children }: Props) => {
         }
       };
 
-      const loopLine = isLoopLine(currentLine);
+      const loopLine = getIsLoopLine(currentLine, trainType);
 
       if (prevStateIsDifferent) {
         switch (headerState.split('_')[0]) {

--- a/src/screens/Main/index.tsx
+++ b/src/screens/Main/index.tsx
@@ -423,6 +423,7 @@ const MainScreen: React.FC = () => {
     isInbound,
     arrived,
     currentLine,
+    trainType,
   });
 
   const nextStopStationIndex = slicedStations.findIndex((s) => {

--- a/src/screens/SelectBound/index.tsx
+++ b/src/screens/SelectBound/index.tsx
@@ -138,7 +138,7 @@ const SelectBoundScreen: React.FC = () => {
 
   const headerLangState = headerState.split('_')[1] as HeaderLangState;
 
-  const isLoopLine = yamanoteLine || osakaLoopLine;
+  const isLoopLine = (yamanoteLine || osakaLoopLine) && !trainType;
   const inbound = inboundStationForLoopLine(
     stations,
     currentIndex,

--- a/src/utils/loopLine.ts
+++ b/src/utils/loopLine.ts
@@ -1,12 +1,16 @@
 import { HeaderLangState } from '../models/HeaderTransitionState';
-import { Line, Station } from '../models/StationAPI';
+import { APITrainType, Line, Station } from '../models/StationAPI';
+import { TrainType } from '../models/TrainType';
 
 export const isYamanoteLine = (lineId: number): boolean => lineId === 11302;
 
 const isOsakaLoopLine = (lineId: number): boolean => lineId === 11623;
 
-export const isLoopLine = (line: Line): boolean => {
-  if (!line) {
+export const getIsLoopLine = (
+  line: Line,
+  trainType: TrainType | APITrainType
+): boolean => {
+  if (!line || trainType) {
     return false;
   }
   return isYamanoteLine(line.id) || isOsakaLoopLine(line.id);

--- a/src/utils/slicedStations.ts
+++ b/src/utils/slicedStations.ts
@@ -1,6 +1,7 @@
-import { Station, Line } from '../models/StationAPI';
+import { Station, Line, APITrainType } from '../models/StationAPI';
+import { TrainType } from '../models/TrainType';
 import getCurrentStationIndex from './currentStationIndex';
-import { isLoopLine } from './loopLine';
+import { getIsLoopLine } from './loopLine';
 
 type Args = {
   stations: Station[];
@@ -8,6 +9,7 @@ type Args = {
   isInbound: boolean;
   currentStation: Station;
   currentLine: Line;
+  trainType: TrainType | APITrainType;
 };
 
 const getSlicedStations = ({
@@ -16,6 +18,7 @@ const getSlicedStations = ({
   currentLine,
   arrived,
   isInbound,
+  trainType,
 }: Args): Station[] => {
   const currentStationIndex = getCurrentStationIndex(stations, currentStation);
   if (arrived) {
@@ -24,7 +27,7 @@ const getSlicedStations = ({
       : stations.slice(0, currentStationIndex + 1).reverse();
   }
 
-  if (isLoopLine(currentLine)) {
+  if (getIsLoopLine(currentLine, trainType)) {
     return isInbound
       ? stations.slice(currentStationIndex - 1)
       : stations.slice(0, currentStationIndex + 2).reverse();


### PR DESCRIPTION
closes #886 

快速等になった大阪環状線はすでに環状線ではない
stateにtrainTypeが定義されている時点で環状線としては快速以上なので、trainTypeがあるときはloopLine扱いにしないようにした