### PR TITLE
通過駅は平均駅間距離計算時には無視す る

### DIFF
--- a/src/hooks/useAverageDistance.ts
+++ b/src/hooks/useAverageDistance.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 import { COMPUTE_DISTANCE_ACCURACY } from '../constants/location'
 import stationState from '../store/atoms/station'
+import { StopCondition } from '../gen/stationapi_pb'
 
 const useAverageDistance = (): number => {
   const { stations } = useRecoilValue(stationState)
@@ -12,20 +13,22 @@ const useAverageDistance = (): number => {
     (): number =>
       !stations.length
         ? 0
-        : stations.reduce((acc, cur, idx, arr) => {
-            const prev = arr[idx - 1]
-            if (!prev) {
-              return acc
-            }
-            const { latitude, longitude } = cur
-            const { latitude: prevLatitude, longitude: prevLongitude } = prev
-            const distance = geolib.getDistance(
-              { latitude, longitude },
-              { latitude: prevLatitude, longitude: prevLongitude },
-              COMPUTE_DISTANCE_ACCURACY
-            )
-            return acc + distance
-          }, 0) / stations.length,
+        : stations
+            .filter((s) => s.stopCondition !== StopCondition.NOT)
+            .reduce((acc, cur, idx, arr) => {
+              const prev = arr[idx - 1]
+              if (!prev) {
+                return acc
+              }
+              const { latitude, longitude } = cur
+              const { latitude: prevLatitude, longitude: prevLongitude } = prev
+              const distance = geolib.getDistance(
+                { latitude, longitude },
+                { latitude: prevLatitude, longitude: prevLongitude },
+                COMPUTE_DISTANCE_ACCURACY
+              )
+              return acc + distance
+            }, 0) / stations.length,
     [stations]
   )
 


### PR DESCRIPTION
直接関係ないが似たようなチケット: #2783
短い間隔で駅があるとしても特急等の場合は勝手が違うので完全な通過駅は平均駅間距離には使わないようにした