### PR TITLE
位置情報取得処理が暴走するバグを修正

### DIFF
--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -1354,7 +1354,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Prod/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TrainLCD;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1392,7 +1392,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Prod/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TrainLCD;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/src/components/FakeStationSettings.tsx
+++ b/src/components/FakeStationSettings.tsx
@@ -210,8 +210,13 @@ const FakeStationSettings: React.FC = () => {
       setLocationState((prev) => ({
         ...prev,
         location: {
+          timestamp: -1,
           coords: {
             accuracy: 0,
+            altitude: 0,
+            altitudeAccuracy: -1,
+            heading: 0,
+            speed: 0,
             latitude: station.latitude,
             longitude: station.longitude,
           },

--- a/src/hooks/useAutoMode.ts
+++ b/src/hooks/useAutoMode.ts
@@ -57,10 +57,15 @@ const useAutoMode = (enabled: boolean): void => {
           setLocation((prev) => ({
             ...prev,
             location: {
+              timestamp: -1,
               coords: {
+                accuracy: 0,
+                altitude: 0,
+                altitudeAccuracy: -1,
+                speed: 0,
+                heading: 0,
                 latitude: stations[0].latitude,
                 longitude: stations[0].longitude,
-                accuracy: 0,
               },
             },
           }))
@@ -86,7 +91,15 @@ const useAutoMode = (enabled: boolean): void => {
             setLocation((prev) => ({
               ...prev,
               location: {
-                coords: { ...center, accuracy: 0 },
+                timestamp: 0,
+                coords: {
+                  ...center,
+                  accuracy: 0,
+                  altitude: 0,
+                  altitudeAccuracy: -1,
+                  speed: 0,
+                  heading: 0,
+                },
               },
             }))
           }
@@ -98,10 +111,15 @@ const useAutoMode = (enabled: boolean): void => {
           setLocation((prev) => ({
             ...prev,
             location: {
+              timestamp: 0,
               coords: {
+                accuracy: 0,
+                altitude: 0,
+                altitudeAccuracy: -1,
+                speed: 0,
+                heading: 0,
                 latitude: stations[stations.length - 1].latitude,
                 longitude: stations[stations.length - 1].longitude,
-                accuracy: 0,
               },
             },
           }))
@@ -127,7 +145,15 @@ const useAutoMode = (enabled: boolean): void => {
             setLocation((prev) => ({
               ...prev,
               location: {
-                coords: { ...center, accuracy: 0 },
+                timestamp: 0,
+                coords: {
+                  ...center,
+                  accuracy: 0,
+                  altitude: 0,
+                  altitudeAccuracy: -1,
+                  speed: 0,
+                  heading: 0,
+                },
               },
             }))
           }
@@ -187,10 +213,15 @@ const useAutoMode = (enabled: boolean): void => {
           setLocation((prev) => ({
             ...prev,
             location: {
+              timestamp: 0,
               coords: {
                 latitude: next.latitude,
                 longitude: next.longitude,
                 accuracy: 0,
+                altitude: 0,
+                altitudeAccuracy: -1,
+                speed: 0,
+                heading: 0,
               },
             },
           }))
@@ -213,10 +244,15 @@ const useAutoMode = (enabled: boolean): void => {
           setLocation((prev) => ({
             ...prev,
             location: {
+              timestamp: 0,
               coords: {
                 latitude: next.latitude,
                 longitude: next.longitude,
                 accuracy: 0,
+                altitude: 0,
+                altitudeAccuracy: -1,
+                speed: 0,
+                heading: 0,
               },
             },
           }))

--- a/src/hooks/useMirroringShare.ts
+++ b/src/hooks/useMirroringShare.ts
@@ -198,24 +198,21 @@ const useMirroringShare = (
         return
       }
 
-      setLocationState((prev) => {
-        if (
-          prev.location?.coords.latitude === latitude ||
-          prev.location?.coords.longitude === longitude
-        ) {
-          return prev
-        }
-        return {
-          ...prev,
-          location: {
-            coords: {
-              latitude,
-              longitude,
-              accuracy,
-            },
+      setLocationState((prev) => ({
+        ...prev,
+        location: {
+          timestamp: -1,
+          coords: {
+            latitude,
+            longitude,
+            accuracy,
+            altitude: 0,
+            altitudeAccuracy: -1,
+            speed: 0,
+            heading: 0,
           },
-        }
-      })
+        },
+      }))
 
       // 受信できたことを報告する
       await updateVisitorTimestamp()

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -63,6 +63,7 @@ let globalSetBGLocation: ((value: Location.LocationObject) => void) | null =
 
 TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }): void => {
   if (error) {
+    console.error(error)
     return
   }
   const { locations } = data as { locations: Location.LocationObject[] }
@@ -121,15 +122,13 @@ const MainScreen: React.FC = () => {
   const setLocation = useSetRecoilState(locationState)
   const setBGLocation = useCallback(
     (location: LocationObject) =>
-      setLocation((prev) => {
-        const isSame =
-          location.coords?.latitude === prev?.location?.coords?.latitude &&
-          location.coords?.longitude === prev?.location?.coords?.longitude
-        if (isSame) {
-          return prev
-        }
-        return { ...prev, location }
-      }),
+      setLocation((prev) => ({
+        ...prev,
+        location: {
+          timestamp: -1,
+          coords: location.coords,
+        },
+      })),
     [setLocation]
   )
   if (!globalSetBGLocation) {
@@ -199,6 +198,7 @@ const MainScreen: React.FC = () => {
           killServiceOnDestroy: true,
         },
       })
+      // await TaskManager.unregisterAllTasksAsync()
     }
     if (!autoModeEnabledRef.current && !subscribingRef.current) {
       startUpdateAsync()

--- a/src/screens/SavedRoutesScreen.tsx
+++ b/src/screens/SavedRoutesScreen.tsx
@@ -133,7 +133,10 @@ const SavedRoutesScreen: React.FC = () => {
       if (!nearestStation) {
         return
       }
-      updateStateAndNavigate(stations, nearestStation)
+      updateStateAndNavigate(
+        stations.map((s) => new Station(s)),
+        new Station(nearestStation)
+      )
     },
     [fetchStationsByRoute, location, updateStateAndNavigate]
   )

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -3,11 +3,7 @@ import { atom } from 'recoil'
 import { RECOIL_STATES } from '../../constants'
 
 export interface LocationState {
-  location:
-    | LocationObject
-    | Pick<LocationObject, 'coords'>
-    | { coords: { accuracy: number; latitude: number; longitude: number } }
-    | null
+  location: LocationObject | null
   badAccuracy: boolean
 }
 


### PR DESCRIPTION
close #3030
暴走バグに関してはtimestampがバックグラウンド位置情報からのデータで動的に変わってしまうのがダメらしく、何度位置を取得してもrecoilに入らないようにした