### PR TITLE
画面遷移時のバグ修正

### DIFF
--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -1,6 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
+import * as Location from 'expo-location';
 import { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
+import { LOCATION_TASK_NAME } from '../constants';
 import navigationState from '../store/atoms/navigation';
 import speechState from '../store/atoms/speech';
 import stationState from '../store/atoms/station';
@@ -15,6 +17,7 @@ const useResetMainState = (): (() => void) => {
   const navigation = useNavigation();
 
   const reset = useCallback(() => {
+    Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
     setNavigation((prev) => ({
       ...prev,
       headerState: isJapanese ? 'CURRENT' : 'CURRENT_EN',

--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -1,0 +1,46 @@
+import { useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
+import { useSetRecoilState } from 'recoil';
+import navigationState from '../store/atoms/navigation';
+import speechState from '../store/atoms/speech';
+import stationState from '../store/atoms/station';
+import { isJapanese } from '../translation';
+import useMirroringShare from './useMirroringShare';
+
+const useResetMainState = (): (() => void) => {
+  const setNavigation = useSetRecoilState(navigationState);
+  const setStation = useSetRecoilState(stationState);
+  const setSpeech = useSetRecoilState(speechState);
+  const { unsubscribe: unsubscribeMirroringShare } = useMirroringShare();
+  const navigation = useNavigation();
+
+  const reset = useCallback(() => {
+    setNavigation((prev) => ({
+      ...prev,
+      headerState: isJapanese ? 'CURRENT' : 'CURRENT_EN',
+      bottomState: 'LINE',
+      leftStations: [],
+    }));
+    setStation((prev) => ({
+      ...prev,
+      selectedDirection: null,
+      selectedBound: null,
+    }));
+    setSpeech((prev) => ({
+      ...prev,
+      muted: true,
+    }));
+    unsubscribeMirroringShare();
+    navigation.navigate('SelectBound');
+  }, [
+    navigation,
+    setNavigation,
+    setSpeech,
+    setStation,
+    unsubscribeMirroringShare,
+  ]);
+
+  return reset;
+};
+
+export default useResetMainState;


### PR DESCRIPTION
closes #1308 

`Permitted.tsx` に戻る処理が入ってて位置情報の取得を許可したあとのすべての画面に影響してた

タスクキル時に対応はできないが closes #1296