### PR TITLE
無意味にステートのリセットをしないようにした

### DIFF
--- a/src/hooks/useNearbyStations.ts
+++ b/src/hooks/useNearbyStations.ts
@@ -6,6 +6,7 @@ import { useSetRecoilState } from 'recoil';
 import { NearbyStationsData } from '../models/StationAPI';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
+import useConnectivity from './useConnectivity';
 
 type PickedLocation = Pick<LocationObject, 'coords'>;
 
@@ -49,8 +50,14 @@ const useNearbyStations = (): [
   const [getStation, { loading, error, data }] =
     useLazyQuery<NearbyStationsData>(NEARBY_STATIONS_TYPE);
 
+  const isInternetAvailable = useConnectivity();
+
   const fetchStation = useCallback(
     (location: PickedLocation) => {
+      if (!isInternetAvailable) {
+        return;
+      }
+
       const { latitude, longitude } = location.coords;
 
       getStation({
@@ -60,7 +67,7 @@ const useNearbyStations = (): [
         },
       });
     },
-    [getStation]
+    [getStation, isInternetAvailable]
   );
 
   useEffect(() => {

--- a/src/hooks/useStationList.ts
+++ b/src/hooks/useStationList.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { StationsByLineIdData } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
+import useConnectivity from './useConnectivity';
 
 const useStationList = (): [
   (lineId: number) => void,
@@ -81,22 +82,29 @@ const useStationList = (): [
 
   const [getStations, { loading, error, data }] =
     useLazyQuery<StationsByLineIdData>(STATIONS_BY_LINE_ID_TYPE, {
-      fetchPolicy: 'no-cache',
+      // ↓なんで必要だったんだっけ
+      // fetchPolicy: 'no-cache',
     });
+
+  const isInternetAvailable = useConnectivity();
 
   const fetchStationListWithTrainTypes = useCallback(
     (lineId: number) => {
+      if (!isInternetAvailable) {
+        return;
+      }
+
       getStations({
         variables: {
           lineId,
         },
       });
     },
-    [getStations]
+    [getStations, isInternetAvailable]
   );
 
   useEffect(() => {
-    if (data?.stationsByLineId) {
+    if (data?.stationsByLineId.length) {
       setStation((prev) => ({
         ...prev,
         stations: data.stationsByLineId,

--- a/src/hooks/useStationListByTrainType.ts
+++ b/src/hooks/useStationListByTrainType.ts
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 import { TrainTypeData } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
 import dropEitherJunctionStation from '../utils/dropJunctionStation';
+import useConnectivity from './useConnectivity';
 
 const useStationListByTrainType = (): [
   (typeId: number) => void,
@@ -83,8 +84,14 @@ const useStationListByTrainType = (): [
     }
   );
 
+  const isInternetAvailable = useConnectivity();
+
   const fetchStation = useCallback(
     (typeId: number) => {
+      if (!isInternetAvailable) {
+        return;
+      }
+
       setStation((prev) => ({
         ...prev,
         stations: [],
@@ -94,7 +101,7 @@ const useStationListByTrainType = (): [
         variables: { id: typeId },
       });
     },
-    [getTrainType, setStation]
+    [getTrainType, isInternetAvailable, setStation]
   );
 
   useEffect(() => {

--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as Location from 'expo-location';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -16,7 +16,6 @@ import Button from '../components/Button';
 import ErrorScreen from '../components/ErrorScreen';
 import Heading from '../components/Heading';
 import { LOCATION_TASK_NAME } from '../constants';
-import useConnectivity from '../hooks/useConnectivity';
 import useStationList from '../hooks/useStationList';
 import useStationListByTrainType from '../hooks/useStationListByTrainType';
 import { directionToDirectionName, LineDirection } from '../models/Bound';
@@ -328,25 +327,29 @@ const SelectBoundScreen: React.FC = () => {
     initialize();
   }, [initialize]);
 
-  const isInternetAvailable = useConnectivity();
+  useFocusEffect(
+    useCallback(() => {
+      if (trainType) {
+        fetchStationListByTrainTypeFunc(trainType.groupId);
+      }
+    }, [fetchStationListByTrainTypeFunc, trainType])
+  );
 
-  useEffect(() => {
-    if (trainType && isInternetAvailable) {
-      fetchStationListByTrainTypeFunc(trainType.groupId);
-    }
-  }, [fetchStationListByTrainTypeFunc, isInternetAvailable, trainType]);
+  useFocusEffect(
+    useCallback(() => {
+      if (!trainType && selectedLine) {
+        fetchStationListFunc(selectedLine.id);
+      }
+    }, [fetchStationListFunc, selectedLine, trainType])
+  );
 
-  useEffect(() => {
-    if (!trainType && isInternetAvailable && selectedLine) {
-      fetchStationListFunc(selectedLine.id);
-    }
-  }, [fetchStationListFunc, isInternetAvailable, selectedLine, trainType]);
-
-  useEffect(() => {
-    if (selectedLine && isInternetAvailable) {
-      fetchStationListFunc(selectedLine.id);
-    }
-  }, [fetchStationListFunc, isInternetAvailable, selectedLine]);
+  useFocusEffect(
+    useCallback(() => {
+      if (selectedLine) {
+        fetchStationListFunc(selectedLine.id);
+      }
+    }, [fetchStationListFunc, selectedLine])
+  );
 
   useEffect(() => {
     const handler = BackHandler.addEventListener('hardwareBackPress', () => {

--- a/src/screens/SelectLine.tsx
+++ b/src/screens/SelectLine.tsx
@@ -62,10 +62,10 @@ const SelectLineScreen: React.FC = () => {
   const isInternetAvailable = useConnectivity();
 
   useEffect(() => {
-    if (location && !station && isInternetAvailable) {
+    if (location && !station) {
       fetchStationFunc(location as Location.LocationObject);
     }
-  }, [fetchStationFunc, isInternetAvailable, location, station]);
+  }, [fetchStationFunc, location, station]);
 
   const navigation = useNavigation();
 


### PR DESCRIPTION
closes #1387 

駅情報のフェッチ処理が何度も走っているのが問題だった
useFocusEffectを使用して必要なときだけフェッチする

その他の修正:
- コンポーネント側で `useConnectivity()` を使ってクエリ発行前にインターネット接続を確認していたが、実際クエリを発行するhooksの方で確認するように修正
- `fetchPolicy: 'no-cache'` を指定していたが別に必要なさそう（要デグレ確認）
