### PR TITLE
ピッカーのバージョン下げ&iOS起動しない問題修正

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1364,7 +1364,7 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNCAsyncStorage (1.18.2):
     - React-Core
-  - RNCPicker (2.5.0):
+  - RNCPicker (2.4.10):
     - React-Core
   - RNDeviceInfo (10.8.0):
     - React-Core
@@ -1827,7 +1827,7 @@ SPEC CHECKSUMS:
   ReactCommon: c68789e9f44e4d5e6c5c9e2688f651779890d8bb
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
-  RNCPicker: 32ca102146bc7d34a8b93a998d9938d9f9ec7898
+  RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
   RNDeviceInfo: 5795b418ed3451ebcaf39384e6cf51f60cb931c9
   RNFBAnalytics: 66696f4ff7bf8d88d1a23bce8a2a3553d5a093a0
   RNFBApp: 0b534885354024f4d171ede8da04521d81bc1767

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@react-native-firebase/messaging": "^18.3.2",
         "@react-native-firebase/remote-config": "^18.3.2",
         "@react-native-firebase/storage": "^18.3.2",
-        "@react-native-picker/picker": "^2.5.0",
+        "@react-native-picker/picker": "2.4.10",
         "@react-navigation/native": "^5.9.8",
         "@react-navigation/stack": "^5.14.9",
         "dayjs": "^1.10.7",
@@ -7563,9 +7563,9 @@
       }
     },
     "node_modules/@react-native-picker/picker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.5.0.tgz",
-      "integrity": "sha512-AEZPKwXavmP4VkUUD6bskCrNF+zgd1RvsXJ208YewZSikGZCo0RLlnQxPDrdKoFpbigSYxbvRU5d8h3TzzeQ8Q==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
+      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
       "peerDependencies": {
         "react": ">=16",
         "react-native": ">=0.57"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@react-native-firebase/messaging": "^18.3.2",
     "@react-native-firebase/remote-config": "^18.3.2",
     "@react-native-firebase/storage": "^18.3.2",
-    "@react-native-picker/picker": "^2.5.0",
     "@react-navigation/native": "^5.9.8",
     "@react-navigation/stack": "^5.14.9",
     "dayjs": "^1.10.7",
@@ -81,7 +80,8 @@
     "react-native-web": "~0.19.6",
     "recoil": "^0.1.2",
     "text-encoding": "^0.7.0",
-    "xregexp": "^5.0.2"
+    "xregexp": "^5.0.2",
+    "@react-native-picker/picker": "2.4.10"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/src/components/RecoilDebugObserver.tsx
+++ b/src/components/RecoilDebugObserver.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useRecoilSnapshot } from 'recoil'
+
+const RecoilDebugObserver = () => {
+  const snapshot = useRecoilSnapshot()
+  useEffect(() => {
+    console.debug('The following atoms were modified:')
+    for (const node of snapshot.getNodes_UNSTABLE({ isModified: true })) {
+      console.debug(node.key, snapshot.getLoadable(node))
+    }
+  }, [snapshot])
+
+  return null
+}
+
+export default RecoilDebugObserver

--- a/src/hooks/useFetchNearbyStation.ts
+++ b/src/hooks/useFetchNearbyStation.ts
@@ -52,10 +52,11 @@ const useFetchNearbyStation = (): ((
           fetchStationError: null,
           fetchStationLoading: false,
         }))
-      } catch (err) {
+      } catch (_err) {
+        const err = _err as Error
         setStation((prev) => ({
           ...prev,
-          fetchStationError: err as Error,
+          fetchStationError: err,
           fetchStationLoading: false,
         }))
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import { StatusBar, Text } from 'react-native'
 import { RecoilRoot } from 'recoil'
 import ErrorFallback from './components/ErrorBoundary'
 import FakeStationSettings from './components/FakeStationSettings'
+import RecoilDebugObserver from './components/RecoilDebugObserver'
 import TuningSettings from './components/TuningSettings'
 import { LOCATION_TASK_NAME } from './constants/location'
 import useAnonymousUser from './hooks/useAnonymousUser'
@@ -114,46 +115,49 @@ const App: React.FC = () => {
       onError={handleBoundaryError}
     >
       <RecoilRoot>
-        <ActionSheetProvider>
-          <NavigationContainer ref={navigationRef}>
-            <StatusBar hidden translucent backgroundColor="transparent" />
+        <>
+          <RecoilDebugObserver />
+          <ActionSheetProvider>
+            <NavigationContainer ref={navigationRef}>
+              <StatusBar hidden translucent backgroundColor="transparent" />
 
-            <Stack.Navigator
-              screenOptions={screenOptions}
-              initialRouteName={permissionsGranted ? 'MainStack' : 'Privacy'}
-            >
-              <Stack.Screen
-                options={options}
-                name="Privacy"
-                component={PrivacyScreen}
-              />
+              <Stack.Navigator
+                screenOptions={screenOptions}
+                initialRouteName={permissionsGranted ? 'MainStack' : 'Privacy'}
+              >
+                <Stack.Screen
+                  options={options}
+                  name="Privacy"
+                  component={PrivacyScreen}
+                />
 
-              <Stack.Screen
-                options={options}
-                name="FakeStation"
-                component={FakeStationSettings}
-              />
+                <Stack.Screen
+                  options={options}
+                  name="FakeStation"
+                  component={FakeStationSettings}
+                />
 
-              <Stack.Screen
-                options={options}
-                name="ConnectMirroringShare"
-                component={ConnectMirroringShareSettings}
-              />
+                <Stack.Screen
+                  options={options}
+                  name="ConnectMirroringShare"
+                  component={ConnectMirroringShareSettings}
+                />
 
-              <Stack.Screen
-                options={options}
-                name="TuningSettings"
-                component={TuningSettings}
-              />
+                <Stack.Screen
+                  options={options}
+                  name="TuningSettings"
+                  component={TuningSettings}
+                />
 
-              <Stack.Screen
-                options={options}
-                name="MainStack"
-                component={MainStack}
-              />
-            </Stack.Navigator>
-          </NavigationContainer>
-        </ActionSheetProvider>
+                <Stack.Screen
+                  options={options}
+                  name="MainStack"
+                  component={MainStack}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
+          </ActionSheetProvider>
+        </>
       </RecoilRoot>
     </ErrorBoundary>
   )


### PR DESCRIPTION
#2526

`@react-native-picker/picker` を `npx expo install` で入れ直したらマイナーバージョンが古くなったので多分バージョンを上げすぎた