### PR TITLE
istablet共通化

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,14 +6,9 @@ import {
   Text,
   TouchableOpacity,
   ViewStyle,
-  Platform,
-  PlatformIOSStatic,
 } from 'react-native';
 import { RFValue } from 'react-native-responsive-fontsize';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
+import isTablet from '../../utils/isTablet';
 
 interface Props {
   children: React.ReactNode;

--- a/src/components/HeaderJRWest/index.tsx
+++ b/src/components/HeaderJRWest/index.tsx
@@ -1,37 +1,28 @@
 /* eslint-disable global-require */
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Platform,
-  PlatformIOSStatic,
-} from 'react-native';
-import { useRecoilValue } from 'recoil';
-import { RFValue } from 'react-native-responsive-fontsize';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-import { CommonHeaderProps } from '../Header/common';
-import katakanaToHiragana from '../../utils/kanaToHiragana';
-import {
-  isYamanoteLine,
-  inboundStationForLoopLine,
-  outboundStationForLoopLine,
-  getIsLoopLine,
-} from '../../utils/loopLine';
-import getCurrentStationIndex from '../../utils/currentStationIndex';
-import { getLineMark } from '../../lineMark';
-import TransferLineMark from '../TransferLineMark';
-import { translate } from '../../translation';
-import getTrainType from '../../utils/getTrainType';
-import navigationState from '../../store/atoms/navigation';
+import { RFValue } from 'react-native-responsive-fontsize';
+import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../../constants/regexp';
+import { getLineMark } from '../../lineMark';
 import { HeaderLangState } from '../../models/HeaderTransitionState';
 import { LineType } from '../../models/StationAPI';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
