### PR TITLE
直接の種別選択の時停車駅を省略しない

### DIFF
--- a/src/components/TrainTypeInfoPage.tsx
+++ b/src/components/TrainTypeInfoPage.tsx
@@ -116,7 +116,10 @@ const TrainTypeItem = React.memo(
   ({
     line,
     outOfLineRange,
-  }: { line: Line | null; outOfLineRange: boolean }) => (
+  }: {
+    line: Line | null;
+    outOfLineRange: boolean;
+  }) => (
     <View
       style={[
         styles.trainTypeItemContainer,
@@ -172,6 +175,10 @@ export const TrainTypeInfoPage: React.FC<Props> = ({
       .filter((s) => !getIsPass(s))
       .filter((s) => s !== undefined);
 
+    if (!fromRouteListModal) {
+      return stops;
+    }
+
     const curIndex = stops.findIndex(
       (s) => s.groupId === currentStation?.groupId
     );
@@ -190,7 +197,12 @@ export const TrainTypeInfoPage: React.FC<Props> = ({
     }
 
     return uniqBy(stops.slice(curIndex), 'id');
-  }, [stations, currentStation?.groupId, finalStation?.groupId]);
+  }, [
+    stations,
+    currentStation?.groupId,
+    finalStation?.groupId,
+    fromRouteListModal,
+  ]);
 
   const afterFinalLines = useMemo(
     () =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 鉄道種別の詳細表示ページのUI定義をより明瞭に改善しました。
	- ユーザーの利用状況に応じた停車駅の一覧表示ロジックを最適化し、表示の一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->