### PR TITLE
kotlinCompilerExtensionVersion上げ

### DIFF
--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -59,7 +59,7 @@ android {
     compose = true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.14"
+    kotlinCompilerExtensionVersion = "1.5.15"
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Jetpack Compose用Kotlinコンパイラ拡張のバージョンを1.5.14から1.5.15に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->