### PR TITLE
通過中の駅を閾値計算に使用しない

### DIFF
--- a/src/hooks/useThreshold.ts
+++ b/src/hooks/useThreshold.ts
@@ -5,7 +5,7 @@ import { useCurrentStation } from './useCurrentStation';
 import { useNextStation } from './useNextStation';
 
 export const useThreshold = () => {
-  const currentStation = useCurrentStation();
+  const currentStation = useCurrentStation(true);
   const nextStation = useNextStation();
 
   const betweenDistance = useMemo(() => {


### PR DESCRIPTION
通過駅からの次の駅への閾値計算だと各駅停車の時と閾値が同じになってしまうので通過駅を到着・接近閾値の計算に使用しない。通過と停車では停車前の速度が違うため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - 内部のデータ取得処理におけるパラメーターを更新し、しきい値に基づく動作の一貫性と信頼性を向上させました。ユーザー向けの表示や公開される機能自体に変更はありませんが、システム全体の安定性が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->