### PR TITLE
同じグループIDを持つ駅が存在する種別で使用する際のバグを修正

### DIFF
--- a/src/hooks/useCurrentStation.ts
+++ b/src/hooks/useCurrentStation.ts
@@ -11,13 +11,22 @@ export const useCurrentStation = (
     stations,
     station: stationFromState,
     selectedDirection,
+    selectedBound,
   } = useAtomValue(stationState);
 
   // NOTE: 選択した路線と現在の駅の路線を一致させる
-  const station = useMemo(
-    () => stations.find((s) => s.groupId === stationFromState?.groupId),
-    [stationFromState?.groupId, stations]
-  );
+  const station = useMemo(() => {
+    if (!selectedBound) {
+      return stations.find((s) => s.groupId === stationFromState?.groupId);
+    }
+
+    return stations.find((s) => s.id === stationFromState?.id);
+  }, [
+    stationFromState?.id,
+    stationFromState?.groupId,
+    stations,
+    selectedBound,
+  ]);
 
   const withTrainTypeStation = useMemo(() => {
     const foundStation = stations

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -45,7 +45,9 @@ export const useNearestStation = (): Station | null => {
     return (
       nearestStations.find(
         (s) => s.id === currentStation?.id || s.id === nextStation?.id
-      ) ?? null
+      ) ??
+      nearestStations[0] ??
+      null
     );
   }, [latitude, longitude, stations, currentStation, nextStation]);
 

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -3,6 +3,7 @@ import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import type { Station } from '~/gen/proto/stationapi_pb';
 import stationState from '../store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
 import { useLocationStore } from './useLocationStore';
 import { useNextStation } from './useNextStation';
 
@@ -10,6 +11,7 @@ export const useNearestStation = (): Station | null => {
   const latitude = useLocationStore((state) => state?.coords.latitude);
   const longitude = useLocationStore((state) => state?.coords.longitude);
   const { stations } = useAtomValue(stationState);
+  const currentStation = useCurrentStation(false);
   const nextStation = useNextStation(false);
 
   const nearestStation = useMemo<Station | null>(() => {
@@ -41,11 +43,11 @@ export const useNearestStation = (): Station | null => {
     );
 
     return (
-      nearestStations.find((s) => s.id === nextStation?.id) ??
-      nearestStations[0] ??
-      null
+      nearestStations.find(
+        (s) => s.id === currentStation?.id || s.id === nextStation?.id
+      ) ?? null
     );
-  }, [latitude, longitude, stations, nextStation]);
+  }, [latitude, longitude, stations, currentStation, nextStation]);
 
   return nearestStation;
 };

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -4,11 +4,13 @@ import { useMemo } from 'react';
 import type { Station } from '~/gen/proto/stationapi_pb';
 import stationState from '../store/atoms/station';
 import { useLocationStore } from './useLocationStore';
+import { useNextStation } from './useNextStation';
 
 export const useNearestStation = (): Station | null => {
   const latitude = useLocationStore((state) => state?.coords.latitude);
   const longitude = useLocationStore((state) => state?.coords.longitude);
   const { stations } = useAtomValue(stationState);
+  const nextStation = useNextStation(false);
 
   const nearestStation = useMemo<Station | null>(() => {
     if (!latitude || !longitude) {
@@ -38,17 +40,12 @@ export const useNearestStation = (): Station | null => {
         sta.longitude === nearestCoordinates.longitude
     );
 
-    // NOTE: 都営大江戸線特例
-    if (
-      // NOTE: どちらのIDも都庁前
-      nearestStations[0]?.id === 9930100 &&
-      nearestStations[1]?.id === 9930101
-    ) {
-      return nearestStations.slice().reverse()[0];
-    }
-
-    return nearestStations[0] ?? null;
-  }, [latitude, longitude, stations]);
+    return (
+      nearestStations.find((s) => s.id === nextStation?.id) ??
+      nearestStations[0] ??
+      null
+    );
+  }, [latitude, longitude, stations, nextStation]);
 
   return nearestStation;
 };

