### PR TITLE
#1820 のデグレ修正とナンバリングバグ修正

### DIFF
--- a/src/components/TransferLineMark.tsx
+++ b/src/components/TransferLineMark.tsx
@@ -81,12 +81,12 @@ const TransferLineMark: React.FC<Props> = ({
   return (
     <View style={numberingIvonContainerStyle}>
       <NumberingIcon
-        shape={mark.shape}
+        shape={mark.signShape}
         lineColor={
           shouldGrayscale ? fadedLineColor : color || `#${line?.lineColorC}`
         }
         stationNumber={`${
-          mark.shape === MARK_SHAPE.JR_UNION ? 'JR' : mark.sign || ''
+          mark.signShape === MARK_SHAPE.JR_UNION ? 'JR' : mark.sign || ''
         }-00`}
         size={size}
       />

--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -153,7 +153,7 @@ const Transfers: React.FC<Props> = ({
                   {lineMark && stationNumbers?.[index]?.stationNumber ? (
                     <View style={styles.numberingIconContainer}>
                       <NumberingIcon
-                        shape={lineMark.shape}
+                        shape={lineMark.signShape}
                         lineColor={`#${stationNumbers?.[index]?.lineSymbolColor}`}
                         stationNumber={
                           stationNumbers?.[index]?.stationNumber ?? ''

--- a/src/hooks/useGetLineMark.ts
+++ b/src/hooks/useGetLineMark.ts
@@ -29,6 +29,7 @@ const useGetLineMark = (): ((
         ...lineMarkOriginal,
         sign: lineMarkOriginal.subSign,
         signPath: lineMarkOriginal.subSignPath,
+        signShape: lineMarkOriginal.subSignShape,
         subSign: undefined,
         subSignPath: undefined,
       } as LineMark;
@@ -36,6 +37,7 @@ const useGetLineMark = (): ((
     if (!transferStationsSymbols.includes(lineMarkOriginal.subSign)) {
       return {
         ...lineMarkOriginal,
+        signShape: lineMarkOriginal.subSignShape,
         subSign: undefined,
         subSignPath: undefined,
       } as LineMark;

--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -4,7 +4,6 @@ import { MarkShape } from '../constants/numbering';
 import { StationNumber } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
-import useCurrentLine from './useCurrentLine';
 import useCurrentStation from './useCurrentStation';
 import useGetLineMark from './useGetLineMark';
 import useNextStation from './useNextStation';
@@ -20,7 +19,6 @@ const useNumbering = (
 
   const [stationNumber, setStationNumber] = useState<StationNumber>();
   const [threeLetterCode, setThreeLetterCode] = useState<string>();
-  const line = useCurrentLine();
 
   const nextStation = useNextStation();
   const currentStation = useCurrentStation();
@@ -59,24 +57,23 @@ const useNumbering = (
   const getLineMarkFunc = useGetLineMark();
 
   const lineMarkShape = useMemo(() => {
-    if (
-      (!arrived && !priorCurrent && nextStation?.currentLine) ||
-      (getIsPass(currentStation) && nextStation?.currentLine)
-    ) {
-      return getLineMarkFunc(nextStation, nextStation.currentLine)?.shape;
+    const currentStationLineMark =
+      currentStation &&
+      getLineMarkFunc(currentStation, currentStation.currentLine);
+    const nextStationLineMark =
+      nextStation && getLineMarkFunc(nextStation, nextStation.currentLine);
+
+    if (priorCurrent && !getIsPass(currentStation)) {
+      return currentStationLineMark?.signShape;
     }
 
-    return (
-      currentStation && line && getLineMarkFunc(currentStation, line)?.shape
-    );
-  }, [
-    arrived,
-    currentStation,
-    getLineMarkFunc,
-    line,
-    nextStation,
-    priorCurrent,
-  ]);
+    if (arrived) {
+      return getIsPass(currentStation)
+        ? nextStationLineMark?.signShape
+        : currentStationLineMark?.signShape;
+    }
+    return nextStationLineMark?.signShape;
+  }, [arrived, currentStation, getLineMarkFunc, nextStation, priorCurrent]);
 
   return [stationNumber, threeLetterCode, lineMarkShape];
 };

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -159,7 +159,7 @@ const useRefreshLeftStations = (
         ? getStationsForLoopLine(currentIndex)
         : getStations(currentIndex);
     setNavigation((prev) => {
-      const isChanged = leftStations[0]?.id !== prev.leftStations[0]?.id;
+      const isChanged = leftStations[1]?.id !== prev.leftStations[1]?.id;
       if (!isChanged) {
         return prev;
       }

--- a/src/hooks/useStationList.ts
+++ b/src/hooks/useStationList.ts
@@ -32,6 +32,24 @@ const useStationList = (): [
           lineSymbol
         }
         threeLetterCode
+        currentLine {
+          id
+          companyId
+          lineColorC
+          name
+          nameR
+          nameK
+          nameZh
+          nameKo
+          lineType
+          lineSymbols {
+            lineSymbol
+          }
+          company {
+            nameR
+            nameEn
+          }
+        }
         lines {
           id
           companyId

--- a/src/lineMark.ts
+++ b/src/lineMark.ts
@@ -3,10 +3,11 @@ import { MarkShape, MARK_SHAPE } from './constants/numbering';
 import { Line } from './models/StationAPI';
 
 export interface LineMark {
-  shape: MarkShape;
+  signShape: MarkShape;
   sign?: string;
   subSign?: string;
   signPath?: number;
+  subSignShape?: MarkShape;
   subSignPath?: number;
   jrUnionSigns?: string[];
   jrUnionSignPaths?: number[];
@@ -22,14 +23,14 @@ export const getLineMark = (line: Line): LineMark | null => {
     // 新幹線
     case 1002: // 東海道新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrc.png'),
       };
     case 1003: // 山陽新幹線
     case 11901: // 博多南線（これは新幹線にするべきなんだろうか）
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrw.png'),
       };
@@ -39,25 +40,25 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 1007: // 山形新幹線
     case 1008: // 秋田新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jre.png'),
       };
     case 1009: // 北陸新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrc.png'),
       };
     case 1010: // 九州新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrk.png'),
       };
     case 1011:
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/shinkansen/jrh.png'),
       };
@@ -80,57 +81,57 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11116:
     case 11117:
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
       };
     // 札幌市営地下鉄
     case 99102: // 南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
         signPath: require('../assets/marks/sapporosubway/n.png'),
       };
     case 99101: // 東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/sapporosubway/t.png'),
       };
     case 99103: // 東豊線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/sapporosubway/h.png'),
       };
     // 函館市電
     case 99105: // ２系統
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
       };
     case 99106: // ５系統
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'D',
       };
     case 99108: // 道南いさりび鉄道線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'sh',
       };
     // 仙台市交通局
     case 99214: // 南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     case 99218: // 東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
       };
     case 11301: // 東海道線（東日本区間）
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JT',
         signPath: require('../assets/marks/jre/jt.png'),
       };
@@ -138,38 +139,38 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11314: // 総武本線
     case 11327: // 成田線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JO',
         signPath: require('../assets/marks/jre/jo.png'),
       };
     case 11332: // 京浜東北線
     case 11307: // 根岸線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JK',
         signPath: require('../assets/marks/jre/jk.png'),
       };
     case 11306: // 横浜線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JH',
         signPath: require('../assets/marks/jre/jh.png'),
       };
     case 11303: // 南武線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JN',
         signPath: require('../assets/marks/jre/jn.png'),
       };
     case 11304: // 鶴見線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JI',
         signPath: require('../assets/marks/jre/ji.png'),
       };
     case 11302: // 山手線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JY',
         signPath: require('../assets/marks/jre/jy.png'),
       };
@@ -177,13 +178,13 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11315: // 青梅線
     case 11316: // 五日市線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JC',
         signPath: require('../assets/marks/jre/jc.png'),
       };
     case 11311: // 中央本線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JC',
         signPath: require('../assets/marks/jre/jc.png'),
         subSign: 'CO',
@@ -191,7 +192,7 @@ export const getLineMark = (line: Line): LineMark | null => {
       };
     case 11313: // 中央・総武線各駅停車
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JB',
         signPath: require('../assets/marks/jre/jb.png'),
       };
@@ -199,25 +200,25 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11323: // 高崎線
     case 11343: // 上野東京ライン
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JU',
         signPath: require('../assets/marks/jre/ju.png'),
       };
     case 11321: // 埼京線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JA',
         signPath: require('../assets/marks/jre/ja.png'),
       };
     case 11229: // JR常磐線(取手～いわき)
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JJ',
         signPath: require('../assets/marks/jre/jj.png'),
       };
     case 11320: // JR常磐線(上野～取手)
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JJ',
         signPath: require('../assets/marks/jre/jj.png'),
         subSign: 'JL',
