### PR TITLE
LineBoardでuseCurrentLineを使う

### DIFF
--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text } from 'react-native';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRecoilValue } from 'recoil';
+import useCurrentLine from '../hooks/useCurrentLine';
 import { StopCondition } from '../models/StationAPI';
 import AppTheme from '../models/Theme';
 import lineState from '../store/atoms/line';
@@ -32,6 +33,7 @@ const styles = StyleSheet.create({
 });
 
 const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
+  const currentLine = useCurrentLine();
   const { theme } = useRecoilValue(themeState);
   const { station } = useRecoilValue(stationState);
   const { selectedLine } = useRecoilValue(lineState);
@@ -71,13 +73,16 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
 
   // [重要] 依存変数をすべてメモ化しないと山手線iPadテーマのアニメーションが何度も走る
   const Inner = useCallback(() => {
+    if (!selectedLine) {
+      return null;
+    }
     switch (theme) {
       case AppTheme.JRWest:
         return (
           <LineBoardWest
             lineColors={lineColors}
             stations={slicedLeftStations}
-            line={belongingLines[0] || selectedLine}
+            line={currentLine || selectedLine}
             lines={belongingLines}
           />
         );
@@ -86,7 +91,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
         return (
           <LineBoardSaikyo
             stations={slicedLeftStations}
-            line={belongingLines[0] || selectedLine}
+            line={currentLine || selectedLine}
             lines={belongingLines}
             hasTerminus={hasTerminus}
             lineColors={lineColors}
@@ -96,7 +101,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
         return (
           <LineBoardLightweight
             stations={slicedLeftStations}
-            line={belongingLines[0] || selectedLine}
+            line={currentLine || selectedLine}
             lines={belongingLines}
             lineColors={lineColors}
           />
@@ -106,14 +111,14 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
           return (
             <LineBoardYamanotePad
               stations={slicedLeftStationsForYamanote}
-              line={belongingLines[0] || selectedLine}
+              line={currentLine || selectedLine}
             />
           );
         }
         return (
           <LineBoardEast
             stations={slicedLeftStations}
-            line={belongingLines[0] || selectedLine}
+            line={currentLine || selectedLine}
             hasTerminus={hasTerminus}
             lines={belongingLines}
             lineColors={lineColors}
@@ -124,7 +129,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
         return (
           <LineBoardEast
             stations={slicedLeftStations}
-            line={belongingLines[0] || selectedLine}
+            line={currentLine || selectedLine}
             hasTerminus={hasTerminus}
             lines={belongingLines}
             lineColors={lineColors}
@@ -134,6 +139,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus }: Props) => {
     }
   }, [
     belongingLines,
+    currentLine,
     hasTerminus,
     lineColors,
     selectedLine,


### PR DESCRIPTION
JYテーマ(iPad)でヘッダーのラインカラーとアニメーションの色が違うバグを修正