### PR TITLE
onLayout処理を廃止

### DIFF
--- a/src/components/Layout/Permitted.tsx
+++ b/src/components/Layout/Permitted.tsx
@@ -50,6 +50,7 @@ const styles = StyleSheet.create({
   root: {
     overflow: 'hidden',
     backgroundColor: '#fff',
+    height: Dimensions.get('window').height,
   },
 });
 
@@ -59,12 +60,6 @@ type Props = {
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const [warningDismissed, setWarningDismissed] = useState(false);
-  const [windowHeight, setWindowHeight] = useState(
-    Dimensions.get('window').height
-  );
-  const onLayout = (): void => {
-    setWindowHeight(Dimensions.get('window').height);
-  };
   const [{ station, stations, selectedDirection, selectedBound }, setStation] =
     useRecoilState(stationState);
   const { selectedLine } = useRecoilValue(lineState);
@@ -188,10 +183,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     return null;
   }, [autoMode, badAccuracy, isInternetAvailable, station, warningDismissed]);
   const onWarningPress = (): void => setWarningDismissed(true);
-
-  const rootExtraStyle = {
-    height: windowHeight,
-  };
 
   const NullableWarningPanel: React.FC = () =>
     warningInfo ? (
@@ -368,7 +359,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         onHandlerStateChange={onLongPress}
         minDurationMs={500}
       >
-        <View style={[styles.root, rootExtraStyle]} onLayout={onLayout}>
+        <View style={styles.root}>
           {/* eslint-disable-next-line no-undef */}
           {devMode && station && location && (
             <DevOverlay location={location as LocationObject} />

--- a/src/components/WarningPanel/index.tsx
+++ b/src/components/WarningPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Dimensions,
   GestureResponderEvent,
@@ -21,14 +21,6 @@ const WarningPanel: React.FC<Props> = ({
   onPress,
   warningLevel,
 }: Props) => {
-  const [windowWidth, setWindowWidth] = useState(
-    Dimensions.get('window').width
-  );
-
-  const onLayout = (): void => {
-    setWindowWidth(Dimensions.get('window').width);
-  };
-
   const borderColor = (() => {
     switch (warningLevel) {
       case 'URGENT':
@@ -44,7 +36,7 @@ const WarningPanel: React.FC<Props> = ({
 
   const styles = StyleSheet.create({
     root: {
-      width: windowWidth / 2,
+      width: Dimensions.get('window').width / 2,
       backgroundColor: '#333',
       borderColor,
       borderLeftWidth: 16,
@@ -70,7 +62,7 @@ const WarningPanel: React.FC<Props> = ({
   });
 
   return (
-    <TouchableWithoutFeedback onLayout={onLayout} onPress={onPress}>
+    <TouchableWithoutFeedback onPress={onPress}>
       <View style={styles.root}>
         <Text style={styles.message}>{text}</Text>
         <Text style={styles.dismissMessage}>{translate('tapToClose')}</Text>


### PR DESCRIPTION
closes #1226

まず呼ばれないにしても不要な処理を走らせたり放置しておくのは良くないと思うのでレイアウト変更時の処理を削除