### PR TITLE
800mフィルターの削除

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -12,7 +12,6 @@ export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;
 export const BAD_ACCURACY_THRESHOLD = 200; // m
-export const ARRIVED_CANCELLATION_THRESHOLD = 800; // m
 // オートモード
 export const AUTO_MODE_RUNNING_DURATION = 15000;
 export const AUTO_MODE_STOPPING_DURATION = AUTO_MODE_RUNNING_DURATION + 1000;

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -5,7 +5,6 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { ARRIVED_GRACE_PERIOD_MS } from '~/constants';
 import type { Station } from '../../gen/proto/stationapi_pb';
 import {
-  ARRIVED_CANCELLATION_THRESHOLD,
   ARRIVED_MAXIMUM_SPEED,
   BAD_ACCURACY_THRESHOLD,
 } from '../constants/threshold';
@@ -57,11 +56,6 @@ const useRefreshStation = (): void => {
 
     if (!latitude || !longitude || !nearestStation || inGracePeriod) {
       return true;
-    }
-
-    // NOTE: 位置情報の取得誤差が一定以上ある場合は停車判定を無視する
-    if (accuracy && accuracy > ARRIVED_CANCELLATION_THRESHOLD) {
-      return false;
     }
 
     if (speed && !getIsPass(nearestStation)) {


### PR DESCRIPTION
めちゃくちゃ裏目に出た

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 到着判定時の精度しきい値によるキャンセル処理を削除し、より柔軟に到着判定が行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->