### PR TITLE
一定条件で暴走するバグを修正

### DIFF
--- a/src/hooks/useDetectBadAccuracy.ts
+++ b/src/hooks/useDetectBadAccuracy.ts
@@ -1,13 +1,11 @@
 import { useEffect } from 'react'
-import { useRecoilState, useRecoilValue } from 'recoil'
+import { useRecoilState } from 'recoil'
 import locationState from '../store/atoms/location'
-import stationState from '../store/atoms/station'
 import { getArrivedThreshold } from '../utils/threshold'
 import useAverageDistance from './useAverageDistance'
 import { useCurrentLine } from './useCurrentLine'
 
 const useDetectBadAccuracy = (): void => {
-  const { stations } = useRecoilValue(stationState)
   const [{ location }, setLocation] = useRecoilState(locationState)
 
   const currentLine = useCurrentLine()
@@ -33,11 +31,10 @@ const useDetectBadAccuracy = (): void => {
       }))
     }
   }, [
-    location?.coords?.accuracy,
-    currentLine,
-    setLocation,
-    stations,
     avgDistance,
+    currentLine?.lineType,
+    location?.coords.accuracy,
+    setLocation,
   ])
 }
 

--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -1,11 +1,13 @@
+import * as Location from 'expo-location'
 import { useCallback } from 'react'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { LOCATION_TASK_NAME } from '../constants'
+import mirroringShareState from '../store/atoms/mirroringShare'
 import navigationState from '../store/atoms/navigation'
 import speechState from '../store/atoms/speech'
 import stationState from '../store/atoms/station'
 import { isJapanese } from '../translation'
 import useMirroringShare from './useMirroringShare'
-import mirroringShareState from '../store/atoms/mirroringShare'
 
 const useResetMainState = (): (() => void) => {
   const setNavigationState = useSetRecoilState(navigationState)
@@ -15,6 +17,13 @@ const useResetMainState = (): (() => void) => {
   const { unsubscribe: unsubscribeMirroringShare } = useMirroringShare()
 
   const reset = useCallback(async () => {
+    const isStarted = await Location.hasStartedLocationUpdatesAsync(
+      LOCATION_TASK_NAME
+    )
+    if (isStarted) {
+      await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+    }
+
     setNavigationState((prev) => ({
       ...prev,
       headerState: isJapanese ? 'CURRENT' : 'CURRENT_EN',

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -213,24 +213,15 @@ const MainScreen: React.FC = () => {
 
   useFocusEffect(
     useCallback(() => {
-      const startUpdateLocationAsync = async () => {
-        if (!autoModeEnabledRef.current && !subscribingRef.current) {
-          await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-            accuracy: locationAccuracyRef.current,
-            foregroundService: {
-              notificationTitle: translate('bgAlertTitle'),
-              notificationBody: translate('bgAlertContent'),
-              killServiceOnDestroy: true,
-            },
-          })
-        }
-      }
-
-      startUpdateLocationAsync()
-
-      return () => {
-        Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
-        globalSetBGLocation = null
+      if (!autoModeEnabledRef.current && !subscribingRef.current) {
+        Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+          accuracy: locationAccuracyRef.current,
+          foregroundService: {
+            notificationTitle: translate('bgAlertTitle'),
+            notificationBody: translate('bgAlertContent'),
+            killServiceOnDestroy: true,
+          },
+        })
       }
     }, [])
   )

--- a/src/screens/SelectLine.tsx
+++ b/src/screens/SelectLine.tsx
@@ -1,7 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation } from '@react-navigation/native'
 import * as Location from 'expo-location'
-import * as TaskManager from 'expo-task-manager'
 import React, { useCallback, useEffect } from 'react'
 import { Alert, ScrollView, StyleSheet, View } from 'react-native'
 import { useRecoilState, useSetRecoilState } from 'recoil'
@@ -99,9 +98,15 @@ const SelectLineScreen: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    if (TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {
-      Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+    const stopLocationUpdatesAsync = async () => {
+      const isStarted = await Location.hasStartedLocationUpdatesAsync(
+        LOCATION_TASK_NAME
+      )
+      if (isStarted) {
+        await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+      }
     }
+    stopLocationUpdatesAsync()
   }, [])
 
   const navigation = useNavigation()


### PR DESCRIPTION
`useFocusEffect` のコード内に位置情報取得を止めるためのクリーンアップ関数があるとされると暴走するようで、戻る時位置情報取得を自動的に止める方法を副作用から分離した