### PR TITLE
ErrorBoundaryの採用とレイアウト修正

### DIFF
--- a/android/app/src/main/assets/translations/en.json
+++ b/android/app/src/main/assets/translations/en.json
@@ -122,5 +122,6 @@
   "subscribedNotice": "Connecting to the mirroring share.",
   "mirroringShareEnded": "You have been disconnected from the mirroring share.",
   "subscribeProhibitedError": "You cannot connect to the mirroring share during publishing.",
-  "annoucementTitle": "Announcement"
+  "annoucementTitle": "Announcement",
+  "appCrashedText": "An unexpected problem has occurred with the application. We apologize for the inconvenience, but please try again from the beginning."
 }

--- a/android/app/src/main/assets/translations/ja.json
+++ b/android/app/src/main/assets/translations/ja.json
@@ -122,5 +122,6 @@
   "subscribedNotice": "ミラーリングシェアに接続中です。",
   "mirroringShareEnded": "ミラーリングシェアから切断されました。",
   "subscribeProhibitedError": "配信中はミラーリングシェアに接続できません。",
-  "annoucementTitle": "お知らせ"
+  "annoucementTitle": "お知らせ",
+  "appCrashedText": "アプリで予期しない問題が発生しました。大変恐れ入りますが、もう一度最初からやり直してください。"
 }

--- a/ios/TrainLCD/translations/en.json
+++ b/ios/TrainLCD/translations/en.json
@@ -122,5 +122,6 @@
   "subscribedNotice": "Connecting to the mirroring share.",
   "mirroringShareEnded": "You have been disconnected from the mirroring share.",
   "subscribeProhibitedError": "You cannot connect to the mirroring share during publishing.",
-  "annoucementTitle": "Announcement"
+  "annoucementTitle": "Announcement",
+  "appCrashedText": "An unexpected problem has occurred with the application. We apologize for the inconvenience, but please try again from the beginning."
 }

--- a/ios/TrainLCD/translations/ja.json
+++ b/ios/TrainLCD/translations/ja.json
@@ -122,5 +122,6 @@
   "subscribedNotice": "ミラーリングシェアに接続中です。",
   "mirroringShareEnded": "ミラーリングシェアから切断されました。",
   "subscribeProhibitedError": "配信中はミラーリングシェアに接続できません。",
-  "annoucementTitle": "お知らせ"
+  "annoucementTitle": "お知らせ",
+  "appCrashedText": "アプリで予期しない問題が発生しました。大変恐れ入りますが、もう一度最初からやり直してください。"
 }

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -9,7 +9,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#fcfcfc',
-    paddingHorizontal: 32,
   },
   text: {
     fontSize: RFValue(16),
@@ -17,6 +16,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: RFValue(21),
     marginBottom: 4,
+    paddingHorizontal: 32,
   },
   boldText: {
     fontWeight: 'bold',
@@ -26,6 +26,7 @@ const styles = StyleSheet.create({
     fontSize: RFValue(24),
     lineHeight: undefined,
     fontWeight: 'bold',
+    paddingHorizontal: 32,
   },
   button: {
     borderRadius: 4,
@@ -35,7 +36,9 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     color: '#fff',
-    marginBottom: 0,
+    fontSize: RFValue(16),
+    textAlign: 'center',
+    lineHeight: RFValue(21),
   },
   linkText: {
     color: '#03a9f4',
@@ -69,14 +72,14 @@ const ErrorScreen: React.FC<Props> = ({
 
     {onRetryPress ? (
       <TouchableOpacity onPress={onRetryPress} style={styles.button}>
-        <Text style={[styles.text, styles.boldText, styles.buttonText]}>
+        <Text style={[styles.boldText, styles.buttonText]}>
           {translate('retry')}
         </Text>
       </TouchableOpacity>
     ) : null}
     {recoverable ? (
       <TouchableOpacity onPress={onRecoverErrorPress} style={styles.button}>
-        <Text style={[styles.text, styles.boldText, styles.buttonText]}>
+        <Text style={[styles.boldText, styles.buttonText]}>
           {translate('startStationTitle')}
         </Text>
       </TouchableOpacity>

--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -26,9 +26,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: RFValue(18),
     marginBottom: 12,
-  },
-  boldText: {
-    fontWeight: 'bold',
+    paddingHorizontal: 32,
   },
   headingText: {
     color: '#03a9f4',
@@ -43,12 +41,18 @@ const styles = StyleSheet.create({
     marginTop: 24,
   },
   buttonText: {
+    fontSize: RFValue(14),
     color: '#fff',
-    marginBottom: 0,
+    textAlign: 'center',
+    lineHeight: RFValue(18),
+    fontWeight: 'bold',
   },
   linkText: {
+    fontSize: RFValue(14),
+    textAlign: 'center',
+    lineHeight: RFValue(18),
     color: '#03a9f4',
-    marginBottom: 0,
+    fontWeight: 'bold',
   },
   link: {
     borderBottomColor: '#03a9f4',
@@ -147,17 +151,13 @@ const PrivacyScreen: React.FC = () => {
       <Text style={[styles.text, styles.headingText]}>
         {translate('privacyTitle')}
       </Text>
-      <Text style={[styles.text]}>{translate('privacyDescription')}</Text>
+      <Text style={styles.text}>{translate('privacyDescription')}</Text>
 
-      <TouchableOpacity style={[styles.link]} onPress={openPrivacyPolicyIAB}>
-        <Text style={[styles.text, styles.boldText, styles.linkText]}>
-          {translate('privacyPolicy')}
-        </Text>
+      <TouchableOpacity style={styles.link} onPress={openPrivacyPolicyIAB}>
+        <Text style={styles.linkText}>{translate('privacyPolicy')}</Text>
       </TouchableOpacity>
       <TouchableOpacity onPress={handleApprovePress} style={styles.button}>
-        <Text style={[styles.text, styles.boldText, styles.buttonText]}>
-          {translate('approve')}
-        </Text>
+        <Text style={styles.buttonText}>{translate('approve')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );


### PR DESCRIPTION
![simulator_screenshot_111DCBF9-B69B-45D6-B65D-FA1875FA54B7](https://user-images.githubusercontent.com/32848922/164277598-cadb2c25-a56b-43de-91c9-ffca98f87057.png)

開発中もしくは開発者モードのときにはエラーの詳細も表示する（このスクショでは `An error thrown from the SelectLine screen!` の部分)

closes #1373