### PR TITLE
一定条件でLive Activitiesの前の駅が全く関係ない駅になるバグを修正

### DIFF
--- a/src/components/LineBoardWest.tsx
+++ b/src/components/LineBoardWest.tsx
@@ -290,7 +290,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   const station = useRecoilValue(currentStationSelector({}))
   const transferLines = useTransferLinesFromStation(stationInLoop)
   const nextStation = useNextStation(true, stationInLoop)
-  const prevStation = usePreviousStation()
+  const prevStation = usePreviousStation(false)
 
   const currentStationIndex = useMemo(
     () =>

--- a/src/hooks/usePreviousStation.ts
+++ b/src/hooks/usePreviousStation.ts
@@ -4,14 +4,18 @@ import { Station } from '../../gen/proto/stationapi_pb'
 import stationState from '../store/atoms/station'
 import { currentStationSelector } from '../store/selectors/currentStation'
 import dropEitherJunctionStation from '../utils/dropJunctionStation'
+import getIsPass from '../utils/isPass'
 
-const usePreviousStation = (): Station | undefined => {
+const usePreviousStation = (skipPass = true): Station | undefined => {
   const { stations: stationsFromState, selectedDirection } =
     useRecoilValue(stationState)
 
   const stations = useMemo(
-    () => dropEitherJunctionStation(stationsFromState, selectedDirection),
-    [selectedDirection, stationsFromState]
+    () =>
+      dropEitherJunctionStation(stationsFromState, selectedDirection).filter(
+        (s) => (skipPass ? getIsPass(s) : true)
+      ),
+    [selectedDirection, skipPass, stationsFromState]
   )
 
   const station = useRecoilValue(


### PR DESCRIPTION
JRWテーマでも同じカスタムフックが使われていたが沼りそうなので前と同じ処理のままにした