### PR TITLE
淡路町駅が表示されないバグを修正

### DIFF
--- a/src/utils/dropJunctionStation.ts
+++ b/src/utils/dropJunctionStation.ts
@@ -4,7 +4,7 @@ import { Station } from '../models/StationAPI';
 const dropEitherJunctionStation = (stations: Station[]): Station[] =>
   stations.filter((s, i, arr): boolean => {
     const prv = arr[i - 1];
-    if (prv && prv.groupId === s.groupId) {
+    if (prv?.name === s.name && prv?.groupId === s.groupId) {
       return !prv;
     }
     return true;


### PR DESCRIPTION
closes #1342
![image](https://user-images.githubusercontent.com/32848922/160280141-7b2141c9-0640-4bd9-8126-692522a5b202.png)
御茶ノ水と淡路町駅が同じぐるグループIDでブチギレ散らかしてる