### PR TITLE
駅名検索 グループID+駅名で集約 現在地の駅も検索結果に出るように仕様変更

### DIFF
--- a/src/components/StationList.tsx
+++ b/src/components/StationList.tsx
@@ -46,7 +46,7 @@ const ItemCell = ({
   onSelect: (item: Station) => void;
   withoutTransfer?: boolean;
 }) => {
-  const ownLine = item.line;
+  const ownLine = useMemo(() => item.line, [item.line]);
   const otherLines = useMemo(
     () => item.lines.filter((l) => l.id !== ownLine?.id),
     [item.lines, ownLine?.id]

--- a/src/screens/FakeStationSettingsScreen.tsx
+++ b/src/screens/FakeStationSettingsScreen.tsx
@@ -106,7 +106,7 @@ const FakeStationSettingsScreen: React.FC = () => {
       navigation.goBack();
       return;
     }
-    navigation.navigate('MainStack');
+    navigation.navigate('MainStack' as never);
   }, [navigation]);
 
   const handleSubmit = useCallback(() => {
@@ -130,13 +130,9 @@ const FakeStationSettingsScreen: React.FC = () => {
     [byCoordsData, byNameData]
   );
 
-  // NOTE: 今いる駅は出なくていい
   const groupedStations = useMemo(
-    () =>
-      groupStations(foundStations).filter(
-        (sta) => sta.groupId !== currentStation?.groupId
-      ),
-    [currentStation?.groupId, foundStations]
+    () => groupStations(foundStations),
+    [foundStations]
   );
 
   const handleStationPress = useCallback(

--- a/src/utils/groupStations.ts
+++ b/src/utils/groupStations.ts
@@ -4,7 +4,10 @@ import { PREFECTURES_JA, PREFECTURES_ROMAN } from '../constants';
 export const groupStations = (stations: Station[]): Station[] => {
   return stations
     .filter(
-      (sta, idx, arr) => arr.findIndex((s) => s.name === sta.name) === idx
+      (sta, idx, arr) =>
+        arr.findIndex(
+          (s) => s.groupId === sta.groupId && s.name === sta.name
+        ) === idx
     )
     .map((sta, idx, arr) => {
       // 駅名が同じだが都道府県は違う場合は都道府県名を付与する

--- a/src/utils/groupStations.ts
+++ b/src/utils/groupStations.ts
@@ -4,7 +4,7 @@ import { PREFECTURES_JA, PREFECTURES_ROMAN } from '../constants';
 export const groupStations = (stations: Station[]): Station[] => {
   return stations
     .filter(
-      (sta, idx, arr) => arr.findIndex((s) => s.groupId === sta.groupId) === idx
+      (sta, idx, arr) => arr.findIndex((s) => s.name === sta.name) === idx
     )
     .map((sta, idx, arr) => {
       // 駅名が同じだが都道府県は違う場合は都道府県名を付与する


### PR DESCRIPTION
close https://github.com/TrainLCD/MobileApp/issues/4199

先に https://github.com/TrainLCD/StationAPI/pull/1250 APIの変更が必要

ついでに選択中の駅も検索結果に出るようにした（結構前の挙動に戻した）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **パフォーマンス改善**
  - 一部のリスト表示で再計算の最適化を行い、画面のパフォーマンスを向上しました。

- **仕様変更**
  - 駅グループの重複判定を厳格化し、同じグループIDでも駅名が異なる場合は別扱いとなるよう変更しました。

- **内部処理の調整**
  - 設定画面での駅グループ一覧の表示ロジックを簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->