### PR TITLE
経路検索でライブアクティビティが増殖するバグを修正

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -26,7 +26,6 @@ import useReport from '../hooks/useReport';
 import useReportEligibility from '../hooks/useReportEligibility';
 import { useResetMainState } from '../hooks/useResetMainState';
 import { useThemeStore } from '../hooks/useThemeStore';
-import { useUpdateLiveActivities } from '../hooks/useUpdateLiveActivities';
 import { useWarningInfo } from '../hooks/useWarningInfo';
 import type { AppTheme } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
@@ -62,7 +61,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   useCheckStoreVersion();
   useAppleWatch();
   useAndroidWearable();
-  useUpdateLiveActivities();
   useListenMessaging();
 
   const user = useCachedInitAnonymousUser();

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -221,11 +221,11 @@ export const useUpdateLiveActivities = (): void => {
   }, [activityState, selectedBound, started]);
 
   useEffect(() => {
-    if (!selectedBound) {
+    return () => {
       stopLiveActivity();
       setStarted(false);
-    }
-  }, [selectedBound]);
+    };
+  }, []);
 
   useEffect(() => {
     if (started) {

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -35,6 +35,7 @@ import useTransferLines from '../hooks/useTransferLines';
 import useTransitionHeaderState from '../hooks/useTransitionHeaderState';
 import { useTypeWillChange } from '../hooks/useTypeWillChange';
 import { useUpdateBottomState } from '../hooks/useUpdateBottomState';
+import { useUpdateLiveActivities } from '../hooks/useUpdateLiveActivities';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
@@ -105,6 +106,7 @@ const MainScreen: React.FC = () => {
   useStartBackgroundLocationUpdates();
   const resetMainState = useResetMainState();
   useTTS();
+  useUpdateLiveActivities();
 
   const { pause: pauseBottomTimer } = useUpdateBottomState();
 


### PR DESCRIPTION
close #3991 

なぜPermittedにuseUpdateLiveActivitiesをおく必要があったのかは思い出せないけど不要でありMain画面にのみ必要なことは確か

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
	- Live Activitiesに関連するフックの使用方法を変更しました。
	- コンポーネント間のフック依存関係を最適化しました。

- **変更点**
	- `Permitted`コンポーネントからLive Activitiesのインポートを削除
	- `Main`スクリーンに`useUpdateLiveActivities`フックを追加
	- Live Activitiesの更新ロジックを調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->