### PR TITLE
JSに関係ない修正のときはESLintとJestを走らせない

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
 
 jobs:
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
 
 env:
   cache-version: v1


### PR DESCRIPTION
close #2663

src配下はjs/tsだけに限定してもいいのだが墓穴掘りたくないので一旦この条件