@@ -225,41 +226,41 @@ export const getLineMark = (line: Line): LineMark | null => {
       };
     case 11326: // 京葉線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JE',
         signPath: require('../assets/marks/jre/je.png'),
       };
     case 11305: // 武蔵野線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JM',
         signPath: require('../assets/marks/jre/jm.png'),
       };
     case 11333: // 湘南新宿ライン
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JS',
         signPath: require('../assets/marks/jre/js.png'),
       };
     case 11328: // 成田エクスプレス
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '',
       };
     case 99309:
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TX',
       };
     case 99336: // 東京モノレール
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'MO',
         signPath: require('../assets/marks/tokyomonorail/mo.png'),
       };
     case 99337: // りんかい線
       return {
-        shape: MARK_SHAPE.TWR,
+        signShape: MARK_SHAPE.TWR,
         sign: 'R',
         signPath: require('../assets/marks/rinkai/r.png'),
       };
@@ -270,39 +271,39 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 22004: // 豊島線
     case 22005: // 狭山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SI',
         signPath: require('../assets/marks/seibu/si.png'),
       };
     case 22006: // 西武山口線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SY',
         signPath: require('../assets/marks/seibu/sy.png'),
       };
     case 22007: // 新宿線
     case 22008: // 拝島線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SS',
         signPath: require('../assets/marks/seibu/ss.png'),
       };
     case 22009: // 西武園線
     case 22010: // 国分寺線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SK',
         signPath: require('../assets/marks/seibu/sk.png'),
       };
     case 22011: // 多摩湖線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'ST',
         signPath: require('../assets/marks/seibu/st.png'),
       };
     case 22012: // 多摩川線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SW',
         signPath: require('../assets/marks/seibu/sw.png'),
       };
@@ -310,13 +311,13 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 21001: // 東上線
     case 21007: // 越生線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TJ',
         signPath: require('../assets/marks/tobu/tj.png'),
       };
     case 21002: // 伊勢崎線（スカイツリーライン）
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TS',
         signPath: require('../assets/marks/tobu/ts.png'),
         subSign: 'TI',
@@ -325,7 +326,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 21005: // 亀戸線
     case 21006: // 大師線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TS',
         signPath: require('../assets/marks/tobu/ts.png'),
       };
@@ -333,7 +334,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 21011: // 桐生線
     case 21012: // 小泉線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TI',
         signPath: require('../assets/marks/tobu/ti.png'),
       };
@@ -341,13 +342,13 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 21008: // 宇都宮線
     case 21009: // 鬼怒川線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TN',
         signPath: require('../assets/marks/tobu/tn.png'),
       };
     case 21004: // 野田線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TD',
         signPath: require('../assets/marks/tobu/td.png'),
       };
@@ -358,62 +359,62 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 27004: // 逗子線
     case 27005: // 久里浜線
       return {
-        shape: MARK_SHAPE.KEIKYU,
+        signShape: MARK_SHAPE.KEIKYU,
         sign: 'KK',
         signPath: require('../assets/marks/keikyu/kk.png'),
       };
     // 東急
     case 26001: // 東横線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TY',
         signPath: require('../assets/marks/tokyu/ty.png'),
       };
     case 26002: // 目黒線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'MG',
         signPath: require('../assets/marks/tokyu/mg.png'),
       };
     case 26003: // 田園都市線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'DT',
         signPath: require('../assets/marks/tokyu/dt.png'),
       };
     case 26004: // 大井町線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'OM',
         signPath: require('../assets/marks/tokyu/om.png'),
       };
     case 26005: // 池上線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'IK',
         signPath: require('../assets/marks/tokyu/ik.png'),
       };
     case 26006: // 多摩川線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TM',
         signPath: require('../assets/marks/tokyu/tm.png'),
       };
     case 26007: // 世田谷線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_DARK_TEXT,
         sign: 'SG',
         signPath: require('../assets/marks/tokyu/sg.png'),
       };
     case 26008: // こどもの国線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'KD',
         signPath: require('../assets/marks/tokyu/kd.png'),
       };
     case 99310: // みなとみらい線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'MM',
         signPath: require('../assets/marks/minatomirai/mm.png'),
       };
@@ -422,159 +423,159 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 29002: // いずみ野線
     case 29003: // 新横浜線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'SO',
         signPath: require('../assets/marks/sotetsu/so.png'),
       };
     // 横浜市交通局
     case 99316: // ブルーライン
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'B',
         signPath: require('../assets/marks/yokohamamunicipal/b.png'),
       };
     case 99343: // グリーンライン
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'G',
         signPath: require('../assets/marks/yokohamamunicipal/g.png'),
       };
     case 99320: // 江ノ電
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'EN',
         signPath: require('../assets/marks/enoden/en.png'),
       };
     case 99338: // 東葉高速鉄道線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'TR',
         signPath: require('../assets/marks/toyorapid/tr.png'),
       };
     case 99307: // 東葉高速鉄道線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'SR',
         signPath: require('../assets/marks/saitamarapid/sr.png'),
       };
     case 99334: // 多摩都市モノレール
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TT',
         signPath: require('../assets/marks/tamamonorail/tt.png'),
       };
     case 99321: // ニューシャトル
       return {
-        shape: MARK_SHAPE.NEW_SHUTTLE,
+        signShape: MARK_SHAPE.NEW_SHUTTLE,
         sign: 'NS',
         signPath: require('../assets/marks/newshuttle/ns.png'),
       };
     case 99335: // 銚子電鉄線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'CD',
         signPath: require('../assets/marks/choshi/cd.png'),
       };
     case 99331: // 千葉都市モノレール
     case 99332: // 千葉都市モノレール
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'CM',
         signPath: require('../assets/marks/chibamonorail/cm.png'),
       };
     case 28001: // 東京メトロ銀座線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'G',
         signPath: require('../assets/marks/tokyometro/g.png'),
       };
     case 28002: // 東京メトロ丸ノ内線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
         signPath: require('../assets/marks/tokyometro/m.png'),
       };
     case 28003: // 東京メトロ日比谷線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/tokyometro/h.png'),
       };
     case 28004: // 東京メトロ東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/tokyometro/t.png'),
       };
     case 28005: // 東京メトロ千代田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'C',
         signPath: require('../assets/marks/tokyometro/c.png'),
       };
     case 28006: // 東京メトロ有楽町線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
         signPath: require('../assets/marks/tokyometro/y.png'),
       };
     case 28008: // 東京メトロ半蔵門線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Z',
         signPath: require('../assets/marks/tokyometro/z.png'),
       };
     case 28009: // 東京メトロ南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
         signPath: require('../assets/marks/tokyometro/n.png'),
       };
     case 28010: // 東京メトロ副都心線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'F',
         signPath: require('../assets/marks/tokyometro/f.png'),
       };
     case 99302: // 都営浅草線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'A',
         signPath: require('../assets/marks/toei/a.png'),
       };
     case 99303: // 都営三田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'I',
         signPath: require('../assets/marks/toei/i.png'),
       };
     case 99304: // 都営新宿線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
         signPath: require('../assets/marks/toei/s.png'),
       };
     case 99301: // 都営大江戸線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'E',
         signPath: require('../assets/marks/toei/e.png'),
       };
     case 99311: // ゆりかもめ
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'U',
         signPath: require('../assets/marks/yurikamome/u.png'),
       };
     case 99305: // 都電荒川線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'SA',
         signPath: require('../assets/marks/toden/sa.png'),
       };
     case 99342: // 日暮里舎人ライナー
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'NT',
         signPath: require('../assets/marks/nippori-toneri-liner/nt.png'),
       };
@@ -586,37 +587,37 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 24005:
     case 24007:
       return {
-        shape: MARK_SHAPE.KEIO,
+        signShape: MARK_SHAPE.KEIO,
         sign: 'KO',
         signPath: require('../assets/marks/keio/ko.png'),
       };
     case 24006: // 井の頭線
       return {
-        shape: MARK_SHAPE.KEIO,
+        signShape: MARK_SHAPE.KEIO,
         sign: 'IN',
         signPath: require('../assets/marks/keio/in.png'),
       };
     case 25001: // 小田急小田原線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OH',
         signPath: require('../assets/marks/odakyu/oh.png'),
       };
     case 25002: // 小田急江ノ島線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OE',
         signPath: require('../assets/marks/odakyu/oe.png'),
       };
     case 25003: // 小田急多摩線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OT',
         signPath: require('../assets/marks/odakyu/ot.png'),
       };
     case 99339: // 箱根登山鉄道鉄道線
       return {
-        shape: MARK_SHAPE.HAKONE,
+        signShape: MARK_SHAPE.HAKONE,
         sign: 'OH',
         signPath: require('../assets/marks/hakone/oh.png'),
       };
@@ -627,38 +628,41 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 23004: // 千葉
     case 23005: // 千原
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'KS',
         signPath: require('../assets/marks/keisei/ks.png'),
       };
     case 23006: // 成田スカイアクセス
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'KS',
         signPath: require('../assets/marks/keisei/ks2.png'),
