### PR TITLE
現時点でMetricKitは必要ないのでコードから削除

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 import Firebase
-import MetricKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -27,17 +26,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.window?.rootViewController = rootViewController
     self.window?.makeKeyAndVisible()
     
-    MXMetricManager.shared.add(self)
     FirebaseApp.configure()
     
     return true
   }
-  
-  func applicationWillTerminate(_ application: UIApplication) {
-    MXMetricManager.shared.remove(self)
-  }
-}
-
-extension AppDelegate: MXMetricManagerSubscriber {
-  func didReceive(_ payloads: [MXMetricPayload]) {}
 }


### PR DESCRIPTION
Organizerのメトリクスに出ている値が取れない理由はMetricKitが入っていないからという理由だと実装時勘違いしていて、実際出ていなかった理由は情報が足りなかっただけっぽい