### PR TITLE
bump picker and recoil version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1362,7 +1362,7 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNCAsyncStorage (1.18.2):
     - React-Core
-  - RNCPicker (2.4.10):
+  - RNCPicker (2.5.0):
     - React-Core
   - RNDeviceInfo (10.8.0):
     - React-Core
@@ -1821,7 +1821,7 @@ SPEC CHECKSUMS:
   ReactCommon: c68789e9f44e4d5e6c5c9e2688f651779890d8bb
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
-  RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
+  RNCPicker: 32ca102146bc7d34a8b93a998d9938d9f9ec7898
   RNDeviceInfo: 5795b418ed3451ebcaf39384e6cf51f60cb931c9
   RNFBAnalytics: 66696f4ff7bf8d88d1a23bce8a2a3553d5a093a0
   RNFBApp: 0b534885354024f4d171ede8da04521d81bc1767

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@react-native-firebase/messaging": "^18.3.2",
         "@react-native-firebase/remote-config": "^18.3.2",
         "@react-native-firebase/storage": "^18.3.2",
-        "@react-native-picker/picker": "2.4.10",
+        "@react-native-picker/picker": "2.5.0",
         "@react-navigation/native": "^5.9.8",
         "@react-navigation/stack": "^5.14.9",
         "dayjs": "^1.10.7",
@@ -69,7 +69,7 @@
         "react-native-view-shot": "3.7.0",
         "react-native-watch-connectivity": "^1.0.11",
         "react-native-web": "~0.19.6",
-        "recoil": "^0.1.2",
+        "recoil": "^0.7.7",
         "text-encoding": "^0.7.0",
         "xregexp": "^5.0.2"
       },
@@ -7551,9 +7551,9 @@
       }
     },
     "node_modules/@react-native-picker/picker": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
-      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.5.0.tgz",
+      "integrity": "sha512-AEZPKwXavmP4VkUUD6bskCrNF+zgd1RvsXJ208YewZSikGZCo0RLlnQxPDrdKoFpbigSYxbvRU5d8h3TzzeQ8Q==",
       "peerDependencies": {
         "react": ">=16",
         "react-native": ">=0.57"
@@ -13974,6 +13974,11 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.4.2.tgz",
       "integrity": "sha512-gUxWq42l5ldaRplcKb4Pw5O4XBONWZgz3vxIIXnfIeJj8Jc3wYiq2O4c9xzx/NGbbPEej4rhI62C9eTENwLGNw=="
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -23244,9 +23249,12 @@
       }
     },
     "node_modules/recoil": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.1.3.tgz",
-      "integrity": "sha512-/Rm7wN7jqCjhtFK1TgtK0V115SUXNu6d4QYvwxWNLydib0QChSmpB6U8CaHoRPS0MFWtAIsD/IFjpbfk/OYm7Q==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
       "peerDependencies": {
         "react": ">=16.13.1"
       },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@react-native-firebase/messaging": "^18.3.2",
     "@react-native-firebase/remote-config": "^18.3.2",
     "@react-native-firebase/storage": "^18.3.2",
+    "@react-native-picker/picker": "2.5.0",
     "@react-navigation/native": "^5.9.8",
     "@react-navigation/stack": "^5.14.9",
     "dayjs": "^1.10.7",
@@ -75,10 +76,9 @@
     "react-native-view-shot": "3.7.0",
     "react-native-watch-connectivity": "^1.0.11",
     "react-native-web": "~0.19.6",
-    "recoil": "^0.1.2",
+    "recoil": "^0.7.7",
     "text-encoding": "^0.7.0",
-    "xregexp": "^5.0.2",
-    "@react-native-picker/picker": "2.4.10"
+    "xregexp": "^5.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",


### PR DESCRIPTION
#2526

`Recoil` と `@react-native-picker/picker` のバージョンを上げたらピッカーのアイテム選択時の挙動不審が直った(iOS)