### PR TITLE
種別変更する駅タイミングが実際のタイミングより前の駅で表示されるバグを修正

### DIFF
--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -734,9 +734,7 @@ const TypeChangeNotify: React.FC = () => {
   const nextTrainType = useNextTrainType();
 
   const currentTypeStations = stations.filter(
-    (s) =>
-      s.trainType?.typeId === trainType?.typeId &&
-      s.line?.id === currentLine?.id
+    (s) => s.trainType?.typeId === trainType?.typeId
   );
 
   const reversedStations = stations.slice().reverse();


### PR DESCRIPTION
この一行消していいのか微妙にわからないのでチェックは念入りにする必要がありそう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 駅の表示選定処理を簡素化し、選択された列車タイプに合致する駅情報が、より幅広く利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->