### PR TITLE
bump kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
     compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
     targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.24'
+    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.25'
 
     ndkVersion = "26.1.10909125"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Androidビルド設定で使用されるKotlinのデフォルトバージョンを1.9.24から1.9.25に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->