### PR TITLE
wearable FOREGROUND_SERVICE

### DIFF
--- a/android/wearable/src/main/AndroidManifest.xml
+++ b/android/wearable/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
   <uses-feature android:name="android.hardware.type.watch" />
 
   <uses-permission android:name="android.permission.WAKE_LOCK" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
   <application
     android:allowBackup="true"


### PR DESCRIPTION
Expo 50にしてから必要なPermissionになったらしくWearableのパッケージには使用する旨のPermissionが設定されていなかったので追加した