### PR TITLE
Marqueeのスクロール速度調整

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -22,10 +22,10 @@ const Marquee = ({ children }: Props) => {
 
   const startScroll = useCallback(
     (width: number) => {
-      // 1ピクセルあたり15msで計算し、3秒〜10秒の範囲に制限
+      // 1ピクセルあたり15msで計算し、3秒〜30秒の範囲に制限
       const durationPerPixel = 15;
       const minDuration = 3000;
-      const maxDuration = 10000;
+      const maxDuration = 30000;
       const duration = Math.min(
         Math.max(width * durationPerPixel, minDuration),
         maxDuration


### PR DESCRIPTION
#4290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - マーキーのスクロールアニメーションの最大時間が10秒から30秒に延長され、幅広いコンテンツでもよりゆっくりスクロールできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->