### PR TITLE
翻訳キー名typo

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -125,7 +125,7 @@
   "publishShareText": "Check my location on the Train LCD!",
   "publishProhibited": "You cannot publish a position while subscribing to another person.",
   "publisherNotReady": "The publisher has not selected a destination.",
-  "annoucementTitle": "Announcement",
+  "announcementTitle": "Announcement",
   "appCrashedText": "An unexpected problem has occurred with the app. We apologize for the inconvenience, but please try again from the beginning.",
   "stacktrace": "Stacktrace",
   "newVersionAvailableText": "A new version of TrainLCD is now available in the app store 🎉\nPlease update!",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -126,7 +126,7 @@
   "publishShareText": "TrainLCDで私の位置を確認してください！",
   "publishProhibited": "配信に接続している間は新たに配信できません。",
   "publisherNotReady": "配信者が行き先を選択していません。",
-  "annoucementTitle": "お知らせ",
+  "announcementTitle": "お知らせ",
   "appCrashedText": "アプリで予期しない問題が発生しました。大変恐れ入りますが、もう一度最初からやり直してください。",
   "stacktrace": "スタックトレース",
   "newVersionAvailableText": "TrainLCDの新しいバージョンがアプリストアにリリースされました🎉\nぜひアップデートしてみてください！",

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -294,36 +294,40 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       return;
     }
 
-    Alert.alert(translate('annoucementTitle'), translate('reportConfirmText'), [
-      {
-        text: translate('agree'),
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            setSendingReport(true);
-            await sendReport({
-              reportType: 'feedback',
-              description: reportDescription.trim(),
-              screenShotBase64,
-            });
-            setSendingReport(false);
-            Alert.alert(
-              translate('annoucementTitle'),
-              translate('reportSuccessText')
-            );
-            handleNewReportModalClose();
-          } catch (err) {
-            console.error(err);
-            setSendingReport(false);
-            Alert.alert(translate('errorTitle'), translate('reportError'));
-          }
+    Alert.alert(
+      translate('announcementTitle'),
+      translate('reportConfirmText'),
+      [
+        {
+          text: translate('agree'),
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              setSendingReport(true);
+              await sendReport({
+                reportType: 'feedback',
+                description: reportDescription.trim(),
+                screenShotBase64,
+              });
+              setSendingReport(false);
+              Alert.alert(
+                translate('announcementTitle'),
+                translate('reportSuccessText')
+              );
+              handleNewReportModalClose();
+            } catch (err) {
+              console.error(err);
+              setSendingReport(false);
+              Alert.alert(translate('errorTitle'), translate('reportError'));
+            }
+          },
         },
-      },
-      {
-        text: translate('disagree'),
-        style: 'cancel',
-      },
-    ]);
+        {
+          text: translate('disagree'),
+          style: 'cancel',
+        },
+      ]
+    );
   }, [
     descriptionLowerLimit,
     handleNewReportModalClose,

--- a/src/hooks/useAutoModeAlert.ts
+++ b/src/hooks/useAutoModeAlert.ts
@@ -18,7 +18,7 @@ export const useAutoModeAlert = () => {
         );
         if (autoModeEnabled && !enableLegacyAutoMode && !alreadyConfirmed) {
           Alert.alert(
-            translate('annoucementTitle'),
+            translate('announcementTitle'),
             translate('autoModeV2AlertText'),
             [
               {

--- a/src/hooks/useCheckStoreVersion.ts
+++ b/src/hooks/useCheckStoreVersion.ts
@@ -6,7 +6,7 @@ import { translate } from '../translation';
 export const useCheckStoreVersion = (): void => {
   const showUpdateRequestDialog = useCallback((storeURL: string) => {
     Alert.alert(
-      translate('annoucementTitle'),
+      translate('announcementTitle'),
       translate('newVersionAvailableText'),
       [
         { text: translate('cancel'), style: 'cancel' },

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -263,7 +263,7 @@ const MainScreen: React.FC = () => {
       const bgPermStatus = await Location.getBackgroundPermissionsAsync();
       if (warningDismissed !== 'true' && !bgPermStatus?.granted && !isClip()) {
         Alert.alert(
-          translate('annoucementTitle'),
+          translate('announcementTitle'),
           translate('alwaysPermissionNotGrantedAlertText'),
           [
             {
@@ -306,7 +306,7 @@ const MainScreen: React.FC = () => {
         );
         if (bgStatus === 'granted' && dozeAlertDismissed !== 'true') {
           Alert.alert(
-            translate('annoucementTitle'),
+            translate('announcementTitle'),
             translate('dozeAlertText'),
             [
               {
@@ -326,7 +326,7 @@ const MainScreen: React.FC = () => {
                     await Linking.openSettings();
                   } catch (error) {
                     Alert.alert(
-                      translate('annoucementTitle'),
+                      translate('announcementTitle'),
                       translate('failedToOpenSettings'),
                       [{ text: 'OK' }]
                     );

--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -84,7 +84,7 @@ const PrivacyScreen: React.FC = () => {
   const handleLocationDenied = useCallback(
     (devicePermissionDenied?: boolean) => {
       Alert.alert(
-        translate('annoucementTitle'),
+        translate('announcementTitle'),
         translate(
           devicePermissionDenied ? 'privacyDeniedByDevice' : 'privacyDenied'
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 各画面やアラートで表示されるタイトルの翻訳キーのタイポを修正し、正しい「announcementTitle」が使用されるようになりました。表示内容自体に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->