### PR TITLE
到着閾値修正

### DIFF
--- a/__tests__/utils/threshold.test.ts
+++ b/__tests__/utils/threshold.test.ts
@@ -32,9 +32,11 @@ describe('utils/threshold.ts', () => {
       // [lineType, avgBetweenStations, expectedThreshold]
       [LineType.BulletTrain, 10000, 1500],
       [LineType.BulletTrain, 1000, 400],
+      [LineType.Subway, 3000, 500],
       [LineType.Subway, 2500, 500],
       [LineType.Subway, 1000, 200],
       [LineType.Subway, 500, 100],
+      [LineType.Normal, 3000, 500],
       [LineType.Normal, 2500, 500],
       [LineType.Normal, 1000, 200],
       [LineType.Normal, 500, 100],

--- a/__tests__/utils/threshold.test.ts
+++ b/__tests__/utils/threshold.test.ts
@@ -30,12 +30,12 @@ describe('utils/threshold.ts', () => {
   describe('getArrivedThreshold', () => {
     it.each([
       // [lineType, avgBetweenStations, expectedThreshold]
-      [LineType.BulletTrain, 10000, 1500],
-      [LineType.BulletTrain, 1000, 1000],
-      [LineType.Subway, 1500, 300],
+      [LineType.BulletTrain, 10000, 2500],
+      [LineType.BulletTrain, 1000, 400],
+      [LineType.Subway, 2500, 500],
       [LineType.Subway, 1000, 200],
       [LineType.Subway, 500, 100],
-      [LineType.Normal, 1500, 300],
+      [LineType.Normal, 2500, 500],
       [LineType.Normal, 1000, 200],
       [LineType.Normal, 500, 100],
     ])(

--- a/__tests__/utils/threshold.test.ts
+++ b/__tests__/utils/threshold.test.ts
@@ -30,7 +30,7 @@ describe('utils/threshold.ts', () => {
   describe('getArrivedThreshold', () => {
     it.each([
       // [lineType, avgBetweenStations, expectedThreshold]
-      [LineType.BulletTrain, 10000, 2500],
+      [LineType.BulletTrain, 10000, 1500],
       [LineType.BulletTrain, 1000, 400],
       [LineType.Subway, 2500, 500],
       [LineType.Subway, 1000, 200],

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -12,7 +12,7 @@ const getMaxThreshold = (
   switch (lineType) {
     case LineType.BulletTrain:
       return operationType === 'ARRIVING'
-        ? baseThreshold * 5
+        ? baseThreshold * 3
         : baseThreshold * 10
     default:
       return baseThreshold

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -12,7 +12,7 @@ const getMaxThreshold = (
   switch (lineType) {
     case LineType.BulletTrain:
       return operationType === 'ARRIVING'
-        ? baseThreshold * 3
+        ? baseThreshold * 5
         : baseThreshold * 10
     default:
       return baseThreshold
@@ -61,7 +61,7 @@ export const getArrivedThreshold = (
   const threshold = (() => {
     switch (lineType) {
       case LineType.BulletTrain:
-        return base * 5
+        return base * 2
       default:
         return base
     }


### PR DESCRIPTION
到着距離上限 300m->500m
新幹線の到着閾値はmasterのものから変えてしまうとデバッグが大変なので新幹線の閾値調整は別タスクにしたい