### PR TITLE
種別変更通知バグ修正

### DIFF
--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -10,7 +10,6 @@ import useCurrentLine from '../hooks/useCurrentLine';
 import { APITrainType, StopCondition } from '../models/StationAPI';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
-import getIsPass from '../utils/isPass';
 import isTablet from '../utils/isTablet';
 import { getIsLocal } from '../utils/localType';
 import { heightScale, widthScale } from '../utils/scale';
@@ -158,16 +157,16 @@ const TypeChangeNotify: React.FC = () => {
   );
   const afterAllStopLastStation =
     reversedStations[reversedFinalPassedStationIndex - 1];
-  const currentLineIsStopAtAllStations = !stations
-    .filter((s) => s.currentLine?.id === currentLine?.id)
-    .filter((s) => getIsPass(s)).length;
+  // 「~から先は各駅に止まります」を表示するフラグ
   const isNextTypeIsLocal =
+    // 次の路線の種別が各停・普通
     getIsLocal(nextTrainType) &&
-    !currentLineIsStopAtAllStations &&
-    selectedDirection === 'INBOUND'
-      ? reversedCurrentStationIndex > reversedFinalPassedStationIndex
-      : reversedCurrentStationIndex < reversedFinalPassedStationIndex;
-
+    // 現在の種別が各停・普通の場合は表示しない
+    !getIsLocal(typedTrainType) &&
+    // 最後に各駅に停まる駅の路線が次の路線の種別と同じ
+    afterAllStopLastStation?.currentLine?.id === nextTrainType?.id &&
+    // 次の停車駅パターン変更駅が現在の駅より前の駅ではない
+    reversedCurrentStationIndex > reversedFinalPassedStationIndex;
   const currentLineLastStation = useMemo(() => {
     if (
       isNextTypeIsLocal &&

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -156,7 +156,7 @@ const TypeChangeNotify: React.FC = () => {
     (s) => s.groupId === station?.groupId
   );
   const afterAllStopLastStation =
-    reversedStations[reversedFinalPassedStationIndex - 1];
+    reversedStations[reversedFinalPassedStationIndex - 2];
   // 「~から先は各駅に止まります」を表示するフラグ
   const isNextTypeIsLocal =
     // 次の路線の種別が各停・普通
@@ -164,7 +164,7 @@ const TypeChangeNotify: React.FC = () => {
     // 現在の種別が各停・普通の場合は表示しない
     !getIsLocal(typedTrainType) &&
     // 最後に各駅に停まる駅の路線が次の路線の種別と同じ
-    afterAllStopLastStation?.currentLine?.id === nextTrainType?.id &&
+    afterAllStopLastStation?.currentLine?.id === nextTrainType?.line?.id &&
     // 次の停車駅パターン変更駅が現在の駅より前の駅ではない
     reversedCurrentStationIndex > reversedFinalPassedStationIndex;
   const currentLineLastStation = useMemo(() => {


### PR DESCRIPTION
https://github.com/TrainLCD/MobileApp/pull/1581 のデグレ
下記のバグを修正
- 次の路線から各駅に停まるわけじゃないのに表示される
  - 中央林間から久喜方面に向かうと「新越谷から先は〜」が表示されてしまう
  - ちなみに南町田から久喜方面を見ると東武動物公園で変わる表示になる
 - 次の路線から快速になるのに「各駅に止まります」と表示される
   - 福知山から嵯峨野線直通で京都方面を見ると亀岡から先は各駅に停まる扱いになる（実際は園部から快速に変わる）
 
## 種別変更になるパターン
![simulator_screenshot_3D283272-1002-476A-87E9-3EC00B3F6504](https://user-images.githubusercontent.com/32848922/179785517-a5d4c6e6-0b22-4e8c-9a32-dc324588ed84.png)
![simulator_screenshot_0E397B38-9535-4700-8808-46DCB8030925](https://user-images.githubusercontent.com/32848922/179785723-efc92fde-3a38-45c2-a6db-6dc7821fbb15.png)
![simulator_screenshot_BBDA0C56-FC91-4D4A-9FE2-C262813E8AEA](https://user-images.githubusercontent.com/32848922/179785847-c141ff78-b626-4371-8ff4-f97194553c4f.png)

## 各駅に止まるパターン
![simulator_screenshot_FDFFC5FE-8513-4528-AB43-67001236F99B](https://user-images.githubusercontent.com/32848922/179793843-00d9a39d-3525-4eb3-aea4-e1e237360b14.png)

## 下記の通り前回の修正からのデグレは見つかっていない
![simulator_screenshot_D8191848-8B9A-4DAD-8E33-B9A037690E4F](https://user-images.githubusercontent.com/32848922/179786016-0341df83-b125-4ed5-802f-99fbdaddd4c2.png)
 