### PR TITLE
Live Activitiesの通過駅の扱い修正

### DIFF
--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -4,6 +4,7 @@ import { parenthesisRegexp } from '../constants'
 import { directionToDirectionName } from '../models/Bound'
 import stationState from '../store/atoms/station'
 import { isJapanese } from '../translation'
+import getIsPass from '../utils/isPass'
 import {
   startLiveActivity,
   stopLiveActivity,
@@ -91,7 +92,7 @@ export const useUpdateLiveActivities = (): void => {
 
   const stoppedStation = useMemo(
     () =>
-      arrivedFromState && !approachingFromState
+      arrivedFromState && !approachingFromState && !getIsPass(currentStation)
         ? currentStation
         : previousStation,
     [approachingFromState, arrivedFromState, currentStation, previousStation]


### PR DESCRIPTION
ロック画面のライブアクティビティの左側の駅が通過駅を表示してしまっているので通過時は無視するようにした