### PR TITLE
ウェアラブルのナンバリングの括弧を外す

### DIFF
--- a/android/wearable/src/main/java/me/tinykitten/trainlcd/WearApp.kt
+++ b/android/wearable/src/main/java/me/tinykitten/trainlcd/WearApp.kt
@@ -123,7 +123,7 @@ fun WearApp(
                             Text(
                                 modifier = Modifier.fillMaxWidth(),
                                 textAlign = TextAlign.Center,
-                                text = "(${payload.stationNumber})",
+                                text = "${payload.stationNumber}",
                                 fontSize = 16.sp
                             )
                         }

--- a/ios/WatchApp Extension/Views/RootView.swift
+++ b/ios/WatchApp Extension/Views/RootView.swift
@@ -23,7 +23,7 @@ struct RootView: View {
         .multilineTextAlignment(.center)
         .font(.title2)
       if let stationNumber = station.stationNumber {
-        Text("(\(stationNumber))")
+        Text(stationNumber)
           .multilineTextAlignment(.center)
           .font(.caption)
       } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• スタイル  
　- ウェアラブルアプリで表示される駅番号のフォーマットが変更され、従来の括弧付きから直接数字のみのシンプルな表示に更新されました。これにより、ユーザーインターフェースがすっきりし、見やすさが向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->