### PR TITLE
シェアできない理由をアラートに表示

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -372,7 +372,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       await Share.open(options)
     } catch (err) {
       if ((err as { message: string }).message !== 'User did not share') {
-        Alert.alert(translate('couldntShare'))
+        Alert.alert(
+          `${translate('couldntShare')} ${(err as { message: string }).message}`
+        )
       }
     }
   }, [currentLine])


### PR DESCRIPTION
あまりいい方法ではないと思うのでProdからは消すべきかもしれない