### PR TITLE
8駅以下の路線で表示が崩れるバグを修正

### DIFF
--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -123,7 +123,7 @@ const useRefreshLeftStations = (
         stations.length
       );
 
-      if (slicedStations.length < 8) {
+      if (slicedStations.length < 8 && stations.length > 8) {
         return stations.slice(stations.length - 8, stations.length);
       }
       return slicedStations;


### PR DESCRIPTION
千葉モノレール１号線で発生したバグの修正
![simulator_screenshot_84E9224B-C7F7-4B7C-ABB9-2200E79B5721](https://user-images.githubusercontent.com/32848922/145670652-77151034-6f47-4e30-a403-0f84a86a984f.png)

