### PR TITLE
阪神・山陽線ナンバリング記号実装

### DIFF
--- a/ios/TrainLCD/Info.plist
+++ b/ios/TrainLCD/Info.plist
@@ -57,6 +57,7 @@
 		<string>Fonts/FrutigerNeueLTPro-Bold.ttf</string>
 		<string>Fonts/FuturaLTPro-Bold.ttf</string>
 		<string>Fonts/myriadpro-bold.ttf</string>
+		<string>Fonts/verdana-bold.ttf</string>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>

--- a/src/components/NumberingIcon.tsx
+++ b/src/components/NumberingIcon.tsx
@@ -15,6 +15,7 @@ import NumberingIconReversedRoundHorizontal from './NumberingIconReversedRoundHo
 import NumberingIconReversedSquare from './NumberingIconReversedSquare';
 import NumberingIconReversedSquareWest from './NumberingIconReversedSquareWest';
 import NumberingIconRound from './NumberingIconRound';
+import NumberingIconSanyo from './NumberingIconSanyo';
 import NumberingIconSapporo from './NumberingIconSapporo';
 import NumberingIconSquare from './NumberingIconSquare';
 import NumberingIconTWR from './NumberingIconTWR';
@@ -59,6 +60,14 @@ const NumberingIcon: React.FC<Props> = ({
     case MarkShape.hanshin:
       return (
         <NumberingIconHanshin
+          lineColor={lineColor}
+          stationNumber={stationNumber}
+          size={size}
+        />
+      );
+    case MarkShape.sanyo:
+      return (
+        <NumberingIconSanyo
           lineColor={lineColor}
           stationNumber={stationNumber}
           size={size}

--- a/src/components/NumberingIcon.tsx
+++ b/src/components/NumberingIcon.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { MarkShape, NumberingIconSize } from '../constants/numbering';
 import NumberingIconHalfSquare from './NumberingIconHalfSquare';
+import NumberingIconHankyu from './NumberingIconHankyu';
+import NumberingIconHanshin from './NumberingIconHanshin';
 import NumberingIconKeihan from './NumberingIconKeihan';
 import NumberingIconKeikyu from './NumberingIconKeikyu';
 import NumberingIconKeio from './NumberingIconKeio';
@@ -13,7 +15,6 @@ import NumberingIconReversedRoundHorizontal from './NumberingIconReversedRoundHo
 import NumberingIconReversedSquare from './NumberingIconReversedSquare';
 import NumberingIconReversedSquareWest from './NumberingIconReversedSquareWest';
 import NumberingIconRound from './NumberingIconRound';
-import NumberingIconRoundThin from './NumberingIconRoundThin';
 import NumberingIconSapporo from './NumberingIconSapporo';
 import NumberingIconSquare from './NumberingIconSquare';
 import NumberingIconTWR from './NumberingIconTWR';
@@ -47,9 +48,17 @@ const NumberingIcon: React.FC<Props> = ({
           size={size}
         />
       );
-    case MarkShape.roundThin:
+    case MarkShape.hankyu:
       return (
-        <NumberingIconRoundThin
+        <NumberingIconHankyu
+          lineColor={lineColor}
+          stationNumber={stationNumber}
+          size={size}
+        />
+      );
+    case MarkShape.hanshin:
+      return (
+        <NumberingIconHanshin
           lineColor={lineColor}
           stationNumber={stationNumber}
           size={size}

--- a/src/components/NumberingIcon.tsx
+++ b/src/components/NumberingIcon.tsx
@@ -54,7 +54,6 @@ const NumberingIcon: React.FC<Props> = ({
         <NumberingIconHankyu
           lineColor={lineColor}
           stationNumber={stationNumber}
-          size={size}
         />
       );
     case MarkShape.hanshin:
@@ -62,7 +61,6 @@ const NumberingIcon: React.FC<Props> = ({
         <NumberingIconHanshin
           lineColor={lineColor}
           stationNumber={stationNumber}
-          size={size}
         />
       );
     case MarkShape.sanyo:
@@ -104,7 +102,6 @@ const NumberingIcon: React.FC<Props> = ({
         <NumberingIconKeikyu
           lineColor={lineColor}
           stationNumber={stationNumber}
-          size={size}
         />
       );
     case MarkShape.kintetsu:

--- a/src/components/NumberingIconHankyu.tsx
+++ b/src/components/NumberingIconHankyu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import FONTS from '../constants/fonts';
 import { NumberingIconSize } from '../constants/numbering';
@@ -74,10 +74,6 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? -4 : -2,
   },
-  longStationNumberAdditional: {
-    fontSize: isTablet ? 20 * 1.5 : 20,
-    letterSpacing: -2,
-  },
 });
 
 const NumberingIconHankyu: React.FC<Props> = ({
@@ -87,13 +83,6 @@ const NumberingIconHankyu: React.FC<Props> = ({
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
-  const isIncludesSubNumber = stationNumber.includes('-');
-  const stationNumberTextStyles = useMemo(() => {
-    if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
-    }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
 
   if (size === 'tiny') {
     return (
@@ -127,7 +116,7 @@ const NumberingIconHankyu: React.FC<Props> = ({
       <Text style={[styles.lineSymbol, { color: lineColor }]}>
         {lineSymbol}
       </Text>
-      <Text style={[stationNumberTextStyles, { color: lineColor }]}>
+      <Text style={[styles.stationNumber, { color: lineColor }]}>
         {stationNumber}
       </Text>
     </View>

--- a/src/components/NumberingIconHankyu.tsx
+++ b/src/components/NumberingIconHankyu.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import FONTS from '../constants/fonts';
-import { NumberingIconSize } from '../constants/numbering';
 import isTablet from '../utils/isTablet';
 
 type Props = {
   stationNumber: string;
   lineColor: string;
-  size?: NumberingIconSize;
 };
 
 const styles = StyleSheet.create({
@@ -28,45 +26,6 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? 4 : 2,
   },
-  rootTiny: {
-    width: 25.6,
-    height: 25.6,
-    borderRadius: 25.6 / 2,
-    borderWidth: 4,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  rootSmall: {
-    width: 38,
-    height: 38,
-    borderRadius: 38 / 2,
-    borderWidth: 6,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  lineSymbolTiny: {
-    fontSize: 14,
-    lineHeight: 14,
-    textAlign: 'center',
-    fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: 2,
-  },
-  lineSymbolSmall: {
-    fontSize: 18,
-    lineHeight: 18,
-    textAlign: 'center',
-    fontFamily: FONTS.FrutigerNeueLTProBold,
-  },
-  lineSymbolSmallLong: {
-    fontSize: 12,
-    lineHeight: 12,
-    textAlign: 'center',
-    fontFamily: FONTS.FrutigerNeueLTProBold,
-  },
   stationNumber: {
     fontSize: isTablet ? 35 * 1.5 : 35,
     lineHeight: isTablet ? 35 * 1.5 : 35,
@@ -79,37 +38,9 @@ const styles = StyleSheet.create({
 const NumberingIconHankyu: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
   lineColor,
-  size,
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
-
-  if (size === 'tiny') {
-    return (
-      <View style={[styles.rootTiny, { borderColor: lineColor }]}>
-        <Text style={[styles.lineSymbolTiny, { color: lineColor }]}>
-          {lineSymbol}
-        </Text>
-      </View>
-    );
-  }
-
-  if (size === 'small') {
-    return (
-      <View style={[styles.rootSmall, { borderColor: lineColor }]}>
-        <Text
-          style={[
-            lineSymbol.length === 2
-              ? styles.lineSymbolSmallLong
-              : styles.lineSymbolSmall,
-            { color: lineColor },
-          ]}
-        >
-          {lineSymbol}
-        </Text>
-      </View>
-    );
-  }
 
   return (
     <View style={[styles.root, { borderColor: lineColor }]}>
@@ -121,10 +52,6 @@ const NumberingIconHankyu: React.FC<Props> = ({
       </Text>
     </View>
   );
-};
-
-NumberingIconHankyu.defaultProps = {
-  size: 'default',
 };
 
 export default NumberingIconHankyu;

--- a/src/components/NumberingIconHankyu.tsx
+++ b/src/components/NumberingIconHankyu.tsx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const NumberingIconRoundThin: React.FC<Props> = ({
+const NumberingIconHankyu: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
   lineColor,
   size,
@@ -134,8 +134,8 @@ const NumberingIconRoundThin: React.FC<Props> = ({
   );
 };
 
-NumberingIconRoundThin.defaultProps = {
+NumberingIconHankyu.defaultProps = {
   size: 'default',
 };
 
-export default NumberingIconRoundThin;
+export default NumberingIconHankyu;

--- a/src/components/NumberingIconHanshin.tsx
+++ b/src/components/NumberingIconHanshin.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import FONTS from '../constants/fonts';
-import { NumberingIconSize } from '../constants/numbering';
 import isTablet from '../utils/isTablet';
 
 type Props = {
   stationNumber: string;
   lineColor: string;
-  size?: NumberingIconSize;
 };
 
 const styles = StyleSheet.create({
@@ -28,45 +26,6 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.VerdanaBold,
     marginTop: isTablet ? 4 : 2,
   },
-  rootTiny: {
-    width: 25.6,
-    height: 25.6,
-    borderRadius: 25.6 / 2,
-    borderWidth: 4,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  rootSmall: {
-    width: 38,
-    height: 38,
-    borderRadius: 38 / 2,
-    borderWidth: 6,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  lineSymbolTiny: {
-    fontSize: 14,
-    lineHeight: 14,
-    textAlign: 'center',
-    fontFamily: FONTS.VerdanaBold,
-    marginTop: 2,
-  },
-  lineSymbolSmall: {
-    fontSize: 18,
-    lineHeight: 18,
-    textAlign: 'center',
-    fontFamily: FONTS.VerdanaBold,
-  },
-  lineSymbolSmallLong: {
-    fontSize: 12,
-    lineHeight: 12,
-    textAlign: 'center',
-    fontFamily: FONTS.VerdanaBold,
-  },
   stationNumber: {
     fontSize: isTablet ? 35 * 1.5 : 35,
     lineHeight: isTablet ? 35 * 1.5 : 35,
@@ -79,37 +38,9 @@ const styles = StyleSheet.create({
 const NumberingIconHanshin: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
   lineColor,
-  size,
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
-
-  if (size === 'tiny') {
-    return (
-      <View style={[styles.rootTiny, { borderColor: lineColor }]}>
-        <Text style={[styles.lineSymbolTiny, { color: lineColor }]}>
-          {lineSymbol}
-        </Text>
-      </View>
-    );
-  }
-
-  if (size === 'small') {
-    return (
-      <View style={[styles.rootSmall, { borderColor: lineColor }]}>
-        <Text
-          style={[
-            lineSymbol.length === 2
-              ? styles.lineSymbolSmallLong
-              : styles.lineSymbolSmall,
-            { color: lineColor },
-          ]}
-        >
-          {lineSymbol}
-        </Text>
-      </View>
-    );
-  }
 
   return (
     <View style={[styles.root, { borderColor: lineColor }]}>
@@ -121,10 +52,6 @@ const NumberingIconHanshin: React.FC<Props> = ({
       </Text>
     </View>
   );
-};
-
-NumberingIconHanshin.defaultProps = {
-  size: 'default',
 };
 
 export default NumberingIconHanshin;

--- a/src/components/NumberingIconHanshin.tsx
+++ b/src/components/NumberingIconHanshin.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import FONTS from '../constants/fonts';
+import { NumberingIconSize } from '../constants/numbering';
+import isTablet from '../utils/isTablet';
+
+type Props = {
+  stationNumber: string;
+  lineColor: string;
+  size?: NumberingIconSize;
+};
+
+const styles = StyleSheet.create({
+  root: {
+    width: isTablet ? 72 * 1.5 : 72,
+    height: isTablet ? 72 * 1.5 : 72,
+    borderRadius: (isTablet ? 72 * 1.5 : 72) / 2,
+    borderWidth: isTablet ? 4 * 1.5 : 4,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    backgroundColor: 'white',
+  },
+  lineSymbol: {
+    fontSize: isTablet ? 21 * 1.5 : 21,
+    lineHeight: isTablet ? 21 * 1.5 : 21,
+    textAlign: 'center',
+    fontFamily: FONTS.VerdanaBold,
+    marginTop: isTablet ? 4 : 2,
+  },
+  rootTiny: {
+    width: 25.6,
+    height: 25.6,
+    borderRadius: 25.6 / 2,
+    borderWidth: 4,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    backgroundColor: 'white',
+  },
+  rootSmall: {
+    width: 38,
+    height: 38,
+    borderRadius: 38 / 2,
+    borderWidth: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    backgroundColor: 'white',
+  },
+  lineSymbolTiny: {
+    fontSize: 14,
+    lineHeight: 14,
+    textAlign: 'center',
+    fontFamily: FONTS.VerdanaBold,
+    marginTop: 2,
+  },
+  lineSymbolSmall: {
+    fontSize: 18,
+    lineHeight: 18,
+    textAlign: 'center',
+    fontFamily: FONTS.VerdanaBold,
+  },
+  lineSymbolSmallLong: {
+    fontSize: 12,
+    lineHeight: 12,
+    textAlign: 'center',
+    fontFamily: FONTS.VerdanaBold,
+  },
+  stationNumber: {
+    fontSize: isTablet ? 35 * 1.5 : 35,
+    lineHeight: isTablet ? 35 * 1.5 : 35,
+    textAlign: 'center',
+    fontFamily: FONTS.VerdanaBold,
+    marginTop: isTablet ? -4 : -2,
+  },
+  longStationNumberAdditional: {
+    fontSize: isTablet ? 20 * 1.5 : 20,
+    letterSpacing: -2,
+  },
+});
+
+const NumberingIconHanshin: React.FC<Props> = ({
+  stationNumber: stationNumberRaw,
+  lineColor,
+  size,
+}: Props) => {
+  const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
+  const stationNumber = stationNumberRest.join('-');
+  const isIncludesSubNumber = stationNumber.includes('-');
+  const stationNumberTextStyles = useMemo(() => {
+    if (isIncludesSubNumber) {
+      return [styles.stationNumber, styles.longStationNumberAdditional];
+    }
+    return styles.stationNumber;
+  }, [isIncludesSubNumber]);
+
+  if (size === 'tiny') {
+    return (
+      <View style={[styles.rootTiny, { borderColor: lineColor }]}>
+        <Text style={[styles.lineSymbolTiny, { color: lineColor }]}>
+          {lineSymbol}
+        </Text>
+      </View>
+    );
+  }
+
+  if (size === 'small') {
+    return (
+      <View style={[styles.rootSmall, { borderColor: lineColor }]}>
+        <Text
+          style={[
+            lineSymbol.length === 2
+              ? styles.lineSymbolSmallLong
+              : styles.lineSymbolSmall,
+            { color: lineColor },
+          ]}
+        >
+          {lineSymbol}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.root, { borderColor: lineColor }]}>
+      <Text style={[styles.lineSymbol, { color: lineColor }]}>
+        {lineSymbol}
+      </Text>
+      <Text style={[stationNumberTextStyles, { color: lineColor }]}>
+        {stationNumber}
+      </Text>
+    </View>
+  );
+};
+
+NumberingIconHanshin.defaultProps = {
+  size: 'default',
+};
+
+export default NumberingIconHanshin;

--- a/src/components/NumberingIconHanshin.tsx
+++ b/src/components/NumberingIconHanshin.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import FONTS from '../constants/fonts';
 import { NumberingIconSize } from '../constants/numbering';
@@ -74,10 +74,6 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.VerdanaBold,
     marginTop: isTablet ? -4 : -2,
   },
-  longStationNumberAdditional: {
-    fontSize: isTablet ? 20 * 1.5 : 20,
-    letterSpacing: -2,
-  },
 });
 
 const NumberingIconHanshin: React.FC<Props> = ({
@@ -87,13 +83,6 @@ const NumberingIconHanshin: React.FC<Props> = ({
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
-  const isIncludesSubNumber = stationNumber.includes('-');
-  const stationNumberTextStyles = useMemo(() => {
-    if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
-    }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
 
   if (size === 'tiny') {
     return (
@@ -127,7 +116,7 @@ const NumberingIconHanshin: React.FC<Props> = ({
       <Text style={[styles.lineSymbol, { color: lineColor }]}>
         {lineSymbol}
       </Text>
-      <Text style={[stationNumberTextStyles, { color: lineColor }]}>
+      <Text style={[styles.stationNumber, { color: lineColor }]}>
         {stationNumber}
       </Text>
     </View>

--- a/src/components/NumberingIconKeikyu.tsx
+++ b/src/components/NumberingIconKeikyu.tsx
@@ -1,13 +1,11 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import FONTS from '../constants/fonts';
-import { NumberingIconSize } from '../constants/numbering';
 import isTablet from '../utils/isTablet';
 
 type Props = {
   stationNumber: string;
   lineColor: string;
-  size?: NumberingIconSize;
 };
 
 const styles = StyleSheet.create({
@@ -28,41 +26,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
-  rootTiny: {
-    width: 25.6,
-    height: 25.6,
-    borderRadius: 25.6 / 2,
-    borderWidth: 4,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  rootSmall: {
-    width: 38,
-    height: 38,
-    borderRadius: 38 / 2,
-    borderWidth: 6,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'column',
-    backgroundColor: 'white',
-  },
-  lineSymbolTiny: {
-    color: '#00386D',
-    fontSize: 14,
-    lineHeight: 14,
-    textAlign: 'center',
-    fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
-  },
-  lineSymbolSmall: {
-    color: '#00386D',
-    fontSize: 22 * 0.75,
-    lineHeight: 22 * 0.75,
-    textAlign: 'center',
-    fontFamily: FONTS.FuturaLTPro,
-  },
   stationNumber: {
     color: '#00386D',
     fontSize: isTablet ? 26 * 1.5 : 26,
@@ -79,7 +42,6 @@ const styles = StyleSheet.create({
 const NumberingIconKeikyu: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
   lineColor,
-  size,
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
@@ -91,32 +53,12 @@ const NumberingIconKeikyu: React.FC<Props> = ({
     return styles.stationNumber;
   }, [isIncludesSubNumber]);
 
-  if (size === 'tiny') {
-    return (
-      <View style={[styles.rootTiny, { borderColor: lineColor }]}>
-        <Text style={styles.lineSymbolTiny}>{lineSymbol}</Text>
-      </View>
-    );
-  }
-
-  if (size === 'small') {
-    return (
-      <View style={[styles.rootSmall, { borderColor: lineColor }]}>
-        <Text style={styles.lineSymbolSmall}>{lineSymbol}</Text>
-      </View>
-    );
-  }
-
   return (
     <View style={[styles.root, { borderColor: lineColor }]}>
       <Text style={styles.lineSymbol}>{lineSymbol}</Text>
       <Text style={stationNumberTextStyles}>{stationNumber}</Text>
     </View>
   );
-};
-
-NumberingIconKeikyu.defaultProps = {
-  size: 'default',
 };
 
 export default NumberingIconKeikyu;

--- a/src/components/NumberingIconSanyo.tsx
+++ b/src/components/NumberingIconSanyo.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import FONTS from '../constants/fonts';
+import { NumberingIconSize } from '../constants/numbering';
+import isTablet from '../utils/isTablet';
+
+type Props = {
+  stationNumber: string;
+  lineColor: string;
+  size?: NumberingIconSize;
+};
+
+const styles = StyleSheet.create({
+  root: {
+    borderWidth: isTablet ? 4 : 2,
+    width: isTablet ? 72 * 1.5 : 72,
+    height: isTablet ? 72 * 1.5 : 72,
+    borderRadius: isTablet ? 72 * 1.5 : 72,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  inner: {
+    width: isTablet ? 66 * 1.5 : 66,
+    height: isTablet ? 66 * 1.5 : 66,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    borderRadius: isTablet ? 70 * 1.5 : 70,
+    borderWidth: 1,
+    borderColor: 'white',
+  },
+  lineSymbol: {
+    color: 'white',
+    fontSize: isTablet ? 20 * 1.5 : 20,
+    lineHeight: isTablet ? 20 * 1.5 : 20,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    marginTop: isTablet ? 4 * 1.2 : 4,
+  },
+  rootTiny: {
+    width: 25.6,
+    height: 25.6,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 16.8,
+    borderWidth: 1,
+  },
+  tinyInner: {
+    width: 21.6,
+    height: 21.6,
+    borderRadius: 21.6 / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  rootSmall: {
+    width: isTablet ? 38 * 1.5 : 38,
+    height: isTablet ? 38 * 1.5 : 38,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    borderRadius: isTablet ? 38 * 1.5 : 38,
+    borderWidth: isTablet ? 2 : 1,
+    borderColor: 'white',
+  },
+  smallInner: {
+    width: isTablet ? 33 * 1.5 : 33,
+    height: isTablet ? 33 * 1.5 : 33,
+    borderRadius: (isTablet ? 33 * 1.5 : 33) / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  lineSymbolTiny: {
+    color: 'white',
+    fontSize: 12,
+    lineHeight: 12,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    marginTop: 2,
+  },
+  lineSymbolSmall: {
+    color: 'white',
+    fontSize: isTablet ? 18 * 1.5 : 18,
+    lineHeight: isTablet ? 18 * 1.5 : 18,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    marginTop: isTablet ? 6 : 4,
+  },
+  stationNumber: {
+    color: 'white',
+    fontSize: isTablet ? 35 * 1.5 : 35,
+    lineHeight: isTablet ? 35 * 1.5 : 35,
+    marginTop: isTablet ? -2 * 1.2 : -2,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+  },
+});
+
+const NumberingIconSanyo: React.FC<Props> = ({
+  stationNumber: stationNumberRaw,
+  lineColor,
+  size,
+}: Props) => {
+  const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
+  const stationNumber = stationNumberRest.join('');
+
+  if (size === 'tiny') {
+    return (
+      <View style={[styles.rootTiny, { borderColor: lineColor }]}>
+        <View style={[styles.tinyInner, { backgroundColor: lineColor }]}>
+          <Text style={styles.lineSymbolTiny}>{lineSymbol}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (size === 'small') {
+    return (
+      <View style={[styles.rootSmall, { borderColor: lineColor }]}>
+        <View style={[styles.smallInner, { backgroundColor: lineColor }]}>
+          <Text style={styles.lineSymbolSmall}>{lineSymbol}</Text>
+        </View>
+      </View>
+    );
+  }
+  return (
+    <View style={[styles.root, { borderColor: lineColor }]}>
+      <View style={[styles.inner, { backgroundColor: lineColor }]}>
+        <Text style={styles.lineSymbol}>{lineSymbol}</Text>
+        <Text style={styles.stationNumber}>{stationNumber}</Text>
+      </View>
+    </View>
+  );
+};
+
+NumberingIconSanyo.defaultProps = {
+  size: 'default',
+};
+
+export default NumberingIconSanyo;

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -13,6 +13,10 @@ const FONTS = {
     ios: 'Frutiger Neue LT Pro',
     android: 'FrutigerNeueLTPro-Bold',
   }),
+  VerdanaBold: Platform.select({
+    ios: 'Verdana Bold',
+    android: 'verdana-bold',
+  }),
 };
 
 export default FONTS;

--- a/src/constants/numbering.ts
+++ b/src/constants/numbering.ts
@@ -17,6 +17,7 @@ export enum MarkShape {
   keihan,
   hankyu,
   hanshin,
+  sanyo,
   jrUnion,
   bulletTrainUnion,
 }

--- a/src/constants/numbering.ts
+++ b/src/constants/numbering.ts
@@ -1,6 +1,5 @@
 export enum MarkShape {
   round,
-  roundThin,
   reversedRound,
   reversedRoundHorizontal,
   square,
@@ -16,6 +15,8 @@ export enum MarkShape {
   kintetsu,
   nankai,
   keihan,
+  hankyu,
+  hanshin,
   jrUnion,
   bulletTrainUnion,
 }

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1280,6 +1280,11 @@ export const getLineMark = (line: Line): LineMark | null => {
         signPath: require('../assets/marks/osakametro/y.png'),
       };
     case 99621: // 大阪メトロ中央線
+      return {
+        shape: MarkShape.reversedRound,
+        sign: 'C',
+        signPath: require('../assets/marks/osakametro/c.png'),
+      };
     case 99622: // 大阪メトロ千日前線
       return {
         shape: MarkShape.reversedRound,

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1359,6 +1359,13 @@ export const getLineMark = (line: Line): LineMark | null => {
         sign: 'HS',
         signPath: require('../assets/marks/hanshin/hs.png'),
       };
+    // 山陽電鉄
+    case 99637:
+    case 99638:
+      return {
+        shape: MarkShape.sanyo,
+        sign: 'SY',
+      };
     // 近鉄
     case 31001: // 難波線
     case 31020: // 奈良線

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1331,14 +1331,14 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 34005: // 甲陽線
     case 34006: // 伊丹線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kobe.png'),
       };
     case 34002: // 宝塚線
     case 34007: // 箕面線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/takarazuka.png'),
       };
@@ -1346,7 +1346,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 34008: // 千里線
     case 34009: // 嵐山線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kyoto.png'),
       };
@@ -1355,7 +1355,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 35002: // なんば線
     case 35003: // 武庫川線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hanshin,
         sign: 'HS',
         signPath: require('../assets/marks/hanshin/hs.png'),
       };
@@ -1487,7 +1487,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 99634: // 公園都市線
     case 99635: // 粟生線
       return {
-        shape: MarkShape.reversedRound,
+        shape: MarkShape.hanshin,
         sign: 'KB',
         signPath: require('../assets/marks/kobe/kb.png'),
       };
@@ -2984,14 +2984,14 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 34005: // 甲陽線
     case 34006: // 伊丹線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kobe_g.png'),
       };
     case 34002: // 宝塚線
     case 34007: // 箕面線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/takarazuka_g.png'),
       };
@@ -2999,7 +2999,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 34008: // 千里線
     case 34009: // 嵐山線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hankyu,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kyoto_g.png'),
       };
@@ -3008,7 +3008,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 35002: // なんば線
     case 35003: // 武庫川線
       return {
-        shape: MarkShape.roundThin,
+        shape: MarkShape.hanshin,
         sign: 'HS',
         signPath: require('../assets/marks/hanshin/hs_g.png'),
       };


### PR DESCRIPTION
![simulator_screenshot_25BB1175-44FA-4053-B3ED-CF4F68E32610](https://user-images.githubusercontent.com/32848922/178144923-e83f1bc8-f9bb-4646-b3b0-28016e74fbc8.png)
![simulator_screenshot_A5AD6480-3A5F-468E-B230-6F27EB3BA1F9](https://user-images.githubusercontent.com/32848922/178149723-edc32469-71bc-41a0-9a33-61325a25bcd9.png)


`roundThin` シェイプを阪神・阪急両方に使っていましたが `roundThin` を `hankyu` に改名して阪急のみで使用し、 `hanshin` シェイプを新規に実装して阪神電車全線で使うように修正しました
阪神の記号には新しくVerdana Boldを使ってます