### PR TITLE
何度も種別ロードが走るバグを修正

### DIFF
--- a/src/hooks/useStationListByTrainType.ts
+++ b/src/hooks/useStationListByTrainType.ts
@@ -78,11 +78,7 @@ const useStationListByTrainType = (): [
   `;
   const [getTrainType, { loading, error, data }] = useLazyQuery<TrainTypeData>(
     TRAIN_TYPE,
-    {
-      // FIXME: 外したい
-      fetchPolicy: 'network-only',
-      notifyOnNetworkStatusChange: true,
-    }
+    { fetchPolicy: 'no-cache', notifyOnNetworkStatusChange: true }
   );
 
   const isInternetAvailable = useConnectivity();


### PR DESCRIPTION
closes #1419

多分駅数が多い路線で無限ロードが走っているのが顕著に見えるだけですべての種別で発生していたのかも