### PR TITLE
小田原でiPad乗換案内がトチ狂うバグを修正

### DIFF
--- a/src/utils/getLineMarks.ts
+++ b/src/utils/getLineMarks.ts
@@ -70,8 +70,7 @@ const getLineMarks = ({
   const withoutJRLineMarks = notJRLines.map((l) =>
     grayscale ? getLineMarkGrayscale(l) : getLineMark(l)
   );
-  const isJROmitted =
-    jrLines.length >= OMIT_JR_THRESHOLD || bulletTrainUnionMark;
+  const isJROmitted = jrLines.length >= OMIT_JR_THRESHOLD;
 
   const lineMarks = isJROmitted
     ? [


### PR DESCRIPTION
なんで `|| bulletTrainUnionMark` したのか思い出せないけどとりあえず動いた
![image](https://user-images.githubusercontent.com/32848922/144484771-97c27ea9-70d5-4224-bf1d-61e977ec0f67.png)
