### PR TITLE
埼京線TrainTypeBoxアニメーションのバグ修正

### DIFF
--- a/src/components/TrainTypeBoxSaikyo.tsx
+++ b/src/components/TrainTypeBoxSaikyo.tsx
@@ -192,7 +192,7 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
           toValue: 0,
           duration: headerTransitionDelay,
           easing: EasingNode.ease,
-        }).start(() => resolve());
+        }).start(({ finished }) => finished && resolve());
       }),
     [headerTransitionDelay, textOpacityAnim]
   );


### PR DESCRIPTION
#2049 の対応漏れ