### PR TITLE
直近で選んだ路線の通過駅が関係のない路線の停車情報に反映されるバグを修正

### DIFF
--- a/src/hooks/useMyApolloClient.ts
+++ b/src/hooks/useMyApolloClient.ts
@@ -20,6 +20,8 @@ const useMyApolloClient = (): ApolloClient<NormalizedCacheObject> => {
       new InMemoryCache({
         dataIdFromObject(responseObject) {
           switch (responseObject.__typename) {
+            case 'Station':
+              return `${responseObject.__typename}:${responseObject.id}:${responseObject.stopCondition}`;
             case 'Line':
               return `${responseObject.__typename}:${responseObject.id}:${
                 (responseObject.transferStation as Station)?.id


### PR DESCRIPTION
再現手順
- 渋谷駅で操作を開始する
- 半蔵門線を選んで東急線内準急種別を選択
- 中央林間方面を確認し、二子新地駅が通過駅であることを確認
- 半蔵門線から田園都市線に選択路線を変える
- 何も操作せず中央林間方面を選択
- 新しく選んだ路線だから各停設定だが二子新地駅が通過駅と表示される

解決策
同じ駅IDでも優等種別の場合通過情報が停車だけではなくなるので、停車情報もキャッシュのキーにした