### PR TITLE
山手線・名城線が逆になってた

### DIFF
--- a/src/hooks/useBounds.ts
+++ b/src/hooks/useBounds.ts
@@ -28,7 +28,6 @@ const useBounds = (): {
 
   const {
     isLoopLine,
-    isMeijoLine,
     inboundStationsForLoopLine,
     outboundStationsForLoopLine,
   } = useLoopLine();
@@ -69,9 +68,6 @@ const useBounds = (): {
     }
 
     if (!trainType || getIsLocal(trainType)) {
-      if (isMeijoLine) {
-        return [outboundStationsForLoopLine, inboundStationsForLoopLine];
-      }
       if (isLoopLine) {
         return [inboundStationsForLoopLine, outboundStationsForLoopLine];
       }
@@ -90,7 +86,6 @@ const useBounds = (): {
     currentStation,
     inboundStationsForLoopLine,
     isLoopLine,
-    isMeijoLine,
     outboundStationsForLoopLine,
     stations,
     trainType,

--- a/src/utils/trainTypeString.ts
+++ b/src/utils/trainTypeString.ts
@@ -2,7 +2,7 @@ import { type TrainType, TrainTypeKind } from '../../gen/proto/stationapi_pb';
 
 // 301 = 私鉄各駅停車
 export const getIsLocal = (tt: TrainType | null): boolean =>
-  tt?.kind === TrainTypeKind.Default || true;
+  (tt?.kind ?? TrainTypeKind.Default) === TrainTypeKind.Default;
 export const getIsRapid = (tt: TrainType | null): boolean =>
   tt?.kind === TrainTypeKind.Rapid;
 export const getIsLtdExp = (tt: TrainType | null): boolean =>

--- a/src/utils/trainTypeString.ts
+++ b/src/utils/trainTypeString.ts
@@ -2,7 +2,7 @@ import { type TrainType, TrainTypeKind } from '../../gen/proto/stationapi_pb';
 
 // 301 = 私鉄各駅停車
 export const getIsLocal = (tt: TrainType | null): boolean =>
-  tt?.kind === TrainTypeKind.Default;
+  tt?.kind === TrainTypeKind.Default || true;
 export const getIsRapid = (tt: TrainType | null): boolean =>
   tt?.kind === TrainTypeKind.Rapid;
 export const getIsLtdExp = (tt: TrainType | null): boolean =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - ステーションの境界情報取得処理を整理し、`isMeijoLine`に依存しない一貫した表示が実現されるよう改善しました。
  - 電車の種類判定ロジックを更新し、`TrainType`が`null`または`undefined`の場合でも正しく判定できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->