### PR TITLE
シミュレーションモードバグ修正

### DIFF
--- a/src/constants/simulationMode.ts
+++ b/src/constants/simulationMode.ts
@@ -2,7 +2,7 @@ import { LineType } from '../../gen/proto/stationapi_pb';
 
 // 路線種別による最高速度
 export const LINE_TYPE_MAX_SPEEDS_IN_M_S: Record<LineType, number> = {
-  [LineType.BulletTrain]: 83.33333333333, // 300km/h
+  [LineType.BulletTrain]: 88.88888889, // 320km/h
   [LineType.MonorailOrAGT]: 22.22222222222, // 80km/h
   [LineType.Normal]: 25, // 90km/h
   [LineType.OtherLineType]: 25, // 90km/h

--- a/src/hooks/useInRadiusStation.ts
+++ b/src/hooks/useInRadiusStation.ts
@@ -1,9 +1,9 @@
-import { useRecoilValue } from 'recoil';
-import { useEffect, useState } from 'react';
-import stationState from '~/store/atoms/station';
 import type { Station } from 'gen/proto/stationapi_pb';
-import { useLocationStore } from './useLocationStore';
 import isPointWithinRadius from 'geolib/es/isPointWithinRadius';
+import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import stationState from '~/store/atoms/station';
+import { useLocationStore } from './useLocationStore';
 
 export const useInRadiusStation = (radius: number) => {
   const { stations, station } = useRecoilValue(stationState);

--- a/src/hooks/useInRadiusStation.ts
+++ b/src/hooks/useInRadiusStation.ts
@@ -1,0 +1,36 @@
+import { useRecoilValue } from 'recoil';
+import { useEffect, useState } from 'react';
+import stationState from '~/store/atoms/station';
+import type { Station } from 'gen/proto/stationapi_pb';
+import { useLocationStore } from './useLocationStore';
+import isPointWithinRadius from 'geolib/es/isPointWithinRadius';
+
+export const useInRadiusStation = (radius: number) => {
+  const { stations, station } = useRecoilValue(stationState);
+
+  const latitude = useLocationStore()?.coords.latitude;
+  const longitude = useLocationStore()?.coords.longitude;
+
+  const [latestMatchedStation, setLatestMatchedStation] =
+    useState<Station | null>(station);
+
+  useEffect(() => {
+    if (!latitude || !longitude) {
+      return;
+    }
+
+    const matchedStation = stations.find((s) =>
+      isPointWithinRadius(
+        { latitude, longitude },
+        { latitude: s.latitude, longitude: s.longitude },
+        radius
+      )
+    );
+
+    if (matchedStation) {
+      setLatestMatchedStation(matchedStation);
+    }
+  }, [latitude, longitude, stations, radius]);
+
+  return latestMatchedStation;
+};

--- a/src/hooks/useInRadiusStation.ts
+++ b/src/hooks/useInRadiusStation.ts
@@ -8,8 +8,9 @@ import { useLocationStore } from './useLocationStore';
 export const useInRadiusStation = (radius: number) => {
   const { stations, station } = useRecoilValue(stationState);
 
-  const latitude = useLocationStore()?.coords.latitude;
-  const longitude = useLocationStore()?.coords.longitude;
+  const locationState = useLocationStore();
+  const latitude = locationState?.coords.latitude;
+  const longitude = locationState?.coords.longitude;
 
   const [latestMatchedStation, setLatestMatchedStation] =
     useState<Station | null>(station);

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -17,20 +17,16 @@ import getIsPass from '../utils/isPass';
 import { useCurrentLine } from './useCurrentLine';
 import { useLocationStore } from './useLocationStore';
 import { useNextStation } from './useNextStation';
+import { useInRadiusStation } from './useInRadiusStation';
 
 export const useSimulationMode = (enabled: boolean): void => {
-  const {
-    stations: rawStations,
-    selectedDirection,
-    station,
-  } = useRecoilValue(stationState);
+  const { stations: rawStations, selectedDirection } =
+    useRecoilValue(stationState);
   const currentLine = useCurrentLine();
 
   const segmentIndexRef = useRef(0);
   const childIndexRef = useRef(0);
   const speedProfilesRef = useRef<number[][]>([]);
-
-  const nextStation = useNextStation(false);
 
   const stations = useMemo(
     () => dropEitherJunctionStation(rawStations, selectedDirection),
@@ -41,6 +37,11 @@ export const useSimulationMode = (enabled: boolean): void => {
     () => currentLine?.lineType ?? LineType.Normal,
     [currentLine]
   );
+
+  const station = useInRadiusStation(
+    LINE_TYPE_MAX_SPEEDS_IN_M_S[currentLine?.lineType ?? LineType.Normal] / 2
+  );
+  const nextStation = useNextStation(false, station ?? undefined);
 
   const maybeRevsersedStations = useMemo(
     () =>
@@ -93,7 +94,7 @@ export const useSimulationMode = (enabled: boolean): void => {
     });
 
     segmentIndexRef.current = maybeRevsersedStations.findIndex(
-      (s) => s.id === station?.id
+      (s) => s.groupId === station?.groupId
     );
     speedProfilesRef.current = speedProfiles;
     childIndexRef.current = 0;

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -15,9 +15,9 @@ import stationState from '../store/atoms/station';
 import dropEitherJunctionStation from '../utils/dropJunctionStation';
 import getIsPass from '../utils/isPass';
 import { useCurrentLine } from './useCurrentLine';
+import { useInRadiusStation } from './useInRadiusStation';
 import { useLocationStore } from './useLocationStore';
 import { useNextStation } from './useNextStation';
-import { useInRadiusStation } from './useInRadiusStation';
 
 export const useSimulationMode = (enabled: boolean): void => {
   const { stations: rawStations, selectedDirection } =


### PR DESCRIPTION
駅到着時ぴったり止まるようになった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 現在地が指定した半径内の駅に該当するか判定する新しいフックを追加しました。

- **機能改善**
  - シミュレーションモードで現在駅と次駅の判定方法が改善され、より正確な駅判定が行われるようになりました。
  - 「新幹線」タイプの最大速度が320km/hに引き上げられました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->