### PR TITLE
やっぱり平均駅間距離を使わないとダメ

### DIFF
--- a/src/hooks/useAverageDistance.ts
+++ b/src/hooks/useAverageDistance.ts
@@ -1,0 +1,40 @@
+import getDistance from 'geolib/es/getDistance'
+import { useMemo } from 'react'
+import { useRecoilValue } from 'recoil'
+import { StopCondition } from '../../gen/proto/stationapi_pb'
+import stationState from '../store/atoms/station'
+
+const useAverageDistance = (): number => {
+  const { stations } = useRecoilValue(stationState)
+
+  const stopStations = useMemo(
+    () => stations.filter((s) => s.stopCondition !== StopCondition.Not),
+    [stations]
+  )
+
+  // 駅配列から平均駅間距離（直線距離）を求める
+  const avgDistance = useMemo(
+    (): number =>
+      !stopStations.length
+        ? 0
+        : stopStations.reduce((acc, cur, idx, arr) => {
+            const prev = arr[idx - 1]
+            if (!prev) {
+              return acc
+            }
+            const { latitude, longitude } = cur
+            const { latitude: prevLatitude, longitude: prevLongitude } = prev
+            const distance = getDistance(
+              { latitude, longitude },
+              { latitude: prevLatitude, longitude: prevLongitude },
+              100
+            )
+            return acc + distance
+          }, 0) / stopStations.length,
+    [stopStations]
+  )
+
+  return avgDistance
+}
+
+export default useAverageDistance


### PR DESCRIPTION
#3339 #3350 のデグレ
前後の駅間で駅間距離を取ると到着時に到着フラグの更新と到着フラグのチェックが同時に行われて無限にステートが更新されてしまうので全線の停車駅で平均を取ってそちらを停車・接近の閾値に使ってもらうようにした

この計算は路線選択ごとに実行される認識なのでパフォーマンスへの影響は多分ない