### PR TITLE
接続駅データ破棄処理のロールバック

### DIFF
--- a/src/utils/dropJunctionStation.ts
+++ b/src/utils/dropJunctionStation.ts
@@ -8,7 +8,7 @@ const dropEitherJunctionStation = (
 ): Station[] =>
   stations.filter((s, i, arr): boolean => {
     const station = direction === 'INBOUND' ? arr[i - 1] : arr[i + 1];
-    if (station?.name === s.name && station?.groupId === s.groupId) {
+    if (station?.groupId === s.groupId) {
       return !station;
     }
     return true;


### PR DESCRIPTION
closes #1806

[データの方を修正](https://github.com/TrainLCD/StationAPI/pull/428)してアプリ側のコードは不要になったと思うのでもとに戻した