### PR TITLE
接近・到着判定閾値抜本的変更

### DIFF
--- a/src/hooks/useResetMainState.ts
+++ b/src/hooks/useResetMainState.ts
@@ -21,7 +21,6 @@ export const useResetMainState = () => {
       selectedBound: null,
       arrived: true,
       approaching: false,
-      averageDistance: null,
     }));
   }, [setNavigationState, setStationState]);
 

--- a/src/hooks/useThreshold.ts
+++ b/src/hooks/useThreshold.ts
@@ -1,43 +1,35 @@
 import { useMemo } from 'react';
-import { LineType } from '../../gen/proto/stationapi_pb';
 import { APPROACHING_MAX_THRESHOLD, ARRIVED_MAX_THRESHOLD } from '../constants';
-import { useCurrentLine } from './useCurrentLine';
 import { useDistanceToNextStation } from './useDistanceToNextStation';
 
 export const useThreshold = () => {
-  const currentLine = useCurrentLine();
   const distanceToNextStation = useDistanceToNextStation();
 
   const approachingThreshold = useMemo(() => {
-    if (!currentLine) {
+    if (!distanceToNextStation) {
       return APPROACHING_MAX_THRESHOLD;
     }
 
-    const threshold = currentLine.averageDistance / 2;
+    const threshold = distanceToNextStation / 2;
     if (threshold > APPROACHING_MAX_THRESHOLD) {
       return APPROACHING_MAX_THRESHOLD;
     }
-    if (threshold > distanceToNextStation) {
-      return distanceToNextStation / 2;
-    }
+
     return threshold;
-  }, [currentLine, distanceToNextStation]);
+  }, [distanceToNextStation]);
 
   const arrivedThreshold = useMemo(() => {
-    if (!currentLine) {
+    if (!distanceToNextStation) {
       return ARRIVED_MAX_THRESHOLD;
     }
 
-    const threshold = currentLine.averageDistance / 5;
-
-    if (threshold > distanceToNextStation) {
-      return distanceToNextStation / 5;
-    }
+    const threshold = distanceToNextStation / 5;
     if (threshold > ARRIVED_MAX_THRESHOLD) {
       return ARRIVED_MAX_THRESHOLD;
     }
+
     return threshold;
-  }, [currentLine, distanceToNextStation]);
+  }, [distanceToNextStation]);
 
   return { approachingThreshold, arrivedThreshold };
 };

--- a/src/hooks/useThreshold.ts
+++ b/src/hooks/useThreshold.ts
@@ -28,15 +28,10 @@ export const useThreshold = () => {
       return ARRIVED_MAX_THRESHOLD;
     }
 
-    const isNarrowBetweenStation =
-      currentLine.lineType === LineType.Tram ||
-      currentLine.lineType === LineType.MonorailOrAGT;
-
-    const threshold =
-      currentLine.averageDistance / (isNarrowBetweenStation ? 6 : 5);
+    const threshold = currentLine.averageDistance / 5;
 
     if (threshold > distanceToNextStation) {
-      return distanceToNextStation / (isNarrowBetweenStation ? 6 : 5);
+      return distanceToNextStation / 5;
     }
     if (threshold > ARRIVED_MAX_THRESHOLD) {
       return ARRIVED_MAX_THRESHOLD;

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -324,7 +324,6 @@ const MainScreen: React.FC = () => {
         selectedBound: null,
         arrived: true,
         approaching: false,
-        averageDistance: null,
         stations: [],
       }));
       navigation.dispatch(StackActions.replace('SelectBound'));

--- a/src/store/atoms/station.ts
+++ b/src/store/atoms/station.ts
@@ -6,7 +6,6 @@ import type { LineDirection } from '../../models/Bound';
 export interface StationState {
   arrived: boolean;
   approaching: boolean;
-  averageDistance: number | null;
   station: Station | null;
   stations: Station[];
   selectedDirection: LineDirection | null;
@@ -17,7 +16,6 @@ export interface StationState {
 export const initialStationState: StationState = {
   arrived: true,
   approaching: false,
-  averageDistance: null,
   station: null,
   stations: [],
   selectedDirection: null,


### PR DESCRIPTION
~~#4142 の変更で余計な計算になった説がある~~
路線自体の平均駅間距離ではなく次の駅までの距離で接近・到着閾値を計算するようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - `averageDistance` プロパティをステート管理から削除し、関連するロジックを簡素化しました。これにより、ステート構造がシンプルになり、距離関連データの扱いに影響を与える可能性があります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->