### PR TITLE
iPhone 14 Proでの種別変更通知のレイアウト改善

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1140,7 +1140,7 @@ PODS:
     - React-Core
   - RNCPicker (2.4.2):
     - React-Core
-  - RNDeviceInfo (8.7.1):
+  - RNDeviceInfo (10.2.1):
     - React-Core
   - RNFastImage (8.5.11):
     - React-Core
@@ -1567,7 +1567,7 @@ SPEC CHECKSUMS:
   ReactCommon: ab1003b81be740fecd82509c370a45b1a7dda0c1
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
-  RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
+  RNDeviceInfo: c31137f22ee779fe3931d1a8d60cc1af80ef4077
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNFBApp: 9646e09d041ea159b84584865212e4cf33acd179
   RNFBAuth: af943e3ba071b5f4d18896c31e6cba3a77b1fa08

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.5",
     "react-native-anchor-point": "^1.0.2",
-    "react-native-device-info": "^8.4.7",
+    "react-native-device-info": "^10.2.1",
     "react-native-fast-image": "^8.3.7",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "~2.5.0",

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -220,10 +220,10 @@ const TypeChangeNotify: React.FC = () => {
       const first = nextTrainType.nameR[0].toLowerCase();
       switch (first) {
         case 'a':
-        case 'i':
-        case 'u':
         case 'e':
+        case 'i':
         case 'o':
+        case 'u':
           return 'an';
         default:
           return 'a';

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useMemo } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
-import { hasDynamicIsland, hasNotch } from 'react-native-device-info';
+import { hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../constants/regexp';
@@ -256,26 +256,14 @@ const TypeChangeNotify: React.FC = () => {
     if (isTablet) {
       return widthScale(barRight - 64);
     }
-    if (hasDynamicIsland()) {
-      return widthScale(barRight);
-    }
-    if (!hasNotch()) {
-      return widthScale(barRight);
-    }
-    return widthScale(barRight - 32);
+    return widthScale(barRight);
   }, []);
 
   const trainTypeRightVal = useMemo(() => {
     if (isTablet) {
       return widthScale(barRight - 84);
     }
-    if (hasDynamicIsland()) {
-      return widthScale(barRight);
-    }
-    if (!hasNotch()) {
-      return widthScale(barRight);
-    }
-    return widthScale(barRight - 32);
+    return widthScale(barRight);
   }, []);
 
   const lineTextTopVal = useMemo(() => {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useMemo } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
-import { hasNotch } from 'react-native-device-info';
+import { hasDynamicIsland, hasNotch } from 'react-native-device-info';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useRecoilValue } from 'recoil';
 import { parenthesisRegexp } from '../constants/regexp';
@@ -256,6 +256,9 @@ const TypeChangeNotify: React.FC = () => {
     if (isTablet) {
       return widthScale(barRight - 64);
     }
+    if (hasDynamicIsland()) {
+      return widthScale(barRight);
+    }
     if (!hasNotch()) {
       return widthScale(barRight);
     }
@@ -265,6 +268,9 @@ const TypeChangeNotify: React.FC = () => {
   const trainTypeRightVal = useMemo(() => {
     if (isTablet) {
       return widthScale(barRight - 84);
+    }
+    if (hasDynamicIsland()) {
+      return widthScale(barRight);
     }
     if (!hasNotch()) {
       return widthScale(barRight);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9444,10 +9444,10 @@ react-native-codegen@^0.69.2:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-device-info@^8.4.7:
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.7.1.tgz#fbb06f87dbbc4423abe713874699fb2e6e99fd15"
-  integrity sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==
+react-native-device-info@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.2.1.tgz#49189a73aba4804f61c5075c074d19db4a6e0f49"
+  integrity sha512-vXmcLThnCnrdhiJr7O4jaDY/xouFRshhGAU4HYkiSi5ShSXE+QqFQwKqICdHtw06VeX3ydZg3j0puG0lbTKVEA==
 
 react-native-fast-image@^8.3.7:
   version "8.5.11"


### PR DESCRIPTION
closes #1740

ライブラリのバージョン上げただけでそこそこなんとかなったがデグレったのでiPhone 14 Pro向けの修正を追加