### PR TITLE
特急種別の場合シミュレーションモードの最高速度を130km/hまで引き上げる

### DIFF
--- a/src/constants/simulationMode.ts
+++ b/src/constants/simulationMode.ts
@@ -1,4 +1,4 @@
-import { LineType } from '../../gen/proto/stationapi_pb';
+import { LineType, TrainTypeKind } from '../../gen/proto/stationapi_pb';
 
 // 路線種別による最高速度
 export const LINE_TYPE_MAX_SPEEDS_IN_M_S: Record<LineType, number> = {
@@ -8,6 +8,17 @@ export const LINE_TYPE_MAX_SPEEDS_IN_M_S: Record<LineType, number> = {
   [LineType.OtherLineType]: 25, // 90km/h
   [LineType.Subway]: 22.22222222222, // 80km/h
   [LineType.Tram]: 11.11111111111, // 40km/h
+} as const;
+// 列車種別による最高速度
+export const TRAIN_TYPE_KIND_MAX_SPEEDS_IN_M_S: Record<
+  TrainTypeKind,
+  number | null
+> = {
+  [TrainTypeKind.Branch]: null,
+  [TrainTypeKind.Default]: null,
+  [TrainTypeKind.Rapid]: null,
+  [TrainTypeKind.Express]: null,
+  [TrainTypeKind.LimitedExpress]: 36.1111111111, // 130km/h
 } as const;
 // 路線種別による加速度
 export const LINE_TYPE_MAX_ACCEL_IN_M_S: Record<LineType, number> = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - シミュレーション時の最大速度判定に列車種別（例：特急）を考慮し、該当する場合は種別ごとの最大速度を適用するようになりました。

- **バグ修正**
  - 駅データが空やnullの場合、位置情報の更新や初期化処理が正しく行われるよう改善されました。

- **テスト**
  - シミュレーションモードのフックに関するテストケースを追加し、さまざまなエッジケースや異常系の動作確認を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->