### PR TITLE
アプリの縦幅を固定した

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -45,6 +45,7 @@ import WarningPanel from './WarningPanel'
 
 const styles = StyleSheet.create({
   root: {
+    overflow: 'hidden',
     height: Dimensions.get('window').height,
   },
 })

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -45,9 +45,7 @@ import WarningPanel from './WarningPanel'
 
 const styles = StyleSheet.create({
   root: {
-    overflow: 'hidden',
-    minHeight: Dimensions.get('window').height,
-    height: '100%',
+    height: Dimensions.get('window').height,
   },
 })
 


### PR DESCRIPTION
そもそも固定しないとダメ
Androidタブでの表示ずれに効果的説