### PR TITLE
メイン画面離脱時のヘッダアニメーション削除

### DIFF
--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -391,9 +391,10 @@ const HeaderSaikyo: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(false);
     if (!selectedBound) {
       setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
     }
     fade();
   }, [fade, selectedBound]);

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -367,9 +367,10 @@ const HeaderTY: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(false);
     if (!selectedBound) {
       setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
     }
     fade();
   }, [fade, selectedBound]);

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -367,9 +367,10 @@ const HeaderTokyoMetro: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(false);
     if (!selectedBound) {
       setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
     }
     fade();
   }, [fade, selectedBound]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ヘッダーのフェードアウトアニメーションの表示タイミングと条件を見直しました。これにより、特定の状態でのみ適切に実行されるようになり、表示の変化がより安定し、スムーズなユーザー体験を実現しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->