### PR TITLE
Revert "30km/h -> 40km/h"

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -7,7 +7,7 @@ export const LONG_PRESS_DURATION = 500;
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
 export const ARRIVED_MAX_THRESHOLD = 500;
-export const ARRIVED_MAXIMUM_SPEED = 40; // km/h
+export const ARRIVED_MAXIMUM_SPEED = 30; // km/h
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;


### PR DESCRIPTION
Reverts TrainLCD/MobileApp#4179
逆効果だった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 到着時の速度上限が従来の40 km/hから30 km/hに更新され、アプリケーションの挙動が改善されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->