### PR TITLE
メイン画面から離れて種別が各停になったあと再度行き先を選ぶと停車駅が引き継がれてしまうバグを修正

### DIFF
--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -22,6 +22,7 @@ export const useResetMainState = () => {
       arrived: true,
       approaching: false,
       averageDistance: null,
+      stations: [],
     }))
   }, [setNavigationState, setStationState])
 


### PR DESCRIPTION
1. 優等種別を選んで任意の行き先に設定する
2. メイン画面から離脱
3. 再度任意の行き先を選ぶ
4. 直近で指定した優等種別の停車駅が引き継がれてしまうが、TTBは普通等で表示される

そもそも種別を初期化しないほうがいい気もする