### PR TITLE
TTBから種別名がはみ出すバグを修正

### DIFF
--- a/src/components/TrainTypeBoxJL.tsx
+++ b/src/components/TrainTypeBoxJL.tsx
@@ -86,13 +86,13 @@ const TrainTypeBoxJL: React.FC<Props> = ({
   const trainTypeName = useMemo(() => {
     switch (headerLangState) {
       case 'EN':
-        return trainTypeNameR;
+        return trainTypeNameR.split('\n')[0]?.trim();
       case 'ZH':
-        return trainTypeNameZh;
+        return trainTypeNameZh.split('\n')[0]?.trim();
       case 'KO':
-        return trainTypeNameKo;
+        return trainTypeNameKo.split('\n')[0]?.trim();
       default:
-        return trainTypeNameJa;
+        return trainTypeNameJa.split('\n')[0]?.trim();
     }
   }, [
     headerLangState,
@@ -102,13 +102,19 @@ const TrainTypeBoxJL: React.FC<Props> = ({
     trainTypeNameZh,
   ]);
 
+
+  const numberOfLines = useMemo(
+    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
+    [trainTypeName]
+  );
+
   return (
     <View style={styles.box}>
       <View style={styles.innerBox}>
         {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
           trainTypeName.split('').map((char, idx) => (
             <Typography
-              numberOfLines={1}
+              numberOfLines={numberOfLines}
               adjustsFontSizeToFit
               style={{
                 ...styles.text,

--- a/src/components/TrainTypeBoxJL.tsx
+++ b/src/components/TrainTypeBoxJL.tsx
@@ -102,19 +102,13 @@ const TrainTypeBoxJL: React.FC<Props> = ({
     trainTypeNameZh,
   ]);
 
-
-  const numberOfLines = useMemo(
-    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
-    [trainTypeName]
-  );
-
   return (
     <View style={styles.box}>
       <View style={styles.innerBox}>
         {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
           trainTypeName.split('').map((char, idx) => (
             <Typography
-              numberOfLines={numberOfLines}
+              numberOfLines={1}
               adjustsFontSizeToFit
               style={{
                 ...styles.text,

--- a/src/components/TrainTypeBoxJL.tsx
+++ b/src/components/TrainTypeBoxJL.tsx
@@ -102,13 +102,18 @@ const TrainTypeBoxJL: React.FC<Props> = ({
     trainTypeNameZh,
   ]);
 
+  const numberOfLines = useMemo(
+    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
+    [trainTypeName]
+  );
+
   return (
     <View style={styles.box}>
       <View style={styles.innerBox}>
         {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
           trainTypeName.split('').map((char, idx) => (
             <Typography
-              numberOfLines={1}
+              numberOfLines={numberOfLines}
               adjustsFontSizeToFit
               style={{
                 ...styles.text,

--- a/src/components/TrainTypeBoxJL.tsx
+++ b/src/components/TrainTypeBoxJL.tsx
@@ -42,6 +42,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: isTablet ? 36 : 24,
     lineHeight: isTablet ? 55 : 35,
+    flex: 1,
   },
 });
 
@@ -107,6 +108,8 @@ const TrainTypeBoxJL: React.FC<Props> = ({
         {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
           trainTypeName.split('').map((char, idx) => (
             <Typography
+              numberOfLines={1}
+              adjustsFontSizeToFit
               style={{
                 ...styles.text,
                 color: trainTypeColor,
@@ -120,6 +123,8 @@ const TrainTypeBoxJL: React.FC<Props> = ({
           ))
         ) : (
           <Typography
+            numberOfLines={1}
+            adjustsFontSizeToFit
             style={{
               ...styles.text,
               color: trainTypeColor,

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -75,13 +75,13 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
   const trainTypeName = useMemo(() => {
     switch (headerLangState) {
       case 'EN':
-        return trainTypeNameR;
+        return trainTypeNameR.split('\n')[0]?.trim();
       case 'ZH':
-        return trainTypeNameZh;
+        return trainTypeNameZh.split('\n')[0]?.trim();
       case 'KO':
-        return trainTypeNameKo;
+        return trainTypeNameKo.split('\n')[0]?.trim();
       default:
-        return trainTypeNameJa;
+        return trainTypeNameJa.split('\n')[0]?.trim();
     }
   }, [
     headerLangState,
@@ -101,12 +101,17 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
     return trainType?.color ?? '#222';
   }, [trainType]);
 
+  const numberOfLines = useMemo(
+    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
+    [trainTypeName]
+  );
+
   return (
     <View style={styles.box}>
       {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
         trainTypeName.split('').map((char, idx) => (
           <Typography
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             adjustsFontSizeToFit
             style={{
               ...styles.text,

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     transform: [{ skewX: '-5deg' }],
     fontSize: isTablet ? 36 : 24,
+    flex: 1
   },
 });
 
@@ -105,6 +106,8 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
       {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
         trainTypeName.split('').map((char, idx) => (
           <Typography
+            numberOfLines={1}
+            adjustsFontSizeToFit
             style={{
               ...styles.text,
               color: trainTypeColor,
@@ -118,6 +121,8 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
         ))
       ) : (
         <Typography
+          numberOfLines={1}
+          adjustsFontSizeToFit
           style={{
             ...styles.text,
             color: trainTypeColor,

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     transform: [{ skewX: '-5deg' }],
     fontSize: isTablet ? 36 : 24,
-    flex: 1
+    flex: 1,
   },
 });
 

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -101,17 +101,12 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
     return trainType?.color ?? '#222';
   }, [trainType]);
 
-  const numberOfLines = useMemo(
-    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
-    [trainTypeName]
-  );
-
   return (
     <View style={styles.box}>
       {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
         trainTypeName.split('').map((char, idx) => (
           <Typography
-            numberOfLines={numberOfLines}
+            numberOfLines={1}
             adjustsFontSizeToFit
             style={{
               ...styles.text,

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -101,12 +101,17 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
     return trainType?.color ?? '#222';
   }, [trainType]);
 
+  const numberOfLines = useMemo(
+    () => (trainTypeName.split('\n')[0].length <= 10 ? 1 : 2),
+    [trainTypeName]
+  );
+
   return (
     <View style={styles.box}>
       {headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName) ? (
         trainTypeName.split('').map((char, idx) => (
           <Typography
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             adjustsFontSizeToFit
             style={{
               ...styles.text,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **スタイル**
  - 列車種別名のテキストが自動的にフォントサイズ調整され、1～2行に収まるようになりました。表示領域に合わせてテキストが見やすくなります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->