### PR TITLE
useCurrentStation実装

### DIFF
--- a/src/hooks/useCurrentStation.ts
+++ b/src/hooks/useCurrentStation.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import { Station } from '../models/StationAPI';
+import stationState from '../store/atoms/station';
+
+const useCurrentStation = (withTrainTypes?: boolean): Station | undefined => {
+  const { station, rawStations, stationsWithTrainTypes } =
+    useRecoilValue(stationState);
+  const stations = useMemo(
+    () => (withTrainTypes ? stationsWithTrainTypes : rawStations),
+    [rawStations, stationsWithTrainTypes, withTrainTypes]
+  );
+
+  return stations.find((rs) => rs.groupId === station?.groupId);
+};
+
+export default useCurrentStation;

--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -6,6 +6,7 @@ import { StationNumber } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import useCurrentLine from './useCurrentLine';
+import useCurrentStation from './useCurrentStation';
 import useNextStation from './useNextStation';
 
 const useNumbering = (
@@ -15,22 +16,14 @@ const useNumbering = (
   string | undefined,
   MarkShape | null | undefined
 ] => {
-  const { arrived, station, rawStations } = useRecoilValue(stationState);
+  const { arrived } = useRecoilValue(stationState);
 
   const [stationNumber, setStationNumber] = useState<StationNumber>();
   const [threeLetterCode, setThreeLetterCode] = useState<string>();
   const line = useCurrentLine();
 
   const nextStation = useNextStation();
-  const currentStation = useMemo(
-    () =>
-      rawStations.find(
-        (rs) =>
-          rs.groupId === station?.groupId &&
-          (rs.currentLine ? rs.currentLine?.id === line?.id : true)
-      ),
-    [rawStations, line?.id, station?.groupId]
-  );
+  const currentStation = useCurrentStation();
 
   useEffect(() => {
     if (arrived || forceCurrent) {

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -1,20 +1,20 @@
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import navigationState from '../store/atoms/navigation';
-import stationState from '../store/atoms/station';
 import { isJapanese } from '../translation';
 import {
   startLiveActivity,
   stopLiveActivity,
   updateLiveActivity,
 } from '../utils/native/liveActivityModule';
+import useCurrentStation from './useCurrentStation';
 import useNextStation from './useNextStation';
 import useNumbering from './useNumbering';
 
 const useUpdateLiveActivities = (): void => {
   const { headerState } = useRecoilValue(navigationState);
-  const { station } = useRecoilValue(stationState);
 
+  const currentStation = useCurrentStation();
   const nextStation = useNextStation();
   const [currentNumbering] = useNumbering(true);
   const [nextNumbering] = useNumbering();
@@ -27,7 +27,9 @@ const useUpdateLiveActivities = (): void => {
 
   useEffect(() => {
     updateLiveActivity({
-      stationName: isJapanese ? station?.name ?? '' : station?.nameR ?? '',
+      stationName: isJapanese
+        ? currentStation?.name ?? ''
+        : currentStation?.nameR ?? '',
       nextStationName: isJapanese
         ? nextStation?.name ?? ''
         : nextStation?.nameR ?? '',
@@ -38,12 +40,12 @@ const useUpdateLiveActivities = (): void => {
     });
   }, [
     currentNumbering?.stationNumber,
+    currentStation?.name,
+    currentStation?.nameR,
     headerState,
     nextNumbering?.stationNumber,
     nextStation?.name,
     nextStation?.nameR,
-    station?.name,
-    station?.nameR,
   ]);
 };
 

--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -1,5 +1,5 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -14,6 +14,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import Button from '../components/Button';
 import ErrorScreen from '../components/ErrorScreen';
 import Heading from '../components/Heading';
+import useCurrentStation from '../hooks/useCurrentStation';
 import useStationList from '../hooks/useStationList';
 import useStationListByTrainType from '../hooks/useStationListByTrainType';
 import { directionToDirectionName, LineDirection } from '../models/Bound';
@@ -82,10 +83,8 @@ const SelectBoundScreen: React.FC = () => {
     setStation,
   ] = useRecoilState(stationState);
 
-  const currentStation = useMemo(
-    () => stationsWithTrainTypes.find((s) => station?.groupId === s.groupId),
-    [station?.groupId, stationsWithTrainTypes]
-  );
+  const currentStation = useCurrentStation(true);
+
   const [withTrainTypes, setWithTrainTypes] = useState(false);
   const localType = findLocalType(
     stationsWithTrainTypes.find((s) => station?.groupId === s.groupId)

--- a/src/screens/TrainTypeSettingsScreen.tsx
+++ b/src/screens/TrainTypeSettingsScreen.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, BackHandler, StyleSheet, View } from 'react-native';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import FAB from '../components/FAB';
 import Heading from '../components/Heading';
+import useCurrentStation from '../hooks/useCurrentStation';
 import { APITrainType, TrainDirection } from '../models/StationAPI';
 import lineState from '../store/atoms/line';
 import navigationState from '../store/atoms/navigation';
@@ -22,15 +23,12 @@ const styles = StyleSheet.create({
 
 const TrainTypeSettings: React.FC = () => {
   const { selectedLine } = useRecoilValue(lineState);
-  const { station, stationsWithTrainTypes } = useRecoilValue(stationState);
   const { trainType } = useRecoilValue(navigationState);
   const navigation = useNavigation();
   const [trainTypes, setTrainTypes] = useState<APITrainType[]>([]);
 
-  const currentStation = useMemo(
-    () => stationsWithTrainTypes.find((s) => station?.groupId === s.groupId),
-    [station?.groupId, stationsWithTrainTypes]
-  );
+  const currentStation = useCurrentStation(true);
+
   const items = useMemo(
     () =>
       trainTypes.map((tt) => ({


### PR DESCRIPTION
Live Activities動作時　急行種別を選択時に通過駅で「ただいま」ステートならないようにもした ref: #1734
本当は前の停車駅を表示したい(スクショははこね号新宿駅発):
![simulator_screenshot_168FD0B4-B307-47B1-A009-CEEE727D4B8F](https://user-images.githubusercontent.com/32848922/194802123-6df93873-a033-42a3-96b5-244e99e09a1d.png)
