### PR TITLE
Revert "ライブアクティビティの更新処理を1つのuseEffectでまとめる"

### DIFF
--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -155,18 +155,26 @@ export const useUpdateLiveActivities = (): void => {
     if (!IS_LIVE_ACTIVITIES_ELIGIBLE_PLATFORM) {
       return
     }
-
-    if (!selectedBound) {
-      stopLiveActivity()
-      setStarted(false)
-      return
-    }
-
     if (selectedBound && !started && activityState) {
       startLiveActivity(activityState)
       setStarted(true)
     }
-
-    updateLiveActivity(activityState)
   }, [activityState, selectedBound, started])
+
+  useEffect(() => {
+    if (!IS_LIVE_ACTIVITIES_ELIGIBLE_PLATFORM) {
+      return
+    }
+    if (!selectedBound) {
+      stopLiveActivity()
+      setStarted(false)
+    }
+  }, [selectedBound])
+
+  useEffect(() => {
+    if (!IS_LIVE_ACTIVITIES_ELIGIBLE_PLATFORM) {
+      return
+    }
+    updateLiveActivity(activityState)
+  }, [activityState])
 }


### PR DESCRIPTION
This reverts commit ae0cf3edf587d55e17ea817e916fbc96778d087a.

ライブアクティビティ出すタイミングを全て一緒のuseEffectが発火するタイミングにしてたけど普通に無駄なアプデが発生するので戻した