### PR TITLE
ヘッダーフォント関係の修正

### DIFF
--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Dimensions, StyleSheet, View } from 'react-native'
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native'
 import Animated, {
   Easing,
   interpolate,
@@ -34,7 +34,6 @@ import { RFValue } from '../utils/rfValue'
 import Clock from './Clock'
 import NumberingIcon from './NumberingIcon'
 import TrainTypeBox from './TrainTypeBoxSaikyo'
-import Typography from './Typography'
 
 const { width: windowWidth } = Dimensions.get('window')
 
@@ -72,7 +71,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
   stateWrapper: {
-    flex: 1,
+    width: windowWidth * 0.14,
     justifyContent: 'flex-end',
     alignItems: 'flex-end',
     marginRight: 12,
@@ -84,14 +83,16 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#3a3a3a',
     textAlign: 'right',
+    lineHeight: Platform.select({ android: RFValue(21) }),
   },
   stationNameWrapper: {
-    width: windowWidth * 0.72,
+    flex: 1,
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
   stationNameContainer: {
     position: 'absolute',
+    alignItems: 'flex-end',
     justifyContent: 'center',
   },
   stationName: {
@@ -479,56 +480,32 @@ const HeaderSaikyo: React.FC = () => {
             <Animated.Text
               style={[boundTopAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography style={styles.connectedLines}>
+              <Text style={styles.connectedLines}>
                 {connectedLines?.length && isJapaneseState
                   ? `${connectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{boundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{boundText}</Text>
             </Animated.Text>
 
             <Animated.Text
               style={[boundBottomAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography style={styles.connectedLines}>
+              <Text style={styles.connectedLines}>
                 {connectedLines?.length && prevIsJapaneseState
                   ? `${prevConnectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{prevBoundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{prevBoundText}</Text>
             </Animated.Text>
           </View>
         </View>
         <View style={styles.bottom}>
           <View style={styles.stateWrapper}>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={stateText.includes('\n') ? 2 : 1}
-              style={[
-                stateTopAnimatedStyles,
-                styles.state,
-                {
-                  height: stateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateTopAnimatedStyles, styles.state]}>
               {stateText}
             </Animated.Text>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={prevStateText.includes('\n') ? 2 : 1}
-              style={[
-                stateBottomAnimatedStyles,
-                styles.state,
-                {
-                  height: prevStateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateBottomAnimatedStyles, styles.state]}>
               {prevStateText}
             </Animated.Text>
           </View>
@@ -542,43 +519,41 @@ const HeaderSaikyo: React.FC = () => {
               allowScaling
             />
           ) : null}
-          <View>
-            <View style={styles.stationNameWrapper}>
-              <View style={styles.stationNameContainer}>
-                <Animated.Text
-                  adjustsFontSizeToFit
-                  numberOfLines={1}
-                  style={[
-                    topNameAnimatedStyles,
-                    styles.stationName,
-                    topNameAnimatedAnchorStyle,
-                    {
-                      fontSize: STATION_NAME_FONT_SIZE,
-                      transformOrigin: 'top',
-                    },
-                  ]}
-                >
-                  {stationText}
-                </Animated.Text>
-              </View>
+          <View style={styles.stationNameWrapper}>
+            <View style={styles.stationNameContainer}>
+              <Animated.Text
+                adjustsFontSizeToFit
+                numberOfLines={1}
+                style={[
+                  topNameAnimatedStyles,
+                  styles.stationName,
+                  topNameAnimatedAnchorStyle,
+                  {
+                    fontSize: STATION_NAME_FONT_SIZE,
+                    transformOrigin: 'top',
+                  },
+                ]}
+              >
+                {stationText}
+              </Animated.Text>
+            </View>
 
-              <View style={styles.stationNameContainer}>
-                <Animated.Text
-                  adjustsFontSizeToFit
-                  numberOfLines={1}
-                  style={[
-                    bottomNameAnimatedStyles,
-                    styles.stationName,
-                    bottomNameAnimatedAnchorStyle,
-                    {
-                      fontSize: STATION_NAME_FONT_SIZE,
-                      transformOrigin: 'bottom',
-                    },
-                  ]}
-                >
-                  {prevStationText}
-                </Animated.Text>
-              </View>
+            <View style={styles.stationNameContainer}>
+              <Animated.Text
+                adjustsFontSizeToFit
+                numberOfLines={1}
+                style={[
+                  bottomNameAnimatedStyles,
+                  styles.stationName,
+                  bottomNameAnimatedAnchorStyle,
+                  {
+                    fontSize: STATION_NAME_FONT_SIZE,
+                    transformOrigin: 'bottom',
+                  },
+                ]}
+              >
+                {prevStationText}
+              </Animated.Text>
             </View>
           </View>
         </View>

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
-    paddingBottom: 4,
+    paddingBottom: isTablet ? 4 : 2,
   },
   boundWrapper: {
     flex: 1,

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -48,7 +48,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
-    paddingBottom: 8,
   },
   boundWrapper: {
     flex: 1,

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -48,6 +48,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
+    paddingBottom: 4,
   },
   boundWrapper: {
     flex: 1,

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Dimensions, StyleSheet, View } from 'react-native'
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native'
 import Animated, {
   Easing,
   interpolate,
@@ -32,7 +32,6 @@ import { getNumberingColor } from '../utils/numbering'
 import { RFValue } from '../utils/rfValue'
 import NumberingIcon from './NumberingIcon'
 import TrainTypeBox from './TrainTypeBox'
-import Typography from './Typography'
 
 const { width: windowWidth } = Dimensions.get('window')
 
@@ -73,7 +72,7 @@ const styles = StyleSheet.create({
     fontSize: RFValue(18),
   },
   stateWrapper: {
-    flex: 1,
+    width: windowWidth * 0.14,
     justifyContent: 'flex-end',
     alignItems: 'flex-end',
     marginRight: 12,
@@ -85,9 +84,10 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#fff',
     textAlign: 'right',
+    lineHeight: Platform.select({ android: RFValue(21) }),
   },
   stationNameWrapper: {
-    width: windowWidth * 0.72,
+    flex: 1,
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
@@ -450,7 +450,7 @@ const HeaderTY: React.FC = () => {
             <Animated.Text
               style={[boundTopAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography
+              <Text
                 adjustsFontSizeToFit
                 numberOfLines={1}
                 style={styles.connectedLines}
@@ -458,13 +458,13 @@ const HeaderTY: React.FC = () => {
                 {connectedLines?.length && isJapaneseState
                   ? `${connectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{boundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{boundText}</Text>
             </Animated.Text>
             <Animated.Text
               style={[boundBottomAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography
+              <Text
                 adjustsFontSizeToFit
                 numberOfLines={1}
                 style={styles.connectedLines}
@@ -472,41 +472,17 @@ const HeaderTY: React.FC = () => {
                 {connectedLines?.length && prevIsJapaneseState
                   ? `${prevConnectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{prevBoundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{prevBoundText}</Text>
             </Animated.Text>
           </View>
         </View>
         <View style={styles.bottom}>
           <View style={styles.stateWrapper}>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={stateText.includes('\n') ? 2 : 1}
-              style={[
-                stateTopAnimatedStyles,
-                styles.state,
-                {
-                  height: stateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateTopAnimatedStyles, styles.state]}>
               {stateText}
             </Animated.Text>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={prevStateText.includes('\n') ? 2 : 1}
-              style={[
-                stateBottomAnimatedStyles,
-                styles.state,
-                {
-                  height: prevStateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateBottomAnimatedStyles, styles.state]}>
               {prevStateText}
             </Animated.Text>
           </View>

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Dimensions, StyleSheet, View } from 'react-native'
+import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native'
 import Animated, {
   Easing,
   interpolate,
@@ -36,7 +36,6 @@ import { getNumberingColor } from '../utils/numbering'
 import { RFValue } from '../utils/rfValue'
 import NumberingIcon from './NumberingIcon'
 import TrainTypeBox from './TrainTypeBox'
-import Typography from './Typography'
 
 const { width: windowWidth } = Dimensions.get('window')
 
@@ -84,7 +83,7 @@ const styles = StyleSheet.create({
     fontSize: RFValue(18),
   },
   stateWrapper: {
-    flex: 1,
+    width: windowWidth * 0.14,
     justifyContent: 'flex-end',
     alignItems: 'flex-end',
     marginRight: 12,
@@ -95,14 +94,16 @@ const styles = StyleSheet.create({
     fontSize: RFValue(18),
     fontWeight: 'bold',
     textAlign: 'right',
+    lineHeight: Platform.select({ android: RFValue(21) }),
   },
   stationNameWrapper: {
-    width: windowWidth * 0.72,
+    flex: 1,
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
   stationNameContainer: {
     position: 'absolute',
+    alignItems: 'flex-end',
     justifyContent: 'center',
   },
   stationName: {
@@ -450,7 +451,7 @@ const HeaderTokyoMetro: React.FC = () => {
             <Animated.Text
               style={[boundTopAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography
+              <Text
                 adjustsFontSizeToFit
                 numberOfLines={1}
                 style={styles.connectedLines}
@@ -458,13 +459,13 @@ const HeaderTokyoMetro: React.FC = () => {
                 {connectedLines?.length && isJapaneseState
                   ? `${connectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{boundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{boundText}</Text>
             </Animated.Text>
             <Animated.Text
               style={[boundBottomAnimatedStyles, styles.boundTextContainer]}
             >
-              <Typography
+              <Text
                 adjustsFontSizeToFit
                 numberOfLines={1}
                 style={styles.connectedLines}
@@ -472,41 +473,17 @@ const HeaderTokyoMetro: React.FC = () => {
                 {connectedLines?.length && prevIsJapaneseState
                   ? `${prevConnectionText}直通 `
                   : null}
-              </Typography>
-              <Typography style={styles.boundText}>{prevBoundText}</Typography>
+              </Text>
+              <Text style={styles.boundText}>{prevBoundText}</Text>
             </Animated.Text>
           </View>
         </View>
         <View style={styles.bottom}>
           <View style={styles.stateWrapper}>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={stateText.includes('\n') ? 2 : 1}
-              style={[
-                stateTopAnimatedStyles,
-                styles.state,
-                {
-                  height: stateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateTopAnimatedStyles, styles.state]}>
               {stateText}
             </Animated.Text>
-            <Animated.Text
-              adjustsFontSizeToFit
-              numberOfLines={prevStateText.includes('\n') ? 2 : 1}
-              style={[
-                stateBottomAnimatedStyles,
-                styles.state,
-                {
-                  height: prevStateText.includes('\n')
-                    ? STATION_NAME_FONT_SIZE
-                    : undefined,
-                },
-              ]}
-            >
+            <Animated.Text style={[stateBottomAnimatedStyles, styles.state]}>
               {prevStateText}
             </Animated.Text>
           </View>


### PR DESCRIPTION
- ステートの文字が小さくなりすぎる問題の修正
- 埼京線テーマのヘッダにpaddingBottom: 8が入っているが幅が大きすぎるのでスマホ2、タブレット4に縮小

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **スタイルの更新**
	- 複数のヘッダーコンポーネントで、プラットフォーム固有のテキストレンダリングとレイアウトを改善
	- `Typography` コンポーネントから `Text` コンポーネントへの移行
	- テキストスタイルとラッパーのレイアウトを最適化

- **パフォーマンス改善**
	- アニメーションテキストコンポーネントのプロパティを簡素化

これらの変更により、異なるプラットフォーム間でのテキスト表示の一貫性と柔軟性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->