### PR TITLE
直通関係のバグ修正

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -71,7 +71,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   } | null>(null);
   const [msFeatureModalShow, setMsFeatureModalShow] = useState(false);
 
-  const { station, stations, rawStations, selectedDirection, selectedBound } =
+  const { station, stations, selectedDirection, selectedBound } =
     useRecoilValue(stationState);
   const { location, badAccuracy } = useRecoilValue(locationState);
   const setTheme = useSetRecoilState(themeState);
@@ -96,14 +96,14 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
 
   const stationWithNumber = useMemo(
     () =>
-      rawStations
+      stations
         .filter((s) => !getIsPass(s))
         .find(
           (s) =>
             s.groupId === station?.groupId &&
             currentLine?.id === s.currentLine?.id
         ),
-    [currentLine?.id, rawStations, station?.groupId]
+    [currentLine?.id, stations, station?.groupId]
   );
 
   const viewShotRef = useRef<ViewShot>(null);

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -133,12 +133,8 @@ const styles = StyleSheet.create({
 
 const TypeChangeNotify: React.FC = () => {
   const { trainType } = useRecoilValue(navigationState);
-  const {
-    selectedDirection,
-    rawStations: stations,
-    selectedBound,
-    station,
-  } = useRecoilValue(stationState);
+  const { selectedDirection, stations, selectedBound, station } =
+    useRecoilValue(stationState);
   const typedTrainType = trainType as APITrainType;
 
   const currentLine = useCurrentLine();

--- a/src/hooks/useConnectedLines.ts
+++ b/src/hooks/useConnectedLines.ts
@@ -24,7 +24,7 @@ const useConnectedLines = (excludePassed = true): Line[] => {
   const excludeSameNameLines = (lines: Line[]): Line[] =>
     lines.filter(
       // 乗車中の路線と同じ名前の路線をしばき倒す
-      (l) => currentLine?.nameK !== l.nameK
+      (l) => currentLine?.id !== l.id
     );
 
   const joinedLineIds = typedTrainType.lines.map((l) => l.id);

--- a/src/hooks/useCurrentLine.ts
+++ b/src/hooks/useCurrentLine.ts
@@ -2,23 +2,34 @@ import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Line } from '../models/StationAPI';
 import lineState from '../store/atoms/line';
-import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
+import useCurrentStation from './useCurrentStation';
 
 const useCurrentLine = (): Line | null => {
-  const { rawStations, selectedDirection } = useRecoilValue(stationState);
-  const { leftStations } = useRecoilValue(navigationState);
+  const { stations, selectedDirection } = useRecoilValue(stationState);
   const { selectedLine } = useRecoilValue(lineState);
+
+  const currentStation = useCurrentStation();
 
   // 副都心線を選択しているのに次の駅到着まで東横線になるバグに対する対処
   // 副都心線に限らずデータ上直通運転が設定されているすべての駅で発生していたはず
   const actualCurrentStation = useMemo(
     () =>
       (selectedDirection === 'INBOUND'
-        ? rawStations.slice().reverse()
-        : rawStations
-      ).find((rs) => rs.groupId === leftStations[0]?.groupId),
-    [leftStations, rawStations, selectedDirection]
+        ? stations.slice().reverse()
+        : stations
+      ).find(
+        (rs) =>
+          rs.groupId === currentStation?.groupId &&
+          rs.currentLine?.id &&
+          currentStation?.currentLine?.id
+      ),
+    [
+      currentStation?.currentLine?.id,
+      currentStation?.groupId,
+      stations,
+      selectedDirection,
+    ]
   );
 
   const currentLine = useMemo(

--- a/src/hooks/useCurrentStation.ts
+++ b/src/hooks/useCurrentStation.ts
@@ -4,14 +4,14 @@ import { Station } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
 
 const useCurrentStation = (withTrainTypes?: boolean): Station | undefined => {
-  const { station, rawStations, stationsWithTrainTypes } =
+  const { station, stations, stationsWithTrainTypes } =
     useRecoilValue(stationState);
-  const stations = useMemo(
-    () => (withTrainTypes ? stationsWithTrainTypes : rawStations),
-    [rawStations, stationsWithTrainTypes, withTrainTypes]
+  const switchedStations = useMemo(
+    () => (withTrainTypes ? stationsWithTrainTypes : stations),
+    [stations, stationsWithTrainTypes, withTrainTypes]
   );
 
-  return stations.find((rs) => rs.groupId === station?.groupId);
+  return switchedStations.find((rs) => rs.groupId === station?.groupId);
 };
 
 export default useCurrentStation;

--- a/src/hooks/useMirroringShare.ts
+++ b/src/hooks/useMirroringShare.ts
@@ -37,7 +37,6 @@ type StorePayload = {
   trainType: APITrainType | APITrainTypeMinimum | null | undefined;
   selectedDirection: LineDirection;
   stations: Station[];
-  rawStations: Station[];
   initialStation: Station;
 };
 
@@ -61,7 +60,7 @@ const useMirroringShare = (
     selectedBound: mySelectedBound,
     selectedDirection: mySelectedDirection,
     station: myStation,
-    rawStations: myRawStations,
+    stations: myStations,
   } = useRecoilValue(stationState);
   const { trainType: myTrainType } = useRecoilValue(navigationState);
   const {
@@ -206,7 +205,6 @@ const useMirroringShare = (
           trainType: publisherTrainType,
           stations: publisherStations = [],
           selectedDirection: publisherSelectedDirection,
-          rawStations: publisherRawStations = [],
           initialStation: publisherInitialStation,
         } = data.val() as StorePayload;
 
@@ -244,7 +242,6 @@ const useMirroringShare = (
           return {
             ...prev,
             stations: publisherStations,
-            rawStations: publisherRawStations,
             selectedBound: publisherSelectedBound,
             selectedDirection: publisherSelectedDirection,
             station: publisherInitialStation,
@@ -398,8 +395,7 @@ const useMirroringShare = (
         selectedBound: mySelectedBound,
         selectedDirection: mySelectedDirection,
         trainType: myTrainType,
-        stations: myRawStations, // 受信側で加工するので敢えて無加工のデータを使っている
-        rawStations: myRawStations,
+        stations: myStations, // 受信側で加工するので敢えて無加工のデータを使っている
         initialStation: myStation,
         timestamp: database.ServerValue.TIMESTAMP,
       } as StorePayload);
@@ -413,7 +409,7 @@ const useMirroringShare = (
     myLocation?.coords.accuracy,
     myLocation?.coords.latitude,
     myLocation?.coords.longitude,
-    myRawStations,
+    myStations,
     mySelectedBound,
     mySelectedDirection,
     mySelectedLine,

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -7,6 +7,7 @@ import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import themeState from '../store/atoms/theme';
 import getCurrentStationIndex from '../utils/currentStationIndex';
+import dropEitherJunctionStation from '../utils/dropJunctionStation';
 import getIsPass from '../utils/isPass';
 import {
   isMeijoLine,
@@ -18,17 +19,23 @@ const useRefreshLeftStations = (
   selectedLine: Line | null,
   direction: LineDirection | null
 ): void => {
-  const { station: normalStation, stations: normalStations } =
-    useRecoilValue(stationState);
+  const {
+    station: normalStation,
+    stations: normalStations,
+    selectedDirection,
+  } = useRecoilValue(stationState);
   const [{ trainType }, setNavigation] = useRecoilState(navigationState);
   const { theme } = useRecoilValue(themeState);
 
   const stations = useMemo(
     () =>
-      theme === APP_THEME.JR_WEST
-        ? normalStations.filter((s) => !getIsPass(s))
-        : normalStations,
-    [normalStations, theme]
+      dropEitherJunctionStation(
+        theme === APP_THEME.JR_WEST
+          ? normalStations.filter((s) => !getIsPass(s))
+          : normalStations,
+        selectedDirection
+      ),
+    [normalStations, selectedDirection, theme]
   );
   const station = useMemo(() => {
     if (theme === APP_THEME.JR_WEST) {

--- a/src/hooks/useStationList.ts
+++ b/src/hooks/useStationList.ts
@@ -154,7 +154,6 @@ const useStationList = (): [
       setStation((prev) => ({
         ...prev,
         stations: data.stationsByLineId,
-        rawStations: data.stationsByLineId,
         // 再帰的にTrainTypesは取れないのでバックアップしておく
         stationsWithTrainTypes: data.stationsByLineId,
       }));

--- a/src/hooks/useStationListByTrainType.ts
+++ b/src/hooks/useStationListByTrainType.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { TrainTypeData } from '../models/StationAPI';
 import stationState from '../store/atoms/station';
-import dropEitherJunctionStation from '../utils/dropJunctionStation';
 import useConnectivity from './useConnectivity';
 
 const useStationListByTrainType = (): [
@@ -138,11 +137,7 @@ const useStationListByTrainType = (): [
     if (data?.trainType) {
       setStation((prev) => ({
         ...prev,
-        stations: dropEitherJunctionStation(
-          data.trainType.stations,
-          selectedDirection || 'INBOUND'
-        ),
-        rawStations: data.trainType.stations,
+        stations: data.trainType.stations,
       }));
     }
   }, [data, selectedDirection, setStation]);

--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -192,7 +192,6 @@ const SelectBoundScreen: React.FC = () => {
     setStation((prev) => ({
       ...prev,
       stations: [],
-      rawStations: [],
     }));
     setNavigationState((prev) => ({
       ...prev,

--- a/src/store/atoms/station.ts
+++ b/src/store/atoms/station.ts
@@ -8,7 +8,6 @@ export interface StationState {
   approaching: boolean;
   station: Station | null;
   stations: Station[];
-  rawStations: Station[];
   scoredStations: Station[];
   fetchStationError: Error | null;
   fetchStationListError: Error | null;
@@ -22,7 +21,6 @@ export const initialStationState = {
   approaching: false,
   station: null,
   stations: [],
-  rawStations: [],
   scoredStations: [],
   fetchStationError: null,
   fetchStationListError: null,

--- a/src/utils/dropJunctionStation.ts
+++ b/src/utils/dropJunctionStation.ts
@@ -4,13 +4,10 @@ import { Station } from '../models/StationAPI';
 // ２路線の接続駅は前の路線の最後の駅データを捨てる
 const dropEitherJunctionStation = (
   stations: Station[],
-  direction: LineDirection
+  direction: LineDirection | null
 ): Station[] =>
   stations.filter((s, i, arr): boolean => {
     const station = direction === 'INBOUND' ? arr[i - 1] : arr[i + 1];
-    if (station?.groupId === s.groupId) {
-      return false;
-    }
-    return true;
+    return station?.groupId !== s.groupId;
   });
 export default dropEitherJunctionStation;


### PR DESCRIPTION
closes #1178

`dropEitherJunctionStation` の第2引数の `direction` が代入されていない状態で使用されていてユーザーが方面を選んでから処理を実行するようにした
ついでに `rawStations` と `stations` が全く同じ値になったので `rawStations` フィールド自体消した