+        subSignShape: MARK_SHAPE.KEISEI,
+        subSign: 'HS',
+        subSignPath: require('../assets/marks/hokuso/hs.png'),
       };
     case 99329: // 新京成
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'SL',
         signPath: require('../assets/marks/shinkeisei/sl.png'),
       };
     case 99340: // 北総線
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'HS',
         signPath: require('../assets/marks/hokuso/hs.png'),
       };
 
     case 99324: // 芝山線
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'SR',
         signPath: require('../assets/marks/shibayama/sr.png'),
       };
     case 99333: // 流鉄流山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'RN',
       };
     // JR西日本
@@ -669,19 +673,19 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11603: // 神戸線
     case 11608: // 山陽線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'A',
         signPath: require('../assets/marks/jrw/a.png'),
       };
     case 11609: // JR山陽本線(姫路～岡山)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/jrw/s2.png'),
       };
     case 11610: // JR山陽本線(岡山～三原)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'W',
         signPath: require('../assets/marks/jrw/w.png'),
         subSign: 'X',
@@ -689,13 +693,13 @@ export const getLineMark = (line: Line): LineMark | null => {
       };
     case 11709: // 宇野線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'L',
         signPath: require('../assets/marks/jrw/l2.png'),
       };
     case 11611: // JR山陽本線(三原～岩国)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'G',
         signPath: require('../assets/marks/jrw/g2.png'),
         subSign: 'R',
@@ -703,179 +707,182 @@ export const getLineMark = (line: Line): LineMark | null => {
       };
     case 11511: // 草津線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'C',
         signPath: require('../assets/marks/jrw/c.png'),
       };
     case 11705: // 境線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'C',
         signPath: require('../assets/marks/jrw/c2.png'),
       };
     case 11618: // 奈良線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'D',
         signPath: require('../assets/marks/jrw/d.png'),
       };
     case 11616: // JR山陰本線(豊岡～米子)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'A',
         signPath: require('../assets/marks/jrw/a2.png'),
       };
     case 11701: // JR山陰本線(米子～益田)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'D',
         signPath: require('../assets/marks/jrw/d.png'),
       };
     case 11614: // 嵯峨野線
     case 11615: // 山陰線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'E',
         signPath: require('../assets/marks/jrw/e.png'),
       };
     case 11641: // おおさか東線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'F',
         signPath: require('../assets/marks/jrw/f.png'),
       };
     case 11629: // 宝塚線
     case 11630: // 福知山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
         sign: 'G',
         signPath: require('../assets/marks/jrw/g.png'),
+        subSignShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        subSign: 'A',
+        subSignPath: require('../assets/marks/jrw/a.png'),
       };
     case 11625: // 東西線
     case 11617: // 学研都市線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'H',
         signPath: require('../assets/marks/jrw/h.png'),
       };
     case 11632: // 加古川線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'I',
         signPath: require('../assets/marks/jrw/i.png'),
       };
     case 11635: // 播但線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'J',
         signPath: require('../assets/marks/jrw/j.png'),
       };
     case 11633: // 姫新線
     case 11634:
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'K',
         signPath: require('../assets/marks/jrw/k.png'),
       };
     case 11622: // 舞鶴線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'L',
         signPath: require('../assets/marks/jrw/l.png'),
       };
     case 11623: // 大阪環状線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'O',
         signPath: require('../assets/marks/jrw/o.png'),
       };
     case 11624: // ゆめ咲線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'P',
         signPath: require('../assets/marks/jrw/p.png'),
       };
     case 11714: // 芸備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'P',
         signPath: require('../assets/marks/jrw/p2.png'),
       };
     case 11607: // 大和路線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Q',
         signPath: require('../assets/marks/jrw/q.png'),
       };
     case 11626: // 阪和線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
         sign: 'R',
         signPath: require('../assets/marks/jrw/r.png'),
       };
     case 11628: // 関西空港線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/jrw/s.png'),
       };
     case 11636: // 和歌山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'T',
         signPath: require('../assets/marks/jrw/t.png'),
       };
     case 11637: // 万葉まほろば線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'U',
         signPath: require('../assets/marks/jrw/u.png'),
       };
     case 11509: // 関西線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'V',
         signPath: require('../assets/marks/jrw/v.png'),
       };
     case 11703: // 伯備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'V',
         signPath: require('../assets/marks/jrw/v2.png'),
       };
     case 11639: // きのくに線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'W',
         signPath: require('../assets/marks/jrw/w2.png'),
       };
     case 11715: // 津山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'T',
         signPath: require('../assets/marks/jrw/t2.png'),
       };
     case 11713: // 吉備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'U',
         signPath: require('../assets/marks/jrw/u2.png'),
       };
     case 11720: // 福塩線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Z',
         signPath: require('../assets/marks/jrw/z.png'),
       };
     case 11710: // 瀬戸大橋線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'M',
         signPath: require('../assets/marks/jrw/m.png'),
       };
     case 11631: // 赤穂線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'N',
         signPath: require('../assets/marks/jrw/n.png'),
         subSign: 'A',
@@ -883,31 +890,31 @@ export const getLineMark = (line: Line): LineMark | null => {
       };
     case 11704: // 因美線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b2.png'),
       };
     case 11717: // 可部線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b3.png'),
       };
     case 11605: // 湖西線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b.png'),
       };
     case 11706: // 木次線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'E',
         signPath: require('../assets/marks/jrw/e2.png'),
       };
     case 11716: // 呉線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Y',
         signPath: require('../assets/marks/jrw/y.png'),
       };
@@ -916,310 +923,310 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 11502: // 東海道本線（浜松〜岐阜）
     case 11503: // 東海道本線（岐阜〜米原）
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CA',
         signPath: require('../assets/marks/jrc/ca.png'),
       };
     case 11505: // 御殿場線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CB',
         signPath: require('../assets/marks/jrc/cb.png'),
       };
     case 11402: // 身延線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CC',
         signPath: require('../assets/marks/jrc/cc.png'),
       };
     case 11413: // 飯田線（豊橋～天竜峡）
     case 11414: // 飯田線（天竜峡～辰野）
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CD',
         signPath: require('../assets/marks/jrc/cd.png'),
       };
     case 11506: // 武豊線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CE',
         signPath: require('../assets/marks/jrc/ce.png'),
       };
     case 11411: // 中央本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CF',
         signPath: require('../assets/marks/jrc/cf.png'),
       };
     case 11416: // 高山本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CG',
         signPath: require('../assets/marks/jrc/cg.png'),
       };
     case 11507: // 太多線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CI',
         signPath: require('../assets/marks/jrc/ci.png'),
       };
     case 11508: // 関西本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CJ',
         signPath: require('../assets/marks/jrc/cj.png'),
       };
     // JR九州
     case 11902: // 鹿児島本線(下関・門司港～博多)
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JA',
       };
     case 11903: // 鹿児島本線(博多～八代)
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JB',
       };
     case 11908: // 福北ゆたか線
     case 11911: // 福北ゆたか線(折尾～桂川)
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JC',
       };
     case 11917: // 香椎線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JD',
       };
     case 11910: // 若松線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JE',
       };
     case 11906: // 日豊本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JF',
       };
     case 11912: // 原田線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JG',
       };
     case 11905: // 長崎本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JH',
       };
     case 11914: // 日田彦山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JI',
       };
     case 11915: // 日田彦山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JJ',
       };
     case 11909: // 日田彦山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'JK',
       };
     // 福岡市営地下鉄
     case 99905: // 空港線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'K',
       };
     case 99906: // 箱崎線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
       };
     case 99907: // 箱崎線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     // 西日本鉄道
     case 36001: // 天神大牟田線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'T',
       };
     case 36002: // 太宰府線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'D',
       };
     case 36003: // 甘木
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'A',
       };
     case 36004: // 貝塚線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'NK',
       };
     case 99909: // 筑豊電気鉄道線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'CK',
       };
     // 熊本市電
     case 99922: // A系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'A',
       };
     case 99923: // B系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'B',
       };
     // 鹿児島市電
     case 99925: // 1系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'I',
       };
     case 99926: // 2系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'N',
       };
     // 名古屋市営地下鉄
     case 99513: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/nagoyamunicipal/h.png'),
       };
     case 99514: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
         signPath: require('../assets/marks/nagoyamunicipal/m.png'),
       };
     case 99515: // 名港線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'E',
         signPath: require('../assets/marks/nagoyamunicipal/e.png'),
       };
     case 99516: // 鶴舞線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/nagoyamunicipal/t.png'),
       };
     case 99517: // 桜通線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
         signPath: require('../assets/marks/nagoyamunicipal/s.png'),
       };
     case 99518: // 上飯田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'K',
         signPath: require('../assets/marks/nagoyamunicipal/k.png'),
       };
     // 名鉄
     case 30001: // 名古屋本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'NH',
         signPath: require('../assets/marks/meitetsu/nh.png'),
       };
     case 30002: // 豊川線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'TK',
         signPath: require('../assets/marks/meitetsu/tk.png'),
       };
     case 30003: // 西尾線
     case 30004: // 蒲郡線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'GN',
         signPath: require('../assets/marks/meitetsu/gn.png'),
       };
     case 30005: // 三河線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'MU',
         signPath: require('../assets/marks/meitetsu/mu.png'),
       };
     case 30006: // 豊田線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'TT',
         signPath: require('../assets/marks/meitetsu/tt.png'),
       };
     case 30008: // 常滑線
     case 30007: // 空港線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'TA',
         signPath: require('../assets/marks/meitetsu/ta.png'),
       };
     case 30009: // 河和線
     case 30010: // 知多新線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'KC',
         signPath: require('../assets/marks/meitetsu/kc.png'),
       };
     case 30013: // 津島線
     case 30014: // 尾西線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'TB',
         signPath: require('../assets/marks/meitetsu/tb.png'),
       };
     case 30020: // 竹鼻線
     case 30021: // 羽島線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'TH',
         signPath: require('../assets/marks/meitetsu/th.png'),
       };
     case 30015: // 犬山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'IY',
         signPath: require('../assets/marks/meitetsu/iy.png'),
       };
     case 30016: // 各務原線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'KG',
         signPath: require('../assets/marks/meitetsu/kg.png'),
       };
     case 30017: // 広見線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'HM',
         signPath: require('../assets/marks/meitetsu/hm.png'),
       };
     case 30018: // 小牧線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'KM',
         signPath: require('../assets/marks/meitetsu/km.png'),
       };
     case 30012: // 瀬戸線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'ST',
         signPath: require('../assets/marks/meitetsu/st.png'),
       };
     case 30011: // 築港線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE,
