### PR TITLE
直通先の路線を乗り換え扱いにしない

### DIFF
--- a/src/components/LineBoard/index.tsx
+++ b/src/components/LineBoard/index.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import useCurrentLine from '../../hooks/useCurrentLine';
-import { APITrainType } from '../../models/StationAPI';
+import useBelongingLines from '../../hooks/useBelongingLines';
 import AppTheme from '../../models/Theme';
 import lineState from '../../store/atoms/line';
 import navigationState from '../../store/atoms/navigation';
@@ -19,10 +18,9 @@ export interface Props {
 
 const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
   const { theme } = useRecoilValue(themeState);
-  const { arrived, station, selectedDirection } = useRecoilValue(stationState);
+  const { arrived, station } = useRecoilValue(stationState);
   const { selectedLine } = useRecoilValue(lineState);
-  const { trainType, leftStations } = useRecoilValue(navigationState);
-  const currentLine = useCurrentLine();
+  const { leftStations } = useRecoilValue(navigationState);
   const slicedLeftStations = leftStations.slice(0, 8);
   const currentStationIndex = slicedLeftStations.findIndex(
     (s) => s.groupId === station?.groupId
@@ -32,38 +30,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
     8
   );
 
-  const belongingLines = useMemo(() => {
-    const joinedLineIds = (trainType as APITrainType)?.lines.map((l) => l.id);
-
-    const currentLineLines = slicedLeftStations.map((s) =>
-      s.lines.find((l) => l.id === currentLine.id)
-    );
-
-    const currentLineIndex = joinedLineIds?.findIndex(
-      (lid) => currentLine.id === lid
-    );
-
-    const slicedIds =
-      selectedDirection === 'INBOUND'
-        ? joinedLineIds?.slice(currentLineIndex + 1, joinedLineIds?.length)
-        : joinedLineIds
-            ?.slice()
-            ?.reverse()
-            ?.slice(
-              joinedLineIds?.length - currentLineIndex,
-              joinedLineIds?.length
-            );
-
-    const foundLines = slicedLeftStations.map((s) =>
-      s.lines.find((l) => slicedIds?.find((ild) => l.id === ild))
-    );
-
-    return currentLineLines.map((l, i) =>
-      !l
-        ? foundLines[i]
-        : slicedLeftStations[i]?.lines.find((il) => l.id === il.id)
-    );
-  }, [currentLine.id, selectedDirection, slicedLeftStations, trainType]);
+  const belongingLines = useBelongingLines(slicedLeftStations);
 
   const lineColors = useMemo(
     () => belongingLines.map((s) => s?.lineColorC),

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -51,7 +51,7 @@ export const getArrivedThreshold = (lineType: LineType): number => {
   }
 };
 
-export const OMIT_JR_THRESHOLD = 4; // これ以上JR線があったら「JR線」で省略しよう
+export const OMIT_JR_THRESHOLD = 2; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;
 
 export const PREFS_JA = [

--- a/src/hooks/useBelongingLines.ts
+++ b/src/hooks/useBelongingLines.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import { APITrainType, Line, Station } from '../models/StationAPI';
+import navigationState from '../store/atoms/navigation';
+import stationState from '../store/atoms/station';
+import useCurrentLine from './useCurrentLine';
+
+const useBelongingLines = (leftStations: Station[]): Line[] => {
+  const { trainType } = useRecoilValue(navigationState);
+  const { selectedDirection } = useRecoilValue(stationState);
+
+  const currentLine = useCurrentLine();
+
+  const belongingLines = useMemo(() => {
+    const joinedLineIds = (trainType as APITrainType)?.lines.map((l) => l.id);
+
+    const currentLineLines = leftStations.map((s) =>
+      s.lines.find((l) => l.id === currentLine.id)
+    );
+
+    const currentLineIndex = joinedLineIds?.findIndex(
+      (lid) => currentLine.id === lid
+    );
+
+    const slicedIds =
+      selectedDirection === 'INBOUND'
+        ? joinedLineIds?.slice(currentLineIndex + 1, joinedLineIds?.length)
+        : joinedLineIds
+            ?.slice()
+            ?.reverse()
+            ?.slice(
+              joinedLineIds?.length - currentLineIndex,
+              joinedLineIds?.length
+            );
+
+    const foundLines = leftStations.map((s) =>
+      s.lines.find((l) => slicedIds?.find((ild) => l.id === ild))
+    );
+
+    return currentLineLines.map((l, i) =>
+      !l ? foundLines[i] : leftStations[i]?.lines.find((il) => l.id === il.id)
+    );
+  }, [currentLine.id, leftStations, selectedDirection, trainType]);
+
+  return belongingLines;
+};
+
+export default useBelongingLines;


### PR DESCRIPTION
closes #1091 
![simulator_screenshot_5AA4E953-DE3B-457F-BD62-D73EF9B4C418](https://user-images.githubusercontent.com/32848922/143979300-475b2ea8-1cfa-4833-b738-89bac7977fc5.png)
![simulator_screenshot_E80B5E83-C62B-4521-9D84-CDE451B06AA2](https://user-images.githubusercontent.com/32848922/143979303-e7b48505-d430-4c3b-b500-18664e1691f9.png)
大阪駅JR線のiPad専用乗換案内に「A」のマークがなく、乗換案内にも「A」はないので動作確認OK

