### PR TITLE
いくつかの路線ナンバリング対応

### DIFF
--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1702,6 +1702,19 @@ export const getLineMark = (line: Line): LineMark | null => {
         shape: MarkShape.round,
         sign: 'AN',
       };
+    case 99614: // 北大阪急行線
+      return {
+        shape: MarkShape.reversedRound,
+        sign: 'M',
+      };
+    case 99626: // 大阪モノレール線
+      return {
+        shape: MarkShape.reversedSquare,
+      };
+    case 99530: // 伊勢鉄道伊勢線
+      return {
+        shape: MarkShape.round,
+      };
     default:
       return null;
   }
@@ -3355,6 +3368,19 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       return {
         shape: MarkShape.round,
         sign: 'AN',
+      };
+    case 99614: // 北大阪急行線
+      return {
+        shape: MarkShape.reversedRound,
+        sign: 'M',
+      };
+    case 99626: // 大阪モノレール線
+      return {
+        shape: MarkShape.reversedSquare,
+      };
+    case 99530: // 伊勢鉄道伊勢線
+      return {
+        shape: MarkShape.round,
       };
     default:
       return null;

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -1715,6 +1715,11 @@ export const getLineMark = (line: Line): LineMark | null => {
       return {
         shape: MarkShape.round,
       };
+    case 99407: // 上高地線
+      return {
+        shape: MarkShape.round,
+        sign: 'AK',
+      };
     default:
       return null;
   }
@@ -3381,6 +3386,11 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 99530: // 伊勢鉄道伊勢線
       return {
         shape: MarkShape.round,
+      };
+    case 99407: // 上高地線
+      return {
+        shape: MarkShape.round,
+        sign: 'AK',
       };
     default:
       return null;

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -970,6 +970,7 @@ export const getLineMark = (line: Line): LineMark | null => {
         sign: 'JB',
       };
     case 11908: // 福北ゆたか線
+    case 11911: // 福北ゆたか線(折尾～桂川)
       return {
         shape: MarkShape.halfSquare,
         sign: 'JC',
@@ -2630,6 +2631,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
         sign: 'JB',
       };
     case 11908: // 福北ゆたか線
+    case 11911: // 福北ゆたか線(折尾～桂川)
       return {
         shape: MarkShape.reversedSquare,
         sign: 'JC',


### PR DESCRIPTION
#1571

ナンバリングシンボルがない大阪モノレール線と伊勢鉄道伊勢線の表示には https://github.com/TrainLCD/StationAPI/pull/326 のマージが必須