+        signShape: MARK_SHAPE.HALF_SQUARE,
         sign: 'CH',
         signPath: require('../assets/marks/meitetsu/ch.png'),
       };
@@ -1230,13 +1237,13 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 32005: // 南海加太線
     case 32006: // 南海多奈川線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/main.png'),
       };
     case 32002: // 南海空港線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/airport.png'),
       };
@@ -1244,102 +1251,102 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 32008: // 南海高野山ケーブル
     case 32009: // 南海汐見橋線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/koya.png'),
       };
     case 99616: // 泉北高速鉄道線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'SB',
         signPath: require('../assets/marks/senhoku/sb.png'),
       };
     case 99629: // 阪堺線
     case 99628: // 上町線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'HN',
         signPath: require('../assets/marks/hankai/hn.png'),
       };
     case 99610: // 京都市営地下鉄烏丸線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'K',
         signPath: require('../assets/marks/kyotomunicipal/k.png'),
       };
     case 99611: // 京都市営地下鉄東西線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'T',
         signPath: require('../assets/marks/kyotomunicipal/t.png'),
       };
     case 99618: // 大阪メトロ御堂筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'M',
         signPath: require('../assets/marks/osakametro/m.png'),
       };
     case 99619: // 大阪メトロ谷町線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'T',
         signPath: require('../assets/marks/osakametro/t.png'),
       };
     case 99620: // 大阪メトロ四つ橋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'Y',
         signPath: require('../assets/marks/osakametro/y.png'),
       };
     case 99621: // 大阪メトロ中央線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'C',
         signPath: require('../assets/marks/osakametro/c.png'),
       };
     case 99622: // 大阪メトロ千日前線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'S',
         signPath: require('../assets/marks/osakametro/s.png'),
       };
     case 99623: // 大阪メトロ堺筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'K',
         signPath: require('../assets/marks/osakametro/k.png'),
       };
     case 99624: // 大阪メトロ長堀鶴見緑地線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'N',
         signPath: require('../assets/marks/osakametro/n.png'),
       };
     case 99652: // 大阪メトロ今里筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'I',
         signPath: require('../assets/marks/osakametro/i.png'),
       };
     case 99625: // 南港ポートタウン線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'P',
         signPath: require('../assets/marks/osakametro/p.png'),
       };
     case 99608: // 宮福線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'F',
       };
     case 99653: // 宮舞線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'M',
       };
     case 99609: // 宮豊線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'T',
       };
     // 阪急線
@@ -1348,14 +1355,14 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 34005: // 甲陽線
     case 34006: // 伊丹線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kobe.png'),
       };
     case 34002: // 宝塚線
     case 34007: // 箕面線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/takarazuka.png'),
       };
@@ -1363,7 +1370,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 34008: // 千里線
     case 34009: // 嵐山線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kyoto.png'),
       };
@@ -1372,7 +1379,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 35002: // なんば線
     case 35003: // 武庫川線
       return {
-        shape: MARK_SHAPE.HANSHIN,
+        signShape: MARK_SHAPE.HANSHIN,
         sign: 'HS',
         signPath: require('../assets/marks/hanshin/hs.png'),
       };
@@ -1380,126 +1387,126 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 99637:
     case 99638:
       return {
-        shape: MARK_SHAPE.SANYO,
+        signShape: MARK_SHAPE.SANYO,
         sign: 'SY',
       };
     // 近鉄
     case 31001: // 難波線
     case 31020: // 奈良線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'A',
       };
     case 31016: // 生駒線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'G',
       };
     case 31025: // 京都線
     case 31002: // 橿原線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'B',
       };
     case 31011: // 天理線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'H',
       };
     case 31017: // 田原線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'I',
       };
     case 31005: // 大阪線
     case 31021: // 信貴線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'D',
       };
     case 31027: // 名古屋線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'E',
       };
     case 31019: // 鈴鹿線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'L',
       };
     case 31008: // 湯の山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'K',
       };
     case 31009: // 山田線
     case 31010: // 鳥羽線
     case 31015: // 志摩線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'M',
       };
     case 31003: // 南大阪線
     case 31007: // 吉野線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'F',
       };
     case 31012: // 道明寺線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'N',
       };
     case 31022: // 長野線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'O',
       };
     case 31018: // 御所線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'P',
       };
     case 31026: // 生駒ケーブル
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'Y',
       };
     case 31023: // けいはんな線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'C',
       };
     // 神戸市営地下鉄
     case 99645: // 西神線
     case 99646: // 山手線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/kobemunicipal/seishin.png'),
       };
     case 99647: // 海岸線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'K',
         signPath: require('../assets/marks/kobemunicipal/kaigan.png'),
       };
     // 神戸新交通
     case 99648: // ポートライナー
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'P',
       };
     case 99649: // 六甲アイランド線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'R',
       };
     // 能勢電鉄
     case 99615: // 妙見線
     case 99640: // 日生線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'NS',
         signPath: require('../assets/marks/nose/ns.png'),
       };
@@ -1511,7 +1518,7 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 99634: // 公園都市線
     case 99635: // 粟生線
       return {
-        shape: MARK_SHAPE.HANSHIN,
+        signShape: MARK_SHAPE.HANSHIN,
         sign: 'KB',
         signPath: require('../assets/marks/kobe/kb.png'),
       };
@@ -1522,29 +1529,29 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 33004: // 鴨東線
     case 33008: // 中之島線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'KH',
       };
     case 33006: // 石山坂本線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'OT',
       };
     case 33007: // 京津線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'OT',
       };
     // 京福
     case 99612: // 嵐山本線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'A',
         signPath: require('../assets/marks/keihuku/a.png'),
       };
     case 99613: // 北野線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'B',
         signPath: require('../assets/marks/keihuku/b.png'),
       };
@@ -1552,54 +1559,54 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 99606: // 叡山本線
     case 99607: // 鞍馬線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'E',
       };
     // 岡山電気軌道
     case 99706: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
       };
     case 99707: // 清輝橋線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
       };
     case 99704: // 水島本線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'MR',
       };
     // 広島電鉄
     case 99711: // 本線・宮島線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'M',
       };
     case 99716: // 横川線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'Y',
       };
     case 99710: // 宇品線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'U',
       };
     case 99714: // 江波線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'E',
       };
     case 99717: // 白島線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'W',
       };
     case 99713: // 皆実線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'H',
       };
     // 伊予鉄
@@ -1607,133 +1614,133 @@ export const getLineMark = (line: Line): LineMark | null => {
     case 99807: // 横河原線
     case 99805: // 郡中線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'IY',
       };
     case 99808: // 1系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '1',
       };
     case 99809: // 2系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '2',
       };
     case 99810: // 3系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '3',
       };
     case 99811: // 5系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '5',
       };
     case 99812: // 6系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '6',
       };
     // ことでん
     case 99802: // 琴平線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'K',
       };
     case 99803: // 長尾線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'N',
       };
     case 99804: // 志度線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'S',
       };
     case 11806: // 予讃線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
       };
     case 11801: // 土讃線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'D',
       };
     case 11808: // 予土線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'G',
       };
     case 11802: // 高徳線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
       };
     case 11805: // 鳴門線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     case 11803: // 徳島線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'B',
       };
     case 11804: // 牟岐線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
       };
     case 99816: // ごめん・なはり線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'GN',
       };
     case 99814: // 中村線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'TK',
       };
     case 99203: // 弘南鉄道大鰐線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'KW',
         signPath: require('../assets/marks/konan/kw.png'),
       };
     case 99501: // 伊豆急行線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'IZ',
         signPath: require('../assets/marks/izukyu/iz.png'),
       };
     case 99509: // あおなみ線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'AN',
       };
     case 99614: // 北大阪急行線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'M',
       };
     case 99626: // 大阪モノレール線
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     case 99530: // 伊勢鉄道伊勢線
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     case 99407: // 上高地線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'AK',
       };
     case 99927: // ゆいレール
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     default:
       return null;
