### PR TITLE
iOS Canary版のビルド番号修正

### DIFF
--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1653</string>
+	<string>1654</string>
 	<key>CURRENT_SCHEME_NAME</key>
 	<string>CanaryTrainLCD</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
ズレて開発版ビルドができなくなってた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリケーションのバージョンが `1653` から `1654` に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->