### PR TITLE
ミラーリングシェア配信・購読時のバグ修正

### DIFF
--- a/src/hooks/useMirroringShare.ts
+++ b/src/hooks/useMirroringShare.ts
@@ -36,7 +36,6 @@ type StorePayload = {
   selectedBound: Station;
   trainType: APITrainType | APITrainTypeMinimum | null | undefined;
   selectedDirection: LineDirection;
-  station: Station;
   stations: Station[];
   rawStations: Station[];
   theme: AppTheme;
@@ -55,7 +54,7 @@ const useMirroringShare = (): {
 } => {
   const { location } = useRecoilValue(locationState);
   const { selectedLine } = useRecoilValue(lineState);
-  const { station, rawStations, stations, selectedBound, selectedDirection } =
+  const { rawStations, stations, selectedBound, selectedDirection } =
     useRecoilValue(stationState);
   const { trainType } = useRecoilValue(navigationState);
   const {
@@ -179,7 +178,6 @@ const useMirroringShare = (): {
           selectedLine: publisherSelectedLine,
           selectedBound: publisherSelectedBound,
           trainType: publisherTrainType,
-          station: publisherStation,
           stations: publisherStations = [],
           selectedDirection: publisherSelectedDirection,
           rawStations: publisherRawStations = [],
@@ -202,7 +200,6 @@ const useMirroringShare = (): {
         }));
         set(stationState, (prev) => ({
           ...prev,
-          station: publisherStation,
           stations: publisherStations,
           rawStations: publisherRawStations,
           selectedDirection:
@@ -303,6 +300,8 @@ const useMirroringShare = (): {
           throw new Error(translate('subscribeProhibitedError'));
         }
 
+        resetState();
+
         await auth().signInAnonymously();
 
         const newDbRef = database().ref(
@@ -345,7 +344,7 @@ const useMirroringShare = (): {
           await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
         }
       },
-    [getMyUID, onSnapshotValueChange, updateVisitorTimestamp]
+    [getMyUID, onSnapshotValueChange, resetState, updateVisitorTimestamp]
   );
 
   const publishAsync = useCallback(async () => {
@@ -358,7 +357,6 @@ const useMirroringShare = (): {
         selectedBound,
         selectedDirection,
         trainType,
-        station,
         stations,
         rawStations,
         theme,
@@ -378,7 +376,6 @@ const useMirroringShare = (): {
     selectedBound,
     selectedDirection,
     selectedLine,
-    station,
     stations,
     theme,
     trainType,

--- a/src/hooks/useMirroringShare.ts
+++ b/src/hooks/useMirroringShare.ts
@@ -158,6 +158,9 @@ const useMirroringShare = (): {
       async (data: FirebaseDatabaseTypes.DataSnapshot) => {
         // 多分ミラーリングシェアが終了されてる
         if (!data.exists()) {
+          if (dbRef.current) {
+            dbRef.current.off('value', onSnapshotValueChange);
+          }
           resetState();
           Alert.alert(
             translate('annoucementTitle'),

--- a/src/hooks/useTransitionHeaderState.ts
+++ b/src/hooks/useTransitionHeaderState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { HEADER_CONTENT_TRANSITION_INTERVAL } from '../constants';
 import { HeaderTransitionState } from '../models/HeaderTransitionState';
@@ -16,16 +16,16 @@ const useTransitionHeaderState = (): void => {
     { headerState, leftStations, stationForHeader, enabledLanguages },
     setNavigation,
   ] = useRecoilState(navigationState);
-  const [intervalId, setIntervalId] = useState<NodeJS.Timeout>();
   const headerStateRef = useValueRef(headerState);
+  const intervalIdRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
     return (): void => {
-      if (intervalId) {
-        clearInterval(intervalId);
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
       }
     };
-  }, [intervalId]);
+  }, [intervalIdRef]);
 
   const showNextExpression =
     leftStations.length > 1 &&
@@ -40,6 +40,10 @@ const useTransitionHeaderState = (): void => {
     nextStation?.nameZh?.length && nextStation?.nameKo?.length;
 
   useEffect(() => {
+    if (intervalIdRef.current) {
+      return;
+    }
+
     const interval = setInterval(() => {
       const currentHeaderState = headerStateRef.current.split(
         '_'
@@ -118,7 +122,7 @@ const useTransitionHeaderState = (): void => {
           break;
       }
     }, HEADER_CONTENT_TRANSITION_INTERVAL);
-    setIntervalId(interval);
+    intervalIdRef.current = interval;
   }, [
     enabledLanguages,
     headerStateRef,

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { BOTTOM_CONTENT_TRANSITION_INTERVAL } from '../constants';
 import navigationState from '../store/atoms/navigation';
@@ -9,16 +9,16 @@ import useValueRef from './useValueRef';
 
 const useUpdateBottomState = (): [() => void] => {
   const [{ bottomState }, setNavigation] = useRecoilState(navigationState);
-  const [intervalId, setIntervalId] = useState<NodeJS.Timer>();
   const bottomStateRef = useValueRef(bottomState);
+  const intervalIdRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
     return (): void => {
-      if (intervalId) {
-        clearInterval(intervalId);
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
       }
     };
-  }, [intervalId]);
+  }, [intervalIdRef]);
 
   const nextTrainTypeIsDifferent = useNextTrainTypeIsDifferent();
   const nextTrainTypeIsDifferentRef = useValueRef(nextTrainTypeIsDifferent);
@@ -36,6 +36,10 @@ const useUpdateBottomState = (): [() => void] => {
   const shouldHideTypeChangeRef = useRef(shouldHideTypeChange);
 
   const updateFunc = useCallback(() => {
+    if (intervalIdRef.current) {
+      return;
+    }
+
     const interval = setInterval(() => {
       switch (bottomStateRef.current) {
         case 'LINE':
@@ -76,7 +80,7 @@ const useUpdateBottomState = (): [() => void] => {
           break;
       }
     }, BOTTOM_CONTENT_TRANSITION_INTERVAL);
-    setIntervalId(interval);
+    intervalIdRef.current = interval;
   }, [
     bottomStateRef,
     nextTrainTypeIsDifferentRef,

--- a/src/screens/ConnectMirroringShareSettings/index.tsx
+++ b/src/screens/ConnectMirroringShareSettings/index.tsx
@@ -111,7 +111,7 @@ const ConnectMirroringShareSettings: React.FC = () => {
             {translate('back')}
           </Button>
           <Button
-            disabled={loading}
+            disabled={loading || !publisherId.trim().length}
             style={styles.button}
             onPress={handleSubmit}
           >

--- a/src/screens/ConnectMirroringShareSettings/index.tsx
+++ b/src/screens/ConnectMirroringShareSettings/index.tsx
@@ -52,6 +52,7 @@ const ConnectMirroringShareSettings: React.FC = () => {
 
   const navigation = useNavigation();
   const [publisherId, setPublisherId] = useState('');
+  const [loading, setLoading] = useState(false);
   const { subscribe } = useMirroringShare();
 
   const handlePressBack = useCallback(async () => {
@@ -62,14 +63,16 @@ const ConnectMirroringShareSettings: React.FC = () => {
 
   const handleSubmit = useCallback(async () => {
     try {
+      setLoading(true);
       await subscribe(publisherId.trim());
-
       navigation.navigate('Main');
     } catch (err) {
       Alert.alert(
         translate('errorTitle'),
         (err as { message: string }).message
       );
+    } finally {
+      setLoading(false);
     }
   }, [navigation, publisherId, subscribe]);
 
@@ -107,7 +110,11 @@ const ConnectMirroringShareSettings: React.FC = () => {
           <Button style={styles.button} onPress={handlePressBack}>
             {translate('back')}
           </Button>
-          <Button style={styles.button} onPress={handleSubmit}>
+          <Button
+            disabled={loading}
+            style={styles.button}
+            onPress={handleSubmit}
+          >
             {translate('connect')}
           </Button>
         </View>


### PR DESCRIPTION
closes #1305 

- ミラーリングシェアの切断がうまく動作していなかった
-  タイムスタンプ更新用に何回もDB接続を生成していた
- 購読用接続を無意味に２本作っていた
- ミラーリングシェア接続時に接続ボタンが何度も押せるようになっていた
- ~~配信側の送信ペエスがバカ速いとアニメーションがガタついてしまうので応急処置として１秒間購読を間引くことにした~~
  - 同期がしづらくなるのでいったんやめ
- 前回の送信から100m移動しない限りデータを送信しないことにした