### PR TITLE
方面選択から路線選択に戻る時はリプレースする

### DIFF
--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -115,7 +115,7 @@ const SelectBoundScreen: React.FC = () => {
       leftStations: [],
       fetchedTrainTypes: [],
     }));
-    navigation.navigate('SelectLine' as never);
+    navigation.dispatch(StackActions.replace('SelectLine'));
   }, [navigation, setLineState, setNavigationState, setStationState]);
 
   const handleBoundSelected = useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - 画面遷移の挙動を改善し、一度の操作で次の画面へ切り替わる際、前の画面の履歴が残らなくなりました。これにより、不要な戻り操作が避けられ、よりシームレスなユーザー体験が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->