### PR TITLE
乗り換えパネルから乗り換える時はリプレースする

### DIFF
--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -320,7 +320,7 @@ const MainScreen: React.FC = () => {
         averageDistance: null,
         stations: [],
       }));
-      navigation.navigate('SelectBound' as never);
+      navigation.dispatch(StackActions.replace('SelectBound'));
     },
     [navigation, setLineState, setNavigationState, setStationState]
   );


### PR DESCRIPTION
navigateだとTTSが重なって再生されてしまう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- 画面遷移のナビゲーション動作を改善し、目的の画面への移動後に不要な履歴が残らないよう変更しました。これにより、ユーザーが戻る操作を行った際の挙動が改善され、よりスムーズな体験が提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->