### PR TITLE
TaskManager.defineTaskをuseEffectでラップ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "google-protobuf": "^3.21.2",
         "grpc-web": "^1.4.2",
         "i18n-js": "^3.5.1",
-        "jest-expo": "~49.0.0",
         "lodash": "^4.17.20",
         "polished": "^4.1.3",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "google-protobuf": "^3.21.2",
     "grpc-web": "^1.4.2",
     "i18n-js": "^3.5.1",
-    "jest-expo": "~49.0.0",
     "lodash": "^4.17.20",
     "polished": "^4.1.3",
     "react": "18.2.0",


### PR DESCRIPTION
#3030

バックグラウンドの位置情報取得の実装をする際 `TaskManager.defineTask` をコンポーネントの外に置かないとエラーがでてた気がするが、普通に動いてる（うろ覚え）