### PR TITLE
現在の時点で実質各停のときは種別変更通知画面を表示しない

### DIFF
--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -161,13 +161,17 @@ const TypeChangeNotify: React.FC = () => {
     return currentLineStations[0];
   }, [currentLineStations, selectedDirection]);
 
+  const currentLineIsStopAtAllStations = !stations
+    .filter((s) => s.lines.findIndex((l) => l.id === currentLine.id) !== -1)
+    .filter((s) => s.pass).length;
+
   const headingTexts = useMemo((): {
     jaPrefix: string;
     enPrefix: string;
     jaSuffix?: string;
     enSuffix?: string;
   } => {
-    if (getIsLocal(nextTrainType)) {
+    if (getIsLocal(nextTrainType) && !currentLineIsStopAtAllStations) {
       return {
         jaPrefix: `${currentLineLastStation.name}から先は各駅にとまります`,
         enPrefix: `The train stops at all stations after ${currentLineLastStation.nameR}.`,


### PR DESCRIPTION
closes #972

![Simulator Screen Shot - iPad (8th generation) - 2021-09-07 at 15 54 12](https://user-images.githubusercontent.com/32848922/132298158-ac3b434f-65f5-48c0-85ae-aef14d5df513.png)

そもそも表示しないほうで実装しようと思ったけど割と複雑になりそうだったので現在の路線が実質各停＆＆次の種別が違う場合は次の種別を表示するようにした