### PR TITLE
APIから来た色データに#があるなし関係なく期待通り表示されるようにした

### DIFF
--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -23,6 +23,7 @@ import isTablet from '../utils/isTablet';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { getIsLoopLine, isMeijoLine } from '../utils/loopLine';
 import { getNumberingColor } from '../utils/numbering';
+import prependHEX from '../utils/prependHEX';
 import CommonHeaderProps from './CommonHeaderProps';
 import NumberingIcon from './NumberingIcon';
 import TransferLineMark from './TransferLineMark';
@@ -639,7 +640,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => currentLine && `#${currentLine.lineColorC}`,
+    () => prependHEX(currentLine?.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -640,7 +640,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC ?? '#000'),
+    () => currentLine?.lineColorC && prependHEX(currentLine.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -640,7 +640,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC),
+    () => prependHEX(currentLine?.lineColorC ?? '#000'),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -576,7 +576,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC),
+    () => prependHEX(currentLine?.lineColorC ?? '#000'),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -31,6 +31,7 @@ import isTablet from '../utils/isTablet';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { getIsLoopLine, isMeijoLine } from '../utils/loopLine';
 import { getNumberingColor } from '../utils/numbering';
+import prependHEX from '../utils/prependHEX';
 import Clock from './Clock';
 import CommonHeaderProps from './CommonHeaderProps';
 import NumberingIcon from './NumberingIcon';
