### PR TITLE
駅指定時ナンバリング表示されない問題修正

### DIFF
--- a/src/components/FakeStationSettings.tsx
+++ b/src/components/FakeStationSettings.tsx
@@ -138,6 +138,10 @@ const FakeStationSettings: React.FC = () => {
         address
         latitude
         longitude
+        stationNumbers {
+          lineSymbolColor
+          stationNumber
+        }
         lines {
           id
           companyId
@@ -166,6 +170,10 @@ const FakeStationSettings: React.FC = () => {
         address
         latitude
         longitude
+        stationNumbers {
+          lineSymbolColor
+          stationNumber
+        }
         lines {
           id
           companyId

--- a/src/components/FakeStationSettings.tsx
+++ b/src/components/FakeStationSettings.tsx
@@ -141,6 +141,7 @@ const FakeStationSettings: React.FC = () => {
         stationNumbers {
           lineSymbolColor
           stationNumber
+          lineSymbol
         }
         lines {
           id
@@ -150,6 +151,9 @@ const FakeStationSettings: React.FC = () => {
           nameR
           nameK
           lineType
+          lineSymbols {
+            lineSymbol
+          }
         }
       }
     }
@@ -173,6 +177,12 @@ const FakeStationSettings: React.FC = () => {
         stationNumbers {
           lineSymbolColor
           stationNumber
+          lineSymbol
+        }
+        currentLine {
+          lineSymbols {
+            lineSymbol
+          }
         }
         lines {
           id
@@ -182,6 +192,9 @@ const FakeStationSettings: React.FC = () => {
           nameR
           nameK
           lineType
+          lineSymbols {
+            lineSymbol
+          }
         }
       }
     }

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -41,7 +41,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
   isLast,
 }: CommonHeaderProps) => {
   const { headerState, trainType } = useRecoilValue(navigationState);
-  const { selectedBound, selectedDirection, stations } =
+  const { selectedBound, selectedDirection, stations, arrived } =
     useRecoilValue(stationState);
   const [stateText, setStateText] = useState(translate('nowStoppingAt'));
   const [stationText, setStationText] = useState(station.name);
@@ -734,18 +734,17 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
     return line && getLineMark(line)?.shape;
   }, [headerState, line, nextStation?.currentLine]);
   const currentStationNumber = useMemo(
-    () => getCurrentStationNumber(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationNumber(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const threeLetterCode = useMemo(
-    () => getCurrentStationThreeLetterCode(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationThreeLetterCode(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const lineColor = useMemo(() => line && `#${line.lineColorC}`, [line]);
   const numberingColor = useMemo(
-    () =>
-      getNumberingColor(headerState, currentStationNumber, nextStation, line),
-    [currentStationNumber, headerState, line, nextStation]
+    () => getNumberingColor(arrived, currentStationNumber, nextStation, line),
+    [arrived, currentStationNumber, line, nextStation]
   );
 
   return (

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -180,7 +180,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
   const prevStateText = useValueRef(stateText).current;
   const prevBoundText = useValueRef(boundText).current;
   const { trainType, headerState } = useRecoilValue(navigationState);
-  const { stations, selectedBound, selectedDirection } =
+  const { stations, selectedBound, selectedDirection, arrived } =
     useRecoilValue(stationState);
   const prevHeaderStateRef = useRef(headerState);
 
@@ -596,18 +596,17 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
   }, [headerState, line, nextStation?.currentLine]);
 
   const currentStationNumber = useMemo(
-    () => getCurrentStationNumber(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationNumber(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const threeLetterCode = useMemo(
-    () => getCurrentStationThreeLetterCode(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationThreeLetterCode(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const lineColor = useMemo(() => line && `#${line.lineColorC}`, [line]);
   const numberingColor = useMemo(
-    () =>
-      getNumberingColor(headerState, currentStationNumber, nextStation, line),
-    [currentStationNumber, headerState, line, nextStation]
+    () => getNumberingColor(arrived, currentStationNumber, nextStation, line),
+    [arrived, currentStationNumber, line, nextStation]
   );
 
   return (

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -153,7 +153,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
   const prevStateText = useValueRef(stateText).current;
   const prevBoundText = useValueRef(boundText).current;
   const { headerState, trainType } = useRecoilValue(navigationState);
-  const { stations, selectedDirection, selectedBound } =
+  const { stations, selectedDirection, selectedBound, arrived } =
     useRecoilValue(stationState);
   const prevHeaderStateRef = useRef(headerState);
 
@@ -559,18 +559,17 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
   }, [headerState, line, nextStation?.currentLine]);
 
   const currentStationNumber = useMemo(
-    () => getCurrentStationNumber(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationNumber(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const threeLetterCode = useMemo(
-    () => getCurrentStationThreeLetterCode(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationThreeLetterCode(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const lineColor = useMemo(() => line && `#${line.lineColorC}`, [line]);
   const numberingColor = useMemo(
-    () =>
-      getNumberingColor(headerState, currentStationNumber, nextStation, line),
-    [currentStationNumber, headerState, line, nextStation]
+    () => getNumberingColor(arrived, currentStationNumber, nextStation, line),
+    [arrived, currentStationNumber, line, nextStation]
   );
 
   return (

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -138,7 +138,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
   const prevStationName = useValueRef(stationText).current;
   const prevStateText = useValueRef(stateText).current;
   const prevBoundText = useValueRef(boundText).current;
-  const { selectedBound, stations, selectedDirection } =
+  const { selectedBound, stations, selectedDirection, arrived } =
     useRecoilValue(stationState);
   const { headerState, trainType } = useRecoilValue(navigationState);
   const prevHeaderStateRef = useRef(headerState);
@@ -551,18 +551,17 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
   }, [headerState, line, nextStation?.currentLine]);
 
   const currentStationNumber = useMemo(
-    () => getCurrentStationNumber(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationNumber(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const threeLetterCode = useMemo(
-    () => getCurrentStationThreeLetterCode(headerState, station, nextStation),
-    [headerState, nextStation, station]
+    () => getCurrentStationThreeLetterCode(arrived, station, nextStation),
+    [arrived, nextStation, station]
   );
   const lineColor = useMemo(() => line && `#${line.lineColorC}`, [line]);
   const numberingColor = useMemo(
-    () =>
-      getNumberingColor(headerState, currentStationNumber, nextStation, line),
-    [currentStationNumber, headerState, line, nextStation]
+    () => getNumberingColor(arrived, currentStationNumber, nextStation, line),
+    [arrived, currentStationNumber, line, nextStation]
   );
 
   return (

--- a/src/hooks/useFetchNearbyStation.ts
+++ b/src/hooks/useFetchNearbyStation.ts
@@ -32,6 +32,10 @@ const useFetchNearbyStation = (): [
         distance
         latitude
         longitude
+        stationNumbers {
+          lineSymbolColor
+          stationNumber
+        }
         lines {
           id
           companyId

--- a/src/hooks/useFetchNearbyStation.ts
+++ b/src/hooks/useFetchNearbyStation.ts
@@ -35,6 +35,7 @@ const useFetchNearbyStation = (): [
         stationNumbers {
           lineSymbolColor
           stationNumber
+          lineSymbol
         }
         lines {
           id
@@ -46,6 +47,9 @@ const useFetchNearbyStation = (): [
           nameZh
           nameKo
           lineType
+          lineSymbols {
+            lineSymbol
+          }
         }
       }
     }

--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -28,6 +28,7 @@ const useResetMainState = (): (() => void) => {
       ...prev,
       selectedDirection: null,
       selectedBound: null,
+      arrived: true,
     }));
     setSpeech((prev) => ({
       ...prev,

--- a/src/hooks/useStationList.ts
+++ b/src/hooks/useStationList.ts
@@ -29,6 +29,7 @@ const useStationList = (): [
         stationNumbers {
           lineSymbolColor
           stationNumber
+          lineSymbol
         }
         threeLetterCode
         lines {
@@ -41,6 +42,9 @@ const useStationList = (): [
           nameZh
           nameKo
           lineType
+          lineSymbols {
+            lineSymbol
+          }
         }
         trainTypes {
           id
@@ -58,6 +62,9 @@ const useStationList = (): [
             nameK
             lineColorC
             companyId
+            lineSymbols {
+              lineSymbol
+            }
             company {
               nameR
               nameEn
@@ -78,6 +85,9 @@ const useStationList = (): [
               name
               nameR
               lineColorC
+              lineSymbols {
+                lineSymbol
+              }
             }
           }
         }

--- a/src/hooks/useStationListByTrainType.ts
+++ b/src/hooks/useStationListByTrainType.ts
@@ -37,6 +37,7 @@ const useStationListByTrainType = (): [
           stationNumbers {
             lineSymbolColor
             stationNumber
+            lineSymbol
           }
           threeLetterCode
           currentLine {
@@ -49,6 +50,9 @@ const useStationListByTrainType = (): [
             nameZh
             nameKo
             lineType
+            lineSymbols {
+              lineSymbol
+            }
             company {
               nameR
               nameEn
@@ -64,6 +68,9 @@ const useStationListByTrainType = (): [
             nameZh
             nameKo
             lineType
+            lineSymbols {
+              lineSymbol
+            }
             company {
               nameR
               nameEn
@@ -77,6 +84,9 @@ const useStationListByTrainType = (): [
           nameK
           lineColorC
           companyId
+          lineSymbols {
+            lineSymbol
+          }
           company {
             nameR
             nameEn

--- a/src/models/StationAPI.ts
+++ b/src/models/StationAPI.ts
@@ -109,6 +109,11 @@ export interface Company {
   nameEn: string;
 }
 
+export interface LineSymbol {
+  lineSymbol: string;
+  lineSymbolColor: string;
+}
+
 export interface Line {
   id: number;
   companyId: number;
@@ -119,6 +124,7 @@ export interface Line {
   nameZh: string;
   nameKo: string;
   lineType: LineType;
+  lineSymbols: LineSymbol[];
   company: Company;
   __typename: 'Line';
 }

--- a/src/store/atoms/station.ts
+++ b/src/store/atoms/station.ts
@@ -20,7 +20,7 @@ export interface StationState {
 const stationState = atom<StationState>({
   key: RECOIL_STATES.station,
   default: {
-    arrived: false,
+    arrived: true,
     approaching: false,
     station: null,
     stations: [],

--- a/src/utils/numbering.ts
+++ b/src/utils/numbering.ts
@@ -1,26 +1,21 @@
-import { HeaderTransitionState } from '../models/HeaderTransitionState';
 import { Line, Station, StationNumber } from '../models/StationAPI';
 
 export const getCurrentStationNumber = (
-  headerState: HeaderTransitionState,
+  arrived: boolean,
   station: Station,
   nextStation?: Station
 ): StationNumber | undefined =>
-  headerState.split('_')[0] === 'CURRENT'
-    ? station.stationNumbers?.[0]
-    : nextStation?.stationNumbers?.[0];
+  arrived ? station.stationNumbers?.[0] : nextStation?.stationNumbers?.[0];
 
 export const getCurrentStationThreeLetterCode = (
-  headerState: HeaderTransitionState,
+  arrived: boolean,
   station: Station,
   nextStation?: Station
 ): string | undefined =>
-  headerState.split('_')[0] === 'CURRENT'
-    ? station.threeLetterCode
-    : nextStation?.threeLetterCode;
+  arrived ? station.threeLetterCode : nextStation?.threeLetterCode;
 
 export const getNumberingColor = (
-  headerState: HeaderTransitionState,
+  arrived: boolean,
   currentStationNumber: StationNumber | undefined,
   nextStation: Station | undefined,
   line: Line | null | undefined
@@ -28,7 +23,7 @@ export const getNumberingColor = (
   if (currentStationNumber?.lineSymbolColor) {
     return `#${currentStationNumber?.lineSymbolColor}`;
   }
-  if (headerState.split('_')[0] !== 'CURRENT' && nextStation?.currentLine) {
+  if (arrived && nextStation?.currentLine) {
     return `#${nextStation.currentLine?.lineColorC}`;
   }
   return `#${line?.lineColorC}`;

--- a/src/utils/numbering.ts
+++ b/src/utils/numbering.ts
@@ -4,8 +4,17 @@ export const getCurrentStationNumber = (
   arrived: boolean,
   station: Station,
   nextStation?: Station
-): StationNumber | undefined =>
-  arrived ? station.stationNumbers?.[0] : nextStation?.stationNumbers?.[0];
+): StationNumber | undefined => {
+  if (arrived) {
+    const matchedStationNumber = station.stationNumbers.find((sn) =>
+      station.currentLine?.lineSymbols.find(
+        (ls) => ls.lineSymbol === sn.lineSymbol
+      )
+    );
+    return matchedStationNumber;
+  }
+  return nextStation?.stationNumbers[0];
+};
 
 export const getCurrentStationThreeLetterCode = (
   arrived: boolean,


### PR DESCRIPTION
![simulator_screenshot_D65333DF-296F-496C-9595-0A26BED18265](https://user-images.githubusercontent.com/32848922/169661562-7b645edd-5ed8-4642-aec7-a0479e8d04af.png)
- 豊洲駅でゆりかもめなのに有楽町線のナンバリングが出るバグも修正
- 路線に種別データがはいっていないときはナンバリングが表示されない既知のバグが存在するので後で直さないといけない