### PR TITLE
LineBoard Android版デグレ修正

### DIFF
--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -111,12 +111,10 @@ const styles = StyleSheet.create({
     paddingBottom: isTablet ? 6 : 84,
   },
   stationName: {
-    textAlign: 'center',
     fontSize: RFValue(18),
     fontWeight: 'bold',
     marginLeft: isTablet ? 6 : 3,
     marginBottom: Platform.select({ android: -3, ios: 0 }),
-    includeFontPadding: false,
   },
   stationNameHorizontal: {
     fontSize: RFValue(18),

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -116,7 +116,6 @@ const styles = StyleSheet.create({
     paddingBottom: isTablet ? 0 : 64,
   },
   stationName: {
-    textAlign: 'center',
     fontSize: RFValue(18),
     fontWeight: 'bold',
   },
@@ -162,10 +161,11 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   stationNumber: {
-    width: screenWidth / 9,
+    width: isTablet ? 60 : 45,
     fontSize: RFValue(12),
     fontWeight: 'bold',
     marginLeft: -5,
+    textAlign: 'center',
   },
   marksContainer: { top: 38, position: 'absolute' },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 駅名テキストの中央揃えを解除し、フォントパディング設定を削除しました。
  - 駅番号テキストの幅をデバイスに応じて調整し、中央揃えを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->