### PR TITLE
useGetLineMark引数修正

### DIFF
--- a/src/hooks/useGetLineMark.ts
+++ b/src/hooks/useGetLineMark.ts
@@ -11,17 +11,17 @@ const useGetLineMark = (): (({
   station,
   line,
 }: {
-  numberingIndex: number;
+  numberingIndex?: number;
   station?: Station | undefined;
   line: Line;
 }) => LineMarkWithCurrentLineMark | null) => {
   const func = useCallback(
     ({
-      numberingIndex,
+      numberingIndex = 0,
       station,
       line,
     }: {
-      numberingIndex: number;
+      numberingIndex?: number;
       station?: Station;
       line: Line;
     }): LineMarkWithCurrentLineMark | null => {


### PR DESCRIPTION
`SelectLine` で `numberingIndex` を指定していなかったけど一旦0を初期値として設定することで指定を不要にした