### PR TITLE
速度が利用できる時は30km/h以下になるまで停車判定をしない

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -7,7 +7,7 @@ export const LONG_PRESS_DURATION = 500;
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
 export const ARRIVED_MAX_THRESHOLD = 500;
-export const ARRIVED_MAXIMUM_SPEED = 30;
+export const ARRIVED_MAXIMUM_SPEED = 30; // km/h
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;

--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -7,6 +7,7 @@ export const LONG_PRESS_DURATION = 500;
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
 export const ARRIVED_MAX_THRESHOLD = 500;
+export const ARRIVED_MAXIMUM_SPEED = 30;
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -3,6 +3,7 @@ import isPointWithinRadius from 'geolib/es/isPointWithinRadius';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { Station } from '../../gen/proto/stationapi_pb';
+import { ARRIVED_MAXIMUM_SPEED } from '../constants/threshold';
 import navigationState from '../store/atoms/navigation';
 import notifyState from '../store/atoms/notify';
 import stationState from '../store/atoms/station';
@@ -31,6 +32,7 @@ const useRefreshStation = (): void => {
   const setNavigation = useSetRecoilState(navigationState);
   const latitude = useLocationStore((state) => state?.coords.latitude);
   const longitude = useLocationStore((state) => state?.coords.longitude);
+  const speed = useLocationStore((state) => state?.coords.speed);
 
   const nextStation = useNextStation(true);
   const approachingNotifiedIdRef = useRef<number>();
@@ -47,6 +49,19 @@ const useRefreshStation = (): void => {
       return true;
     }
 
+    if (speed) {
+      return (
+        isPointWithinRadius(
+          { latitude, longitude },
+          {
+            latitude: nearestStation.latitude,
+            longitude: nearestStation.longitude,
+          },
+          arrivedThreshold
+        ) && speed < ARRIVED_MAXIMUM_SPEED
+      );
+    }
+
     return isPointWithinRadius(
       { latitude, longitude },
       {
@@ -55,7 +70,7 @@ const useRefreshStation = (): void => {
       },
       arrivedThreshold
     );
-  }, [arrivedThreshold, latitude, longitude, nearestStation]);
+  }, [arrivedThreshold, latitude, longitude, nearestStation, speed]);
 
   const isApproaching = useMemo((): boolean => {
     if (!latitude || !longitude || !nextStation) {

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -50,6 +50,7 @@ const useRefreshStation = (): void => {
     }
 
     if (speed) {
+      const speedKMH = (speed * 3600) / 1000;
       return (
         isPointWithinRadius(
           { latitude, longitude },
@@ -58,7 +59,7 @@ const useRefreshStation = (): void => {
             longitude: nearestStation.longitude,
           },
           arrivedThreshold
-        ) && speed < ARRIVED_MAXIMUM_SPEED
+        ) && speedKMH < ARRIVED_MAXIMUM_SPEED
       );
     }
 


### PR DESCRIPTION
close #3999
30km/hはかなりざっくりなので調整が必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 到着判定に速度の閾値を追加
		- 最大到着速度を30 km/hに設定
	- 位置情報の速度データを利用して到着判定の精度を向上

- **改善点**
	- 地理的な近接性に加えて、速度条件を考慮した到着検出メカニズムを実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->