### PR TITLE
どえらいパフォーマンス改善

### DIFF
--- a/src/constants/state.ts
+++ b/src/constants/state.ts
@@ -18,4 +18,5 @@ export const RECOIL_STATES = {
   isEnSelector: 'isEnSelector',
   currentStationSelector: 'currentStationSelector',
   currentLineSelector: 'currentLineSelector',
+  autoModeEnabledSelector: 'autoModeEnabledSelector',
 }

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -1,17 +1,14 @@
 import * as Location from 'expo-location'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useRecoilValue } from 'recoil'
 import { LOCATION_TASK_NAME } from '../constants'
-import navigationState from '../store/atoms/navigation'
 import { accuracySelector } from '../store/selectors/accuracy'
+import { autoModeEnabledSelector } from '../store/selectors/autoMode'
 import { translate } from '../translation'
 
 export const useStartBackgroundLocationUpdates = () => {
-  const { autoModeEnabled } = useRecoilValue(navigationState)
-  const { locationServiceAccuracy } = useRecoilValue(accuracySelector)
-
-  const autoModeEnabledRef = useRef(autoModeEnabled)
-  const locationAccuracyRef = useRef(locationServiceAccuracy)
+  const autoModeEnabled = useRecoilValue(autoModeEnabledSelector)
+  const locationServiceAccuracy = useRecoilValue(accuracySelector)
 
   useEffect(() => {
     const startAsync = async () => {
@@ -21,9 +18,9 @@ export const useStartBackgroundLocationUpdates = () => {
       if (isStarted) {
         await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
       }
-      if (!autoModeEnabledRef.current) {
+      if (!autoModeEnabled) {
         await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-          accuracy: locationAccuracyRef.current,
+          accuracy: locationServiceAccuracy,
           activityType: Location.ActivityType.OtherNavigation,
           foregroundService: {
             notificationTitle: translate('bgAlertTitle'),
@@ -38,5 +35,5 @@ export const useStartBackgroundLocationUpdates = () => {
     return () => {
       Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
     }
-  }, [])
+  }, [autoModeEnabled, locationServiceAccuracy])
 }

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -8,12 +8,10 @@ import { translate } from '../translation'
 
 export const useStartBackgroundLocationUpdates = () => {
   const { autoModeEnabled } = useRecoilValue(navigationState)
-  const { locationServiceAccuracy, locationServiceDistanceFilter } =
-    useRecoilValue(accuracySelector)
+  const { locationServiceAccuracy } = useRecoilValue(accuracySelector)
 
   const autoModeEnabledRef = useRef(autoModeEnabled)
   const locationAccuracyRef = useRef(locationServiceAccuracy)
-  const locationServiceDistanceFilterRef = useRef(locationServiceDistanceFilter)
 
   useEffect(() => {
     const startAsync = async () => {
@@ -26,7 +24,6 @@ export const useStartBackgroundLocationUpdates = () => {
       if (!autoModeEnabledRef.current) {
         await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
           accuracy: locationAccuracyRef.current,
-          deferredUpdatesDistance: locationServiceDistanceFilterRef.current,
           activityType: Location.ActivityType.OtherNavigation,
           foregroundService: {
             notificationTitle: translate('bgAlertTitle'),

--- a/src/store/selectors/accuracy.ts
+++ b/src/store/selectors/accuracy.ts
@@ -7,7 +7,8 @@ export const accuracySelector = selector({
   get: ({ get }) => {
     const powerState = get(powerSavingState)
     return (
-      POWER_SETTING_VALUES[powerState.preset] ?? POWER_SETTING_VALUES.BALANCED
+      POWER_SETTING_VALUES[powerState.preset]?.locationServiceAccuracy ??
+      POWER_SETTING_VALUES.BALANCED.locationServiceAccuracy
     )
   },
 })

--- a/src/store/selectors/autoMode.ts
+++ b/src/store/selectors/autoMode.ts
@@ -1,0 +1,8 @@
+import { selector } from 'recoil'
+import { RECOIL_STATES } from '../../constants'
+import navigationState from '../atoms/navigation'
+
+export const autoModeEnabledSelector = selector({
+  key: RECOIL_STATES.autoModeEnabledSelector,
+  get: ({ get }) => get(navigationState).autoModeEnabled,
+})


### PR DESCRIPTION
- deferredUpdatesDistanceは実は指定した方が不安定になっていた説
- useRefを雑に使うよりrecoilのselectorに任せる
- React 18からのuseTransitionを使ってbottom stateの遷移を円滑にした