### PR TITLE
シミュレーションモードの方向転換を早めにした

### DIFF
--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -39,7 +39,7 @@ export const useSimulationMode = (enabled: boolean): void => {
   );
 
   const station = useInRadiusStation(
-    LINE_TYPE_MAX_SPEEDS_IN_M_S[currentLine?.lineType ?? LineType.Normal] / 2
+    LINE_TYPE_MAX_SPEEDS_IN_M_S[currentLine?.lineType ?? LineType.Normal]
   );
   const nextStation = useNextStation(false, station ?? undefined);
 

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -39,7 +39,7 @@ export const useSimulationMode = (enabled: boolean): void => {
   );
 
   const station = useInRadiusStation(
-    LINE_TYPE_MAX_SPEEDS_IN_M_S[currentLine?.lineType ?? LineType.Normal]
+    LINE_TYPE_MAX_SPEEDS_IN_M_S[currentLine?.lineType ?? LineType.Normal] / 1.5
   );
   const nextStation = useNextStation(false, station ?? undefined);
 

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -65,8 +65,8 @@ export const useSimulationMode = (enabled: boolean): void => {
         return [];
       }
 
-      const stationIndex = arr.findIndex((s) => s.id === cur.id);
-      const nextStationIndex = arr.findIndex((s) => s.id === next.id);
+      const stationIndex = arr.findIndex((s) => s.groupId === cur.groupId);
+      const nextStationIndex = arr.findIndex((s) => s.groupId === next.groupId);
 
       const betweenNextStation = arr.slice(stationIndex + 1, nextStationIndex);
 


### PR DESCRIPTION
中央線快速の飯田橋駅通過を検出できなかったので

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 駅を検索する際の半径が拡大され、より広い範囲で最寄り駅が見つかるようになりました。  
  - 駅間の速度プロファイル生成で、駅の識別方法がより正確になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->