### PR TITLE
大阪環状線順序修正

### DIFF
--- a/src/hooks/useLoopLine.ts
+++ b/src/hooks/useLoopLine.ts
@@ -97,9 +97,7 @@ export const useLoopLine = () => {
       return [];
     }
 
-    const reversedStations = isOsakaLoopLine
-      ? stations
-      : stations.slice().reverse();
+    const reversedStations = stations.slice().reverse();
 
     const currentStationIndex = reversedStations.findIndex(
       (s) => s.id === station.id
@@ -115,32 +113,26 @@ export const useLoopLine = () => {
       .filter((s, i, a) => a.findIndex((e) => e.id === s.id) === i);
 
     return majorStations.slice(0, 2);
-  }, [isOsakaLoopLine, isLoopLine, line, majorStationIds, station, stations]);
+  }, [isLoopLine, line, majorStationIds, station, stations]);
 
   const outboundStationsForLoopLine = useMemo((): Station[] => {
     if (!line || !station || !isLoopLine) {
       return [];
     }
 
-    const reversedStations = isOsakaLoopLine
-      ? stations.slice().reverse()
-      : stations;
-
-    const currentStationIndex = reversedStations.findIndex(
-      (s) => s.id === station.id
-    );
+    const currentStationIndex = stations.findIndex((s) => s.id === station.id);
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const majorStations = [
-      ...reversedStations.slice(currentStationIndex),
-      ...reversedStations.slice(0, currentStationIndex),
+      ...stations.slice(currentStationIndex),
+      ...stations.slice(0, currentStationIndex),
     ]
       .filter((s) => majorStationIds.includes(s.id))
       .filter((s) => s.id !== station.id)
       .filter((s, i, a) => a.findIndex((e) => e.id === s.id) === i);
 
     return majorStations.slice(0, 2);
-  }, [isOsakaLoopLine, isLoopLine, line, majorStationIds, station, stations]);
+  }, [isLoopLine, line, majorStationIds, station, stations]);
 
   return {
     isYamanoteLine,

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -7,11 +7,11 @@ import stationState from '../store/atoms/station';
 import getCurrentStationIndex from '../utils/currentStationIndex';
 import dropEitherJunctionStation from '../utils/dropJunctionStation';
 import getIsPass from '../utils/isPass';
+import { getIsLocal } from '../utils/trainTypeString';
 import { useCurrentLine } from './useCurrentLine';
 import useCurrentTrainType from './useCurrentTrainType';
 import { useLoopLine } from './useLoopLine';
 import { useThemeStore } from './useThemeStore';
-import { getIsLocal } from '../utils/trainTypeString';
 
 const useRefreshLeftStations = (): void => {
   const {

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -11,6 +11,7 @@ import { useCurrentLine } from './useCurrentLine';
 import useCurrentTrainType from './useCurrentTrainType';
 import { useLoopLine } from './useLoopLine';
 import { useThemeStore } from './useThemeStore';
+import { getIsLocal } from '../utils/trainTypeString';
 
 const useRefreshLeftStations = (): void => {
   const {
@@ -72,16 +73,8 @@ const useRefreshLeftStations = (): void => {
               currentStationIndex + 1
             )
             .reverse();
-          // 山手線と大阪環状線はちょっと処理が違う
-          if (currentStationIndex < 7 && isOsakaLoopLine) {
-            const nextStations = stations
-              .slice()
-              .reverse()
-              .slice(currentStationIndex - 1, 7);
-            return [...inboundPendingStations, ...nextStations];
-          }
 
-          if ((currentStationIndex < 7 && isYamanoteLine) || isMeijoLine) {
+          if (currentStationIndex < 7 || isMeijoLine) {
             const nextStations = stations
               .slice()
               .reverse()
@@ -113,14 +106,7 @@ const useRefreshLeftStations = (): void => {
           return [];
       }
     },
-    [
-      currentLine,
-      isMeijoLine,
-      isOsakaLoopLine,
-      isYamanoteLine,
-      selectedDirection,
-      stations,
-    ]
+    [currentLine, isMeijoLine, selectedDirection, stations]
   );
 
   const getStations = useCallback(
@@ -163,7 +149,7 @@ const useRefreshLeftStations = (): void => {
       return false;
     }
 
-    if (isOsakaLoopLine && trainType) {
+    if (isOsakaLoopLine && !getIsLocal(trainType)) {
       return false;
     }
     return isYamanoteLine || isOsakaLoopLine || isMeijoLine;
@@ -175,7 +161,7 @@ const useRefreshLeftStations = (): void => {
     }
     const currentIndex = getCurrentStationIndex(stations, station);
     const leftStations =
-      loopLine && !trainType
+      loopLine && getIsLocal(trainType)
         ? getStationsForLoopLine(currentIndex)
         : getStations(currentIndex);
     setNavigation((prev) => {


### PR DESCRIPTION
#4121 の修正は間違いだった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 駅リストの並び順を見直し、常に一貫した表示となるように簡略化しました。
	- 次の駅情報の取得ロジックを整理し、よりスムーズな駅ナビゲーションを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->