### PR TITLE
10mごとの更新に変更

### DIFF
--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -2,7 +2,6 @@ import * as Location from 'expo-location';
 import { useEffect } from 'react';
 import { LOCATION_TASK_NAME } from '../constants';
 import { translate } from '../translation';
-import { isDevApp } from '../utils/isDevApp';
 import { useApplicationFlagStore } from './useApplicationFlagStore';
 import { useLocationPermissionsGranted } from './useLocationPermissionsGranted';
 import { setLocation } from './useLocationStore';
@@ -38,7 +37,7 @@ export const useStartBackgroundLocationUpdates = () => {
       watchPositionSub = await Location.watchPositionAsync(
         {
           accuracy: Location.Accuracy.BestForNavigation,
-          distanceInterval: isDevApp ? 10 : 100,
+          distanceInterval: 10,
         },
         (pos) => {
           setLocation(pos);

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -26,7 +26,7 @@ export const useStartBackgroundLocationUpdates = () => {
           // NOTE: マップマッチが勝手に行われると電車での経路と大きく異なることがあるはずなので
           // OtherNavigationは必須
           activityType: Location.ActivityType.OtherNavigation,
-          distanceInterval: 100,
+          distanceInterval: 10,
           foregroundService: {
             notificationTitle: translate('bgAlertTitle'),
             notificationBody: translate('bgAlertContent'),


### PR DESCRIPTION
100mごとだと30km/h停車判定に耐えられない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- バックグラウンド位置情報の更新間隔を調整し、位置情報の更新頻度を一貫して10に設定。

- **パフォーマンス改善**
	- 位置情報の更新頻度を最適化し、アプリケーションのモードに関係なく柔軟な追跡を実現。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->