### PR TITLE
残り駅が少ないときのバグを修正

### DIFF
--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -159,7 +159,7 @@ const useRefreshLeftStations = (
         ? getStationsForLoopLine(currentIndex)
         : getStations(currentIndex);
     setNavigation((prev) => {
-      const isChanged = leftStations[1]?.id !== prev.leftStations[1]?.id;
+      const isChanged = leftStations[0]?.id !== prev.leftStations[0]?.id;
       if (!isChanged) {
         return prev;
       }


### PR DESCRIPTION
経路がおかしくなる（練馬から池袋方面を選択したのに表示は飯能方面）