### PR TITLE
CFBundleVersionはCURRENT_PROJECT_VERSIONを使う

### DIFF
--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1654</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CURRENT_SCHEME_NAME</key>
 	<string>CanaryTrainLCD</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1473</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CURRENT_SCHEME_NAME</key>
 	<string>ProdTrainLCD</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/WatchApp Extension/Schemes/Prod/Info.plist
+++ b/ios/WatchApp Extension/Schemes/Prod/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1473</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>NSExtension</key>

--- a/ios/WatchApp/Info.plist
+++ b/ios/WatchApp/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>848</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
       <string>UIInterfaceOrientationPortrait</string>

--- a/ios/WatchApp/Schemes/Prod/Info.plist
+++ b/ios/WatchApp/Schemes/Prod/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1473</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -18,7 +18,10 @@ default_platform(:ios)
 platform :ios do
   desc "Bump version number"
   lane :bump_version do
-    increment_build_number(xcodeproj: "TrainLCD.xcodeproj")
+    increment_build_number(
+      xcodeproj: "TrainLCD.xcodeproj",
+      skip_info_plist: true
+    )
   end
   desc "Push a new beta build to TestFlight"
   lane :deploy do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バージョン管理**
	- 複数の `Info.plist` ファイルで、バージョン番号の管理方法を動的に変更
	- ビルド時に自動的にバージョンを設定できるよう、`$(CURRENT_PROJECT_VERSION)` を使用
	- Fastlaneのビルドプロセスを更新し、Info.plistファイルの自動更新を調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->