### PR TITLE
Dimensions('window')絶対しばくマン

### DIFF
--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
   clockOverride: {
     position: 'absolute',
     top: 8,
-    right: Dimensions.get('window').width * 0.25,
+    right: Dimensions.get('screen').width * 0.25,
   },
   stationNameContainer: {
     flexDirection: 'row',

--- a/src/components/HeaderLED.tsx
+++ b/src/components/HeaderLED.tsx
@@ -135,9 +135,9 @@ const HeaderLED = () => {
 
   const rootHeight = useMemo(() => {
     if (!selectedBound) {
-      return Dimensions.get('window').height / 3;
+      return Dimensions.get('screen').height / 3;
     }
-    return Dimensions.get('window').height / 1.5;
+    return Dimensions.get('screen').height / 1.5;
   }, [selectedBound]);
 
   const headerLangState = useMemo(

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -22,7 +22,7 @@ const Marquee = ({ children }: Props) => {
 
   const startScroll = useCallback(
     (width: number) => {
-      offsetX.value = Dimensions.get('window').width;
+      offsetX.value = Dimensions.get('screen').width;
       offsetX.value = withRepeat(
         withTiming(-width, {
           duration: width * 3,

--- a/src/components/PadLineMarks.tsx
+++ b/src/components/PadLineMarks.tsx
@@ -21,7 +21,7 @@ type Props = {
   theme?: AppTheme;
 };
 
-const screenWidth = Dimensions.get('window').width;
+const screenWidth = Dimensions.get('screen').width;
 
 const stylesNormal = StyleSheet.create({
   root: {

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -40,7 +40,7 @@ import WarningPanel from './WarningPanel';
 const styles = StyleSheet.create({
   root: {
     overflow: 'hidden',
-    height: Dimensions.get('window').height,
+    height: Dimensions.get('screen').height,
   },
 });
 

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
     position: 'absolute',
     top: isTablet ? 55 : 30.25,
-    width: Dimensions.get('window').width,
+    width: Dimensions.get('screen').width,
   },
 });
 

--- a/src/components/TransfersYamanote.tsx
+++ b/src/components/TransfersYamanote.tsx
@@ -65,7 +65,7 @@ const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
   const getLineMarkFunc = useGetLineMark();
   const lines = useTransferLines();
 
-  const flexBasis = useMemo(() => Dimensions.get('window').width / 3, []);
+  const flexBasis = useMemo(() => Dimensions.get('screen').width / 3, []);
 
   const renderTransferLines = (): (JSX.Element | null)[] =>
     lines.map((line) => {

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -24,7 +24,7 @@ import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {
-    height: Dimensions.get('window').height,
+    height: Dimensions.get('screen').height,
     paddingVertical: 24,
   },
   settingItem: {

--- a/src/components/WarningPanel.tsx
+++ b/src/components/WarningPanel.tsx
@@ -36,7 +36,7 @@ const WarningPanel: React.FC<Props> = ({
 
   const styles = StyleSheet.create({
     root: {
-      width: Dimensions.get('window').width / 2,
+      width: Dimensions.get('screen').width / 2,
       backgroundColor: '#333',
       borderColor,
       borderLeftWidth: 16,

--- a/src/screens/NotificationSettingsScreen.tsx
+++ b/src/screens/NotificationSettingsScreen.tsx
@@ -5,7 +5,6 @@ import * as Notifications from 'expo-notifications';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   Alert,
-  Dimensions,
   FlatList,
   StyleSheet,
   TouchableWithoutFeedback,
@@ -30,7 +29,8 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   itemRoot: {
-    width: Dimensions.get('screen').width / 5,
+    flex: 1,
+    marginHorizontal: 8,
     marginBottom: 12,
   },
   item: {

--- a/src/screens/NotificationSettingsScreen.tsx
+++ b/src/screens/NotificationSettingsScreen.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   itemRoot: {
-    width: Dimensions.get('window').width / 5,
+    width: Dimensions.get('screen').width / 5,
     marginBottom: 12,
   },
   item: {

--- a/src/screens/NotificationSettingsScreen.tsx
+++ b/src/screens/NotificationSettingsScreen.tsx
@@ -5,6 +5,7 @@ import * as Notifications from 'expo-notifications';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   Alert,
+  Dimensions,
   FlatList,
   StyleSheet,
   TouchableWithoutFeedback,
@@ -27,10 +28,10 @@ const styles = StyleSheet.create({
   root: {
     width: '100%',
     height: '100%',
+    paddingHorizontal: 24,
   },
   itemRoot: {
-    flex: 1,
-    marginHorizontal: 8,
+    width: Dimensions.get('screen').width / 4,
     marginBottom: 12,
   },
   item: {
@@ -51,7 +52,10 @@ const styles = StyleSheet.create({
     borderColor: '#555',
     marginRight: 12,
   },
-  listContainerStyle: { alignSelf: 'center', paddingBottom: 24 },
+  listContainerStyle: {
+    alignSelf: 'center',
+    width: '100%',
+  },
   headingStyle: {
     marginTop: 24,
     marginBottom: 24,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **レイアウト調整**
	- 画面サイズの計算方法を `Dimensions.get('window')` から `Dimensions.get('screen')` に変更
	- 複数のコンポーネントで画面の高さと幅の取得方法を更新
	- `NotificationSettingsScreen` でのスタイル変更により、アイテムのレイアウトが改善

- **影響**
	- デバイスの画面サイズに応じたより正確なレイアウト表示
	- 異なる画面サイズやオリエンテーションでのコンポーネント表示の最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->