### PR TITLE
「まもなく」状態で中国語と韓国語が飛ばされるバグを修正

### DIFF
--- a/src/hooks/useWatchApproaching.ts
+++ b/src/hooks/useWatchApproaching.ts
@@ -50,8 +50,8 @@ const useWatchApproaching = (): void => {
   }, [arrived, headerState, setNavigation, station])
 
   const isExtraLangAvailable = useMemo(
-    () => !!station?.nameZh || !!station?.nameKo,
-    [station?.nameKo, station?.nameZh]
+    () => !!station?.nameChinese || !!station?.nameKorean,
+    [station?.nameChinese, station?.nameKorean]
   )
 
   useIntervalEffect(


### PR DESCRIPTION
GraphQLのフィールド名を使っていてgRPCのフィールド名と違うのでアプリがnameKoとnameZhがないんだから登録されていないんだろうと勘違いしてたっぽい