@@ -1745,14 +1752,14 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     // 新幹線
     case 1002: // 東海道新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrc_g.png'),
       };
     case 1003: // 山陽新幹線
     case 11901: // 博多南線（これは新幹線にするべきなんだろうか）
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrw_g.png'),
       };
@@ -1762,25 +1769,25 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 1007: // 山形新幹線
     case 1008: // 秋田新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jre_g.png'),
       };
     case 1009: // 北陸新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrc_g.png'),
       };
     case 1010: // 九州新幹線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: '',
         signPath: require('../assets/marks/shinkansen/jrk_g.png'),
       };
     case 1011:
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/shinkansen/jrh_g.png'),
       };
@@ -1788,47 +1795,47 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     // 札幌市営地下鉄
     case 99102: // 南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
         signPath: require('../assets/marks/sapporosubway/n_g.png'),
       };
     case 99101: // 東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/sapporosubway/t_g.png'),
       };
     case 99103: // 東豊線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/sapporosubway/h_g.png'),
       };
     // 函館市電
     case 99105: // ２系統
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
       };
     case 99106: // ５系統
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'D',
       };
     // 仙台市交通局
     case 99214: // 南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     case 99218: // 東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
       };
     case 11301: // 東海道線（東日本区間）
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JT',
         signPath: require('../assets/marks/jre/jt_g.png'),
       };
@@ -1836,38 +1843,38 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 11314: // 総武本線
     case 11327: // 成田線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JO',
         signPath: require('../assets/marks/jre/jo_g.png'),
       };
     case 11332: // 京浜東北線
     case 11307: // 根岸線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JK',
         signPath: require('../assets/marks/jre/jk_g.png'),
       };
     case 11306: // 横浜線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JH',
         signPath: require('../assets/marks/jre/jh_g.png'),
       };
     case 11303: // 南武線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JN',
         signPath: require('../assets/marks/jre/jn_g.png'),
       };
     case 11304: // 鶴見線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JI',
         signPath: require('../assets/marks/jre/ji_g.png'),
       };
     case 11302: // 山手線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JY',
         signPath: require('../assets/marks/jre/jy_g.png'),
       };
@@ -1875,13 +1882,13 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 11315: // 青梅線
     case 11316: // 五日市線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JC',
         signPath: require('../assets/marks/jre/jc_g.png'),
       };
     case 11311: // 中央本線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JC',
         signPath: require('../assets/marks/jre/jc_g.png'),
         subSign: 'CO',
@@ -1889,7 +1896,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       };
     case 11313: // 中央・総武線各駅停車
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JB',
         signPath: require('../assets/marks/jre/jb_g.png'),
       };
@@ -1897,19 +1904,19 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 11323: // 高崎線
     case 11343: // 上野東京ライン
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JU',
         signPath: require('../assets/marks/jre/ju_g.png'),
       };
     case 11321: // 埼京線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JA',
         signPath: require('../assets/marks/jre/ja_g.png'),
       };
     case 11320: // 常磐線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JJ',
         signPath: require('../assets/marks/jre/jj_g.png'),
         subSign: 'JL',
@@ -1917,41 +1924,41 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       };
     case 11326: // 京葉線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JE',
         signPath: require('../assets/marks/jre/je_g.png'),
       };
     case 11305: // 武蔵野線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JM',
         signPath: require('../assets/marks/jre/jm_g.png'),
       };
     case 11333: // 湘南新宿ライン
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'JS',
         signPath: require('../assets/marks/jre/js_g.png'),
       };
     case 11328: // 成田エクスプレス
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '',
       };
     case 99309:
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TX',
       };
     case 99336: // 東京モノレール
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'MO',
         signPath: require('../assets/marks/tokyomonorail/mo_g.png'),
       };
     case 99337: // りんかい線
       return {
-        shape: MARK_SHAPE.TWR,
+        signShape: MARK_SHAPE.TWR,
         sign: 'R',
         signPath: require('../assets/marks/rinkai/r_g.png'),
       };
@@ -1962,39 +1969,39 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 22004: // 豊島線
     case 22005: // 狭山線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SI',
         signPath: require('../assets/marks/seibu/si_g.png'),
       };
     case 22006: // 西武山口線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SY',
         signPath: require('../assets/marks/seibu/sy.png'),
       };
     case 22007: // 新宿線
     case 22008: // 拝島線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SS',
         signPath: require('../assets/marks/seibu/ss_g.png'),
       };
     case 22009: // 西武園線
     case 22010: // 国分寺線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SK',
         signPath: require('../assets/marks/seibu/sk_g.png'),
       };
     case 22011: // 多摩湖線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'ST',
         signPath: require('../assets/marks/seibu/st_g.png'),
       };
     case 22012: // 多摩川線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.HALF_SQUARE_DARK_TEXT,
         sign: 'SW',
         signPath: require('../assets/marks/seibu/sw_g.png'),
       };
@@ -2002,13 +2009,13 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 21001: // 東上線
     case 21007: // 越生線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TJ',
         signPath: require('../assets/marks/tobu/tj_g.png'),
       };
     case 21002: // 伊勢崎線（スカイツリーライン）
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TS',
         signPath: require('../assets/marks/tobu/ts_g.png'),
         subSign: 'TI',
@@ -2017,7 +2024,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 21005: // 亀戸線
     case 21006: // 大師線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TS',
         signPath: require('../assets/marks/tobu/ts_g.png'),
       };
@@ -2025,7 +2032,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 21011: // 桐生線
     case 21012: // 小泉線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TI',
         signPath: require('../assets/marks/tobu/ti_g.png'),
       };
@@ -2033,13 +2040,13 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 21008: // 宇都宮線
     case 21009: // 鬼怒川線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TN',
         signPath: require('../assets/marks/tobu/tn_g.png'),
       };
     case 21004: // 野田線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TD',
         signPath: require('../assets/marks/tobu/td_g.png'),
       };
@@ -2050,62 +2057,62 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 27004: // 逗子線
     case 27005: // 久里浜線
       return {
-        shape: MARK_SHAPE.KEIKYU,
+        signShape: MARK_SHAPE.KEIKYU,
         sign: 'KK',
         signPath: require('../assets/marks/keikyu/kk_g.png'),
       };
     // 東急
     case 26001: // 東横線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TY',
         signPath: require('../assets/marks/tokyu/ty_g.png'),
       };
     case 26002: // 目黒線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'MG',
         signPath: require('../assets/marks/tokyu/mg_g.png'),
       };
     case 26003: // 田園都市線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'DT',
         signPath: require('../assets/marks/tokyu/dt_g.png'),
       };
     case 26004: // 大井町線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'OM',
         signPath: require('../assets/marks/tokyu/om_g.png'),
       };
     case 26005: // 池上線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'IK',
         signPath: require('../assets/marks/tokyu/ik_g.png'),
       };
     case 26006: // 多摩川線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TM',
         signPath: require('../assets/marks/tokyu/tm_g.png'),
       };
     case 26007: // 世田谷線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_DARK_TEXT,
         sign: 'SG',
         signPath: require('../assets/marks/tokyu/sg_g.png'),
       };
     case 26008: // こどもの国線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'KD',
         signPath: require('../assets/marks/tokyu/kd_g.png'),
       };
     case 99310: // みなとみらい線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'MM',
         signPath: require('../assets/marks/minatomirai/mm_g.png'),
       };
