### PR TITLE
一部路線がiPad乗換案内に表示されないバグを修正

### DIFF
--- a/src/utils/getLineMarks.ts
+++ b/src/utils/getLineMarks.ts
@@ -74,9 +74,10 @@ const getLineMarks = ({
     jrLines.length >= OMIT_JR_THRESHOLD || bulletTrainUnionMark;
 
   const lineMarks = isJROmitted
-    ? [bulletTrainUnionMark, jrLineUnionMark, ...withoutJRLineMarks].filter(
-        (m) => !!m
-      )
+    ? [
+        ...[bulletTrainUnionMark, jrLineUnionMark].filter((m) => !!m),
+        ...withoutJRLineMarks,
+      ]
     : omittedTransferLines.map((l) =>
         grayscale ? getLineMarkGrayscale(l) : getLineMark(l)
       );


### PR DESCRIPTION
closes #1128 

新幹線がない状態をしばくためのコードがあおなみ線までしばいてしまった（JR線が登録されている＆＆マーク登録がないものがしばかれる）