### PR TITLE
CPU使用率爆下げおじさん

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,22 @@ import App from './src'
 import { LOCATION_TASK_NAME } from './src/constants'
 import { useLocationStore } from './src/hooks/useLocationStore'
 
-TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
-  if (error) {
-    console.error(error)
-    return
-  }
-  if (data) {
-    const { locations } = data
-    useLocationStore.setState(() => ({
-      location: locations[0],
-    }))
-  }
-})
+const isTaskDefined = TaskManager.isTaskDefined(LOCATION_TASK_NAME)
+
+if (!isTaskDefined) {
+  TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
+    if (error) {
+      console.error(error)
+      return
+    }
+    if (data) {
+      const { locations } = data
+      useLocationStore.setState(() => ({
+        location: locations[0],
+      }))
+    }
+  })
+}
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in the Expo client or in a native build,

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -1,5 +1,6 @@
+import { useFocusEffect } from '@react-navigation/native'
 import * as Location from 'expo-location'
-import { useEffect } from 'react'
+import { useCallback } from 'react'
 import { useRecoilValue } from 'recoil'
 import { LOCATION_TASK_NAME } from '../constants'
 import { accuracySelector } from '../store/selectors/accuracy'
@@ -10,20 +11,28 @@ export const useStartBackgroundLocationUpdates = () => {
   const autoModeEnabled = useRecoilValue(autoModeEnabledSelector)
   const locationServiceAccuracy = useRecoilValue(accuracySelector)
 
-  useEffect(() => {
-    if (!autoModeEnabled) {
-      Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-        accuracy: locationServiceAccuracy,
-        foregroundService: {
-          notificationTitle: translate('bgAlertTitle'),
-          notificationBody: translate('bgAlertContent'),
-          killServiceOnDestroy: true,
-        },
-      })
-    }
+  useFocusEffect(
+    useCallback(() => {
+      Location.hasStartedLocationUpdatesAsync(LOCATION_TASK_NAME).then(
+        (started) => {
+          if (!started && !autoModeEnabled) {
+            Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+              accuracy: locationServiceAccuracy,
+              foregroundService: {
+                notificationTitle: translate('bgAlertTitle'),
+                notificationBody: translate('bgAlertContent'),
+                killServiceOnDestroy: true,
+              },
+            }).catch((err) => {
+              throw err
+            })
+          }
+        }
+      )
 
-    return () => {
-      Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
-    }
-  }, [autoModeEnabled, locationServiceAccuracy])
+      return () => {
+        Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME)
+      }
+    }, [autoModeEnabled, locationServiceAccuracy])
+  )
 }


### PR DESCRIPTION
何度も不要なリスナーを生成していたかもしれない
- useFocusEffectでメイン画面が表示された時のみ位置情報を取得開始
  - 画面から離脱すると位置情報更新が止まる
  - タスクキルされて止まっていない場合は開始しないで放置
    - 再度アプリを起動した際に息の根を止める 