### PR TITLE
Picker廃止

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -173,5 +173,6 @@
   "trainTypeListEmpty": "No matching train types were found.",
   "jlLike": "Joban Line",
   "routeListTitle": "Directions to %{stationName} Station",
-  "legacyAutoModeTitle": "Enable legacy auto mode"
+  "legacyAutoModeTitle": "Enable legacy auto mode",
+  "currentTheme": "Current theme"
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -174,5 +174,5 @@
   "jlLike": "Joban Line",
   "routeListTitle": "Directions to %{stationName} Station",
   "legacyAutoModeTitle": "Enable legacy auto mode",
-  "currentTheme": "Current theme"
+  "inUse": "In use"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -175,5 +175,5 @@
   "jlLike": "常磐線風",
   "routeListTitle": "%{stationName}駅までの経路",
   "legacyAutoModeTitle": "従来のオートモードを有効にする",
-  "currentTheme": "現在のテーマ"
+  "inUse": "使用中"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -174,5 +174,6 @@
   "trainTypeListEmpty": "該当する種別が見つかりませんでした。",
   "jlLike": "常磐線風",
   "routeListTitle": "%{stationName}駅までの経路",
-  "legacyAutoModeTitle": "従来のオートモードを有効にする"
+  "legacyAutoModeTitle": "従来のオートモードを有効にする",
+  "currentTheme": "現在のテーマ"
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3328,30 +3328,6 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNCPicker (2.11.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - RNDeviceInfo (10.14.0):
     - React-Core
   - RNFBAnalytics (21.14.0):
@@ -3813,7 +3789,6 @@ DEPENDENCIES:
   - "ReactCommon/turbomodule/core (from `../node_modules/.pnpm/react-native@0.79.2_@babel+core@7.27.1_@react-native-community+cli@15.1.3_typescript@5._004bb81c9bd4cc34416c2f98968c91c3/node_modules/react-native/ReactCommon`)"
   - "ReactNativeAppClip (from `../node_modules/.pnpm/react-native-app-clip@0.5.1_expo@53.0.9_@babel+core@7.27.1_graphql@16.8.1_react-native@_7d3505d3d5e41db8e0a696c7266b0c14/node_modules/react-native-app-clip/ios`)"
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBAnalytics (from `../node_modules/@react-native-firebase/analytics`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
@@ -4063,8 +4038,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/.pnpm/react-native-app-clip@0.5.1_expo@53.0.9_@babel+core@7.27.1_graphql@16.8.1_react-native@_7d3505d3d5e41db8e0a696c7266b0c14/node_modules/react-native-app-clip/ios"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
-  RNCPicker:
-    :path: "../node_modules/@react-native-picker/picker"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNFBAnalytics:
@@ -4223,7 +4196,6 @@ SPEC CHECKSUMS:
   ReactNativeAppClip: c50da4b8683ead7e0e2cd45fb063ea349bdf3b7f
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 646c1bf2ebfc78d6632a3b0399f471fba8101e73
-  RNCPicker: c4e9fdf00bbd0d37c6c4f1df6eae3d4d7d32f1e3
   RNDeviceInfo: 98bb51ba1519cd3f19f14e7236b5bb1c312c780f
   RNFBAnalytics: b33dc47a5cdf688a58ad284f2c0b184299b59fd3
   RNFBApp: 4105e54d9ca4a1c10893a032268470f670181110

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@react-native-firebase/auth": "^21.6.0",
     "@react-native-firebase/firestore": "^21.6.0",
     "@react-native-firebase/storage": "^21.6.0",
-    "@react-native-picker/picker": "2.11.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.3.1",
     "@sentry/react-native": "~6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       '@react-native-firebase/storage':
         specifier: ^21.6.0
         version: 21.14.0(@react-native-firebase/app@21.14.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.9(@babel/core@7.27.1)(graphql@16.8.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
-      '@react-native-picker/picker':
-        specifier: 2.11.0
-        version: 2.11.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@react-navigation/native':
         specifier: ^7.0.14
         version: 7.1.10(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1520,12 +1517,6 @@ packages:
     resolution: {integrity: sha512-aI3ufzrz6vhrj/oE5i2dQ42xavS3sr1lWySpaBSfoF304vWwV9RqUIZTKQAsaB8PktDO0a3IMwnYwZrx56IddQ==}
     peerDependencies:
       '@react-native-firebase/app': 21.14.0
-
-  '@react-native-picker/picker@2.11.0':
-    resolution: {integrity: sha512-QuZU6gbxmOID5zZgd/H90NgBnbJ3VV6qVzp6c7/dDrmWdX8S0X5YFYgDcQFjE3dRen9wB9FWnj2VVdPU64adSg==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
 
   '@react-native/assets-registry@0.79.2':
     resolution: {integrity: sha512-5h2Z7/+/HL/0h88s0JHOdRCW4CXMCJoROxqzHqxdrjGL6EBD1DdaB4ZqkCOEVSW4Vjhir5Qb97C8i/MPWEYPtg==}
@@ -7061,11 +7052,6 @@ snapshots:
   '@react-native-firebase/storage@21.14.0(@react-native-firebase/app@21.14.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.9(@babel/core@7.27.1)(graphql@16.8.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@react-native-firebase/app': 21.14.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.9(@babel/core@7.27.1)(graphql@16.8.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-
-  '@react-native-picker/picker@2.11.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0)
 
   '@react-native/assets-registry@0.79.2': {}
 

--- a/src/components/ThemeList.tsx
+++ b/src/components/ThemeList.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useMemo } from 'react';
+import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { translate } from '~/translation';
+import type { SettingsTheme } from '~/utils/theme';
+import { useThemeStore } from '../hooks';
+import { APP_THEME, type AppTheme } from '../models/Theme';
+import { RFValue } from '../utils/rfValue';
+import Typography from './Typography';
+
+const styles = StyleSheet.create({
+  cell: { paddingHorizontal: 12, paddingVertical: 16 },
+  stationNameText: {
+    fontSize: RFValue(14),
+  },
+  descriptionText: {
+    fontSize: RFValue(11),
+    marginTop: 12,
+    fontWeight: 'bold',
+  },
+  separator: { height: 1, width: '100%', backgroundColor: '#aaa' },
+  emptyText: {
+    textAlign: 'center',
+    marginTop: 12,
+    fontSize: RFValue(14),
+    fontWeight: 'bold',
+  },
+});
+
+const Separator = () => <View style={styles.separator} />;
+
+const ItemCell = ({
+  item,
+  isSelected,
+  onSelect,
+}: {
+  item: SettingsTheme;
+  onSelect: (item: AppTheme) => void;
+  isSelected: boolean;
+}) => {
+  return (
+    <TouchableOpacity style={styles.cell} onPress={() => onSelect(item.value)}>
+      <Typography
+        style={{
+          ...styles.stationNameText,
+          fontWeight: isSelected ? 'bold' : 'regular',
+        }}
+      >
+        {item.label}
+      </Typography>
+      {isSelected ? (
+        <Typography style={styles.descriptionText}>
+          {translate('currentTheme')}
+        </Typography>
+      ) : null}
+    </TouchableOpacity>
+  );
+};
+
+export const ThemeList = ({
+  data,
+  onSelect,
+}: {
+  data: SettingsTheme[];
+  onSelect: (item: AppTheme) => void;
+}) => {
+  const theme = useThemeStore((state) => state);
+  const isLEDTheme = useMemo(() => theme === APP_THEME.LED, [theme]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: SettingsTheme; index: number }) => {
+      return (
+        <ItemCell
+          item={item}
+          onSelect={onSelect}
+          isSelected={item.value === theme}
+        />
+      );
+    },
+    [onSelect, theme]
+  );
+  const keyExtractor = useCallback(
+    (item: SettingsTheme) => item.value.toString(),
+    []
+  );
+
+  return (
+    <FlatList
+      initialNumToRender={data.length}
+      style={{
+        width: '100%',
+        alignSelf: 'center',
+        borderColor: isLEDTheme ? '#fff' : '#aaa',
+        borderWidth: 1,
+      }}
+      data={data}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      ItemSeparatorComponent={Separator}
+    />
+  );
+};

--- a/src/components/ThemeList.tsx
+++ b/src/components/ThemeList.tsx
@@ -8,25 +8,54 @@ import { RFValue } from '../utils/rfValue';
 import Typography from './Typography';
 
 const styles = StyleSheet.create({
-  cell: { paddingHorizontal: 12, paddingVertical: 16 },
+  cell: {
+    paddingHorizontal: 24,
+    height: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   stationNameText: {
     fontSize: RFValue(14),
-  },
-  descriptionText: {
-    fontSize: RFValue(11),
-    marginTop: 12,
     fontWeight: 'bold',
   },
-  separator: { height: 1, width: '100%', backgroundColor: '#aaa' },
+  activeContainer: {
+    backgroundColor: '#000000',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 16,
+  },
+  activeText: {
+    fontSize: RFValue(11),
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  separator: { height: 1, width: '100%', backgroundColor: '#cfcfcf' },
   emptyText: {
     textAlign: 'center',
     marginTop: 12,
     fontSize: RFValue(14),
     fontWeight: 'bold',
   },
+  checkboxContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
 });
 
 const Separator = () => <View style={styles.separator} />;
+
+const IN_USE_COLOR_MAP: Record<AppTheme, string> = {
+  TOKYO_METRO: '#00a9ce',
+  TY: '#dc143c',
+  YAMANOTE: '#9acd32',
+  JR_WEST: '#0072bc',
+  SAIKYO: '#00ac9a',
+  TOEI: '#45B035',
+  LED: '#212121',
+  JO: '#0067C0',
+  JL: '#808080',
+};
 
 const ItemCell = ({
   item,
@@ -37,20 +66,36 @@ const ItemCell = ({
   onSelect: (item: AppTheme) => void;
   isSelected: boolean;
 }) => {
+  const theme = useThemeStore((state) => state);
+  const isLEDTheme = useMemo(() => theme === APP_THEME.LED, [theme]);
+
+  const rootBackgroundColor = useMemo(() => {
+    if (isLEDTheme) {
+      return 'transparent';
+    }
+    return isSelected ? '#f5f5f5' : '#fff';
+  }, [isSelected, isLEDTheme]);
+
   return (
-    <TouchableOpacity style={styles.cell} onPress={() => onSelect(item.value)}>
-      <Typography
-        style={{
-          ...styles.stationNameText,
-          fontWeight: isSelected ? 'bold' : 'regular',
-        }}
-      >
-        {item.label}
-      </Typography>
+    <TouchableOpacity
+      style={{
+        ...styles.cell,
+        backgroundColor: rootBackgroundColor,
+      }}
+      onPress={() => onSelect(item.value)}
+    >
+      <Typography style={styles.stationNameText}>{item.label}</Typography>
       {isSelected ? (
-        <Typography style={styles.descriptionText}>
-          {translate('currentTheme')}
-        </Typography>
+        <View
+          style={{
+            ...styles.activeContainer,
+            backgroundColor: IN_USE_COLOR_MAP[theme],
+          }}
+        >
+          <Typography style={styles.activeText}>
+            {translate('inUse')}
+          </Typography>
+        </View>
       ) : null}
     </TouchableOpacity>
   );

--- a/src/screens/AppSettings/ThemeSettings.tsx
+++ b/src/screens/AppSettings/ThemeSettings.tsx
@@ -1,27 +1,30 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Picker } from '@react-native-picker/picker';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { ThemeList } from '~/components/ThemeList';
+import { getSettingsThemes } from '~/utils/theme';
 import FAB from '../../components/FAB';
 import Heading from '../../components/Heading';
-import { ASYNC_STORAGE_KEYS, LED_THEME_BG_COLOR } from '../../constants';
+import { ASYNC_STORAGE_KEYS } from '../../constants';
 import { useThemeStore } from '../../hooks';
-import { APP_THEME, type AppTheme } from '../../models/Theme';
+import type { AppTheme } from '../../models/Theme';
 import { translate } from '../../translation';
 import { isDevApp } from '../../utils/isDevApp';
-import getSettingsThemes from './themes';
 
 const styles = StyleSheet.create({
   rootPadding: {
-    padding: 24,
+    marginTop: 12,
+  },
+  listContainer: {
+    height: '100%',
+    paddingBottom: 96,
+    marginTop: 12,
   },
 });
 
 const ThemeSettingsScreen: React.FC = () => {
   const theme = useThemeStore((state) => state);
-
-  const isLEDTheme = theme === APP_THEME.LED;
 
   const onThemeValueChange = useCallback((t: AppTheme) => {
     useThemeStore.setState(t);
@@ -43,29 +46,15 @@ const ThemeSettingsScreen: React.FC = () => {
 
   return (
     <>
-      <View style={styles.rootPadding}>
+      <SafeAreaView style={styles.rootPadding}>
         <Heading>{translate('selectThemeTitle')}</Heading>
-        <Picker
-          selectedValue={theme}
-          onValueChange={onThemeValueChange}
-          dropdownIconColor={isLEDTheme ? '#fff' : '#000'}
-          style={{
-            width: '100%',
-          }}
-        >
-          {unlockedSettingsThemes.map((t) => (
-            <Picker.Item
-              color={isLEDTheme ? '#fff' : '#000'}
-              style={{
-                backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : undefined,
-              }}
-              key={t.value}
-              label={t.label}
-              value={t.value}
-            />
-          ))}
-        </Picker>
-      </View>
+        <View style={styles.listContainer}>
+          <ThemeList
+            data={unlockedSettingsThemes}
+            onSelect={onThemeValueChange}
+          />
+        </View>
+      </SafeAreaView>
       <FAB onPress={onPressBack} icon="checkmark" />
     </>
   );

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,14 +1,14 @@
 import { isClip } from 'react-native-app-clip';
-import { APP_THEME, type AppTheme } from '../../models/Theme';
-import { translate } from '../../translation';
+import { APP_THEME, type AppTheme } from '~/models/Theme';
+import { translate } from '~/translation';
 
-interface SettingsTheme {
+export interface SettingsTheme {
   label: string;
   value: AppTheme;
   devOnly: boolean;
 }
 
-const getSettingsThemes = (): SettingsTheme[] =>
+export const getSettingsThemes = (): SettingsTheme[] =>
   [
     {
       label: translate('tokyoMetroLike'),
@@ -56,5 +56,3 @@ const getSettingsThemes = (): SettingsTheme[] =>
       devOnly: true,
     },
   ].filter((t) => (isClip() ? t.value !== APP_THEME.LED : t)); // App Clip では LED テーマを非表示
-
-export default getSettingsThemes;


### PR DESCRIPTION
Pickerのオプションが全部 `?` と表示されて変更も反映されないバグがライブラリの方にあったのでPicker廃止して駅リストと同じようなレイアウトにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - テーマ選択画面でカスタムリストによるテーマ一覧表示・選択機能を追加しました。

- **改善**
  - テーマ選択UIを従来のドロップダウンからリスト表示に変更し、現在のテーマが分かりやすくなりました。

- **翻訳**
  - 「inUse」（使用中）という新しい翻訳キーを英語・日本語に追加しました。

- **その他**
  - 不要な依存パッケージ（@react-native-picker/picker）を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->