### PR TITLE
テレメトリのログ送信キュー処理実装

### DIFF
--- a/__tests__/hooks/useTelemetrySender.enabled.test.tsx
+++ b/__tests__/hooks/useTelemetrySender.enabled.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useTelemetrySender } from '~/hooks/useTelemetrySender';
 import { useLocationStore } from '~/hooks/useLocationStore';
 import { RecoilRoot } from 'recoil';
@@ -57,10 +57,12 @@ test('should send log when WebSocket is open', () => {
     result.current.sendLog('Test log', 'info');
   });
 
-  expect(mockWebSocketSend).toHaveBeenCalled();
-  const message = JSON.parse(mockWebSocketSend.mock.calls[0][0]);
-  expect(message.type).toBe('log');
-  expect(message.log.message).toBe('Test log');
+  waitFor(() => {
+    expect(mockWebSocketSend).toHaveBeenCalled();
+    const message = JSON.parse(mockWebSocketSend.mock.calls[0][0]);
+    expect(message.type).toBe('log');
+    expect(message.log.message).toBe('Test log');
+  });
 });
 
 test('should throttle log sending within 1s', () => {
@@ -71,7 +73,9 @@ test('should throttle log sending within 1s', () => {
     result.current.sendLog('Second');
   });
 
-  expect(mockWebSocketSend).toHaveBeenCalledTimes(1);
+  waitFor(() => {
+    expect(mockWebSocketSend).toHaveBeenCalledTimes(1);
+  });
 });
 
 test('should not send telemetry if coordinates are null', () => {

--- a/__tests__/hooks/useTelemetrySender.enabled.test.tsx
+++ b/__tests__/hooks/useTelemetrySender.enabled.test.tsx
@@ -22,7 +22,7 @@ beforeEach(() => {
   mockWebSocket = {
     send: mockWebSocketSend,
     close: jest.fn(),
-    readyState: WebSocket.OPEN,
+    readyState: 1, // WebSocket.OPEN
   };
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   (global as any).WebSocket = jest.fn(() => mockWebSocket);

--- a/__tests__/hooks/useTelemetrySender.enabled.test.tsx
+++ b/__tests__/hooks/useTelemetrySender.enabled.test.tsx
@@ -98,6 +98,17 @@ test('should enqueue message if WebSocket is not open', () => {
     result.current.sendLog('Queued message');
   });
   expect(mockWebSocketSend).not.toHaveBeenCalled();
+
+  // WebSocketが開通した時にキューからメッセージが送信されることを検証
+  act(() => {
+    mockWebSocket.readyState = WebSocket.OPEN;
+    // onopen イベントをトリガー
+    mockWebSocket.onopen?.();
+  });
+
+  expect(mockWebSocketSend).toHaveBeenCalled();
+  const message = JSON.parse(mockWebSocketSend.mock.calls[0][0]);
+  expect(message.log.message).toBe('Queued message');
 });
 
 test('should not connect with invalid WebSocket URL', () => {

--- a/__tests__/hooks/useTelemetrySender.enabled.test.tsx
+++ b/__tests__/hooks/useTelemetrySender.enabled.test.tsx
@@ -50,14 +50,14 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-test('should send log when WebSocket is open', () => {
+test('should send log when WebSocket is open', async () => {
   const { result } = renderHook(() => useTelemetrySender(), { wrapper });
 
   act(() => {
     result.current.sendLog('Test log', 'info');
   });
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(mockWebSocketSend).toHaveBeenCalled();
     const message = JSON.parse(mockWebSocketSend.mock.calls[0][0]);
     expect(message.type).toBe('log');
@@ -65,7 +65,7 @@ test('should send log when WebSocket is open', () => {
   });
 });
 
-test('should throttle log sending within 1s', () => {
+test('should throttle log sending within 1s', async () => {
   const { result } = renderHook(() => useTelemetrySender(), { wrapper });
 
   act(() => {
@@ -73,7 +73,7 @@ test('should throttle log sending within 1s', () => {
     result.current.sendLog('Second');
   });
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(mockWebSocketSend).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -40,7 +40,7 @@ export const useTelemetrySender = (
   const socketRef = useRef<WebSocket | null>(null);
   const lastSentRef = useRef<number>(0);
   const THROTTLE_MS = 1000; // 1秒間に1回までの送信に制限
-  const messageQueue: string[] = [];
+  const messageQueue = useRef<string[]>([]).current;
 
   const latitude = useLocationStore((state) => state?.coords.latitude);
   const longitude = useLocationStore((state) => state?.coords.longitude);
@@ -120,42 +120,50 @@ export const useTelemetrySender = (
       socket?.close();
       clearTimeout(reconnectTimeout);
     };
-  }, [wsUrl, sendTelemetryAutomatically]);
+  }, [
+    wsUrl,
+    sendTelemetryAutomatically,
+    messageQueue.length,
+    messageQueue.shift,
+  ]);
 
-  const sendLog = useCallback((message: string, level = 'debug') => {
-    const now = Date.now();
-    if (now - lastSentRef.current < THROTTLE_MS) {
-      return;
-    }
-
-    const payload = TelemetryPayload.safeParse({
-      log: {
-        level,
-        message,
-      },
-      device: Device.modelName ?? 'unknown',
-      timestamp: now,
-    });
-
-    if (payload.error) {
-      console.error('Invalid telemetry payload:', payload.error);
-      return;
-    }
-
-    const strigifiedMessage = JSON.stringify({
-      type: 'log',
-      ...payload.data,
-    });
-
-    if (socketRef.current?.readyState === WebSocket.OPEN && payload.success) {
-      if (payload.data.log) {
-        socketRef.current.send(strigifiedMessage);
-        lastSentRef.current = now;
+  const sendLog = useCallback(
+    (message: string, level = 'debug') => {
+      const now = Date.now();
+      if (now - lastSentRef.current < THROTTLE_MS) {
+        return;
       }
-    } else {
-      messageQueue.push(strigifiedMessage);
-    }
-  }, []);
+
+      const payload = TelemetryPayload.safeParse({
+        log: {
+          level,
+          message,
+        },
+        device: Device.modelName ?? 'unknown',
+        timestamp: now,
+      });
+
+      if (payload.error) {
+        console.error('Invalid telemetry payload:', payload.error);
+        return;
+      }
+
+      const strigifiedMessage = JSON.stringify({
+        type: 'log',
+        ...payload.data,
+      });
+
+      if (socketRef.current?.readyState === WebSocket.OPEN && payload.success) {
+        if (payload.data.log) {
+          socketRef.current.send(strigifiedMessage);
+          lastSentRef.current = now;
+        }
+      } else {
+        messageQueue.push(strigifiedMessage);
+      }
+    },
+    [messageQueue.push]
+  );
 
   const sendTelemetry = useCallback(() => {
     const now = Date.now();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - WebSocketが未接続時にログメッセージをキューに保存し、接続後にまとめて送信するようになりました。
  - 接続・切断時に情報ログが自動送信されるようになりました（自動送信が有効な場合）。

- **バグ修正**
  - 一時的な接続切断時にもログが失われず送信されるよう改善されました。

- **テスト**
  - テレメトリ送信機能のテストが簡素化され、主要な動作に焦点を当てた内容に刷新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->