### PR TITLE
textAlignVertical: 'center'

### DIFF
--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -27,7 +27,7 @@ const Typography = forwardRef((props: TextProps, ref: LegacyRef<Text>) => {
       {
         fontFamily,
         color: isLEDTheme ? '#fff' : '#333',
-        textAlignVertical: 'top',
+        textAlignVertical: 'center',
       },
       props.style,
       // NOTE: LEDテーマ用フォントはファイルサイズが大きいのでボールドの方を廃止した


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - テキストの垂直方向の配置が「上」から「中央」に変更され、表示されるテキストの位置が中央揃えになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->