### PR TITLE
ライブアクティビティで次の駅名が取れない場合停車時と同じレイアウトにする

### DIFF
--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -46,7 +46,7 @@ struct RideSessionWidget: Widget {
     } dynamicIsland: { context in
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
-          if context.state.stopped {
+          if context.state.stopped || context.state.nextStationName.isEmpty {
             EmptyView()
           } else {
             VStack(alignment: .center) {
@@ -65,7 +65,7 @@ struct RideSessionWidget: Widget {
         }
 
         DynamicIslandExpandedRegion(.trailing) {
-          if context.state.stopped {
+          if context.state.stopped || context.state.nextStationName.isEmpty {
             EmptyView()
           } else {
             VStack(alignment: .center) {
@@ -84,7 +84,7 @@ struct RideSessionWidget: Widget {
         }
 
         DynamicIslandExpandedRegion(.center) {
-          if context.state.stopped {
+          if context.state.stopped || context.state.nextStationName.isEmpty {
             VStack(alignment: .center) {
               Text(
                 getRunningStateText(
@@ -133,7 +133,9 @@ struct RideSessionWidget: Widget {
         HStack {
           if context.state.approaching {
             EmptyView()
-          } else if context.state.stopped {
+          } else if context.state.stopped
+            || context.state.nextStationName.isEmpty
+          {
             Image(systemName: "stop.circle")
           }
 
@@ -188,7 +190,9 @@ struct RideSessionWidget: Widget {
 
               Image(systemName: "chevron.forward.dotted.chevron.forward")
             }
-          } else if context.state.stopped {
+          } else if context.state.stopped
+            || context.state.nextStationName.isEmpty
+          {
             VStack(spacing: 0) {
               Text(
                 context.state.stationName
@@ -244,7 +248,7 @@ struct LockScreenLiveActivityContentView: View {
   var body: some View {
     VStack {
       Group {
-        if context.state.stopped {
+        if context.state.stopped || context.state.nextStationName.isEmpty {
           VStack {
             Text(
               getRunningStateText(
@@ -301,10 +305,9 @@ struct LockScreenLiveActivityContentView: View {
                 }
               }
               .frame(minWidth: 0, maxWidth: .infinity)
-              if !context.state.nextStationName.isEmpty {
-                Image(systemName: "arrow.right")
-                  .foregroundColor(.accentColor)
-              }
+
+              Image(systemName: "arrow.right")
+                .foregroundColor(.accentColor)
               VStack {
                 Text(context.state.nextStationName)
                   .bold()
@@ -423,9 +426,7 @@ struct SmartStackLiveActivityContentView: View {
               .font(.headline)
               .bold()
               .multilineTextAlignment(.leading)
-            if !context.state.stationNumber.isEmpty
-              || !context.state.nextStationNumber.isEmpty
-            {
+            if !context.state.stationNumber.isEmpty {
               Text(context.state.stationNumber)
                 .font(.caption)
                 .bold()
@@ -442,9 +443,7 @@ struct SmartStackLiveActivityContentView: View {
               .font(.headline)
               .bold()
               .multilineTextAlignment(.leading)
-            if !context.state.stationNumber.isEmpty
-              || !context.state.nextStationNumber.isEmpty
-            {
+            if !context.state.stationNumber.isEmpty {
               Text(context.state.nextStationNumber)
                 .font(.caption)
                 .bold()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- UI表示の条件チェックを改善し、乗車状況画面で停止状態と次の駅情報の有無がより正確に反映されるようになりました。これにより、各インターフェースが直感的かつ正確な情報を提供します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->