### PR TITLE
ナンバリング記号の表示条件から「selectedBoundがある」条件を撤廃

### DIFF
--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -44,7 +44,7 @@ const useNumbering = (
   }, [selectedBound])
 
   useEffect(() => {
-    if (!selectedBound || !stoppedCurrentStation) {
+    if (!stoppedCurrentStation) {
       return
     }
     if (priorCurrent && !getIsPass(stoppedCurrentStation)) {
@@ -74,7 +74,6 @@ const useNumbering = (
     nextStation?.threeLetterCode,
     nextStationNumberIndex,
     priorCurrent,
-    selectedBound,
     stoppedCurrentStation,
   ])
 


### PR DESCRIPTION
closes #2275
なんで `selectedBound` がない時にはナンバリング記号を非表示にさせたのかは思い出せないが、今のところ依存はしていなさそう