### PR TITLE
Typographyの視覚的な表示をiOSとAndroidで共通化

### DIFF
--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -21,6 +21,8 @@ const Typography = (props: TextProps) => {
       {
         fontFamily,
         color: isLEDTheme ? '#fff' : '#000',
+        includeFontPadding: false,
+        textAlignVertical: 'center' as const,
       },
       overrideStyle,
     ],


### PR DESCRIPTION
アプリの仕様上 `includeFontPadding` が必要なタイミングが少ないと思うので `includeFontPadding: false` をTypographyに設定