### PR TITLE
PermittedでuseDetectBadAccuracy()を呼ばない

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -23,7 +23,6 @@ import useCachedInitAnonymousUser from '../hooks/useCachedAnonymousUser'
 import useCheckStoreVersion from '../hooks/useCheckStoreVersion'
 import useConnectivity from '../hooks/useConnectivity'
 import { useCurrentLine } from '../hooks/useCurrentLine'
-import useDetectBadAccuracy from '../hooks/useDetectBadAccuracy'
 import useListenMessaging from '../hooks/useListenMessaging'
 import useReport from '../hooks/useReport'
 import useReportEligibility from '../hooks/useReportEligibility'
@@ -87,7 +86,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { subscribing } = useRecoilValue(mirroringShareState)
 
   useCheckStoreVersion()
-  useDetectBadAccuracy()
   useAppleWatch()
   useAndroidWearable()
   useUpdateLiveActivities()

--- a/src/hooks/useDetectBadAccuracy.ts
+++ b/src/hooks/useDetectBadAccuracy.ts
@@ -12,13 +12,13 @@ const useDetectBadAccuracy = (): void => {
   const avgDistance = useAverageDistance()
 
   useEffect(() => {
+    if (!location?.coords?.accuracy) {
+      return
+    }
     const maximumAccuracy = getArrivedThreshold(
       currentLine?.lineType,
       avgDistance
     )
-    if (!location?.coords?.accuracy) {
-      return
-    }
     if ((location.coords.accuracy || 0) > maximumAccuracy) {
       setLocation((prev) => ({
         ...prev,

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -35,6 +35,7 @@ import { LineType, StopCondition } from '../gen/stationapi_pb'
 import useAutoMode from '../hooks/useAutoMode'
 import { useCurrentLine } from '../hooks/useCurrentLine'
 import useCurrentStation from '../hooks/useCurrentStation'
+import useDetectBadAccuracy from '../hooks/useDetectBadAccuracy'
 import { useIsLEDTheme } from '../hooks/useIsLEDTheme'
 import { useLoopLine } from '../hooks/useLoopLine'
 import useNextOperatorTrainTypeIsDifferent from '../hooks/useNextOperatorTrainTypeIsDifferent'
@@ -223,6 +224,11 @@ const MainScreen: React.FC = () => {
           },
         })
       }
+
+      return () => {
+        Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+        globalSetBGLocation = null
+      }
     }, [])
   )
 
@@ -239,9 +245,10 @@ const MainScreen: React.FC = () => {
   useTransitionHeaderState()
   useRefreshLeftStations()
   useRefreshStation()
-  const { pause: pauseBottomTimer } = useUpdateBottomState()
   useKeepAwake()
+  useDetectBadAccuracy()
   const handleBackButtonPress = useResetMainState()
+  const { pause: pauseBottomTimer } = useUpdateBottomState()
 
   const transferStation = useMemo(
     () =>


### PR DESCRIPTION
#3007 で直ったと思ってたけど直ってなかった
`Permitted` で `useDetectBadAccuracy()` を実行するとレースコンディションが発生し暴走するので `Main` コンポーネントに移した
仕様的に別にアプリ起動直後に位置情報精度が悪い事を伝えられなくとも問題ないと思う