### PR TITLE
iPad版乗り換え画面メトロテーマ修正&「JR線」は常に折り返す

### DIFF
--- a/src/components/LineBoardEast/index.tsx
+++ b/src/components/LineBoardEast/index.tsx
@@ -375,7 +375,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           lm ? (
             <View
               style={
-                lm.subSign || lm?.jrUnionSigns?.length >= 4
+                lm.subSign || lm?.jrUnionSigns?.length >= 2
                   ? padLineMarksStyle.lineMarkWrapperDouble
                   : padLineMarksStyle.lineMarkWrapper
               }

--- a/src/components/LineBoardEast/index.tsx
+++ b/src/components/LineBoardEast/index.tsx
@@ -524,7 +524,6 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
                 <View
                   style={{
                     position: 'absolute',
-                    top: isTablet ? 38 : 0,
                   }}
                 >
                   <PadLineMarks />

--- a/src/components/LineBoardEast/index.tsx
+++ b/src/components/LineBoardEast/index.tsx
@@ -506,7 +506,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             <View style={[styles.passChevron]}>
               {currentStationIndex < index ? <PassChevronTY /> : null}
             </View>
-            <View style={{ marginTop: 8 }}>
+            <View style={{ position: 'absolute' }}>
               <PadLineMarks />
             </View>
           </View>

--- a/src/components/LineBoardSaikyo/index.tsx
+++ b/src/components/LineBoardSaikyo/index.tsx
@@ -382,7 +382,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           lm ? (
             <View
               style={
-                lm.subSign || lm?.jrUnionSigns?.length >= 4
+                lm.subSign || lm?.jrUnionSigns?.length >= 2
                   ? padLineMarksStyle.lineMarkWrapperDouble
                   : padLineMarksStyle.lineMarkWrapper
               }

--- a/src/components/LineBoardWest/index.tsx
+++ b/src/components/LineBoardWest/index.tsx
@@ -357,7 +357,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           lm ? (
             <View
               style={
-                lm.subSign || lm?.jrUnionSigns?.length >= 4
+                lm.subSign || lm?.jrUnionSigns?.length >= 2
                   ? padLineMarksStyle.lineMarkWrapperDouble
                   : padLineMarksStyle.lineMarkWrapper
               }


### PR DESCRIPTION
closes #1085

前回修正した箇所（文字数アイコンサイズ小さくしたあたりかも）のデグレっぽい
実際どの修正がインパクトを与えたかはいまいちわからず