+import navigationState from '../../store/atoms/navigation';
+import { translate } from '../../translation';
+import getCurrentStationIndex from '../../utils/currentStationIndex';
+import getTrainType from '../../utils/getTrainType';
+import isTablet from '../../utils/isTablet';
+import katakanaToHiragana from '../../utils/kanaToHiragana';
+import {
+  getIsLoopLine,
+  inboundStationForLoopLine,
+  isYamanoteLine,
+  outboundStationForLoopLine,
+} from '../../utils/loopLine';
+import { CommonHeaderProps } from '../Header/common';
+import TransferLineMark from '../TransferLineMark';
 
 const HeaderJRWest: React.FC<CommonHeaderProps> = ({
   station,

--- a/src/components/HeaderSaikyo/index.tsx
+++ b/src/components/HeaderSaikyo/index.tsx
@@ -1,47 +1,37 @@
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
-import {
-  Dimensions,
-  StyleSheet,
-  View,
-  Platform,
-  PlatformIOSStatic,
-  Text,
-} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, {
-  sub,
-  useValue,
-  timing,
-  EasingNode,
-} from 'react-native-reanimated';
-import { useRecoilValue } from 'recoil';
-import { RFValue } from 'react-native-responsive-fontsize';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
 import { withAnchorPoint } from 'react-native-anchor-point';
+import Animated, {
+  EasingNode,
+  sub,
+  timing,
+  useValue,
+} from 'react-native-reanimated';
+import { RFValue } from 'react-native-responsive-fontsize';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRecoilValue } from 'recoil';
+import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
+import useValueRef from '../../hooks/useValueRef';
 import {
   HeaderLangState,
   HeaderTransitionState,
 } from '../../models/HeaderTransitionState';
-import { CommonHeaderProps } from '../Header/common';
+import { APITrainType } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import { isJapanese, translate } from '../../translation';
 import getCurrentStationIndex from '../../utils/currentStationIndex';
+import getTrainType from '../../utils/getTrainType';
+import isTablet from '../../utils/isTablet';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
-  inboundStationForLoopLine,
   getIsLoopLine,
+  inboundStationForLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
-import useValueRef from '../../hooks/useValueRef';
-import { isJapanese, translate } from '../../translation';
+import { CommonHeaderProps } from '../Header/common';
 import TrainTypeBox from '../TrainTypeBoxSaikyo';
-import getTrainType from '../../utils/getTrainType';
-import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
-import navigationState from '../../store/atoms/navigation';
-import { APITrainType } from '../../models/StationAPI';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const styles = StyleSheet.create({
   gradientRoot: {

--- a/src/components/HeaderTY/index.tsx
+++ b/src/components/HeaderTY/index.tsx
@@ -1,47 +1,37 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Dimensions,
-  StyleSheet,
-  View,
-  Platform,
-  PlatformIOSStatic,
-  Text,
-} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
+import { withAnchorPoint } from 'react-native-anchor-point';
 import Animated, {
   EasingNode,
   sub,
-  useValue,
   timing,
+  useValue,
 } from 'react-native-reanimated';
-import { useRecoilValue } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { withAnchorPoint } from 'react-native-anchor-point';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRecoilValue } from 'recoil';
+import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
+import useValueRef from '../../hooks/useValueRef';
 import {
   HeaderLangState,
   HeaderTransitionState,
 } from '../../models/HeaderTransitionState';
-import { CommonHeaderProps } from '../Header/common';
+import { APITrainType } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import { isJapanese, translate } from '../../translation';
 import getCurrentStationIndex from '../../utils/currentStationIndex';
+import getTrainType from '../../utils/getTrainType';
+import isTablet from '../../utils/isTablet';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
-  inboundStationForLoopLine,
   getIsLoopLine,
+  inboundStationForLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
-import useValueRef from '../../hooks/useValueRef';
-import { isJapanese, translate } from '../../translation';
+import { CommonHeaderProps } from '../Header/common';
 import TrainTypeBox from '../TrainTypeBox';
-import getTrainType from '../../utils/getTrainType';
-import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
-import navigationState from '../../store/atoms/navigation';
-import { APITrainType } from '../../models/StationAPI';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const styles = StyleSheet.create({
   gradientRoot: {

--- a/src/components/HeaderTokyoMetro/index.tsx
+++ b/src/components/HeaderTokyoMetro/index.tsx
@@ -1,49 +1,37 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Dimensions,
-  StyleSheet,
-  View,
-  Platform,
-  PlatformIOSStatic,
-  Text,
-} from 'react-native';
-
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
+import { withAnchorPoint } from 'react-native-anchor-point';
 import Animated, {
+  EasingNode,
+  sub,
   timing,
   useValue,
-  sub,
-  EasingNode,
 } from 'react-native-reanimated';
-import { useRecoilValue } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { withAnchorPoint } from 'react-native-anchor-point';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRecoilValue } from 'recoil';
+import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
+import useValueRef from '../../hooks/useValueRef';
 import {
   HeaderLangState,
   HeaderTransitionState,
 } from '../../models/HeaderTransitionState';
-import { CommonHeaderProps } from '../Header/common';
+import { APITrainType } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import { isJapanese, translate } from '../../translation';
 import getCurrentStationIndex from '../../utils/currentStationIndex';
+import getTrainType from '../../utils/getTrainType';
+import isTablet from '../../utils/isTablet';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
-  inboundStationForLoopLine,
   getIsLoopLine,
+  inboundStationForLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
-import useValueRef from '../../hooks/useValueRef';
-import { isJapanese, translate } from '../../translation';
+import { CommonHeaderProps } from '../Header/common';
 import TrainTypeBox from '../TrainTypeBox';
-import getTrainType from '../../utils/getTrainType';
-import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
-import navigationState from '../../store/atoms/navigation';
-import { APITrainType } from '../../models/StationAPI';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-
-const isTablet = isPad || isAndroidTablet;
 
 const styles = StyleSheet.create({
   gradientRoot: {

--- a/src/components/HeaderYamanote/index.tsx
+++ b/src/components/HeaderYamanote/index.tsx
@@ -1,34 +1,25 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useEffect, useState, useCallback } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Platform,
-  PlatformIOSStatic,
-} from 'react-native';
-import { useRecoilValue } from 'recoil';
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { RFValue } from 'react-native-responsive-fontsize';
+import { useRecoilValue } from 'recoil';
+import useValueRef from '../../hooks/useValueRef';
 import {
   HeaderLangState,
   HeaderTransitionState,
 } from '../../models/HeaderTransitionState';
-import { CommonHeaderProps } from '../Header/common';
-import katakanaToHiragana from '../../utils/kanaToHiragana';
-import getCurrentStationIndex from '../../utils/currentStationIndex';
-import useValueRef from '../../hooks/useValueRef';
-import { isJapanese, translate } from '../../translation';
 import navigationState from '../../store/atoms/navigation';
+import { isJapanese, translate } from '../../translation';
+import getCurrentStationIndex from '../../utils/currentStationIndex';
+import isTablet from '../../utils/isTablet';
+import katakanaToHiragana from '../../utils/kanaToHiragana';
 import {
-  inboundStationForLoopLine,
   getIsLoopLine,
+  inboundStationForLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
+import { CommonHeaderProps } from '../Header/common';
 
 const HeaderYamanote: React.FC<CommonHeaderProps> = ({
   station,

--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -1,25 +1,21 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import { Platform, PlatformIOSStatic } from 'react-native';
-import LineBoardWest from '../LineBoardWest';
-import LineBoardEast from '../LineBoardEast';
-import themeState from '../../store/atoms/theme';
+import useCurrentLine from '../../hooks/useCurrentLine';
+import { APITrainType } from '../../models/StationAPI';
 import AppTheme from '../../models/Theme';
-import LineBoardSaikyo from '../LineBoardSaikyo';
+import lineState from '../../store/atoms/line';
 import navigationState from '../../store/atoms/navigation';
 import stationState from '../../store/atoms/station';
-import lineState from '../../store/atoms/line';
+import themeState from '../../store/atoms/theme';
+import isTablet from '../../utils/isTablet';
+import LineBoardEast from '../LineBoardEast';
+import LineBoardSaikyo from '../LineBoardSaikyo';
+import LineBoardWest from '../LineBoardWest';
 import LineBoardYamanotePad from '../LineBoardYamanotePad';
-import { APITrainType } from '../../models/StationAPI';
-import useCurrentLine from '../../hooks/useCurrentLine';
-import isAndroidTablet from '../../utils/isAndroidTablet';
 
 export interface Props {
   hasTerminus: boolean;
 }
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
   const { theme } = useRecoilValue(themeState);

--- a/src/components/LineBoardEast/index.tsx
+++ b/src/components/LineBoardEast/index.tsx
@@ -1,37 +1,33 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Dimensions,
   Platform,
+  StyleProp,
   StyleSheet,
   Text,
-  View,
-  PlatformIOSStatic,
-  StyleProp,
   TextStyle,
+  View,
 } from 'react-native';
-
-import { useRecoilValue } from 'recoil';
 import { hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { Line, Station } from '../../models/StationAPI';
-import Chevron from '../ChervronTY';
-import BarTerminal from '../BarTerminalEast';
-import { getLineMark } from '../../lineMark';
-import { filterWithoutCurrentLine } from '../../utils/line';
-import TransferLineMark from '../TransferLineMark';
-import TransferLineDot from '../TransferLineDot';
-import omitJRLinesIfThresholdExceeded from '../../utils/jr';
-import { isJapanese } from '../../translation';
-import navigationState from '../../store/atoms/navigation';
-import PassChevronTY from '../PassChevronTY';
-import { heightScale, widthScale } from '../../utils/scale';
+import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../../constants/regexp';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import { getLineMark } from '../../lineMark';
+import { Line, Station } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import { isJapanese } from '../../translation';
+import isTablet from '../../utils/isTablet';
+import omitJRLinesIfThresholdExceeded from '../../utils/jr';
+import { filterWithoutCurrentLine } from '../../utils/line';
+import { heightScale, widthScale } from '../../utils/scale';
+import BarTerminal from '../BarTerminalEast';
+import Chevron from '../ChervronTY';
+import PassChevronTY from '../PassChevronTY';
+import TransferLineDot from '../TransferLineDot';
+import TransferLineMark from '../TransferLineMark';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const useBarStyles = ({
   index,

--- a/src/components/LineBoardSaikyo/index.tsx
+++ b/src/components/LineBoardSaikyo/index.tsx
@@ -1,37 +1,33 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Dimensions,
   Platform,
+  StyleProp,
   StyleSheet,
   Text,
-  View,
-  PlatformIOSStatic,
-  StyleProp,
   TextStyle,
+  View,
 } from 'react-native';
-
-import { useRecoilValue } from 'recoil';
 import { hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { Line, Station } from '../../models/StationAPI';
-import Chevron from '../ChervronTY';
-import BarTerminal from '../BarTerminalSaikyo';
-import { getLineMark } from '../../lineMark';
-import { filterWithoutCurrentLine } from '../../utils/line';
-import TransferLineMark from '../TransferLineMark';
-import TransferLineDot from '../TransferLineDot';
-import omitJRLinesIfThresholdExceeded from '../../utils/jr';
-import { isJapanese } from '../../translation';
-import navigationState from '../../store/atoms/navigation';
-import PassChevronTY from '../PassChevronTY';
-import { heightScale, widthScale } from '../../utils/scale';
+import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../../constants/regexp';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import { getLineMark } from '../../lineMark';
+import { Line, Station } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import { isJapanese } from '../../translation';
+import isTablet from '../../utils/isTablet';
+import omitJRLinesIfThresholdExceeded from '../../utils/jr';
+import { filterWithoutCurrentLine } from '../../utils/line';
+import { heightScale, widthScale } from '../../utils/scale';
+import BarTerminal from '../BarTerminalSaikyo';
+import Chevron from '../ChervronTY';
+import PassChevronTY from '../PassChevronTY';
+import TransferLineDot from '../TransferLineDot';
+import TransferLineMark from '../TransferLineMark';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const useBarStyles = ({
   index,

--- a/src/components/LineBoardWest/index.tsx
+++ b/src/components/LineBoardWest/index.tsx
@@ -1,30 +1,28 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Dimensions,
   Platform,
+  StyleProp,
   StyleSheet,
   Text,
-  View,
-  PlatformIOSStatic,
-  StyleProp,
   TextStyle,
+  View,
 } from 'react-native';
-
-import { useRecoilValue } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { Line, Station } from '../../models/StationAPI';
-import Chevron from '../ChevronJRWest';
-import { getLineMark } from '../../lineMark';
-import { filterWithoutCurrentLine } from '../../utils/line';
-import TransferLineMark from '../TransferLineMark';
-import TransferLineDot from '../TransferLineDot';
-import omitJRLinesIfThresholdExceeded from '../../utils/jr';
-import { isJapanese } from '../../translation';
-import navigationState from '../../store/atoms/navigation';
-import { heightScale } from '../../utils/scale';
-import stationState from '../../store/atoms/station';
+import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../../constants/regexp';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import { getLineMark } from '../../lineMark';
+import { Line, Station } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import stationState from '../../store/atoms/station';
+import { isJapanese } from '../../translation';
+import isTablet from '../../utils/isTablet';
+import omitJRLinesIfThresholdExceeded from '../../utils/jr';
+import { filterWithoutCurrentLine } from '../../utils/line';
+import { heightScale } from '../../utils/scale';
+import Chevron from '../ChevronJRWest';
+import TransferLineDot from '../TransferLineDot';
+import TransferLineMark from '../TransferLineMark';
 
 interface Props {
   line: Line;
@@ -33,8 +31,6 @@ interface Props {
   lineColors: string[];
 }
 
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 const barWidth = isTablet ? (windowWidth - 72) / 8 : (windowWidth - 48) / 8;
 

--- a/src/components/LineBoardYamanotePad/index.tsx
+++ b/src/components/LineBoardYamanotePad/index.tsx
@@ -2,35 +2,31 @@ import React, { useMemo } from 'react';
 import {
   Dimensions,
   Platform,
+  StyleProp,
   StyleSheet,
   Text,
-  PlatformIOSStatic,
-  StyleProp,
   TextStyle,
 } from 'react-native';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useRecoilValue } from 'recoil';
-import { Line, Station } from '../../models/StationAPI';
-import omitJRLinesIfThresholdExceeded from '../../utils/jr';
-import PadArch from './PadArch';
 import useAppState from '../../hooks/useAppState';
 import useTransferLines from '../../hooks/useTransferLines';
+import { Line, Station } from '../../models/StationAPI';
+import navigationState from '../../store/atoms/navigation';
+import stationState from '../../store/atoms/station';
+import isTablet from '../../utils/isTablet';
+import omitJRLinesIfThresholdExceeded from '../../utils/jr';
 import {
   getNextInboundStopStation,
   getNextOutboundStopStation,
 } from '../../utils/nextStation';
-import navigationState from '../../store/atoms/navigation';
-import stationState from '../../store/atoms/station';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import PadArch from './PadArch';
 
 interface Props {
   arrived: boolean;
   line: Line;
   stations: Station[];
 }
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const windowWidth = Dimensions.get('window').width;
 const windowHeight = Dimensions.get('window').height;

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -1,28 +1,25 @@
 import React from 'react';
 import {
-  Modal,
-  View,
-  StyleSheet,
-  Text,
-  Platform,
-  PlatformIOSStatic,
-  TextInput,
-  Pressable,
-  KeyboardAvoidingView,
   Dimensions,
   Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
 } from 'react-native';
 import { hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { translate } from '../translation';
-import isAndroidTablet from '../utils/isAndroidTablet';
+import isTablet from '../utils/isTablet';
 import { widthScale } from '../utils/scale';
 import Button from './Button';
 import Heading from './Heading';
 
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 const { height: windowHeight } = Dimensions.get('window');
 
 type Props = {

--- a/src/components/TrainTypeBox/index.tsx
+++ b/src/components/TrainTypeBox/index.tsx
@@ -1,13 +1,6 @@
-import React, { useEffect, useMemo } from 'react';
-import {
-  Platform,
-  PlatformIOSStatic,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useRecoilValue } from 'recoil';
+import React, { useEffect, useMemo } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   EasingNode,
   sub,
@@ -15,29 +8,27 @@ import Animated, {
   useValue,
 } from 'react-native-reanimated';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { translate } from '../../translation';
-import { TrainType } from '../../models/TrainType';
-import navigationState from '../../store/atoms/navigation';
-import useValueRef from '../../hooks/useValueRef';
+import { useRecoilValue } from 'recoil';
 import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
-import { APITrainType, APITrainTypeMinimum } from '../../models/StationAPI';
 import { parenthesisRegexp } from '../../constants/regexp';
 import truncateTrainType from '../../constants/truncateTrainType';
-import { HeaderLangState } from '../../models/HeaderTransitionState';
-import useCurrentLine from '../../hooks/useCurrentLine';
-import stationState from '../../store/atoms/station';
 import useConnectedLines from '../../hooks/useConnectedLines';
-import themeState from '../../store/atoms/theme';
+import useCurrentLine from '../../hooks/useCurrentLine';
+import useValueRef from '../../hooks/useValueRef';
+import { HeaderLangState } from '../../models/HeaderTransitionState';
+import { APITrainType, APITrainTypeMinimum } from '../../models/StationAPI';
 import AppTheme from '../../models/Theme';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import { TrainType } from '../../models/TrainType';
+import navigationState from '../../store/atoms/navigation';
+import stationState from '../../store/atoms/station';
+import themeState from '../../store/atoms/theme';
+import { translate } from '../../translation';
+import isTablet from '../../utils/isTablet';
 
 type Props = {
   trainType: APITrainType | APITrainTypeMinimum | TrainType;
   isTY?: boolean;
 };
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/TrainTypeBoxSaikyo/index.tsx
+++ b/src/components/TrainTypeBoxSaikyo/index.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useMemo } from 'react';
-import { Platform, PlatformIOSStatic, StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useRecoilValue } from 'recoil';
+import React, { useEffect, useMemo } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
 import Animated, {
   EasingNode,
   sub,
@@ -9,25 +8,23 @@ import Animated, {
   useValue,
 } from 'react-native-reanimated';
 import { RFValue } from 'react-native-responsive-fontsize';
-import { translate } from '../../translation';
+import { useRecoilValue } from 'recoil';
+import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
+import { parenthesisRegexp } from '../../constants/regexp';
+import truncateTrainType from '../../constants/truncateTrainType';
+import useValueRef from '../../hooks/useValueRef';
+import { HeaderLangState } from '../../models/HeaderTransitionState';
+import { APITrainType, APITrainTypeMinimum } from '../../models/StationAPI';
 import { TrainType } from '../../models/TrainType';
 import navigationState from '../../store/atoms/navigation';
-import useValueRef from '../../hooks/useValueRef';
-import { HEADER_CONTENT_TRANSITION_DELAY } from '../../constants';
-import { APITrainType, APITrainTypeMinimum } from '../../models/StationAPI';
-import { parenthesisRegexp } from '../../constants/regexp';
+import { translate } from '../../translation';
+import isTablet from '../../utils/isTablet';
 import { getIsLocal, getIsRapid } from '../../utils/localType';
-import truncateTrainType from '../../constants/truncateTrainType';
-import { HeaderLangState } from '../../models/HeaderTransitionState';
-import isAndroidTablet from '../../utils/isAndroidTablet';
 
 type Props = {
   trainType: APITrainType | APITrainTypeMinimum | TrainType;
   lineColor: string;
 };
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/Transfers/index.tsx
+++ b/src/components/Transfers/index.tsx
@@ -1,27 +1,17 @@
-import React from 'react';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-  Platform,
-  PlatformIOSStatic,
-} from 'react-native';
-import { RFValue } from 'react-native-responsive-fontsize';
 import { LinearGradient } from 'expo-linear-gradient';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
+import { RFValue } from 'react-native-responsive-fontsize';
+import { parenthesisRegexp } from '../../constants/regexp';
 import { getLineMark } from '../../lineMark';
 import { Line } from '../../models/StationAPI';
+import AppTheme from '../../models/Theme';
+import { isJapanese, translate } from '../../translation';
+import isTablet from '../../utils/isTablet';
+import Heading from '../Heading';
 import TransferLineDot from '../TransferLineDot';
 import TransferLineMark from '../TransferLineMark';
-import Heading from '../Heading';
-import { isJapanese, translate } from '../../translation';
-import AppTheme from '../../models/Theme';
-import { parenthesisRegexp } from '../../constants/regexp';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 interface Props {
   onPress: () => void;

--- a/src/components/TransfersYamanote/index.tsx
+++ b/src/components/TransfersYamanote/index.tsx
@@ -1,25 +1,14 @@
 import React, { useMemo } from 'react';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-  Platform,
-  PlatformIOSStatic,
-} from 'react-native';
-
-import { RFValue } from 'react-native-responsive-fontsize';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
+import { RFValue } from 'react-native-responsive-fontsize';
+import { parenthesisRegexp } from '../../constants/regexp';
 import { getLineMark } from '../../lineMark';
 import { Line } from '../../models/StationAPI';
+import { isJapanese, translate } from '../../translation';
+import isTablet from '../../utils/isTablet';
 import TransferLineDot from '../TransferLineDot';
 import TransferLineMark from '../TransferLineMark';
-import { isJapanese, translate } from '../../translation';
-import { parenthesisRegexp } from '../../constants/regexp';
-import isAndroidTablet from '../../utils/isAndroidTablet';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 interface Props {
   onPress: () => void;

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1,13 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useMemo } from 'react';
-import {
-  Dimensions,
-  Platform,
-  PlatformIOSStatic,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
 import { hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useRecoilValue } from 'recoil';
@@ -17,13 +10,10 @@ import useCurrentLine from '../hooks/useCurrentLine';
 import { APITrainType } from '../models/StationAPI';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
-import isAndroidTablet from '../utils/isAndroidTablet';
+import isTablet from '../utils/isTablet';
 import { getIsLocal } from '../utils/localType';
 import { heightScale, widthScale } from '../utils/scale';
 import BarTerminalEast from './BarTerminalEast';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
 
 const { width: windowWidth } = Dimensions.get('window');
 const barLeft = widthScale(33);
@@ -204,6 +194,7 @@ const TypeChangeNotify: React.FC = () => {
     nextTrainType,
     selectedBound.name,
     selectedBound.nameR,
+    currentLineIsStopAtAllStations,
   ]);
 
   const trainTypeLeftVal = useMemo(() => {

--- a/src/screens/Main/index.tsx
+++ b/src/screens/Main/index.tsx
@@ -1,50 +1,49 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import { useKeepAwake } from 'expo-keep-awake';
+import * as Location from 'expo-location';
+import { LocationObject } from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import * as geolib from 'geolib';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
+  BackHandler,
   Dimensions,
+  Linking,
   Platform,
   StyleSheet,
   View,
-  Alert,
-  Linking,
-  BackHandler,
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useKeepAwake } from 'expo-keep-awake';
-import * as Location from 'expo-location';
-import * as TaskManager from 'expo-task-manager';
-import { LocationObject } from 'expo-location';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { useNavigation } from '@react-navigation/native';
-import * as geolib from 'geolib';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
-import useTransitionHeaderState from '../../hooks/useTransitionHeaderState';
-import useUpdateBottomState from '../../hooks/useUpdateBottomState';
-import useRefreshStation from '../../hooks/useRefreshStation';
-import useRefreshLeftStations from '../../hooks/useRefreshLeftStations';
-import useWatchApproaching from '../../hooks/useWatchApproaching';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import LineBoard from '../../components/LineBoard';
 import Transfers from '../../components/Transfers';
+import TransfersYamanote from '../../components/TransfersYamanote';
+import TypeChangeNotify from '../../components/TypeChangeNotify';
 import {
   LOCATION_TASK_NAME,
   RUNNING_DURATION,
   WHOLE_DURATION,
 } from '../../constants';
-import { isJapanese, translate } from '../../translation';
-import lineState from '../../store/atoms/line';
-import stationState from '../../store/atoms/station';
-import navigationState from '../../store/atoms/navigation';
-import locationState from '../../store/atoms/location';
-import { getIsLoopLine, isYamanoteLine } from '../../utils/loopLine';
-import speechState from '../../store/atoms/speech';
-import useValueRef from '../../hooks/useValueRef';
-import themeState from '../../store/atoms/theme';
-import AppTheme from '../../models/Theme';
-import TransfersYamanote from '../../components/TransfersYamanote';
-import useTransferLines from '../../hooks/useTransferLines';
-import TypeChangeNotify from '../../components/TypeChangeNotify';
 import useNextTrainTypeIsDifferent from '../../hooks/useNextTrainTypeIsDifferent';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import useRefreshLeftStations from '../../hooks/useRefreshLeftStations';
+import useRefreshStation from '../../hooks/useRefreshStation';
 import useShouldHideTypeChange from '../../hooks/useShouldHideTypeChange';
+import useTransferLines from '../../hooks/useTransferLines';
+import useTransitionHeaderState from '../../hooks/useTransitionHeaderState';
+import useUpdateBottomState from '../../hooks/useUpdateBottomState';
+import useValueRef from '../../hooks/useValueRef';
+import useWatchApproaching from '../../hooks/useWatchApproaching';
+import AppTheme from '../../models/Theme';
+import lineState from '../../store/atoms/line';
+import locationState from '../../store/atoms/location';
+import navigationState from '../../store/atoms/navigation';
+import speechState from '../../store/atoms/speech';
+import stationState from '../../store/atoms/station';
+import themeState from '../../store/atoms/theme';
+import { isJapanese, translate } from '../../translation';
+import { getIsLoopLine, isYamanoteLine } from '../../utils/loopLine';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let globalSetBGLocation = (location: LocationObject): void => undefined;
@@ -136,7 +135,7 @@ const MainScreen: React.FC = () => {
   }, [setSpeech]);
 
   useEffect(() => {
-    if (Platform.OS === 'android' && !isAndroidTablet) {
+    if (Platform.OS === 'android') {
       const f = async (): Promise<void> => {
         const firstOpenPassed = await AsyncStorage.getItem(
           '@TrainLCD:dozeConfirmed'

--- a/src/screens/SelectLine/index.tsx
+++ b/src/screens/SelectLine/index.tsx
@@ -1,34 +1,29 @@
-import React, { useEffect, useCallback, useState } from 'react';
+import { useNetInfo } from '@react-native-community/netinfo';
+import analytics from '@react-native-firebase/analytics';
+import { useNavigation } from '@react-navigation/native';
+import * as Location from 'expo-location';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   ScrollView,
   StyleSheet,
   View,
-  Platform,
-  PlatformIOSStatic,
-  ActivityIndicator,
 } from 'react-native';
-import * as Location from 'expo-location';
-import { useNavigation } from '@react-navigation/native';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import analytics from '@react-native-firebase/analytics';
-import { useNetInfo } from '@react-native-community/netinfo';
 import Button from '../../components/Button';
+import ErrorScreen from '../../components/ErrorScreen';
 import FAB from '../../components/FAB';
-import { getLineMark } from '../../lineMark';
-import { Line, LineType } from '../../models/StationAPI';
 import Heading from '../../components/Heading';
 import useNearbyStations from '../../hooks/useNearbyStations';
-import { isJapanese, translate } from '../../translation';
-import ErrorScreen from '../../components/ErrorScreen';
-import stationState from '../../store/atoms/station';
-import locationState from '../../store/atoms/location';
+import { getLineMark } from '../../lineMark';
+import { Line, LineType } from '../../models/StationAPI';
 import lineState from '../../store/atoms/line';
-import isAndroidTablet from '../../utils/isAndroidTablet';
+import locationState from '../../store/atoms/location';
 import navigationState from '../../store/atoms/navigation';
-
-const { isPad } = Platform as PlatformIOSStatic;
-const isTablet = isPad || isAndroidTablet;
+import stationState from '../../store/atoms/station';
+import { isJapanese, translate } from '../../translation';
+import isTablet from '../../utils/isTablet';
 
 const styles = StyleSheet.create({
   rootPadding: {

--- a/src/utils/isAndroidTablet.ts
+++ b/src/utils/isAndroidTablet.ts
@@ -1,6 +1,0 @@
-import { Platform, PlatformIOSStatic } from 'react-native';
-import { isTablet } from 'react-native-device-info';
-
-const { isPad } = Platform as PlatformIOSStatic;
-
-export default isTablet() && !isPad;

--- a/src/utils/isTablet.ts
+++ b/src/utils/isTablet.ts
@@ -1,0 +1,3 @@
+import { isTablet } from 'react-native-device-info';
+
+export default isTablet();

--- a/src/utils/jr.ts
+++ b/src/utils/jr.ts
@@ -1,9 +1,9 @@
 import {
   JR_LINE_MAX_ID,
-  OMIT_JR_THRESHOLD,
   MAX_PRIVATE_COUNT_FOR_OMIT_JR,
+  OMIT_JR_THRESHOLD,
 } from '../constants';
-import { LineType, Line } from '../models/StationAPI';
+import { Line, LineType } from '../models/StationAPI';
 
 const isJRLine = (line: Line): boolean => line.companyId <= JR_LINE_MAX_ID;
 
@@ -48,6 +48,10 @@ const omitJRLinesIfThresholdExceeded = (lines: Line[]): Line[] => {
       __typename: 'Line',
       nameZh: 'JR线',
       nameKo: 'JR선',
+      company: {
+        nameR: 'JR',
+        nameEn: 'JR',
+      },
     });
     return withoutJR;
   }


### PR DESCRIPTION
`const isTablet = isPad || isAndroidTablet`みたいなのが横行してたので`react-native-device-info`の`isTablet`をそのまま使うことにした