### PR TITLE
Androidだけビルドが失敗するのでbump expo-task-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "expo-notifications": "~0.29.8",
         "expo-screen-capture": "~7.0.0",
         "expo-splash-screen": "~0.29.13",
-        "expo-task-manager": "~12.0.3",
+        "expo-task-manager": "~12.0.6",
         "expo-web-browser": "~14.0.1",
         "geolib": "^3.3.4",
         "i18n-js": "^3.5.1",
@@ -9595,11 +9595,12 @@
       }
     },
     "node_modules/expo-task-manager": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-12.0.3.tgz",
-      "integrity": "sha512-XNbDWPqBJw9kuWrYFhpcjRBbuxMUlgiFdEUHpm7VmMqGmm86UAZTO20zSGkM0U25yIcmQgsHiEbfV9B2S84dqA==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-12.0.6.tgz",
+      "integrity": "sha512-yGbS64OL95z7tAQAvryy0sGHuQgrcpvnJsdyuGL8MA9bcPtr+kytLZ4dOCDac7foQS7+FLDGgtiAR6v/64B5Pg==",
+      "license": "MIT",
       "dependencies": {
-        "unimodules-app-loader": "~5.0.0"
+        "unimodules-app-loader": "~5.0.1"
       },
       "peerDependencies": {
         "expo": "*",
@@ -17102,9 +17103,10 @@
       }
     },
     "node_modules/unimodules-app-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-5.0.0.tgz",
-      "integrity": "sha512-0Zc3u344NmlvyQBmcgnxHcQhrLeFV4hn80U6S4YwAfaexXCWmiHOzMe4+P+YhgHiRWb5lJgadr08hLbee3XTHg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-5.0.1.tgz",
+      "integrity": "sha512-JI4dUMOovvLrZ1U/mrQrR73cxGH26H7NpfBxwE0hk59CBOyHO4YYpliI3hPSGgZzt+YEy2VZR6nrspSUXY8jyw==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "expo-notifications": "~0.29.8",
     "expo-screen-capture": "~7.0.0",
     "expo-splash-screen": "~0.29.13",
-    "expo-task-manager": "~12.0.3",
+    "expo-task-manager": "~12.0.6",
     "expo-web-browser": "~14.0.1",
     "geolib": "^3.3.4",
     "i18n-js": "^3.5.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 依存パッケージ「expo-task-manager」をバージョン ~12.0.3 から ~12.0.6 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->