### PR TITLE
shouldGrayscaleの条件を駅名と同じにした

### DIFF
--- a/src/components/LineBoardEast/index.tsx
+++ b/src/components/LineBoardEast/index.tsx
@@ -318,11 +318,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   );
 
   const passed = index <= currentStationIndex || (!index && !arrived);
-  const shouldGrayscale = arrived
-    ? index < currentStationIndex
-    : index <= currentStationIndex ||
-      (!index && !arrived) ||
-      getIsPass(station);
+  const shouldGrayscale =
+    getIsPass(station) ||
+    (arrived && currentStationIndex === index ? false : passed);
 
   const transferLines = filterWithoutCurrentLine(stations, line, index).filter(
     (l) => lines.findIndex((il) => l.id === il?.id) === -1

--- a/src/components/LineBoardSaikyo/index.tsx
+++ b/src/components/LineBoardSaikyo/index.tsx
@@ -331,11 +331,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   );
 
   const passed = index <= currentStationIndex || (!index && !arrived);
-  const shouldGrayscale = arrived
-    ? index < currentStationIndex
-    : index <= currentStationIndex ||
-      (!index && !arrived) ||
-      getIsPass(station);
+  const shouldGrayscale =
+    getIsPass(station) ||
+    (arrived && currentStationIndex === index ? false : passed);
 
   const lineMarks = getLineMarks({
     transferLines,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32848922/146414006-44131294-3eec-4404-b8d9-78ddfb3134aa.png)

closes #1143
ややこしい処理してたけどよく考えたら駅名が灰色だったら必ず乗り換えも灰色になるべきだった
