### PR TITLE
ナンバリング情報がないときにWatch Appでリスト表示から除外されるバグを修正

### DIFF
--- a/ios/WatchApp Extension/Views/StationListView.swift
+++ b/ios/WatchApp Extension/Views/StationListView.swift
@@ -29,7 +29,8 @@ struct StationListView: View {
                 Text("\(isJa ? station.name : station.nameR)(\(stationNumber))")
                   .opacity(station.pass ? 0.25 : 1)
               } else {
-                EmptyView()
+                Text("\(isJa ? station.name : station.nameR)")
+                  .opacity(station.pass ? 0.25 : 1)
               }
             }
           }


### PR DESCRIPTION
closes #1811 