### PR TITLE
直通先計算で終点駅が直通先の次の駅に接続していない場合、実質接続していない路線は省く

### DIFF
--- a/src/hooks/useConnectedLines.ts
+++ b/src/hooks/useConnectedLines.ts
@@ -116,10 +116,21 @@ const useConnectedLines = (excludePassed = true): Line[] => {
         // 処理中のindexがcurrentIndexより小さい場合、
         // 処理が終わった配列を展開しグループ化されていない
         // 配列の最初から現在のindexまでを返し、次のループへ
-        return acc.concat(notGroupedJoinedLines.slice(0, currentIndex));
+        return acc.concat(notGroupedJoinedLines.slice(0, currentIndex + 1));
       }, [])
       // ループ設計上路線が重複する可能性があるのでここで重複をしばく
-      .filter((l, i, arr) => arr.findIndex((il) => il.id === l.id) === i);
+      .filter((l, i, arr) => arr.findIndex((il) => il.id === l.id) === i)
+      // NOTE: 終点駅が直通先の次の駅に接続していない場合、実質接続していない路線は省く
+      // 例: 池袋→元町・中華街の際横浜を終点と指定した際にみなとみらい線が入り込む
+      .filter((l) => {
+        if (
+          stations.filter((s) => s.line?.id === selectedBound?.line?.id)
+            .length === 1
+        ) {
+          return l.id !== selectedBound.line?.id;
+        }
+        return true;
+      });
 
     return excludeSameNameLines(
       joinedLines.filter(

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -214,7 +214,9 @@ const RouteSearchScreen = () => {
           stations: asTerminus ? terminatedStations : stations,
           selectedDirection: direction,
           selectedBound: asTerminus
-            ? selectedStation
+            ? direction === 'INBOUND'
+              ? terminatedStations[terminatedStations.length - 1]
+              : terminatedStations[0]
             : direction === 'INBOUND'
               ? (stations[stations.length - 1] ?? null)
               : (stations[0] ?? null),
@@ -254,7 +256,9 @@ const RouteSearchScreen = () => {
         stations: asTerminus ? terminatedStations : stations,
         selectedDirection: direction,
         selectedBound: asTerminus
-          ? selectedStation
+          ? direction === 'INBOUND'
+            ? terminatedStations[terminatedStations.length - 1]
+            : terminatedStations[0]
           : direction === 'INBOUND'
             ? stations[stations.length - 1]
             : stations[0],


### PR DESCRIPTION
例として池袋→元町・中華街の際横浜を終点と指定した際にみなとみらい線が入り込まないようになる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
	- 路線検索画面での駅選択ロジックを最適化
	- 接続路線のフィルタリング処理を改善

- **バグ修正**
	- 方向判定アルゴリズムを更新し、より正確な乗り換え駅の選択を実現

これらの変更により、アプリケーションの路線検索機能の精度と使いやすさが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->