### PR TITLE
品川駅発山手線外回り電車で大崎駅の乗換案内が正しく表示されないバグを修正

### DIFF
--- a/src/utils/slicedStations.ts
+++ b/src/utils/slicedStations.ts
@@ -1,8 +1,8 @@
 import {
-  Station,
-  Line,
   APITrainType,
   APITrainTypeMinimum,
+  Line,
+  Station,
 } from '../models/StationAPI';
 import { TrainType } from '../models/TrainType';
 import getCurrentStationIndex from './currentStationIndex';
@@ -33,6 +33,12 @@ const getSlicedStations = ({
   }
 
   if (getIsLoopLine(currentLine, trainType)) {
+    // 山手線 品川 大阪環状線 寺田町
+    if (stations.length - 1 === currentStationIndex) {
+      return isInbound
+        ? stations.slice(currentStationIndex - 1)
+        : stations.slice(0, currentStationIndex + 2);
+    }
     return isInbound
       ? stations.slice(currentStationIndex - 1)
       : stations.slice(0, currentStationIndex + 2).reverse();


### PR DESCRIPTION
closes #1121 
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-12-02 at 15 59 00](https://user-images.githubusercontent.com/32848922/144373423-be9984a5-3ff1-4661-a8a6-ee6703331d08.png)
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-12-02 at 15 59 03](https://user-images.githubusercontent.com/32848922/144373436-fb707812-e7f9-407b-8102-512fbbb98acb.png)

