### PR TITLE
まもなく表示に切り替わる際に不要そうな条件の削除

### DIFF
--- a/src/hooks/useTransitionHeaderState.ts
+++ b/src/hooks/useTransitionHeaderState.ts
@@ -195,7 +195,7 @@ const useTransitionHeaderState = (): void => {
           break;
       }
 
-      if (approaching && !arrived) {
+      if (approaching) {
         switch (currentHeaderState) {
           case 'CURRENT':
           case 'NEXT':
@@ -233,7 +233,6 @@ const useTransitionHeaderState = (): void => {
         }
       }
     }, [
-      arrived,
       approaching,
       enabledLanguages,
       headerStateRef,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 駅が接近中の場合のヘッダー状態の遷移タイミングを調整し、より正確に動作するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->