### PR TITLE
threshold.ts を更新

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -6,7 +6,7 @@ export const DEFAULT_HEADER_TRANSITION_DELAY = 500; // ms
 export const LONG_PRESS_DURATION = 500;
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
-export const ARRIVED_MAX_THRESHOLD = 500;
+export const ARRIVED_MAX_THRESHOLD = 300;
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;


### PR DESCRIPTION
到着が早すぎる気がするので到着閾値を500mから300mに短縮
上記問題は停車判定で改善できる可能性があるので一旦このPRは保留

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **設定の更新**
	- 到着の最大しきい値を500から300に調整しました。
	- この変更により、アプリケーション内の特定の条件判定ロジックに影響を与える可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->