### PR TITLE
iPhone 8/SE2で種別表示のフォントサイズ拡大

### DIFF
--- a/src/components/TrainTypeBox/index.tsx
+++ b/src/components/TrainTypeBox/index.tsx
@@ -1,6 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useEffect, useMemo } from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
+import { hasNotch } from 'react-native-device-info';
 import Animated, {
   EasingNode,
   sub,
@@ -209,6 +210,16 @@ const TrainTypeBox: React.FC<Props> = ({ trainType, isTY }: Props) => {
         return 21;
       }
       return 16;
+    }
+
+    if (!hasNotch()) {
+      if (!isEn && trainTypeName?.length <= 5) {
+        return 18;
+      }
+      if (isEn && trainTypeNameR?.length > 10) {
+        return 11;
+      }
+      return 18;
     }
 
     if (!isEn && trainTypeName?.length <= 5) {

--- a/src/components/TrainTypeBoxSaikyo/index.tsx
+++ b/src/components/TrainTypeBoxSaikyo/index.tsx
@@ -1,6 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useEffect, useMemo } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
+import { hasNotch } from 'react-native-device-info';
 import Animated, {
   EasingNode,
   sub,
@@ -174,6 +175,16 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
         return 18;
       }
       return 16;
+    }
+
+    if (!hasNotch()) {
+      if (!isEn && trainTypeName?.length <= 5) {
+        return 18;
+      }
+      if (isEn && trainTypeNameR?.length > 10) {
+        return 11;
+      }
+      return 18;
     }
 
     if (!isEn && trainTypeName?.length <= 5) {


### PR DESCRIPTION
closes #810
![simulator_screenshot_5C428158-558D-4DC4-8129-8767B0F9D305](https://user-images.githubusercontent.com/32848922/143036920-9e2715ba-797e-48bb-94f6-46bec43d9b3f.png)
![simulator_screenshot_F93257F4-B1FF-4A27-A05A-07B45D5B802F](https://user-images.githubusercontent.com/32848922/143036989-73d98f56-521f-42d4-b935-d18ca492b19f.png)


