### PR TITLE
位置情報取得調整

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -292,7 +292,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     ) : null;
 
   const { showActionSheetWithOptions } = useActionSheet();
-  const isActionSheetAlreadyPresentRef = useRef(false);
 
   const handleShare = useCallback(async () => {
     if (!viewShotRef || !currentLine) {
@@ -360,10 +359,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       return;
     }
 
-    if (
-      nativeEvent.state === State.ACTIVE &&
-      !isActionSheetAlreadyPresentRef.current
-    ) {
+    if (nativeEvent.state === State.ACTIVE) {
       await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
       const buttons = Platform.select({
@@ -387,8 +383,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           cancelButtonIndex: (buttons || []).length - 1,
         },
         (buttonIndex) => {
-          isActionSheetAlreadyPresentRef.current = true;
-
           switch (buttonIndex) {
             // iOS: back, Android: share
             case 0:
@@ -431,7 +425,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
             default:
               break;
           }
-          isActionSheetAlreadyPresentRef.current = false;
         }
       );
     }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -109,12 +109,6 @@ export const PREFS_EN = [
   'Okinawa',
 ];
 
-export const LOCATION_TASK_NAME = 'trainlcd-background-location-task';
-// 位置情報更新間隔(ms)
-export const LOCATION_DEFERRED_UPDATES_INTERVAL = 10 * 1000;
-// 位置情報取得タイムアウト(ms)
-export const LOCATION_DEFERRED_UPDATE_TIMEOUT = 30 * 1000;
-
 export const RUNNING_DURATION = 15000;
 export const STOPPING_DURATION = RUNNING_DURATION + 1000;
 export const WHOLE_DURATION = RUNNING_DURATION + STOPPING_DURATION;
@@ -127,5 +121,3 @@ export const MS_POLLING_INTERVAL = 1000 * 30;
 export const MS_LONG_DURATION_THRESHOLD = 1000 * 60;
 
 export const STATION_NAME_FONT_SIZE = RFValue(45);
-
-export const HUBENY_ACCURACY = 100;

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -1,0 +1,5 @@
+export const LOCATION_TASK_NAME = 'trainlcd-background-location-task';
+// 位置情報更新間隔(ms)
+export const LOCATION_DEFERRED_UPDATES_INTERVAL = 10 * 1000;
+// 端末上の駅直線距離計算誤差(m)
+export const GET_DISTANCE_ACCURACY = 1000;

--- a/src/hooks/useMirroringShare.ts
+++ b/src/hooks/useMirroringShare.ts
@@ -8,11 +8,8 @@ import * as geolib from 'geolib';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
-import {
-  LOCATION_TASK_NAME,
-  MS_LONG_DURATION_THRESHOLD,
-  MS_POLLING_INTERVAL,
-} from '../constants';
+import { MS_LONG_DURATION_THRESHOLD, MS_POLLING_INTERVAL } from '../constants';
+import { LOCATION_TASK_NAME } from '../constants/location';
 import { LineDirection } from '../models/Bound';
 import { LatLon } from '../models/LatLon';
 import {

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -3,7 +3,7 @@ import * as geolib from 'geolib';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Vibration } from 'react-native';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { HUBENY_ACCURACY } from '../constants';
+import { GET_DISTANCE_ACCURACY } from '../constants/location';
 import { LineType, Station } from '../models/StationAPI';
 import locationState from '../store/atoms/location';
 import navigationState from '../store/atoms/navigation';
@@ -132,7 +132,7 @@ const useRefreshStation = (): void => {
         const distance = geolib.getDistance(
           { latitude, longitude },
           { latitude: s.latitude, longitude: s.longitude },
-          HUBENY_ACCURACY
+          GET_DISTANCE_ACCURACY
         );
         return { ...s, distance };
       });

--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -3,7 +3,7 @@ import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { LOCATION_TASK_NAME } from '../constants';
+import { LOCATION_TASK_NAME } from '../constants/location';
 import navigationState from '../store/atoms/navigation';
 import speechState from '../store/atoms/speech';
 import stationState from '../store/atoms/station';

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -18,12 +18,11 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import LineBoard from '../components/LineBoard';
 import Transfers from '../components/Transfers';
 import TypeChangeNotify from '../components/TypeChangeNotify';
+import AsyncStorageKeys from '../constants/asyncStorageKeys';
 import {
   LOCATION_DEFERRED_UPDATES_INTERVAL,
-  LOCATION_DEFERRED_UPDATE_TIMEOUT,
   LOCATION_TASK_NAME,
-} from '../constants';
-import AsyncStorageKeys from '../constants/asyncStorageKeys';
+} from '../constants/location';
 import useAutoMode from '../hooks/useAutoMode';
 import useCurrentLine from '../hooks/useCurrentLine';
 import useNextTrainTypeIsDifferent from '../hooks/useNextTrainTypeIsDifferent';
@@ -57,8 +56,7 @@ if (!isLocationTaskDefined) {
     }
     const { locations } = data as { locations: LocationObject[] };
     if (locations[0]) {
-      console.log(locations[0].coords.latitude, locations[0].coords.longitude);
-      globalSetBGLocation(locations[0]);
+      requestAnimationFrame(() => globalSetBGLocation(locations[0]));
     }
   });
 }
@@ -179,9 +177,8 @@ const MainScreen: React.FC = () => {
       );
       if (!isStarted) {
         await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-          accuracy: Location.Accuracy.High,
+          accuracy: Location.Accuracy.Balanced,
           deferredUpdatesInterval: LOCATION_DEFERRED_UPDATES_INTERVAL,
-          deferredUpdatesTimeout: LOCATION_DEFERRED_UPDATE_TIMEOUT,
           foregroundService: {
             notificationTitle: translate('bgAlertTitle'),
             notificationBody: translate('bgAlertContent'),

--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -16,7 +16,7 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import Button from '../components/Button';
 import ErrorScreen from '../components/ErrorScreen';
 import Heading from '../components/Heading';
-import { LOCATION_TASK_NAME } from '../constants';
+import { LOCATION_TASK_NAME } from '../constants/location';
 import useStationList from '../hooks/useStationList';
 import useStationListByTrainType from '../hooks/useStationListByTrainType';
 import { directionToDirectionName, LineDirection } from '../models/Bound';

--- a/src/utils/stationDistance.ts
+++ b/src/utils/stationDistance.ts
@@ -1,4 +1,5 @@
 import * as geolib from 'geolib';
+import { GET_DISTANCE_ACCURACY } from '../constants/location';
 import { Station } from '../models/StationAPI';
 
 // 駅配列から平均駅間距離（直線距離）を求める
@@ -15,7 +16,8 @@ export const getAvgStationBetweenDistances = (stations: Station[]): number =>
         const { latitude: prevLatitude, longitude: prevLongitude } = prev;
         const distance = geolib.getDistance(
           { latitude, longitude },
-          { latitude: prevLatitude, longitude: prevLongitude }
+          { latitude: prevLatitude, longitude: prevLongitude },
+          GET_DISTANCE_ACCURACY
         );
         return acc + distance;
       }, 0) / stations.length;


### PR DESCRIPTION
- 位置情報取得タイムアウトの撤廃
- `geolib.getDistance()` の精度を1000m変更
- 位置情報更新時にrafを使用
- 位置情報精度をbalancedに変更
- 不要なActionSheet関係の処理を削除