--- a/src/hooks/useNextStation.ts
+++ b/src/hooks/useNextStation.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import type { Station } from '~/gen/proto/stationapi_pb';
 import { APP_THEME } from '../models/Theme';
 import stationState from '../store/atoms/station';
-import dropEitherJunctionStation from '../utils/dropJunctionStation';
 import getIsPass from '../utils/isPass';
 import { useCurrentStation } from './useCurrentStation';
 import { useLoopLine } from './useLoopLine';
@@ -13,8 +12,7 @@ export const useNextStation = (
   ignorePass = true,
   originStation?: Station
 ): Station | undefined => {
-  const { stations: stationsFromState, selectedDirection } =
-    useAtomValue(stationState);
+  const { stations, selectedDirection } = useAtomValue(stationState);
   const theme = useThemeStore();
   const currentStation = useCurrentStation(
     theme === APP_THEME.JR_WEST || theme === APP_THEME.LED
@@ -26,17 +24,12 @@ export const useNextStation = (
     [originStation, currentStation]
   );
 
-  const stations = useMemo(
-    () => dropEitherJunctionStation(stationsFromState, selectedDirection),
-    [selectedDirection, stationsFromState]
-  );
-
   const actualNextStation = useMemo(() => {
     if (isLoopLine) {
       const loopLineStationIndex =
         selectedDirection === 'INBOUND'
-          ? stations.findIndex((s) => s?.groupId === station?.groupId) - 1
-          : stations.findIndex((s) => s?.groupId === station?.groupId) + 1;
+          ? stations.findIndex((s) => s?.id === station?.id) - 1
+          : stations.findIndex((s) => s?.id === station?.id) + 1;
 
       if (!stations[loopLineStationIndex]) {
         return stations[
@@ -49,15 +42,15 @@ export const useNextStation = (
 
     const notLoopLineStationIndex =
       selectedDirection === 'INBOUND'
-        ? stations.findIndex((s) => s?.groupId === station?.groupId) + 1
-        : stations.findIndex((s) => s?.groupId === station?.groupId) - 1;
+        ? stations.findIndex((s) => s?.id === station?.id) + 1
+        : stations.findIndex((s) => s?.id === station?.id) - 1;
 
     return stations[notLoopLineStationIndex];
-  }, [isLoopLine, selectedDirection, station?.groupId, stations]);
+  }, [isLoopLine, selectedDirection, station?.id, stations]);
 
   const nextInboundStopStation = useMemo(() => {
     const inboundCurrentStationIndex = stations.findIndex(
-      (s) => s?.groupId === station?.groupId
+      (s) => s?.id === station?.id
     );
 
     return actualNextStation && getIsPass(actualNextStation) && ignorePass
@@ -65,13 +58,13 @@ export const useNextStation = (
           .slice(inboundCurrentStationIndex - stations.length + 1)
           .find((s) => !getIsPass(s))
       : actualNextStation;
-  }, [actualNextStation, ignorePass, station?.groupId, stations]);
+  }, [actualNextStation, ignorePass, station?.id, stations]);
 
   const nextOutboundStopStation = useMemo(() => {
     const outboundCurrentStationIndex = stations
       .slice()
       .reverse()
-      .findIndex((s) => s?.groupId === station?.groupId);
+      .findIndex((s) => s?.id === station?.id);
 
     return actualNextStation && getIsPass(actualNextStation) && ignorePass
       ? stations

--- a/src/hooks/useNextStation.ts
+++ b/src/hooks/useNextStation.ts
@@ -1,27 +1,29 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import type { Station } from '~/gen/proto/stationapi_pb';
-import { APP_THEME } from '../models/Theme';
+import dropEitherJunctionStation from '~/utils/dropJunctionStation';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import { useCurrentStation } from './useCurrentStation';
 import { useLoopLine } from './useLoopLine';
-import { useThemeStore } from './useThemeStore';
 
 export const useNextStation = (
   ignorePass = true,
   originStation?: Station
 ): Station | undefined => {
-  const { stations, selectedDirection } = useAtomValue(stationState);
-  const theme = useThemeStore();
-  const currentStation = useCurrentStation(
-    theme === APP_THEME.JR_WEST || theme === APP_THEME.LED
-  );
+  const { stations: stationsFromState, selectedDirection } =
+    useAtomValue(stationState);
+  const currentStation = useCurrentStation();
   const { isLoopLine } = useLoopLine();
 
   const station = useMemo(
     () => originStation ?? currentStation,
     [originStation, currentStation]
+  );
+
+  const stations = useMemo(
+    () => dropEitherJunctionStation(stationsFromState, selectedDirection),
+    [selectedDirection, stationsFromState]
   );
 
   const actualNextStation = useMemo(() => {

--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -22,7 +22,7 @@ export const useNumbering = (
 
   const currentLine = useCurrentLine();
   const currentStation = useCurrentStation();
-  const nextStation = useNextStation(true, currentLine?.station);
+  const nextStation = useNextStation(true);
 
   const getStationNumberIndex = useStationNumberIndexFunc();
 

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -15,7 +15,6 @@ import { useThemeStore } from './useThemeStore';
 
 export const useRefreshLeftStations = (): void => {
   const setNavigation = useSetAtom(navigationState);
-  const setStation = useSetAtom(stationState);
   const {
     station: normalStation,
     stations: normalStations,
@@ -167,20 +166,20 @@ export const useRefreshLeftStations = (): void => {
       return;
     }
     const currentIndex = getCurrentStationIndex(stations, station);
+    if (currentIndex === -1) {
+      return;
+    }
     const leftStations =
       loopLine && getIsLocal(trainType)
         ? getStationsForLoopLine(currentIndex)
         : getStations(currentIndex);
-    setNavigation((prev) => {
-      const isChanged = leftStations[0]?.id !== prev.leftStations[0]?.id;
-      if (!isChanged) {
-        return prev;
-      }
-      return {
-        ...prev,
-        leftStations,
-      };
-    });
+    setNavigation((prev) => ({
+      ...prev,
+      leftStations:
+        leftStations[0]?.groupId !== prev.leftStations[0]?.groupId
+          ? leftStations
+          : prev.leftStations,
+    }));
   }, [
     getStations,
     getStationsForLoopLine,

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -177,11 +177,17 @@ export const useRefreshStation = (): void => {
     if (isArrived && !getIsPass(nearestStation)) {
       setStation((prev) => ({
         ...prev,
-        station: nearestStation,
+        station:
+          prev.station?.id !== nearestStation.id
+            ? nearestStation
+            : prev.station,
       }));
       setNavigation((prev) => ({
         ...prev,
-        stationForHeader: nearestStation,
+        stationForHeader:
+          prev.stationForHeader?.id !== nearestStation.id
+            ? nearestStation
+            : prev.stationForHeader,
       }));
     }
   }, [isApproaching, isArrived, nearestStation, setNavigation, setStation]);

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -172,16 +172,13 @@ export const useRefreshStation = (): void => {
       ...prev,
       approaching: isApproaching,
       arrived: isArrived,
+      station:
+        isArrived && prev.station?.id !== nearestStation.id
+          ? nearestStation
+          : prev.station,
     }));
 
     if (isArrived && !getIsPass(nearestStation)) {
-      setStation((prev) => ({
-        ...prev,
-        station:
-          prev.station?.id !== nearestStation.id
-            ? nearestStation
-            : prev.station,
-      }));
       setNavigation((prev) => ({
         ...prev,
         stationForHeader:

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -170,7 +170,7 @@ export const useRefreshStation = (): void => {
 
     setStation((prev) => ({
       ...prev,
-      approaching: isApproaching,
+      approaching: !isArrived && !getIsPass(nearestStation) && isApproaching,
       arrived: isArrived,
       station:
         isArrived && prev.station?.id !== nearestStation.id

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -172,19 +172,16 @@ export const useRefreshStation = (): void => {
       ...prev,
       approaching: isApproaching,
       arrived: isArrived,
-      station:
-        isArrived && prev.station?.id !== nearestStation.id
-          ? nearestStation
-          : prev.station,
     }));
 
     if (isArrived && !getIsPass(nearestStation)) {
+      setStation((prev) => ({
+        ...prev,
+        station: nearestStation,
+      }));
       setNavigation((prev) => ({
         ...prev,
-        stationForHeader:
-          prev.stationForHeader?.id !== nearestStation.id
-            ? nearestStation
-            : prev.stationForHeader,
+        stationForHeader: nearestStation,
       }));
     }
   }, [isApproaching, isArrived, nearestStation, setNavigation, setStation]);

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -63,7 +63,7 @@ export const useSimulationMode = (): void => {
   }, [currentLineType, trainType]);
 
   const station = useInRadiusStation(maxSpeed / 2);
-  const nextStation = useNextStation(false, station ?? undefined);
+  const nextStation = useNextStation(false);
 
   const maybeRevsersedStations = useMemo(
     () =>

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -141,9 +141,9 @@ const RouteSearchScreen = () => {
   const groupedStations = useMemo(
     () =>
       groupStations(byNameData?.stations ?? []).filter(
-        (sta) => sta.groupId !== currentStation?.groupId
+        (sta) => sta.id !== currentStation?.id
       ),
-    [byNameData?.stations, currentStation?.groupId]
+    [byNameData?.stations, currentStation?.id]
   );
 
   const handleStationPress = useCallback(
@@ -176,9 +176,7 @@ const RouteSearchScreen = () => {
 
   const handleSelect = useCallback(
     async (route: Route | undefined, asTerminus: boolean) => {
-      const stop = route?.stops.find(
-        (s) => s.groupId === currentStation?.groupId
-      );
+      const stop = route?.stops.find((s) => s.id === currentStation?.id);
       if (!stop) {
         return;
       }
@@ -190,15 +188,11 @@ const RouteSearchScreen = () => {
           ids: route?.stops.map((r) => r.id),
         });
         const stationInRoute =
-          stations.find((s) => s.groupId === currentStation?.groupId) ?? null;
+          stations.find((s) => s.id === currentStation?.id) ?? null;
 
         const direction: LineDirection =
-          (stations ?? []).findIndex(
-            (s) => s.groupId === currentStation?.groupId
-          ) <
-          (stations ?? []).findIndex(
-            (s) => s.groupId === selectedStation?.groupId
-          )
+          (stations ?? []).findIndex((s) => s.id === currentStation?.id) <
+          (stations ?? []).findIndex((s) => s.id === selectedStation?.id)
             ? 'INBOUND'
             : 'OUTBOUND';
 
@@ -232,12 +226,11 @@ const RouteSearchScreen = () => {
         lineGroupId: trainType.groupId,
       });
 
-      const station =
-        stations.find((s) => s.groupId === currentStation?.groupId) ?? null;
+      const station = stations.find((s) => s.id === currentStation?.id) ?? null;
 
       const direction: LineDirection =
-        stations.findIndex((s) => s.groupId === currentStation?.groupId) <
-        stations.findIndex((s) => s.groupId === selectedStation?.groupId)
+        stations.findIndex((s) => s.id === currentStation?.id) <
+        stations.findIndex((s) => s.id === selectedStation?.id)
           ? 'INBOUND'
           : 'OUTBOUND';
 
@@ -269,7 +262,7 @@ const RouteSearchScreen = () => {
       );
     },
     [
-      currentStation?.groupId,
+      currentStation?.id,
       fetchStationByIdList,
       fetchStationsByLineGroupId,
       navigation,

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -176,7 +176,9 @@ const RouteSearchScreen = () => {
 
   const handleSelect = useCallback(
     async (route: Route | undefined, asTerminus: boolean) => {
-      const stop = route?.stops.find((s) => s.id === currentStation?.id);
+      const stop = route?.stops.find(
+        (s) => s.groupId === currentStation?.groupId
+      );
       if (!stop) {
         return;
       }
@@ -226,7 +228,10 @@ const RouteSearchScreen = () => {
         lineGroupId: trainType.groupId,
       });
 
-      const station = stations.find((s) => s.id === currentStation?.id) ?? null;
+      const station =
+        stations.find((s) => s.id === currentStation?.id) ??
+        stations.find((s) => s.groupId === currentStation?.groupId) ??
+        null;
 
       const direction: LineDirection =
         stations.findIndex((s) => s.id === currentStation?.id) <
@@ -263,6 +268,7 @@ const RouteSearchScreen = () => {
     },
     [
       currentStation?.id,
+      currentStation?.groupId,
       fetchStationByIdList,
       fetchStationsByLineGroupId,
       navigation,

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -176,9 +176,9 @@ const RouteSearchScreen = () => {
 
   const handleSelect = useCallback(
     async (route: Route | undefined, asTerminus: boolean) => {
-      const stop = route?.stops.find(
-        (s) => s.groupId === currentStation?.groupId
-      );
+      const stop =
+        route?.stops.find((s) => s.id === currentStation?.id) ??
+        route?.stops.find((s) => s.groupId === currentStation?.groupId);
       if (!stop) {
         return;
       }

--- a/src/screens/SelectBound.tsx
+++ b/src/screens/SelectBound.tsx
@@ -87,7 +87,9 @@ const SelectBoundScreen: React.FC = () => {
     [fetchedTrainTypes]
   );
 
-  const currentIndex = getCurrentStationIndex(stations, station);
+  const currentIndex = stations.findIndex(
+    (s) => s.groupId === station?.groupId
+  );
 
   const handleSelectBoundBackButtonPress = useCallback(() => {
     setStationState((prev) => ({

--- a/src/utils/currentStationIndex.ts
+++ b/src/utils/currentStationIndex.ts
@@ -3,12 +3,12 @@ import type { Station } from '~/gen/proto/stationapi_pb';
 const getCurrentStationIndex = (
   stations: Station[],
   nearestStation: Station | null
-): number =>
-  stations.findIndex((s) =>
-    s.line?.id === 99301 // NOTE: 99301 = 都営大江戸線
-      ? // NOTE: 都営大江戸線はname判定をすると都庁前駅でずれるので特別比較しないようにしている
-        s.groupId === nearestStation?.groupId
-      : s.name === nearestStation?.name || s.groupId === nearestStation?.groupId
-  );
+): number => {
+  const index = stations.findIndex((s) => s.id === nearestStation?.id);
+  if (index !== -1) {
+    return index;
+  }
+  return stations.findIndex((s) => s.groupId === nearestStation?.groupId);
+};
 
 export default getCurrentStationIndex;


### PR DESCRIPTION
大阪環状線内で快速種別を選んだ時も天王寺駅から他路線に直通せず大阪環状線内で回り続ける不具合など修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 駅の特定や順序に関するロジックが改善され、複数の駅が同じ座標を持つ場合でもより正確に現在駅や次駅を判定できるようになりました。
  - 特定の路線や駅IDに依存した特別な処理が削除され、駅の識別が一貫してIDベースになりました。
  - 駅リストの更新や駅選択時の動作がより安定し、誤った駅が選択される問題が解消されました。

- **リファクタ**
  - 駅インデックス取得処理や状態管理のロジックが簡潔かつ効率的に整理されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->