### PR TITLE
Marqueeのdurationを8500に固定

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -22,16 +22,8 @@ const Marquee = ({ children }: Props) => {
 
   const startScroll = useCallback(
     (width: number) => {
-      // 1ピクセルあたり15msで計算し、3秒〜30秒の範囲に制限
-      const durationPerPixel = 15;
-      const minDuration = 3000;
-      const maxDuration = 30000;
-      const duration = Math.min(
-        Math.max(width * durationPerPixel, minDuration),
-        maxDuration
-      );
       offsetX.value = withRepeat(
-        withTiming(-width, { duration, easing: Easing.linear }),
+        withTiming(-width, { duration: 8500, easing: Easing.linear }),
         -1
       );
     },


### PR DESCRIPTION
close #4290

結局苦情がなかった頃の固定値に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - スクロールアニメーションの速度が一定になり、すべてのコンテンツ幅で同じ速度で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->