### PR TITLE
フィードバックモーダルレイアウト修正

### DIFF
--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -62,23 +62,31 @@ const styles = StyleSheet.create({
     fontSize: RFValue(14),
     fontWeight: 'bold',
     textAlign: 'center',
-    marginTop: 16,
+    marginTop: 8,
   },
   buttonContainer: {
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'center',
     padding: 8,
-    marginTop: 16,
+    marginTop: 8,
   },
   button: {
+    marginTop: 8,
     marginHorizontal: 8,
     width: widthScale(64),
   },
   charCount: {
+    position: 'absolute',
+    right: 0,
     fontWeight: 'bold',
     textAlign: 'right',
     color: '#555555',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });
 
@@ -132,7 +140,17 @@ const NewReportModal: React.FC<Props> = ({
           <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
           >
-            <Heading>{translate('report')}</Heading>
+            <View style={styles.header}>
+              <Heading>{translate('report')}</Heading>
+
+              {needsLeftCount < 0 ? (
+                <Typography style={styles.charCount}>
+                  あと{Math.abs(needsLeftCount)}文字必要です
+                </Typography>
+              ) : (
+                <Typography style={styles.charCount}>送信可能です</Typography>
+              )}
+            </View>
 
             <TextInput
               autoFocus
@@ -148,14 +166,6 @@ const NewReportModal: React.FC<Props> = ({
                 lowerLimit: descriptionLowerLimit,
               })}
             />
-
-            {needsLeftCount < 0 ? (
-              <Typography style={styles.charCount}>
-                あと{Math.abs(needsLeftCount)}文字必要です
-              </Typography>
-            ) : (
-              <Typography style={styles.charCount}>送信可能です</Typography>
-            )}
           </KeyboardAvoidingView>
           <Typography
             style={{


### PR DESCRIPTION
![simulator_screenshot_85CB247B-5B27-4EFB-8872-CE4C4D97BCDE](https://github.com/user-attachments/assets/709192d1-8b67-4118-99c1-f0e2da4f6b3f)
文字カウントが右下にあるとKeyboardAvoidingViewの都合で注意書きと文字カウントが被って何文字打てばいいのかわからん状況に陥ったりしていて右上の空白地帯に文字カウントを移動させた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- モーダルのヘッダーとキャラクターカウントの表示レイアウトを調整
	- 垂直方向の余白を減らし、より簡潔なデザインに
	- キャラクターカウントの表示ロジックを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->