### PR TITLE
新幹線を在来線としてカウントしない

### DIFF
--- a/src/utils/jr.ts
+++ b/src/utils/jr.ts
@@ -33,7 +33,7 @@ const omitJRLinesIfThresholdExceeded = (lines: Line[]): Line[] => {
   const jrLinesWithBT = jrLines.filter(
     (line: Line) => line.lineType === LineType.BulletTrain
   );
-  if (jrLines.length >= OMIT_JR_THRESHOLD) {
+  if (jrLinesWithoutBT.length >= OMIT_JR_THRESHOLD) {
     withoutJR.unshift({
       id: 1,
       lineColorC: jrCompanyColor(jrLinesWithoutBT[0].companyId),


### PR DESCRIPTION
closes #1124
相生駅で「新幹線・JR線となっていたところが「山陽新幹線・JR赤穂線」表示になったことを確認