### PR TITLE
debounceを使った暴走対策

### DIFF
--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -1,0 +1,41 @@
+import * as Location from 'expo-location'
+import { useEffect, useRef } from 'react'
+import { useRecoilValue } from 'recoil'
+import { LOCATION_TASK_NAME } from '../constants'
+import navigationState from '../store/atoms/navigation'
+import { accuracySelector } from '../store/selectors/accuracy'
+import { translate } from '../translation'
+
+export const useStartBackgroundLocationUpdates = () => {
+  const { autoModeEnabled } = useRecoilValue(navigationState)
+  const { locationServiceAccuracy, locationServiceDistanceFilter } =
+    useRecoilValue(accuracySelector)
+
+  const autoModeEnabledRef = useRef(autoModeEnabled)
+  const locationAccuracyRef = useRef(locationServiceAccuracy)
+  const locationServiceDistanceFilterRef = useRef(locationServiceDistanceFilter)
+
+  useEffect(() => {
+    const startAsync = async () => {
+      const isStarted = await Location.hasStartedLocationUpdatesAsync(
+        LOCATION_TASK_NAME
+      )
+      if (isStarted) {
+        await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+      }
+      if (!autoModeEnabledRef.current) {
+        await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+          accuracy: locationAccuracyRef.current,
+          distanceInterval: locationServiceDistanceFilterRef.current,
+          activityType: Location.ActivityType.OtherNavigation,
+          foregroundService: {
+            notificationTitle: translate('bgAlertTitle'),
+            notificationBody: translate('bgAlertContent'),
+            killServiceOnDestroy: true,
+          },
+        })
+      }
+    }
+    startAsync()
+  }, [])
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import * as Location from 'expo-location'
 import * as TaskManager from 'expo-task-manager'
+import { debounce } from 'lodash'
 import React, { ErrorInfo, useCallback, useEffect, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { ActivityIndicator, StatusBar, StyleSheet, Text } from 'react-native'
@@ -33,6 +34,12 @@ const options = {
   },
 }
 
+const updateLocationState = debounce(
+  (location: Location.LocationObject) =>
+    useLocationStore.setState({ location }),
+  100
+)
+
 TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }): void => {
   if (error) {
     console.error(error)
@@ -40,7 +47,7 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }): void => {
   }
   if (data) {
     const { locations } = data as { locations: Location.LocationObject[] }
-    useLocationStore.setState({ location: locations[0] })
+    updateLocationState(locations[0])
   }
 })
 


### PR DESCRIPTION
TaskManagerがバグって位置データを超高速で送ってきても最短で100ms間引くことで強制的に暴走できないようにした
ちなみに暴走時にステートのアプデ処理を行わなければTaskも落ち着いてくれることはわかっているので100msでデータを更新しまくっても勝手に暴走は止まるはず（もちろん根本的な解決にもなってないし、100msでは早すぎる状況もありそうなので様子見ではある）