### PR TITLE
一部の駅で列車種別リストを取得出来ないバグを修正

### DIFF
--- a/src/hooks/useStationList.ts
+++ b/src/hooks/useStationList.ts
@@ -115,7 +115,7 @@ const useStationList = (
         stations: data.stationsList,
       }))
 
-      if (station?.hasTrainTypes) {
+      if (selectedLine?.station?.hasTrainTypes) {
         await fetchTrainTypes()
       }
       setLoading(false)
@@ -127,8 +127,8 @@ const useStationList = (
     fetchTrainTypes,
     grpcClient,
     selectedLine?.id,
+    selectedLine?.station,
     setStationState,
-    station?.hasTrainTypes,
   ])
 
   const fetchSelectedTrainTypeStations = useCallback(async () => {


### PR DESCRIPTION
本来であれば選択した路線に紐づく駅IDから種別リストを取得するべきであったが、座標から駅IDを取る or 駅検索で駅IDを取るという方法を取った場合、選択した路線に紐づく駅IDとステートに保持してある駅IDが異なり、列車種別を正しく取得できなかった