### PR TITLE
TTS無効時余計な項目を表示しない

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3809,9 +3809,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   abseil: d121da9ef7e2ff4cab7666e76c5a3e0915ae08c3
-  boost: 5b4633648a360f2c7206c0d80b859d935e84182c
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   BoringSSL-GRPC: ca6a8e5d04812fce8ffd6437810c2d46f925eaeb
-  DoubleConversion: f506a3066be30cc16cd411f7f969641c5b1ca95e
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EXApplication: 88ebf1a95f85faa5d2df160016d61f2d060e9438
   EXAV: fc9706da25733f79db3305035ee3bc6174a6590c
   EXConstants: 277129d9a42ba2cf1fad375e7eaa9939005c60be
@@ -3852,21 +3852,21 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 7a7aebb9342d53913a5c890efa88e289d9e5c1bc
   FirebaseSharedSwift: 302ac5967857ad7e7388b15382d705b8c8d892aa
   FirebaseStorage: 4e521b5c833f0f3d488dcbde0c72044d02c59146
-  fmt: 5ac5e6dcabe2bd1a81f50fe511125872ed2041aa
-  glog: df405be20c5f69c02662f3b90832a02fe17ff8fe
+  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleAppMeasurement: ee5c2d2242816773fbf79e5b0563f5355ef1c315
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   "gRPC-C++": 2fa52b3141e7789a28a737f251e0c45b4cb20a87
   gRPC-Core: a27c294d6149e1c39a7d173527119cfbc3375ce4
   GTMSessionFetcher: 923b710231ad3d6f3f0495ac1ced35421e07d9a6
-  hermes-engine: abd0bf20a2c24a25a2e255458c17d9b9bc8e5ed1
+  hermes-engine: 0555a84ea495e8e3b4bde71b597cd87fbb382888
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: c3a617dd95526b047427fd6500172b7838176591
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 2c5e1000b04ab70b53956aa498bf7442c3c6e497
   RCTRequired: 5f785a001cf68a551c5f5040fb4c415672dbb481
   RCTTypeSafety: 6b98db8965005d32449605c0d005ecb4fee8a0f7

--- a/src/screens/AppSettings/index.tsx
+++ b/src/screens/AppSettings/index.tsx
@@ -171,35 +171,36 @@ const AppSettingsScreen: React.FC = () => {
               {translate('autoAnnounceItemTitle')}
             </Typography>
           </View>
+          {speechEnabled ? (
+            <View
+              style={[
+                styles.settingItem,
+                {
+                  flexDirection: 'row',
+                  marginTop: 8,
+                },
+              ]}
+            >
+              {isLEDTheme ? (
+                <LEDThemeSwitch
+                  style={{ marginRight: 8 }}
+                  value={backgroundEnabled}
+                  onValueChange={onBackgroundAudioEnabledValueChange}
+                />
+              ) : (
+                <Switch
+                  style={{ marginRight: 8 }}
+                  value={backgroundEnabled}
+                  onValueChange={onBackgroundAudioEnabledValueChange}
+                />
+              )}
+              <Typography style={styles.settingsItemHeading}>
+                {translate('autoAnnounceBackgroundTitle')}
+              </Typography>
+            </View>
+          ) : null}
 
-          <View
-            style={[
-              styles.settingItem,
-              {
-                flexDirection: 'row',
-                marginTop: 8,
-              },
-            ]}
-          >
-            {isLEDTheme ? (
-              <LEDThemeSwitch
-                style={{ marginRight: 8 }}
-                value={backgroundEnabled}
-                onValueChange={onBackgroundAudioEnabledValueChange}
-              />
-            ) : (
-              <Switch
-                style={{ marginRight: 8 }}
-                value={backgroundEnabled}
-                onValueChange={onBackgroundAudioEnabledValueChange}
-              />
-            )}
-            <Typography style={styles.settingsItemHeading}>
-              {translate('autoAnnounceBackgroundTitle')}
-            </Typography>
-          </View>
-
-          {backgroundEnabled && (
+          {speechEnabled && backgroundEnabled && (
             <Typography style={styles.bgTTSNotice}>
               {translate('bgTtsAlertText')}
             </Typography>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 音声機能が有効なときのみ、背景オーディオの設定オプションが表示されるようになりました。
  - 音声機能と背景オーディオ機能の両方が有効の場合にのみ、背景オーディオの警告メッセージが表示されるよう改善され、不要なオプションの表示を防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->