### PR TITLE
Marqueeの速度を固定値に変更

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
+import isTablet from '../utils/isTablet';
 
 type Props = {
   children: React.ReactElement;
@@ -24,7 +25,7 @@ const Marquee = ({ children }: Props) => {
     (width: number) => {
       offsetX.value = withRepeat(
         withTiming(-width, {
-          duration: width * 3,
+          duration: 8500,
           easing: Easing.linear,
         }),
         -1

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -7,7 +7,6 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
-import isTablet from '../utils/isTablet';
 
 type Props = {
   children: React.ReactElement;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - マルキーのスクロールアニメーションの持続時間を固定値に変更し、コンテンツの幅にかかわらず一貫した表示速度を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->