### PR TITLE
路線の境界表示を隠す(Apple Watch)

### DIFF
--- a/src/providers/AppleWatchProvider.tsx
+++ b/src/providers/AppleWatchProvider.tsx
@@ -88,6 +88,8 @@ const AppleWatchProvider: React.FC<Props> = ({ children }: Props) => {
           nameKo: '',
           lines: switchedStation?.lines.map((l) => ({
             ...l,
+            name: l.name.replace(parenthesisRegexp, ''),
+            nameR: l.nameR.replace(parenthesisRegexp, ''),
             nameZh: '',
             nameKo: '',
           })),
@@ -105,6 +107,8 @@ const AppleWatchProvider: React.FC<Props> = ({ children }: Props) => {
                 ...s,
                 lines: s.lines.map((l) => ({
                   ...l,
+                  name: l.name.replace(parenthesisRegexp, ''),
+                  nameR: l.nameR.replace(parenthesisRegexp, ''),
                   nameZh: '',
                   nameKo: '',
                 })),
@@ -116,6 +120,8 @@ const AppleWatchProvider: React.FC<Props> = ({ children }: Props) => {
                 ...s,
                 lines: s.lines.map((l) => ({
                   ...l,
+                  name: l.name.replace(parenthesisRegexp, ''),
+                  nameR: l.nameR.replace(parenthesisRegexp, ''),
                   nameZh: '',
                   nameKo: '',
                 })),


### PR DESCRIPTION
closes #1209
![7FC72079-199A-403C-8DB5-861046506389_4_5005_c](https://user-images.githubusercontent.com/32848922/147054321-8818ad55-2720-4697-be5f-37541757af12.jpeg)
 中央線に括弧がなくなっているので動作OK
![image](https://user-images.githubusercontent.com/32848922/147056373-0979d6ec-c927-40d2-b8cb-1bc7311f05b0.png)
JR神戸線神戸駅とかだと「JR神戸線」が2回表示されてしまうけど後ほど対応したい https://github.com/TrainLCD/MobileApp/issues/1229