### PR TITLE
再度dozeアラートが出るように修正

### DIFF
--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -3,7 +3,7 @@ export const ASYNC_STORAGE_KEYS = {
   PREVIOUS_THEME: '@TrainLCD:previousTheme',
   ENABLED_LANGUAGES: '@TrainLCD:enabledLanguages',
   SPEECH_ENABLED: '@TrainLCD:speechEnabled',
-  DOSE_CONFIRMED: '@TrainLCD:dozeConfirmed',
+  DOZE_CONFIRMED: '@TrainLCD:dozeConfirmed',
   TTS_NOTICE: '@TrainLCD:ttsNotice',
   LONG_PRESS_NOTICE_DISMISSED: '@TrainLCD:longPressNoticeDismissed',
   ALWAYS_PERMISSION_NOT_GRANTED_WARNING_DISMISSED:

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -3,7 +3,15 @@ import { StackActions, useNavigation } from '@react-navigation/native';
 import { useKeepAwake } from 'expo-keep-awake';
 import * as Location from 'expo-location';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Alert, Dimensions, Pressable, StyleSheet, View } from 'react-native';
+import {
+  Alert,
+  Dimensions,
+  Linking,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { isClip } from 'react-native-app-clip';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import {
@@ -282,6 +290,44 @@ const MainScreen: React.FC = () => {
             },
           ]
         );
+      }
+
+      if (Platform.OS === 'android' && bgPermStatus.granted) {
+        const dozeAlertDismissed = await AsyncStorage.getItem(
+          ASYNC_STORAGE_KEYS.DOZE_CONFIRMED
+        );
+        if (dozeAlertDismissed !== 'true') {
+          Alert.alert(
+            translate('annoucementTitle'),
+            translate('dozeAlertText'),
+            [
+              {
+                text: translate('doNotShowAgain'),
+                style: 'cancel',
+                onPress: async (): Promise<void> => {
+                  await AsyncStorage.setItem(
+                    ASYNC_STORAGE_KEYS.DOZE_CONFIRMED,
+                    'true'
+                  );
+                },
+              },
+              {
+                text: 'OK',
+                onPress: async () => {
+                  try {
+                    await Linking.openSettings();
+                  } catch (error) {
+                    Alert.alert(
+                      translate('annoucementTitle'),
+                      translate('failedToOpenSettings'),
+                      [{ text: 'OK' }]
+                    );
+                  }
+                },
+              },
+            ]
+          );
+        }
       }
     };
     f();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Androidデバイス向けに、背景パーミッションが有効な場合、ユーザーに通知を表示する機能を追加しました。通知では、今後このメッセージを表示しない選択肢や、設定画面へのアクセスが提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->