@@ -2114,159 +2121,159 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 29002: // いずみ野線
     case 29003: // 新横浜線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'SO',
         signPath: require('../assets/marks/sotetsu/so_g.png'),
       };
     // 横浜市交通局
     case 99316: // ブルーライン
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'B',
         signPath: require('../assets/marks/yokohamamunicipal/b_g.png'),
       };
     case 99343: // グリーンライン
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'G',
         signPath: require('../assets/marks/yokohamamunicipal/g_g.png'),
       };
     case 99320: // 江ノ電
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'EN',
         signPath: require('../assets/marks/enoden/en_g.png'),
       };
     case 99338: // 東葉高速鉄道線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'TR',
         signPath: require('../assets/marks/toyorapid/tr_g.png'),
       };
     case 99307: // 東葉高速鉄道線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'SR',
         signPath: require('../assets/marks/saitamarapid/sr_g.png'),
       };
     case 99334: // 多摩都市モノレール
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'TT',
         signPath: require('../assets/marks/tamamonorail/tt_g.png'),
       };
     case 99321: // ニューシャトル
       return {
-        shape: MARK_SHAPE.NEW_SHUTTLE,
+        signShape: MARK_SHAPE.NEW_SHUTTLE,
         sign: 'NS',
         signPath: require('../assets/marks/newshuttle/ns_g.png'),
       };
     case 99335: // 銚子電鉄線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'CD',
         signPath: require('../assets/marks/choshi/cd_g.png'),
       };
     case 99331: // 千葉都市モノレール
     case 99332: // 千葉都市モノレール
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'CM',
         signPath: require('../assets/marks/chibamonorail/cm_g.png'),
       };
     case 28001: // 東京メトロ銀座線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'G',
         signPath: require('../assets/marks/tokyometro/g_g.png'),
       };
     case 28002: // 東京メトロ丸ノ内線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
         signPath: require('../assets/marks/tokyometro/m_g.png'),
       };
     case 28003: // 東京メトロ日比谷線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/tokyometro/h_g.png'),
       };
     case 28004: // 東京メトロ東西線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/tokyometro/t_g.png'),
       };
     case 28005: // 東京メトロ千代田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'C',
         signPath: require('../assets/marks/tokyometro/c_g.png'),
       };
     case 28006: // 東京メトロ有楽町線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
         signPath: require('../assets/marks/tokyometro/y_g.png'),
       };
     case 28008: // 東京メトロ半蔵門線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Z',
         signPath: require('../assets/marks/tokyometro/z_g.png'),
       };
     case 28009: // 東京メトロ南北線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
         signPath: require('../assets/marks/tokyometro/n_g.png'),
       };
     case 28010: // 東京メトロ副都心線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'F',
         signPath: require('../assets/marks/tokyometro/f_g.png'),
       };
     case 99302: // 都営浅草線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'A',
         signPath: require('../assets/marks/toei/a_g.png'),
       };
     case 99303: // 都営三田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'I',
         signPath: require('../assets/marks/toei/i_g.png'),
       };
     case 99304: // 都営新宿線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
         signPath: require('../assets/marks/toei/s_g.png'),
       };
     case 99301: // 都営大江戸線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'E',
         signPath: require('../assets/marks/toei/e_g.png'),
       };
     case 99311: // ゆりかもめ
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'U',
         signPath: require('../assets/marks/yurikamome/u_g.png'),
       };
     case 99305: // 都電荒川線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'SA',
         signPath: require('../assets/marks/toden/sa_g.png'),
       };
     case 99342: // 日暮里舎人ライナー
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'NT',
         signPath: require('../assets/marks/nippori-toneri-liner/nt_g.png'),
       };
@@ -2278,37 +2285,37 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 24005:
     case 24007:
       return {
-        shape: MARK_SHAPE.KEIO,
+        signShape: MARK_SHAPE.KEIO,
         sign: 'KO',
         signPath: require('../assets/marks/keio/ko_g.png'),
       };
     case 24006: // 井の頭線
       return {
-        shape: MARK_SHAPE.KEIO,
+        signShape: MARK_SHAPE.KEIO,
         sign: 'IN',
         signPath: require('../assets/marks/keio/in_g.png'),
       };
     case 25001: // 小田急小田原線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OH',
         signPath: require('../assets/marks/odakyu/oh_g.png'),
       };
     case 25002: // 小田急江ノ島線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OE',
         signPath: require('../assets/marks/odakyu/oe_g.png'),
       };
     case 25003: // 小田急多摩線
       return {
-        shape: MARK_SHAPE.ODAKYU,
+        signShape: MARK_SHAPE.ODAKYU,
         sign: 'OT',
         signPath: require('../assets/marks/odakyu/ot_g.png'),
       };
     case 99339: // 箱根登山鉄道鉄道線
       return {
-        shape: MARK_SHAPE.HAKONE,
+        signShape: MARK_SHAPE.HAKONE,
         sign: 'OH',
         signPath: require('../assets/marks/hakone/oh.png'),
       };
@@ -2319,37 +2326,40 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 23004: // 千葉
     case 23005: // 千原
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'KS',
         signPath: require('../assets/marks/keisei/ks_g.png'),
       };
     case 23006: // 成田スカイアクセス
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'KS',
         signPath: require('../assets/marks/keisei/ks2_g.png'),
+        subSignShape: MARK_SHAPE.KEISEI,
+        subSign: 'HS',
+        subSignPath: require('../assets/marks/hokuso/hs_g.png'),
       };
     case 99329: // 新京成
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'SL',
         signPath: require('../assets/marks/shinkeisei/sl_g.png'),
       };
     case 99340: // 北総線
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'HS',
         signPath: require('../assets/marks/hokuso/hs_g.png'),
       };
     case 99324: // 芝山線
       return {
-        shape: MARK_SHAPE.KEISEI,
+        signShape: MARK_SHAPE.KEISEI,
         sign: 'SR',
         signPath: require('../assets/marks/shibayama/sr_g.png'),
       };
     case 99333: // 流鉄流山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'RN',
       };
     // JR西日本
@@ -2360,19 +2370,19 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 11603: // 神戸線
     case 11608: // 山陽線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'A',
         signPath: require('../assets/marks/jrw/a_g.png'),
       };
     case 11609: // JR山陽本線(姫路～岡山)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/jrw/s2_g.png'),
       };
     case 11610: // JR山陽本線(岡山～三原)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'W',
         signPath: require('../assets/marks/jrw/w_g.png'),
         subSign: 'X',
@@ -2380,13 +2390,13 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       };
     case 11709: // 宇野線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'L',
         signPath: require('../assets/marks/jrw/l2_g.png'),
       };
     case 11611: // JR山陽本線(三原～岩国)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'G',
         signPath: require('../assets/marks/jrw/g2_g.png'),
         subSign: 'R',
@@ -2394,179 +2404,182 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       };
     case 11511: // 草津線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'C',
         signPath: require('../assets/marks/jrw/c_g.png'),
       };
     case 11705: // 境線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'C',
         signPath: require('../assets/marks/jrw/c2_g.png'),
       };
     case 11618: // 奈良線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'D',
         signPath: require('../assets/marks/jrw/d_g.png'),
       };
     case 11616: // JR山陰本線(豊岡～米子)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'A',
         signPath: require('../assets/marks/jrw/a2_g.png'),
       };
     case 11701: // JR山陰本線(米子～益田)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'D',
         signPath: require('../assets/marks/jrw/d_g.png'),
       };
     case 11614: // 嵯峨野線
     case 11615: // 山陰線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'E',
         signPath: require('../assets/marks/jrw/e_g.png'),
       };
     case 11641: // おおさか東線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'F',
         signPath: require('../assets/marks/jrw/f_g.png'),
       };
     case 11629: // 宝塚線
     case 11630: // 福知山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
         sign: 'G',
-        signPath: require('../assets/marks/jrw/g_g.png'),
+        signPath: require('../assets/marks/jrw/g.png'),
+        subSignShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        subSign: 'A',
+        subSignPath: require('../assets/marks/jrw/a.png'),
       };
     case 11625: // 東西線
     case 11617: // 学研都市線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'H',
         signPath: require('../assets/marks/jrw/h_g.png'),
       };
     case 11632: // 加古川線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'I',
         signPath: require('../assets/marks/jrw/i_g.png'),
       };
     case 11635: // 播但線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'J',
         signPath: require('../assets/marks/jrw/j_g.png'),
       };
     case 11633: // 姫新線
     case 11634:
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'K',
         signPath: require('../assets/marks/jrw/k_g.png'),
       };
     case 11622: // 舞鶴線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'L',
         signPath: require('../assets/marks/jrw/l_g.png'),
       };
     case 11623: // 大阪環状線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'O',
         signPath: require('../assets/marks/jrw/o_g.png'),
       };
     case 11624: // ゆめ咲線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'P',
         signPath: require('../assets/marks/jrw/p_g.png'),
       };
     case 11714: // 芸備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'P',
         signPath: require('../assets/marks/jrw/p2_g.png'),
       };
     case 11607: // 大和路線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Q',
         signPath: require('../assets/marks/jrw/q_g.png'),
       };
     case 11626: // 阪和線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST_DARK_TEXT,
         sign: 'R',
         signPath: require('../assets/marks/jrw/r_g.png'),
       };
     case 11628: // 関西空港線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/jrw/s_g.png'),
       };
     case 11636: // 和歌山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'T',
         signPath: require('../assets/marks/jrw/t_g.png'),
       };
     case 11637: // 万葉まほろば線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'U',
         signPath: require('../assets/marks/jrw/u_g.png'),
       };
     case 11509: // 関西線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'V',
         signPath: require('../assets/marks/jrw/v_g.png'),
       };
     case 11703: // 伯備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'V',
         signPath: require('../assets/marks/jrw/v2_g.png'),
       };
     case 11639: // きのくに線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'W',
         signPath: require('../assets/marks/jrw/w2_g.png'),
       };
     case 11715: // 津山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'T',
         signPath: require('../assets/marks/jrw/t2_g.png'),
       };
     case 11713: // 吉備線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'U',
         signPath: require('../assets/marks/jrw/u2_g.png'),
       };
     case 11720: // 福塩線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Z',
         signPath: require('../assets/marks/jrw/z_g.png'),
       };
     case 11710: // 瀬戸大橋線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'M',
         signPath: require('../assets/marks/jrw/m_g.png'),
       };
     case 11631: // 赤穂線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'N',
         signPath: require('../assets/marks/jrw/n_g.png'),
         subSign: 'A',
