### PR TITLE
新幹線の到着最大到着閾値の修正

### DIFF
--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -1,9 +1,15 @@
 import { LineType } from '../models/StationAPI';
 
-const getMaxThreshold = (baseThreshold: number, lineType: LineType): number => {
+const getMaxThreshold = (
+  baseThreshold: number,
+  lineType: LineType,
+  operationType: 'APPROACHING' | 'ARRIVING'
+): number => {
   switch (lineType) {
     case LineType.BulletTrain:
-      return baseThreshold * 10;
+      return operationType === 'ARRIVING'
+        ? baseThreshold * 5
+        : baseThreshold * 10;
     case LineType.Subway:
       return baseThreshold * 1.5;
     default:
@@ -15,7 +21,11 @@ export const getApproachingThreshold = (
   lineType: LineType | undefined,
   avgBetweenStations: number | undefined
 ): number => {
-  const maxThreshold = getMaxThreshold(1000, lineType || LineType.Normal);
+  const maxThreshold = getMaxThreshold(
+    1000,
+    lineType || LineType.Normal,
+    'APPROACHING'
+  );
   const base = avgBetweenStations ? avgBetweenStations / 2 : 1000;
   if (base > maxThreshold) {
     return maxThreshold;
@@ -34,7 +44,11 @@ export const getArrivedThreshold = (
   lineType: LineType | undefined,
   avgBetweenStations: number | undefined
 ): number => {
-  const maxThreshold = getMaxThreshold(300, lineType || LineType.Normal);
+  const maxThreshold = getMaxThreshold(
+    300,
+    lineType || LineType.Normal,
+    'ARRIVING'
+  );
   const base = avgBetweenStations ? avgBetweenStations / 6 : 300;
   if (base > maxThreshold) {
     return maxThreshold;


### PR DESCRIPTION
closes #1248 新幹線、到着してないくせして到着って出ることがあるので到着最大しきい値だけ今までの半分にした