### PR TITLE
Androidカナリア版ビルド失敗暫定対応

### DIFF
--- a/.github/workflows/deploy_android_canary.yml
+++ b/.github/workflows/deploy_android_canary.yml
@@ -5,13 +5,8 @@ on:
     branches:
       - dev
     paths:
-      - 'android/**'
-      - 'src/**'
-      - 'proto/**'
-      - 'assets/**'
-      - 'package.json'
-      - 'package-lock.json'
-
+      - 'android/app/build.gradle'
+      - 'android/wearable/build.gradle.kts'
 env:
   TZ: 'Asia/Tokyo'
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
       applicationIdSuffix ".dev"
       versionNameSuffix "-dev"
       // 10203010 <- 10203(v1.2.3 version name)+01(build number)+0(Android app)
-      versionCode 80302030
+      versionCode 80302040
       versionName "8.3.2"
     }
     prod {

--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -34,7 +34,7 @@ android {
       applicationIdSuffix = ".dev"
       versionNameSuffix = "-dev"
       // 10203011 <- 10203(v1.2.3 version name)+01(build number)+1(Wearable app)
-      versionCode = 80302031
+      versionCode = 80302041
       versionName = "8.3.2"
     }
     create("prod") {


### PR DESCRIPTION
bump versionしないとデプロイ死ぬの忘れてた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- なし

- **バグ修正**
	- なし

- **バージョン更新**
	- Android アプリの開発版バージョンコードを `80302030` から `80302040` に更新
	- Wearable アプリの開発版バージョンコードを `80302031` から `80302041` に更新

- **デプロイメント**
	- GitHub Actions のワークフロートリガーパスを特定の Gradle ファイルに絞り込み

<!-- end of auto-generated comment: release notes by coderabbit.ai -->