### PR TITLE
JRW急行選択時データ補充＆pass条件改善

### DIFF
--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -19,8 +19,7 @@ export interface Props {
 
 const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
   const { theme } = useRecoilValue(themeState);
-  const { arrived, station, stations, selectedDirection } =
-    useRecoilValue(stationState);
+  const { arrived, station, selectedDirection } = useRecoilValue(stationState);
   const { selectedLine } = useRecoilValue(lineState);
   const { trainType, leftStations } = useRecoilValue(navigationState);
   const currentLine = useCurrentLine();
@@ -33,58 +32,10 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
     8
   );
 
-  const notPassStations = useMemo(
-    () =>
-      selectedDirection === 'INBOUND'
-        ? stations.filter((s) => !s.pass)
-        : stations
-            .filter((s) => !s.pass)
-            .slice()
-            .reverse(),
-    [selectedDirection, stations]
-  );
-  const isPassing = useMemo(
-    () => notPassStations.findIndex((s) => s.id === station?.id) === -1,
-    [station?.id, notPassStations]
-  );
-  const nextStopStation = useMemo(
-    () => leftStations.filter((s) => !s.pass)[0],
-    [leftStations]
-  );
-  const lastStoppedStationIndex = useMemo(
-    () => notPassStations.findIndex((s) => s.id === nextStopStation?.id) - 1,
-    [nextStopStation?.id, notPassStations]
-  );
-  const passFiltered = useMemo(() => {
-    if (arrived) {
-      leftStations.filter((s) => !s.pass).slice(0, 8);
-    }
-
-    if (isPassing && lastStoppedStationIndex >= 0) {
-      return Array.from(
-        new Set([
-          notPassStations[lastStoppedStationIndex],
-          ...leftStations.filter((s) => !s.pass).slice(0, 7),
-        ])
-      );
-    }
-
-    return leftStations.filter((s) => !s.pass).slice(0, 8);
-  }, [
-    arrived,
-    isPassing,
-    lastStoppedStationIndex,
-    leftStations,
-    notPassStations,
-  ]);
-
   const belongingLines = useMemo(() => {
     const joinedLineIds = (trainType as APITrainType)?.lines.map((l) => l.id);
 
-    const switchedStations =
-      theme === AppTheme.JRWest ? passFiltered : slicedLeftStations;
-
-    const currentLineLines = switchedStations.map((s) =>
+    const currentLineLines = slicedLeftStations.map((s) =>
       s.lines.find((l) => l.id === currentLine.id)
     );
 
@@ -103,7 +54,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
               joinedLineIds?.length
             );
 
-    const foundLines = switchedStations.map((s) =>
+    const foundLines = slicedLeftStations.map((s) =>
       s.lines.find((l) => slicedIds?.find((ild) => l.id === ild))
     );
 
@@ -112,14 +63,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
         ? foundLines[i]
         : slicedLeftStations[i]?.lines.find((il) => l.id === il.id)
     );
-  }, [
-    currentLine.id,
-    passFiltered,
-    selectedDirection,
-    slicedLeftStations,
-    theme,
-    trainType,
-  ]);
+  }, [currentLine.id, selectedDirection, slicedLeftStations, trainType]);
 
   const lineColors = useMemo(
     () => belongingLines.map((s) => s?.lineColorC),
@@ -131,7 +75,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
       return (
         <LineBoardWest
           lineColors={lineColors}
-          stations={passFiltered}
+          stations={slicedLeftStations}
           line={belongingLines[0] || selectedLine}
           lines={belongingLines}
         />

--- a/src/components/LineBoardWest/index.tsx
+++ b/src/components/LineBoardWest/index.tsx
@@ -415,18 +415,21 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   const nextStationWillPass = allStations[globalCurrentStationIndex + 1]?.pass;
 
+  const customPassedCond =
+    arrived && currentStationIndex === index ? false : passed;
+
   return (
     <View key={station.name} style={styles.stationNameContainer}>
       <StationNamesWrapper
         index={index}
         stations={stations}
         station={station}
-        passed={arrived && currentStationIndex === index ? false : passed}
+        passed={customPassedCond}
       />
       <View
         style={{
           ...styles.lineDot,
-          backgroundColor: passed ? '#aaa' : '#fff',
+          backgroundColor: customPassedCond ? '#aaa' : '#fff',
         }}
       >
         {isTablet && lineMarks.length ? <View style={styles.topBar} /> : null}


### PR DESCRIPTION
closes #1061 
![Simulator Screen Shot - iPhone 13 - 2021-11-28 at 06 16 50](https://user-images.githubusercontent.com/32848922/143724947-b6deceea-945f-4c70-8b25-f7650e8f1d56.png)
![Simulator Screen Shot - iPhone 13 - 2021-11-28 at 06 20 13](https://user-images.githubusercontent.com/32848922/143724952-a8b415a5-ec4a-4ba1-89dc-6effcd642e29.png)
通過駅データが混じってくるとバグったので `AppTheme.JRWest` のときはテーマ実装の方にそもそも駅がなかったことにすることで解決