### PR TITLE
nameではなくgroupIdで比較

### DIFF
--- a/src/utils/nextStation.ts
+++ b/src/utils/nextStation.ts
@@ -8,7 +8,7 @@ const outboundCurrentStationIndex = (
   stations
     .slice()
     .reverse()
-    .findIndex((s) => s?.name === station?.name);
+    .findIndex((s) => s?.groupId === station?.groupId);
 
 export const getNextOutboundStopStation = (
   stations: Station[],
@@ -28,7 +28,7 @@ export const getNextOutboundStopStation = (
 const inboundCurrentStationIndex = (
   stations: Station[],
   station: Station | null | undefined
-): number => stations.slice().findIndex((s) => s?.name === station?.name);
+): number => stations.slice().findIndex((s) => s?.groupId === station?.groupId);
 
 export const getNextInboundStopStation = (
   stations: Station[],


### PR DESCRIPTION
closes #1736
`src/utils/nextStation.ts`を作ったときからnameで比較していたのでデグレの可能性あり