### PR TITLE
山手線テーマのまもなくTTS文言追加

### DIFF
--- a/__tests__/hooks/useTTSText.test.tsx
+++ b/__tests__/hooks/useTTSText.test.tsx
@@ -176,7 +176,7 @@ describe('Without trainType & With numbering', () => {
           wrapper: ({ children }) => <RecoilRoot>{children}</RecoilRoot>,
         }
       )
-      expect(result.current).toEqual(['', ''])
+      expect(result.current).toEqual(['まもなく、<sub alias=\"しんじゅくさんちょうめ\">新宿三丁目</sub>、<sub alias=\"しんじゅくさんちょうめ\">新宿三丁目</sub>。<sub alias=\"とうきょうめとろまるのうちせん\">東京メトロ丸ノ内線</sub>、<sub alias=\"とうきょうめとろふくとしんせん\">東京メトロ副都心線</sub>は、お乗り換えです。', 'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.'])
     })
   })
 

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -394,7 +394,23 @@ const useTTSText = (
                   .join('、')}はお乗り換えです。`
               : ''
           }`,
-          ARRIVING: '',
+          ARRIVING: `まもなく、${isNextStopTerminus ? '終点、' : ''}${
+            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
+            ''
+          }、${
+            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
+            ''
+          }。${
+            transferLines.length
+              ? `${transferLines
+                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
+                  .join('、')}は、お乗り換えです。${
+                  isNextStopTerminus
+                    ? `${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございました。`
+                    : ''
+                }`
+              : ''
+          }`,
         },
         [APP_THEME.JO]: {
           NEXT: '',
@@ -733,7 +749,23 @@ const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: '',
+          ARRIVING: `The next station is ${nextStation?.nameRoman}${
+            isNextStopTerminus ? ', terminal' : ''
+          } ${nextStationNumberText}${
+            transferLines.length
+              ? ` Please change here for ${transferLines
+                  .map((l, i, a) =>
+                    a.length > 1 && a.length - 1 === i
+                      ? `and the ${l.nameRoman}.`
+                      : `the ${l.nameRoman}${a.length === 1 ? '.' : ','}`
+                  )
+                  .join(' ')}`
+              : ''
+          }${
+            isNextStopTerminus
+              ? ' Thank you for traveling with us, and look forward serving you again.'
+              : ''
+          }`,
         },
         [APP_THEME.JO]: {
           NEXT: '',

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -763,7 +763,7 @@ const useTTSText = (
               : ''
           }${
             isNextStopTerminus
-              ? ' Thank you for traveling with us, and look forward serving you again.'
+              ? ' Thank you for traveling with us, and look forward to serving you again.'
               : ''
           }`,
         },
@@ -803,7 +803,7 @@ const useTTSText = (
               : ''
           }${
             isNextStopTerminus
-              ? ' Thank you for traveling with us, and look forward serving you again.'
+              ? ' Thank you for traveling with us, and look forward to serving you again.'
               : ''
           }`,
         },


### PR DESCRIPTION
一旦埼京線テーマと同じ文言

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 案内メッセージが充実され、日本語と英語で次の駅名、終着判定、乗り換え案内など、より詳細な情報を提供するようになりました。終着の場合には感謝の意も表現され、利用者の乗車体験が向上します。
- **テスト**
  - 'YAMANOTE'テーマの'ARRIVING'状態におけるテストケースの期待出力が更新され、正確なSSML出力が生成されることを確認するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->