### PR TITLE
大阪環状線の方面が逆になっているバグを修正

### DIFF
--- a/src/hooks/useLoopLine.ts
+++ b/src/hooks/useLoopLine.ts
@@ -97,7 +97,9 @@ export const useLoopLine = () => {
       return [];
     }
 
-    const reversedStations = stations.slice().reverse();
+    const reversedStations = isOsakaLoopLine
+      ? stations
+      : stations.slice().reverse();
 
     const currentStationIndex = reversedStations.findIndex(
       (s) => s.id === station.id
@@ -113,26 +115,32 @@ export const useLoopLine = () => {
       .filter((s, i, a) => a.findIndex((e) => e.id === s.id) === i);
 
     return majorStations.slice(0, 2);
-  }, [isLoopLine, line, majorStationIds, station, stations]);
+  }, [isOsakaLoopLine, isLoopLine, line, majorStationIds, station, stations]);
 
   const outboundStationsForLoopLine = useMemo((): Station[] => {
     if (!line || !station || !isLoopLine) {
       return [];
     }
 
-    const currentStationIndex = stations.findIndex((s) => s.id === station.id);
+    const reversedStations = isOsakaLoopLine
+      ? stations.slice().reverse()
+      : stations;
+
+    const currentStationIndex = reversedStations.findIndex(
+      (s) => s.id === station.id
+    );
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const majorStations = [
-      ...stations.slice(currentStationIndex),
-      ...stations.slice(0, currentStationIndex),
+      ...reversedStations.slice(currentStationIndex),
+      ...reversedStations.slice(0, currentStationIndex),
     ]
       .filter((s) => majorStationIds.includes(s.id))
       .filter((s) => s.id !== station.id)
       .filter((s, i, a) => a.findIndex((e) => e.id === s.id) === i);
 
     return majorStations.slice(0, 2);
-  }, [isLoopLine, line, majorStationIds, station, stations]);
+  }, [isOsakaLoopLine, isLoopLine, line, majorStationIds, station, stations]);
 
   return {
     isYamanoteLine,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 大阪環状線利用時の駅表示ロジックを見直し、正しい順序で駅情報が表示されるよう改善しました。これにより、現在位置の特定や主要駅の抽出がより正確になり、ユーザー体験の向上に寄与します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->