@@ -575,7 +576,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => currentLine && `#${currentLine.lineColorC}`,
+    () => prependHEX(currentLine?.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -576,7 +576,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC ?? '#000'),
+    () => currentLine?.lineColorC && prependHEX(currentLine.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -31,6 +31,7 @@ import isTablet from '../utils/isTablet';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { getIsLoopLine, isMeijoLine } from '../utils/loopLine';
 import { getNumberingColor } from '../utils/numbering';
+import prependHEX from '../utils/prependHEX';
 import CommonHeaderProps from './CommonHeaderProps';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBox';
@@ -555,7 +556,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => currentLine && `#${currentLine.lineColorC}`,
+    () => prependHEX(currentLine?.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -556,7 +556,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC ?? '#000'),
+    () => currentLine?.lineColorC && prependHEX(currentLine.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -556,7 +556,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC),
+    () => prependHEX(currentLine?.lineColorC ?? '#000'),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -540,7 +540,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC ?? '#000'),
+    () => currentLine?.lineColorC && prependHEX(currentLine.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -31,6 +31,7 @@ import isTablet from '../utils/isTablet';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { getIsLoopLine, isMeijoLine } from '../utils/loopLine';
 import { getNumberingColor } from '../utils/numbering';
+import prependHEX from '../utils/prependHEX';
 import CommonHeaderProps from './CommonHeaderProps';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBox';
@@ -539,7 +540,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => currentLine && `#${currentLine.lineColorC}`,
+    () => prependHEX(currentLine?.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(
@@ -691,7 +692,10 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
       <LinearGradient
         colors={
           currentLine
-            ? [`#${currentLine.lineColorC}aa`, `#${currentLine.lineColorC}ff`]
+            ? [
+                `${prependHEX(currentLine.lineColorC)}aa`,
+                `${prependHEX(currentLine.lineColorC)}ff`,
+              ]
             : ['#b5b5ac', '#b5b5ac']
         }
         style={styles.divider}

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -693,8 +693,8 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
         colors={
           currentLine
             ? [
-                `${prependHEX(currentLine.lineColorC ?? '#000')}aa`,
-                `${prependHEX(currentLine.lineColorC ?? '#000')}ff`,
+                `${prependHEX(currentLine.lineColorC ?? '#000000')}aa`,
+                `${prependHEX(currentLine.lineColorC ?? '#000000')}ff`,
               ]
             : ['#b5b5ac', '#b5b5ac']
         }

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -540,7 +540,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC),
+    () => prependHEX(currentLine?.lineColorC ?? '#000'),
     [currentLine]
   );
   const numberingColor = useMemo(
@@ -693,8 +693,8 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = ({
         colors={
           currentLine
             ? [
-                `${prependHEX(currentLine.lineColorC)}aa`,
-                `${prependHEX(currentLine.lineColorC)}ff`,
+                `${prependHEX(currentLine.lineColorC ?? '#000')}aa`,
+                `${prependHEX(currentLine.lineColorC ?? '#000')}ff`,
               ]
             : ['#b5b5ac', '#b5b5ac']
         }

--- a/src/components/HeaderYamanote.tsx
+++ b/src/components/HeaderYamanote.tsx
@@ -123,7 +123,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC),
+    () => prependHEX(currentLine?.lineColorC ?? '#000'),
     [currentLine]
   );
   const numberingColor = useMemo(
@@ -370,7 +370,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
           style={{
             ...styles.colorBar,
             backgroundColor: currentLine
-              ? prependHEX(currentLine.lineColorC)
+              ? prependHEX(currentLine.lineColorC ?? '#000')
               : '#aaa',
           }}
         />

--- a/src/components/HeaderYamanote.tsx
+++ b/src/components/HeaderYamanote.tsx
@@ -123,7 +123,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => prependHEX(currentLine?.lineColorC ?? '#000'),
+    () => currentLine?.lineColorC && prependHEX(currentLine.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(

--- a/src/components/HeaderYamanote.tsx
+++ b/src/components/HeaderYamanote.tsx
@@ -14,6 +14,7 @@ import isTablet from '../utils/isTablet';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { getIsLoopLine, isMeijoLine } from '../utils/loopLine';
 import { getNumberingColor } from '../utils/numbering';
+import prependHEX from '../utils/prependHEX';
 import Clock from './Clock';
 import CommonHeaderProps from './CommonHeaderProps';
 import NumberingIcon from './NumberingIcon';
@@ -122,7 +123,7 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
 
   const [currentStationNumber, threeLetterCode, lineMarkShape] = useNumbering();
   const lineColor = useMemo(
-    () => currentLine && `#${currentLine.lineColorC}`,
+    () => prependHEX(currentLine?.lineColorC),
     [currentLine]
   );
   const numberingColor = useMemo(
@@ -368,7 +369,9 @@ const HeaderYamanote: React.FC<CommonHeaderProps> = ({
         <View
           style={{
             ...styles.colorBar,
-            backgroundColor: `#${currentLine ? currentLine.lineColorC : 'aaa'}`,
+            backgroundColor: currentLine
+              ? prependHEX(currentLine.lineColorC)
+              : '#aaa',
           }}
         />
         <View style={styles.right}>

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -626,7 +626,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
         {(arrived && currentStationIndex < index + 1) || !passed ? (
           <LinearGradient
             colors={
-              line
+              line.lineColorC
                 ? [
                     `${prependHEX(lineColors[index] || line.lineColorC)}ff`,
                     `${prependHEX(lineColors[index] || line.lineColorC)}bb`,
@@ -662,7 +662,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           <BarTerminal
             style={styles.barTerminal}
             lineColor={
-              line
+              line.lineColorC
                 ? prependHEX(
                     lineColors[lineColors.length - 1] || line.lineColorC
                   )
@@ -764,7 +764,7 @@ const LineBoardEast: React.FC<Props> = ({
           <EmptyStationNameCell
             lastLineColor={
               lineColors[lineColors.length - 1] ||
-              prependHEX(line?.lineColorC, '#fff')
+              prependHEX(line?.lineColorC || '#fff')
             }
             key={i}
             isLast={

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -29,6 +29,7 @@ import getIsPass from '../utils/isPass';
 import isSmallTablet from '../utils/isSmallTablet';
 import isTablet from '../utils/isTablet';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
+import prependHEX from '../utils/prependHEX';
 import { heightScale, widthScale } from '../utils/scale';
 import BarTerminal from './BarTerminalEast';
 import Chevron from './ChervronTY';
@@ -627,8 +628,8 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             colors={
               line
                 ? [
-                    `#${lineColors[index] || line.lineColorC}ff`,
-                    `#${lineColors[index] || line.lineColorC}bb`,
+                    `${prependHEX(lineColors[index] || line.lineColorC)}ff`,
+                    `${prependHEX(lineColors[index] || line.lineColorC)}bb`,
                   ]
                 : ['#000000ff', '#000000bb']
             }
@@ -662,7 +663,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             style={styles.barTerminal}
             lineColor={
               line
-                ? `#${lineColors[lineColors.length - 1] || line.lineColorC}`
+                ? prependHEX(
+                    lineColors[lineColors.length - 1] || line.lineColorC
+                  )
                 : '#000'
             }
             hasTerminus={hasTerminus}
@@ -690,9 +693,7 @@ const EmptyStationNameCell: React.FC<EmptyStationNameCellProps> = ({
   isLast,
   hasTerminus,
 }: EmptyStationNameCellProps) => {
-  const lastLineColor = lastLineColorOriginal.startsWith('#')
-    ? lastLineColorOriginal
-    : `#${lastLineColorOriginal}`;
+  const lastLineColor = prependHEX(lastLineColorOriginal);
   const { left: barLeft, width: barWidth } = useBarStyles({});
 
   return (
@@ -763,7 +764,7 @@ const LineBoardEast: React.FC<Props> = ({
           <EmptyStationNameCell
             lastLineColor={
               lineColors[lineColors.length - 1] ||
-              `#${line?.lineColorC || 'fff'}`
+              prependHEX(line?.lineColorC, '#fff')
             }
             key={i}
             isLast={

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -510,7 +510,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
         {(arrived && currentStationIndex < index + 1) || !passed ? (
           <LinearGradient
             colors={
-              line
+              line?.lineColorC
                 ? [
                     `${prependHEX(lineColors[index] || line.lineColorC)}ff`,
                     `${prependHEX(lineColors[index] || line.lineColorC)}bb`,
@@ -548,7 +548,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           <BarTerminal
             style={styles.barTerminal}
             lineColor={
-              line
+              line?.lineColorC
                 ? prependHEX(
                     lineColors[lineColors.length - 1] || line.lineColorC
                   )

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -28,6 +28,7 @@ import getIsPass from '../utils/isPass';
 import isSmallTablet from '../utils/isSmallTablet';
 import isTablet from '../utils/isTablet';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
+import prependHEX from '../utils/prependHEX';
 import { heightScale, widthScale } from '../utils/scale';
 import BarTerminal from './BarTerminalSaikyo';
 import Chevron from './ChervronTY';
@@ -511,8 +512,8 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             colors={
               line
                 ? [
-                    `#${lineColors[index] || line.lineColorC}ff`,
-                    `#${lineColors[index] || line.lineColorC}bb`,
+                    `${prependHEX(lineColors[index] || line.lineColorC)}ff`,
+                    `${prependHEX(lineColors[index] || line.lineColorC)}bb`,
                   ]
                 : ['#000000ff', '#000000bb']
             }
@@ -548,7 +549,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             style={styles.barTerminal}
             lineColor={
               line
-                ? `#${lineColors[lineColors.length - 1] || line.lineColorC}`
+                ? prependHEX(
+                    lineColors[lineColors.length - 1] || line.lineColorC
+                  )
                 : '#000'
             }
             hasTerminus={hasTerminus}

--- a/src/components/LineBoardWest.tsx
+++ b/src/components/LineBoardWest.tsx
@@ -421,7 +421,9 @@ const LineBoardWest: React.FC<Props> = ({ stations, lineColors }: Props) => {
           style={{
             ...styles.bar,
             left: barWidth * i,
-            backgroundColor: lc ? prependHEX(lc) : prependHEX(line?.lineColorC),
+            backgroundColor: lc
+              ? prependHEX(lc)
+              : prependHEX(line?.lineColorC ?? '#000'),
           }}
         />
       ))}
@@ -449,7 +451,7 @@ const LineBoardWest: React.FC<Props> = ({ stations, lineColors }: Props) => {
       <View
         style={{
           ...styles.barTerminal,
-          borderBottomColor: line
+          borderBottomColor: line.lineColorC
             ? prependHEX(lineColors[lineColors.length - 1] || line.lineColorC)
             : '#000',
         }}

--- a/src/components/LineBoardWest.tsx
+++ b/src/components/LineBoardWest.tsx
@@ -27,6 +27,7 @@ import getIsPass from '../utils/isPass';
 import isSmallTablet from '../utils/isSmallTablet';
 import isTablet from '../utils/isTablet';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
+import prependHEX from '../utils/prependHEX';
 import { heightScale } from '../utils/scale';
 import Chevron from './ChevronJRWest';
 import PadLineMarks from './PadLineMarks';
@@ -420,7 +421,7 @@ const LineBoardWest: React.FC<Props> = ({ stations, lineColors }: Props) => {
           style={{
             ...styles.bar,
             left: barWidth * i,
-            backgroundColor: lc ? `#${lc}` : `#${line?.lineColorC}`,
+            backgroundColor: lc ? prependHEX(lc) : prependHEX(line?.lineColorC),
           }}
         />
       ))}
@@ -449,7 +450,7 @@ const LineBoardWest: React.FC<Props> = ({ stations, lineColors }: Props) => {
         style={{
           ...styles.barTerminal,
           borderBottomColor: line
-            ? `#${lineColors[lineColors.length - 1] || line.lineColorC}`
+            ? prependHEX(lineColors[lineColors.length - 1] || line.lineColorC)
             : '#000',
         }}
       />

--- a/src/components/LineBoardYamanotePad.tsx
+++ b/src/components/LineBoardYamanotePad.tsx
@@ -14,6 +14,7 @@ import lineState from '../store/atoms/line';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import isTablet from '../utils/isTablet';
+import prependHEX from '../utils/prependHEX';
 import PadArch from './PadArch';
 
 interface Props {
@@ -205,10 +206,10 @@ const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
         return s.stationNumbers[stationNumberIndex] && lineMarkShape
           ? {
               stationNumber: s.stationNumbers[stationNumberIndex].stationNumber,
-              lineColor: `#${
+              lineColor: prependHEX(
                 s.stationNumbers[stationNumberIndex]?.lineSymbolColor ??
-                s.currentLine.lineColorC
-              }`,
+                  s.currentLine.lineColorC
+              ),
               lineMarkShape,
             }
           : null;

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -19,6 +19,7 @@ import { parenthesisRegexp } from '../constants/regexp';
 import { LineMark } from '../models/LineMark';
 import { Line, Station } from '../models/StationAPI';
 import getIsPass from '../utils/isPass';
+import prependHEX from '../utils/prependHEX';
 import ChevronYamanote from './ChevronYamanote';
 import NumberingIcon from './NumberingIcon';
 import TransferLineDot from './TransferLineDot';
@@ -428,7 +429,7 @@ class PadArch extends React.PureComponent<Props, State> {
     const pathD3 = `M 0 -64 A ${windowWidth / 1.5} ${windowHeight} 0 0 1 ${
       windowWidth / 1.5
     } ${windowHeight}`;
-    const hexLineColor = `#${line.lineColorC}`;
+    const hexLineColor = prependHEX(line.lineColorC);
 
     return (
       <>

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -429,7 +429,7 @@ class PadArch extends React.PureComponent<Props, State> {
     const pathD3 = `M 0 -64 A ${windowWidth / 1.5} ${windowHeight} 0 0 1 ${
       windowWidth / 1.5
     } ${windowHeight}`;
-    const hexLineColor = prependHEX(line.lineColorC);
+    const hexLineColor = prependHEX(line.lineColorC ?? '#000');
 
     return (
       <>
@@ -492,9 +492,12 @@ class PadArch extends React.PureComponent<Props, State> {
                       }
                     >
                       <NumberingIcon
-                        shape={numberingInfo[i]?.lineMarkShape?.signShape}
-                        lineColor={numberingInfo[i]?.lineColor}
-                        stationNumber={numberingInfo[i]?.stationNumber}
+                        shape={
+                          numberingInfo[i]?.lineMarkShape?.signShape ??
+                          MARK_SHAPE.NOOP
+                        }
+                        lineColor={numberingInfo[i]?.lineColor ?? '#000'}
+                        stationNumber={numberingInfo[i]?.stationNumber ?? ''}
                         allowScaling={false}
                       />
                     </View>

--- a/src/components/TransferLineDot.tsx
+++ b/src/components/TransferLineDot.tsx
@@ -2,6 +2,7 @@ import { grayscale } from 'polished';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Line } from '../models/StationAPI';
+import prependHEX from '../utils/prependHEX';
 
 interface Props {
   line: Line;
@@ -24,7 +25,7 @@ const TransferLineDot: React.FC<Props> = ({
     },
   });
 
-  const fadedLineColor = grayscale(`#${line?.lineColorC || 'ccc'}`);
+  const fadedLineColor = grayscale(prependHEX(line?.lineColorC, '#ccc'));
 
   return (
     <View
@@ -32,7 +33,7 @@ const TransferLineDot: React.FC<Props> = ({
         styles.lineDot,
         {
           backgroundColor: !shouldGrayscale
-            ? `#${line.lineColorC}`
+            ? prependHEX(line.lineColorC)
             : fadedLineColor,
         },
       ]}

--- a/src/components/TransferLineDot.tsx
+++ b/src/components/TransferLineDot.tsx
@@ -25,7 +25,7 @@ const TransferLineDot: React.FC<Props> = ({
     },
   });
 
-  const fadedLineColor = grayscale(prependHEX(line?.lineColorC, '#ccc'));
+  const fadedLineColor = grayscale(prependHEX(line?.lineColorC ?? '#ccc'));
 
   return (
     <View
@@ -33,7 +33,7 @@ const TransferLineDot: React.FC<Props> = ({
         styles.lineDot,
         {
           backgroundColor: !shouldGrayscale
-            ? prependHEX(line.lineColorC)
+            ? prependHEX(line.lineColorC ?? '#000')
             : fadedLineColor,
         },
       ]}

--- a/src/components/TransferLineMark.tsx
+++ b/src/components/TransferLineMark.tsx
@@ -10,6 +10,7 @@ import {
 import { LineMark } from '../models/LineMark';
 import { Line } from '../models/StationAPI';
 import isTablet from '../utils/isTablet';
+import prependHEX from '../utils/prependHEX';
 import NumberingIcon from './NumberingIcon';
 
 interface Props {
@@ -59,7 +60,7 @@ const TransferLineMark: React.FC<Props> = ({
   );
 
   const fadedLineColor = useMemo(
-    () => grayscale(color || `#${line?.lineColorC || 'ccc'}`),
+    () => grayscale(color || prependHEX(line?.lineColorC, '#ccc')),
     [color, line?.lineColorC]
   );
 
@@ -91,7 +92,9 @@ const TransferLineMark: React.FC<Props> = ({
         <NumberingIcon
           shape={mark.signShape}
           lineColor={
-            shouldGrayscale ? fadedLineColor : color || `#${line?.lineColorC}`
+            shouldGrayscale
+              ? fadedLineColor
+              : color || prependHEX(line?.lineColorC)
           }
           stationNumber={`${
             mark.signShape === MARK_SHAPE.JR_UNION ? 'JR' : mark.sign || ''

--- a/src/components/TransferLineMark.tsx
+++ b/src/components/TransferLineMark.tsx
@@ -60,7 +60,7 @@ const TransferLineMark: React.FC<Props> = ({
   );
 
   const fadedLineColor = useMemo(
-    () => grayscale(color || prependHEX(line?.lineColorC, '#ccc')),
+    () => grayscale(color || prependHEX(line?.lineColorC || '#ccc')),
     [color, line?.lineColorC]
   );
 
@@ -94,7 +94,7 @@ const TransferLineMark: React.FC<Props> = ({
           lineColor={
             shouldGrayscale
               ? fadedLineColor
-              : color || prependHEX(line?.lineColorC)
+              : color || prependHEX(line?.lineColorC ?? '#000')
           }
           stationNumber={`${
             mark.signShape === MARK_SHAPE.JR_UNION ? 'JR' : mark.sign || ''

--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -16,6 +16,7 @@ import { APP_THEME, AppTheme } from '../models/Theme';
 import stationState from '../store/atoms/station';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
+import prependHEX from '../utils/prependHEX';
 import Heading from './Heading';
 import NumberingIcon from './NumberingIcon';
 import TransferLineDot from './TransferLineDot';
@@ -172,7 +173,9 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
                   <View style={styles.numberingIconContainer}>
                     <NumberingIcon
                       shape={signShape}
-                      lineColor={`#${stationNumbers[index]?.lineSymbolColor}`}
+                      lineColor={prependHEX(
+                        stationNumbers[index]?.lineSymbolColor
+                      )}
                       stationNumber={stationNumbers[index]?.stationNumber ?? ''}
                       allowScaling={false}
                     />

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -14,6 +14,7 @@ import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import isTablet from '../utils/isTablet';
 import { getIsLocal } from '../utils/localType';
+import prependHEX from '../utils/prependHEX';
 import { heightScale, widthScale } from '../utils/scale';
 import BarTerminalEast from './BarTerminalEast';
 
@@ -374,8 +375,8 @@ const TypeChangeNotify: React.FC = () => {
           />
           <LinearGradient
             colors={[
-              `#${currentTrainType.line.lineColorC}ff`,
-              `#${currentTrainType.line.lineColorC}bb`,
+              `${prependHEX(currentTrainType.line.lineColorC)}ff`,
+              `${prependHEX(currentTrainType.line.lineColorC)}bb`,
             ]}
             style={{
               ...styles.bar,
@@ -421,8 +422,8 @@ const TypeChangeNotify: React.FC = () => {
           />
           <LinearGradient
             colors={[
-              `#${nextTrainType.line.lineColorC}ff`,
-              `#${nextTrainType.line.lineColorC}bb`,
+              `${prependHEX(nextTrainType.line.lineColorC)}ff`,
+              `${prependHEX(nextTrainType.line.lineColorC)}bb`,
             ]}
             style={{
               ...styles.bar,
@@ -433,7 +434,7 @@ const TypeChangeNotify: React.FC = () => {
           />
           <BarTerminalEast
             style={[styles.barTerminal, { right: getBarTerminalRight() }]}
-            lineColor={`#${nextTrainType.line.lineColorC}`}
+            lineColor={prependHEX(nextTrainType.line.lineColorC)}
             hasTerminus={false}
           />
 
@@ -464,7 +465,7 @@ const TypeChangeNotify: React.FC = () => {
                 {
                   ...styles.lineText,
                   top: lineTextTopVal,
-                  color: `#${currentTrainType.line.lineColorC}`,
+                  color: prependHEX(currentTrainType.line.lineColorC),
                   fontSize: RFValue(12),
                   lineHeight: RFValue(Platform.OS === 'ios' ? 12 : 12 + 2),
                 },
@@ -499,7 +500,7 @@ const TypeChangeNotify: React.FC = () => {
                 {
                   ...styles.lineText,
                   top: lineTextTopVal,
-                  color: `#${nextTrainType.line.lineColorC}`,
+                  color: prependHEX(nextTrainType.line.lineColorC),
                   fontSize: RFValue(12),
                   lineHeight: RFValue(Platform.OS === 'ios' ? 12 : 12 + 2),
                 },

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -375,8 +375,8 @@ const TypeChangeNotify: React.FC = () => {
           />
           <LinearGradient
             colors={[
-              `${prependHEX(currentTrainType.line.lineColorC)}ff`,
-              `${prependHEX(currentTrainType.line.lineColorC)}bb`,
+              `${prependHEX(currentTrainType.line.lineColorC ?? '#000000')}ff`,
+              `${prependHEX(currentTrainType.line.lineColorC ?? '#000000')}bb`,
             ]}
             style={{
               ...styles.bar,
@@ -422,8 +422,8 @@ const TypeChangeNotify: React.FC = () => {
           />
           <LinearGradient
             colors={[
-              `${prependHEX(nextTrainType.line.lineColorC)}ff`,
-              `${prependHEX(nextTrainType.line.lineColorC)}bb`,
+              `${prependHEX(nextTrainType.line.lineColorC ?? '#000000')}ff`,
+              `${prependHEX(nextTrainType.line.lineColorC ?? '#000000')}bb`,
             ]}
             style={{
               ...styles.bar,
@@ -434,7 +434,7 @@ const TypeChangeNotify: React.FC = () => {
           />
           <BarTerminalEast
             style={[styles.barTerminal, { right: getBarTerminalRight() }]}
-            lineColor={prependHEX(nextTrainType.line.lineColorC)}
+            lineColor={prependHEX(nextTrainType.line.lineColorC ?? '#000000')}
             hasTerminus={false}
           />
 
@@ -465,7 +465,9 @@ const TypeChangeNotify: React.FC = () => {
                 {
                   ...styles.lineText,
                   top: lineTextTopVal,
-                  color: prependHEX(currentTrainType.line.lineColorC),
+                  color: prependHEX(
+                    currentTrainType.line.lineColorC ?? '#000000'
+                  ),
                   fontSize: RFValue(12),
                   lineHeight: RFValue(Platform.OS === 'ios' ? 12 : 12 + 2),
                 },
@@ -500,7 +502,7 @@ const TypeChangeNotify: React.FC = () => {
                 {
                   ...styles.lineText,
                   top: lineTextTopVal,
-                  color: prependHEX(nextTrainType.line.lineColorC),
+                  color: prependHEX(nextTrainType.line.lineColorC ?? '#000000'),
                   fontSize: RFValue(12),
                   lineHeight: RFValue(Platform.OS === 'ios' ? 12 : 12 + 2),
                 },

--- a/src/screens/SelectLine.tsx
+++ b/src/screens/SelectLine.tsx
@@ -130,7 +130,7 @@ const SelectLineScreen: React.FC = () => {
 
       return (
         <Button
-          color={prependHEX(line.lineColorC)}
+          color={prependHEX(line.lineColorC ?? '#000')}
           key={line.id}
           disabled={!isInternetAvailable && !isLineCached}
           style={styles.button}

--- a/src/screens/SelectLine.tsx
+++ b/src/screens/SelectLine.tsx
@@ -20,6 +20,7 @@ import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { isJapanese, translate } from '../translation';
 import isTablet from '../utils/isTablet';
+import prependHEX from '../utils/prependHEX';
 
 const styles = StyleSheet.create({
   rootPadding: {
@@ -129,7 +130,7 @@ const SelectLineScreen: React.FC = () => {
 
       return (
         <Button
-          color={`#${line.lineColorC}`}
+          color={prependHEX(line.lineColorC)}
           key={line.id}
           disabled={!isInternetAvailable && !isLineCached}
           style={styles.button}

--- a/src/utils/numbering.ts
+++ b/src/utils/numbering.ts
@@ -19,7 +19,7 @@ export const getNumberingColor = (
     return prependHEX(currentStationNumber?.lineSymbolColor);
   }
   if (arrived && nextStation?.currentLine) {
-    return prependHEX(nextStation.currentLine?.lineColorC);
+    return prependHEX(nextStation.currentLine?.lineColorC ?? '#000');
   }
-  return prependHEX(line?.lineColorC);
+  return prependHEX(line?.lineColorC ?? '#000');
 };

--- a/src/utils/numbering.ts
+++ b/src/utils/numbering.ts
@@ -1,4 +1,5 @@
 import { Line, Station, StationNumber } from '../models/StationAPI';
+import prependHEX from './prependHEX';
 
 // TODO: 消す
 export const getCurrentStationThreeLetterCode = (
@@ -15,10 +16,10 @@ export const getNumberingColor = (
   line: Line | null | undefined
 ): string => {
   if (currentStationNumber?.lineSymbolColor) {
-    return `#${currentStationNumber?.lineSymbolColor}`;
+    return prependHEX(currentStationNumber?.lineSymbolColor);
   }
   if (arrived && nextStation?.currentLine) {
-    return `#${nextStation.currentLine?.lineColorC}`;
+    return prependHEX(nextStation.currentLine?.lineColorC);
   }
-  return `#${line?.lineColorC}`;
+  return prependHEX(line?.lineColorC);
 };

--- a/src/utils/prependHEX.ts
+++ b/src/utils/prependHEX.ts
@@ -1,0 +1,18 @@
+/**
+ * string値の先頭に#がついていればそのまま返し、ついていなければ#をつけて返す
+ * 今後APIから渡ってくるデータはすべて#がついているHEXになる予定なので、API切り替えが終了したらこの関数も不要になるはず
+ */
+const prependHEX = (
+  value: string | null | undefined,
+  fallbackHEX = '#000000'
+): string => {
+  if (!value) {
+    return fallbackHEX;
+  }
+  if (value.startsWith('#')) {
+    return value;
+  }
+  return `#${value}`;
+};
+
+export default prependHEX;

--- a/src/utils/prependHEX.ts
+++ b/src/utils/prependHEX.ts
@@ -2,13 +2,7 @@
  * string値の先頭に#がついていればそのまま返し、ついていなければ#をつけて返す
  * 今後APIから渡ってくるデータはすべて#がついているHEXになる予定なので、API切り替えが終了したらこの関数も不要になるはず
  */
-const prependHEX = (
-  value: string | null | undefined,
-  fallbackHEX = '#000000'
-): string => {
-  if (!value) {
-    return fallbackHEX;
-  }
+const prependHEX = (value: string): string => {
   if (value.startsWith('#')) {
     return value;
   }


### PR DESCRIPTION
closes https://github.com/TrainLCD/MobileApp/issues/2170