### PR TITLE
位置情報取得パラメタ修正

### DIFF
--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -199,7 +199,9 @@ const MainScreen: React.FC = () => {
     if (!autoModeEnabledRef.current && !subscribingRef.current) {
       Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
         accuracy: locationAccuracyRef.current,
-        distanceInterval: 100,
+        activityType: Location.ActivityType.AutomotiveNavigation,
+        distanceInterval: 10,
+        pausesUpdatesAutomatically: false,
         foregroundService: {
           notificationTitle: translate('bgAlertTitle'),
           notificationBody: translate('bgAlertContent'),


### PR DESCRIPTION
- `distanceInterval` を `100m` から `10m` と短くした
  - 発車と停車の検出が遅い時があるので
  - トーゼン消費電力も変わってくるのでバッテリ持ちも加味してフィールドテストをする必要がある
- `activityType` に `AutomotiveNavigation` を指定
  - よくわからないが電車で使う前提なので指定して様子見
- `pausesUpdatesAutomatically` を `false` に
  -  勝手に更新が止まるのは普通に困るので最初からこうするべきだった