### PR TITLE
LEDテーマではボールド体フォントを許容しない

### DIFF
--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -30,6 +30,7 @@ const Typography = forwardRef((props: TextProps, ref: LegacyRef<Text>) => {
         textAlignVertical: 'top',
       },
       props.style,
+      // NOTE: LEDテーマ用フォントはファイルサイズが大きいのでボールドの方を廃止した
       isLEDTheme && { fontWeight: 'normal' },
     ],
     [fontFamily, isLEDTheme, props.style]

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -30,6 +30,7 @@ const Typography = forwardRef((props: TextProps, ref: LegacyRef<Text>) => {
         textAlignVertical: 'top',
       },
       props.style,
+      isLEDTheme && { fontWeight: 'normal' },
     ],
     [fontFamily, isLEDTheme, props.style]
   );


### PR DESCRIPTION
LED用フォントデカいのでボールドは消した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **スタイル**
	- LEDテーマが有効な場合、テキストのフォントウェイトが自動的に標準（normal）に調整されるようになりました。これにより、より一貫したタイポグラフィの表示が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->