### PR TITLE
到着閾値戻し

### DIFF
--- a/src/hooks/useThreshold.ts
+++ b/src/hooks/useThreshold.ts
@@ -39,7 +39,7 @@ export const useThreshold = () => {
       return ARRIVED_MAX_THRESHOLD;
     }
 
-    const threshold = betweenDistance / 3;
+    const threshold = betweenDistance / 4;
     if (threshold > ARRIVED_MAX_THRESHOLD) {
       return ARRIVED_MAX_THRESHOLD;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 駅間距離から到着判定のしきい値を計算する際、分母を3から4に変更し、より厳密なしきい値判定となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->