### PR TITLE
種別変更通知画面の画面崩れバグ修正

### DIFF
--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -20,7 +20,7 @@ const barLeft = widthScale(33);
 const barRightSP = hasNotch() ? widthScale(35) : widthScale(38);
 const barRight = isTablet ? widthScale(32 + 4) : barRightSP;
 const barRightAndroid = widthScale(35);
-const barLeftWidth = isTablet ? widthScale(155) : widthScale(155);
+const barLeftWidth = widthScale(155);
 const barRightWidthSP = hasNotch() ? widthScale(153) : widthScale(150);
 const barRightWidth = isTablet ? widthScale(151) : barRightWidthSP;
 const barRightWidthAndroid = widthScale(152);
@@ -64,7 +64,6 @@ const styles = StyleSheet.create({
     width: isTablet ? widthScale(49) : 33.7,
     height: isTablet ? heightScale(49) : 32,
     position: 'absolute',
-    right: isTablet ? widthScale(3.5) : widthScale(21.5),
   },
   centerCircle: {
     position: 'absolute',
@@ -73,7 +72,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     alignSelf: 'center',
     top: heightScale(4),
-    borderRadius: isTablet ? widthScale(8) : 32,
+    borderRadius: isTablet ? widthScale(8) : widthScale(6),
     zIndex: 9999,
   },
   trainTypeLeft: {
@@ -236,6 +235,16 @@ const TypeChangeNotify: React.FC = () => {
     return heightScale(barRight + 8);
   }, []);
 
+  const getBarTerminalRight = (): number => {
+    if (isTablet) {
+      return barRight - widthScale(32);
+    }
+    if (Platform.OS === 'android' && !isTablet) {
+      return barRightAndroid - 30;
+    }
+    return barRight - 30;
+  };
+
   const HeadingJa = () => {
     if (!headingTexts) {
       return null;
@@ -376,7 +385,7 @@ const TypeChangeNotify: React.FC = () => {
             }}
           />
           <BarTerminalEast
-            style={styles.barTerminal}
+            style={[styles.barTerminal, { right: getBarTerminalRight() }]}
             lineColor={`#${nextTrainType.line.lineColorC}`}
             hasTerminus={false}
           />


### PR DESCRIPTION
closes #1147

<img width="835" alt="スクリーンショット 2021-12-05 21 45 13" src="https://user-images.githubusercontent.com/32848922/144747076-3e7d8e25-a946-4cc2-be70-51b602ea253f.png">
<img width="826" alt="スクリーンショット 2021-12-05 21 45 19" src="https://user-images.githubusercontent.com/32848922/144747078-fb4cadd1-a049-4bfe-8bfe-a1741db94a6e.png">
<img width="830" alt="スクリーンショット 2021-12-05 21 45 30" src="https://user-images.githubusercontent.com/32848922/144747082-cc4fa988-6685-4c5d-99ac-2dc380a40387.png">
<img width="821" alt="スクリーンショット 2021-12-05 21 45 52" src="https://user-images.githubusercontent.com/32848922/144747091-01bf7e25-2d5d-4d78-b576-350980840f96.png">
<img width="836" alt="スクリーンショット 2021-12-05 21 50 48" src="https://user-images.githubusercontent.com/32848922/144747262-20007687-593d-4a4f-b6cf-b5549d292b7d.png">
<img width="836" alt="スクリーンショット 2021-12-05 21 56 22" src="https://user-images.githubusercontent.com/32848922/144747451-ba85fcc5-2003-44f3-8b60-5b4757628dd3.png">

