### PR TITLE
GetStationByIdListは駅グループIDではなく駅IDで呼び出す

### DIFF
--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -187,7 +187,7 @@ const RouteSearchScreen = () => {
 
       if (!trainType?.id) {
         const { stations } = await fetchStationByIdList({
-          ids: route?.stops.map((r) => r.groupId),
+          ids: route?.stops.map((r) => r.id),
         });
         const stationInRoute =
           stations.find((s) => s.groupId === currentStation?.groupId) ?? null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 特定の条件下で、駅情報の取得に使用するIDを修正し、正しい駅が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->