@@ -2574,31 +2587,31 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
       };
     case 11704: // 因美線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b2_g.png'),
       };
     case 11717: // 可部線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b3_g.png'),
       };
     case 11605: // 湖西線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'B',
         signPath: require('../assets/marks/jrw/b_g.png'),
       };
     case 11706: // 木次線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'E',
         signPath: require('../assets/marks/jrw/e2_g.png'),
       };
     case 11716: // 呉線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'Y',
         signPath: require('../assets/marks/jrw/y_g.png'),
       };
@@ -2607,310 +2620,310 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 11502: // 東海道本線（浜松〜岐阜）
     case 11503: // 東海道本線（岐阜〜米原）
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CA',
         signPath: require('../assets/marks/jrc/ca_g.png'),
       };
     case 11505: // 御殿場線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CB',
         signPath: require('../assets/marks/jrc/cb_g.png'),
       };
     case 11402: // 身延線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CC',
         signPath: require('../assets/marks/jrc/cc_g.png'),
       };
     case 11413: // 飯田線（豊橋～天竜峡）
     case 11414: // 飯田線（天竜峡～辰野）
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CD',
         signPath: require('../assets/marks/jrc/cd_g.png'),
       };
     case 11506: // 武豊線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CE',
         signPath: require('../assets/marks/jrc/ce_g.png'),
       };
     case 11411: // 中央本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CF',
         signPath: require('../assets/marks/jrc/cf_g.png'),
       };
     case 11416: // 高山本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CG',
         signPath: require('../assets/marks/jrc/cg_g.png'),
       };
     case 11507: // 太多線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CI',
         signPath: require('../assets/marks/jrc/ci_g.png'),
       };
     case 11508: // 関西本線
       return {
-        shape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
+        signShape: MARK_SHAPE.HALF_SQUARE_WITHOUT_ROUND,
         sign: 'CJ',
         signPath: require('../assets/marks/jrc/cj_g.png'),
       };
     // JR九州
     case 11902: // 鹿児島本線(下関・門司港～博多)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JA',
       };
     case 11903: // 鹿児島本線(博多～八代)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JB',
       };
     case 11908: // 福北ゆたか線
     case 11911: // 福北ゆたか線(折尾～桂川)
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JC',
       };
     case 11917: // 香椎線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JD',
       };
     case 11910: // 若松線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JE',
       };
     case 11906: // 日豊本線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JF',
       };
     case 11912: // 原田線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JG',
       };
     case 11905: // 長崎本線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JH',
       };
     case 11914: // 日田彦山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JI',
       };
     case 11915: // 日田彦山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JJ',
       };
     case 11909: // 日田彦山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'JK',
       };
     // 福岡市営地下鉄
     case 99905: // 空港線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'K',
       };
     case 99906: // 箱崎線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
       };
     case 99907: // 箱崎線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     // 西日本鉄道
     case 36001: // 天神大牟田線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'T',
       };
     case 36002: // 太宰府線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'D',
       };
     case 36003: // 甘木
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'A',
       };
     case 36004: // 貝塚線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'NK',
       };
     case 99909: // 筑豊電気鉄道線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'CK',
       };
     // 熊本市電
     case 99922: // A系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'A',
       };
     case 99923: // B系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'B',
       };
     // 鹿児島市電
     case 99925: // 1系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'I',
       };
     case 99926: // 2系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'N',
       };
     // 名古屋市営地下鉄
     case 99513: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
         signPath: require('../assets/marks/nagoyamunicipal/h_g.png'),
       };
     case 99514: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
         signPath: require('../assets/marks/nagoyamunicipal/m_g.png'),
       };
     case 99515: // 名港線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'E',
         signPath: require('../assets/marks/nagoyamunicipal/e_g.png'),
       };
     case 99516: // 鶴舞線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
         signPath: require('../assets/marks/nagoyamunicipal/t_g.png'),
       };
     case 99517: // 桜通線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
         signPath: require('../assets/marks/nagoyamunicipal/s_g.png'),
       };
     case 99518: // 上飯田線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'K',
         signPath: require('../assets/marks/nagoyamunicipal/k_g.png'),
       };
     // 名鉄
     case 30001: // 名古屋本線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'NH',
         signPath: require('../assets/marks/meitetsu/nh_g.png'),
       };
     case 30002: // 豊川線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TK',
         signPath: require('../assets/marks/meitetsu/tk_g.png'),
       };
     case 30003: // 西尾線
     case 30004: // 蒲郡線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'GN',
         signPath: require('../assets/marks/meitetsu/gn_g.png'),
       };
     case 30005: // 三河線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'MU',
         signPath: require('../assets/marks/meitetsu/mu_g.png'),
       };
     case 30006: // 豊田線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TT',
         signPath: require('../assets/marks/meitetsu/tt_g.png'),
       };
     case 30008: // 常滑線
     case 30007: // 空港線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TA',
         signPath: require('../assets/marks/meitetsu/ta_g.png'),
       };
     case 30009: // 河和線
     case 30010: // 知多新線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'KC',
         signPath: require('../assets/marks/meitetsu/kc_g.png'),
       };
     case 30013: // 津島線
     case 30014: // 尾西線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TB',
         signPath: require('../assets/marks/meitetsu/tb_g.png'),
       };
     case 30020: // 竹鼻線
     case 30021: // 羽島線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'TH',
         signPath: require('../assets/marks/meitetsu/th_g.png'),
       };
     case 30015: // 犬山線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'IY',
         signPath: require('../assets/marks/meitetsu/iy_g.png'),
       };
     case 30016: // 各務原線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'KG',
         signPath: require('../assets/marks/meitetsu/kg_g.png'),
       };
     case 30017: // 広見線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'HM',
         signPath: require('../assets/marks/meitetsu/hm_g.png'),
       };
     case 30018: // 小牧線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'KM',
         signPath: require('../assets/marks/meitetsu/km_g.png'),
       };
     case 30012: // 瀬戸線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'ST',
         signPath: require('../assets/marks/meitetsu/st_g.png'),
       };
     case 30011: // 築港線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'CH',
         signPath: require('../assets/marks/meitetsu/ch_g.png'),
       };
@@ -2921,13 +2934,13 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 32005: // 南海加太線
     case 32006: // 南海多奈川線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/main_g.png'),
       };
     case 32002: // 南海空港線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/airport_g.png'),
       };
@@ -2935,102 +2948,102 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 32008: // 南海高野山ケーブル
     case 32009: // 南海汐見橋線
       return {
-        shape: MARK_SHAPE.NANKAI,
+        signShape: MARK_SHAPE.NANKAI,
         sign: 'NK',
         signPath: require('../assets/marks/nankai/koya_g.png'),
       };
     case 99616: // 泉北高速鉄道線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'SB',
         signPath: require('../assets/marks/senhoku/sb_g.png'),
       };
     case 99629: // 阪堺線
     case 99628: // 上町線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'HN',
         signPath: require('../assets/marks/hankai/hn_g.png'),
       };
     case 99610: // 京都市営地下鉄烏丸線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'K',
         signPath: require('../assets/marks/kyotomunicipal/k_g.png'),
       };
     case 99611: // 京都市営地下鉄東西線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'T',
         signPath: require('../assets/marks/kyotomunicipal/t_g.png'),
       };
     case 99618: // 大阪メトロ御堂筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'M',
         signPath: require('../assets/marks/osakametro/m_g.png'),
       };
     case 99619: // 大阪メトロ谷町線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'T',
         signPath: require('../assets/marks/osakametro/t_g.png'),
       };
     case 99620: // 大阪メトロ四つ橋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'Y',
         signPath: require('../assets/marks/osakametro/y_g.png'),
       };
     case 99621: // 大阪メトロ中央線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'C',
         signPath: require('../assets/marks/osakametro/c_g.png'),
       };
     case 99622: // 大阪メトロ千日前線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'S',
         signPath: require('../assets/marks/osakametro/s_g.png'),
       };
     case 99623: // 大阪メトロ堺筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'K',
         signPath: require('../assets/marks/osakametro/k_g.png'),
       };
     case 99624: // 大阪メトロ長堀鶴見緑地線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'N',
         signPath: require('../assets/marks/osakametro/n_g.png'),
       };
     case 99652: // 大阪メトロ今里筋線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'I',
         signPath: require('../assets/marks/osakametro/i_g.png'),
       };
     case 99625: // 南港ポートタウン線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'P',
         signPath: require('../assets/marks/osakametro/p_g.png'),
       };
     case 99608: // 宮福線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'F',
       };
     case 99653: // 宮舞線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'M',
       };
     case 99609: // 宮豊線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'T',
       };
     // 阪急線
