### PR TITLE
行き先を選んだ直後にスリーレターコードが表示されないバグを修正

### DIFF
--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -22,7 +22,7 @@ const useNumbering = (
   const [threeLetterCode, setThreeLetterCode] = useState<string>()
 
   const nextStation = useNextStation()
-  const currentStation = useCurrentStation()
+  const currentStation = useCurrentStation({ withTrainTypes: true })
 
   const getStationNumberIndex = useStationNumberIndexFunc()
 


### PR DESCRIPTION
closes #2231