### PR TITLE
到着時次の駅にすっ飛ばされないようにした

### DIFF
--- a/src/hooks/useThreshold.ts
+++ b/src/hooks/useThreshold.ts
@@ -2,17 +2,21 @@ import getDistance from 'geolib/es/getDistance'
 import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 import { APPROACHING_MAX_THRESHOLD, ARRIVED_MAX_THRESHOLD } from '../constants'
+import stationState from '../store/atoms/station'
 import { currentStationSelector } from '../store/selectors/currentStation'
 import { useNextStation } from './useNextStation'
 
 export const useThreshold = () => {
+  const { arrived } = useRecoilValue(stationState)
   const station = useRecoilValue(
     currentStationSelector({ skipPassStation: true })
   )
   const nextStation = useNextStation(true)
 
   const distance = useMemo(() => {
-    if (!station || !nextStation) {
+    // NOTE: 到着直後に閾値が変わってしまうと到着判定された距離によっては
+    // 次の駅に飛ばされる可能性があるためarrivedも条件に入れている
+    if (!station || !nextStation || arrived) {
       return
     }
     return getDistance(
@@ -20,7 +24,7 @@ export const useThreshold = () => {
       { latitude: nextStation.latitude, longitude: nextStation.longitude },
       100
     )
-  }, [nextStation, station])
+  }, [arrived, nextStation, station])
 
   const approachingThreshold = useMemo(() => {
     const threshold = (distance ?? APPROACHING_MAX_THRESHOLD) / 2


### PR DESCRIPTION
到着閾値が最大閾値ではない時次の駅に到着した直後に到着閾値が狭くなることがある
到着判定直後に閾値が狭くなると停車判定ではなくなり次の駅にカーソルが向かってしまうので到着時は一律で最大閾値を使用して次の駅に向かわないようにした