### PR TITLE
ライブアクティビティの停止処理改善

### DIFF
--- a/ios/LiveActivityModule.swift
+++ b/ios/LiveActivityModule.swift
@@ -54,7 +54,9 @@ class LiveActivityModule: NSObject {
   func stopLiveActivity(_ dic: NSDictionary?) {
     let finalContentState = getStatus(dic)
     Task {
-      await sessionActivity?.end(using: finalContentState, dismissalPolicy: .immediate)
+      for activity in Activity<RideSessionAttributes>.activities {
+        await activity.end(using: finalContentState, dismissalPolicy: .immediate)
+      }
     }
   }
   


### PR DESCRIPTION
2回目移行アプリを開いたときにLive Activitiesが重複して登録されるバグの修正