### PR TITLE
useLocationPermissionsGrantedの初期値をfalseに変更

### DIFF
--- a/src/hooks/useLocationPermissionsGranted.ts
+++ b/src/hooks/useLocationPermissionsGranted.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { AppState } from 'react-native';
 
 export const useLocationPermissionsGranted = () => {
-  const [permissionsGranted, setPermissionsGranted] = useState(true);
+  const [permissionsGranted, setPermissionsGranted] = useState(false);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 位置情報の権限が未確認の場合、初期状態で「未許可」として扱うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->