### PR TITLE
急行種別が自動選択されないバグを修正

### DIFF
--- a/src/screens/SelectBound/index.tsx
+++ b/src/screens/SelectBound/index.tsx
@@ -1,38 +1,38 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { useNetInfo } from '@react-native-community/netinfo';
+import analytics from '@react-native-firebase/analytics';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   BackHandler,
+  ScrollView,
   StyleSheet,
   Text,
   View,
-  ScrollView,
-  Alert,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { RFValue } from 'react-native-responsive-fontsize';
-import analytics from '@react-native-firebase/analytics';
-import { useNetInfo } from '@react-native-community/netinfo';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import Button from '../../components/Button';
+import ErrorScreen from '../../components/ErrorScreen';
+import Heading from '../../components/Heading';
+import useStationList from '../../hooks/useStationList';
+import useStationListByTrainType from '../../hooks/useStationListByTrainType';
 import { directionToDirectionName, LineDirection } from '../../models/Bound';
+import { HeaderLangState } from '../../models/HeaderTransitionState';
 import { Station } from '../../models/StationAPI';
+import lineState from '../../store/atoms/line';
+import navigationState from '../../store/atoms/navigation';
+import stationState from '../../store/atoms/station';
+import themeState from '../../store/atoms/theme';
+import { isJapanese, translate } from '../../translation';
 import getCurrentStationIndex from '../../utils/currentStationIndex';
+import getLocalType from '../../utils/localType';
 import {
   inboundStationForLoopLine,
   isYamanoteLine,
   outboundStationForLoopLine,
 } from '../../utils/loopLine';
-import Heading from '../../components/Heading';
-import useStationList from '../../hooks/useStationList';
-import { isJapanese, translate } from '../../translation';
-import ErrorScreen from '../../components/ErrorScreen';
-import stationState from '../../store/atoms/station';
-import lineState from '../../store/atoms/line';
-import navigationState from '../../store/atoms/navigation';
-import useStationListByTrainType from '../../hooks/useStationListByTrainType';
-import getLocalType from '../../utils/localType';
-import { HeaderLangState } from '../../models/HeaderTransitionState';
-import themeState from '../../store/atoms/theme';
 
 const styles = StyleSheet.create({
   boundLoading: {
@@ -78,11 +78,11 @@ const SelectBoundScreen: React.FC = () => {
   const { theme } = useRecoilValue(themeState);
 
   const currentStation = stationsWithTrainTypes.find(
-    (s) => station?.name === s.name
+    (s) => station?.groupId === s.groupId
   );
   const [withTrainTypes, setWithTrainTypes] = useState(false);
   const localType = getLocalType(
-    stationsWithTrainTypes.find((s) => station?.name === s.name)
+    stationsWithTrainTypes.find((s) => station?.groupId === s.groupId)
   );
   const [{ headerState, trainType, autoMode }, setNavigation] =
     useRecoilState(navigationState);


### PR DESCRIPTION
closes #1022

種別を取得する処理で現在の駅を駅名で取ってくる処理を使用していたが、「成増」が最寄り駅の場合「地下鉄成増」の駅名の駅で種別を取ることが出来なかった

実際の修正はL81から