@@ -3039,14 +3052,14 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 34005: // 甲陽線
     case 34006: // 伊丹線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kobe_g.png'),
       };
     case 34002: // 宝塚線
     case 34007: // 箕面線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/takarazuka_g.png'),
       };
@@ -3054,7 +3067,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 34008: // 千里線
     case 34009: // 嵐山線
       return {
-        shape: MARK_SHAPE.HANKYU,
+        signShape: MARK_SHAPE.HANKYU,
         sign: 'HK',
         signPath: require('../assets/marks/hankyu/kyoto_g.png'),
       };
@@ -3063,7 +3076,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 35002: // なんば線
     case 35003: // 武庫川線
       return {
-        shape: MARK_SHAPE.HANSHIN,
+        signShape: MARK_SHAPE.HANSHIN,
         sign: 'HS',
         signPath: require('../assets/marks/hanshin/hs_g.png'),
       };
@@ -3071,126 +3084,126 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 99637:
     case 99638:
       return {
-        shape: MARK_SHAPE.SANYO,
+        signShape: MARK_SHAPE.SANYO,
         sign: 'SY',
       };
     // 近鉄
     case 31001: // 難波線
     case 31020: // 奈良線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'A',
       };
     case 31016: // 生駒線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'G',
       };
     case 31025: // 京都線
     case 31002: // 橿原線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'B',
       };
     case 31011: // 天理線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'H',
       };
     case 31017: // 田原線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'I',
       };
     case 31005: // 大阪線
     case 31021: // 信貴線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'D',
       };
     case 31027: // 名古屋線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'E',
       };
     case 31019: // 鈴鹿線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'L',
       };
     case 31008: // 湯の山線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'K',
       };
     case 31009: // 山田線
     case 31010: // 鳥羽線
     case 31015: // 志摩線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'M',
       };
     case 31003: // 南大阪線
     case 31007: // 吉野線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'F',
       };
     case 31012: // 道明寺線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'N',
       };
     case 31022: // 長野線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'O',
       };
     case 31018: // 御所線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'P',
       };
     case 31026: // 生駒ケーブル
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'Y',
       };
     case 31023: // けいはんな線
       return {
-        shape: MARK_SHAPE.KINTETSU,
+        signShape: MARK_SHAPE.KINTETSU,
         sign: 'C',
       };
     // 神戸市営地下鉄
     case 99645: // 西神線
     case 99646: // 山手線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'S',
         signPath: require('../assets/marks/kobemunicipal/seishin_g.png'),
       };
     case 99647: // 海岸線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE_WEST,
+        signShape: MARK_SHAPE.REVERSED_SQUARE_WEST,
         sign: 'K',
         signPath: require('../assets/marks/kobemunicipal/kaigan_g.png'),
       };
     // 神戸新交通
     case 99648: // ポートライナー
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'P',
       };
     case 99649: // 六甲アイランド線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'R',
       };
     // 能勢電鉄
     case 99615: // 妙見線
     case 99640: // 日生線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'NS',
         signPath: require('../assets/marks/nose/ns_g.png'),
       };
@@ -3202,7 +3215,7 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 99634: // 公園都市線
     case 99635: // 粟生線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'KB',
         signPath: require('../assets/marks/kobe/kb_g.png'),
       };
@@ -3213,29 +3226,29 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 33004: // 鴨東線
     case 33008: // 中之島線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'KH',
       };
     case 33006: // 石山坂本線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'OT',
       };
     case 33007: // 京津線
       return {
-        shape: MARK_SHAPE.KEIHAN,
+        signShape: MARK_SHAPE.KEIHAN,
         sign: 'OT',
       };
     // 京福
     case 99612: // 嵐山本線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'A',
         signPath: require('../assets/marks/keihuku/a_g.png'),
       };
     case 99613: // 北野線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'B',
         signPath: require('../assets/marks/keihuku/b_g.png'),
       };
@@ -3243,54 +3256,54 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 99606: // 叡山本線
     case 99607: // 鞍馬線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'E',
       };
     // 岡山電気軌道
     case 99706: // 東山線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'H',
       };
     case 99707: // 清輝橋線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'S',
       };
     case 99704: // 水島本線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'MR',
       };
     // 広島電鉄
     case 99711: // 本線・宮島線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'M',
       };
     case 99716: // 横川線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'Y',
       };
     case 99710: // 宇品線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'U',
       };
     case 99714: // 江波線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'E',
       };
     case 99717: // 白島線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'W',
       };
     case 99713: // 皆実線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
+        signShape: MARK_SHAPE.REVERSED_ROUND_HORIZONTAL,
         sign: 'H',
       };
     // 伊予鉄
@@ -3298,133 +3311,133 @@ export const getLineMarkGrayscale = (line: Line): LineMark | null => {
     case 99807: // 横河原線
     case 99805: // 郡中線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'IY',
       };
     case 99808: // 1系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '1',
       };
     case 99809: // 2系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '2',
       };
     case 99810: // 3系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '3',
       };
     case 99811: // 5系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '5',
       };
     case 99812: // 6系統
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: '6',
       };
     // ことでん
     case 99802: // 琴平線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'K',
       };
     case 99803: // 長尾線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'N',
       };
     case 99804: // 志度線
       return {
-        shape: MARK_SHAPE.REVERSED_SQUARE,
+        signShape: MARK_SHAPE.REVERSED_SQUARE,
         sign: 'S',
       };
     case 11806: // 予讃線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'Y',
       };
     case 11801: // 土讃線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'D',
       };
     case 11808: // 予土線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'G',
       };
     case 11802: // 高徳線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'T',
       };
     case 11805: // 鳴門線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'N',
       };
     case 11803: // 徳島線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'B',
       };
     case 11804: // 牟岐線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'M',
       };
     case 99816: // ごめん・なはり線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'GN',
       };
     case 99814: // 中村線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'TK',
       };
     case 99203: // 弘南鉄道大鰐線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'KW',
         signPath: require('../assets/marks/konan/kw_g.png'),
       };
     case 99501: // 伊豆急行線
       return {
-        shape: MARK_SHAPE.SQUARE,
+        signShape: MARK_SHAPE.SQUARE,
         sign: 'IZ',
         signPath: require('../assets/marks/izukyu/iz_g.png'),
       };
     case 99509: // あおなみ線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'AN',
       };
     case 99614: // 北大阪急行線
       return {
-        shape: MARK_SHAPE.REVERSED_ROUND,
+        signShape: MARK_SHAPE.REVERSED_ROUND,
         sign: 'M',
       };
     case 99626: // 大阪モノレール線
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     case 99530: // 伊勢鉄道伊勢線
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     case 99407: // 上高地線
       return {
-        shape: MARK_SHAPE.ROUND,
+        signShape: MARK_SHAPE.ROUND,
         sign: 'AK',
       };
     case 99927: // ゆいレール
       return {
-        shape: MARK_SHAPE.NUMBER_ONLY,
+        signShape: MARK_SHAPE.NUMBER_ONLY,
       };
     default:
       return null;

--- a/src/utils/getLineMarks.ts
+++ b/src/utils/getLineMarks.ts
@@ -5,7 +5,7 @@ import { Line, LINE_TYPE } from '../models/StationAPI';
 import { isJRLine } from './jr';
 
 const mockJR = {
-  shape: MARK_SHAPE.REVERSED_SQUARE,
+  signShape: MARK_SHAPE.REVERSED_SQUARE,
   sign: 'JR',
 };
 
@@ -44,7 +44,7 @@ const getLineMarks = ({
       };
     },
     {
-      shape: MARK_SHAPE.JR_UNION,
+      signShape: MARK_SHAPE.JR_UNION,
       jrUnionSigns: [],
       jrUnionSignPaths: [],
     }
@@ -66,7 +66,7 @@ const getLineMarks = ({
       };
     },
     {
-      shape: MARK_SHAPE.BULLET_TRAIN_UNION,
+      signShape: MARK_SHAPE.BULLET_TRAIN_UNION,
       btUnionSigns: [],
       btUnionSignPaths: [],
     }


### PR DESCRIPTION
次の路線のナンバリングシェイプが反映されなかったり、渋谷駅半蔵門線を選ぶとラウンドシェイプでDT01とでてしまっていたので、田園都市線のものを出すようにした（そもそも半蔵門線を選んでDTでてくるのを直したいが）
たぶん closes #1178