### PR TITLE
ミラーリングシャアGC間隔調整

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,7 +4,7 @@ import * as functions from 'firebase-functions';
 const app = initializeApp();
 
 exports.detectInactiveSubscribersOrPublishers = functions.pubsub
-  .schedule('every 1 minutes')
+  .schedule('every 3 minutes')
   .onRun(async () => {
     const visitorsRef = app.database().ref('/mirroringShare/visitors');
     const visitorsDataSnapshot = await visitorsRef.get();


### PR DESCRIPTION
1分ごとに1分非アクティブな配信を探し出して殺していたが、アプリ側のタイムスタンプ更新が間に合っていないのかサーバー側で勝手に非アクティブ化されているときがそこそこあってGCの巡回間隔を1分から3分に変更した
だいたい電車の長時間停車したときにこうなってしまうのでそもそもの設計の見直しが必要かも