### PR TITLE
列車種別が直通後変更されないバグを修正

### DIFF
--- a/src/hooks/useCurrentTrainType.ts
+++ b/src/hooks/useCurrentTrainType.ts
@@ -2,20 +2,21 @@ import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { type TrainType, TrainTypeKind } from '../../gen/proto/stationapi_pb';
 import navigationState from '../store/atoms/navigation';
-import { useCurrentLine } from './useCurrentLine';
+import { useCurrentStation } from './useCurrentStation';
 
 const useCurrentTrainType = (): TrainType | null => {
   const { trainType, fromBuilder } = useRecoilValue(navigationState);
-  const currentLine = useCurrentLine();
+
+  const currentStation = useCurrentStation();
 
   const currentTrainType = useMemo(
     () =>
       ((trainType?.lines?.length ?? 1) > 1 ||
         trainType?.kind === TrainTypeKind.Branch) &&
       !fromBuilder
-        ? trainType?.lines?.find((l) => l.id === currentLine?.id)?.trainType
+        ? currentStation?.trainType
         : (trainType ?? null),
-    [currentLine?.id, fromBuilder, trainType]
+    [currentStation, fromBuilder, trainType]
   );
 
   return currentTrainType ?? null;

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -89,7 +89,7 @@ const RouteSearchScreen = () => {
   const { mutateAsync: fetchStationByIdList } = useMutation(getStationByIdList);
 
   const {
-    fetchStations: fetchTrainTypeFromTrainTypeId,
+    fetchStations: fetchStationsByLineGroupId,
     isLoading: isTrainTypesLoading,
     error: fetchTrainTypesError,
   } = useTrainTypeStations();
@@ -249,7 +249,7 @@ const RouteSearchScreen = () => {
         return;
       }
 
-      const { stations } = await fetchTrainTypeFromTrainTypeId({
+      const { stations } = await fetchStationsByLineGroupId({
         lineGroupId: trainType.groupId,
       });
 
@@ -269,7 +269,7 @@ const RouteSearchScreen = () => {
 
       setNavigationState((prev) => ({
         ...prev,
-        trainType: station?.trainType ?? null,
+        trainType,
         stationForHeader: station,
       }));
       setStationState((prev) => ({
@@ -292,7 +292,7 @@ const RouteSearchScreen = () => {
     [
       currentStation?.groupId,
       fetchStationByIdList,
-      fetchTrainTypeFromTrainTypeId,
+      fetchStationsByLineGroupId,
       navigation,
       selectedStation?.groupId,
       setNavigationState,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - 電車の種類取得ロジックが、路線から駅情報に基づくものへ変更され、処理が明確化されました。
  - 駅情報の取得機能名称および状態管理が改善され、シンプルで直感的な動作が実現されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->