### PR TITLE
Discord通知にもフィードバック送信者がオートモード使用中か明記

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -404,7 +404,9 @@ ${reporterUid}
               },
               {
                 name: 'オートモード',
-                value: `${autoModeEnabled ? `有効(${enableLegacyAutoMode ? '1.0' : '2.0'})` : '無効'}`,
+                value:
+                  autoModeLabel ??
+                  (autoModeEnabled === false ? '無効' : '不明'),
               },
               {
                 name: 'GitHub Issue',
@@ -438,7 +440,9 @@ ${reporterUid}
               },
               {
                 name: 'オートモード',
-                value: `${autoModeEnabled ? `有効(${enableLegacyAutoMode ? '1.0' : '2.0'})` : '無効'}`,
+                value:
+                  autoModeLabel ??
+                  (autoModeEnabled === false ? '無効' : '不明'),
               },
               {
                 name: 'GitHub Issue',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -403,6 +403,10 @@ ${reporterUid}
                 value: reporterUid,
               },
               {
+                name: 'オートモード',
+                value: `${autoModeEnabled ? `有効(${enableLegacyAutoMode ? '1.0' : '2.0'})` : '無効'}`,
+              },
+              {
                 name: 'GitHub Issue',
                 value: issuesRes.html_url,
               },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -433,6 +433,10 @@ ${reporterUid}
                 value: reporterUid,
               },
               {
+                name: 'オートモード',
+                value: `${autoModeEnabled ? `有効(${enableLegacyAutoMode ? '1.0' : '2.0'})` : '無効'}`,
+              },
+              {
                 name: 'GitHub Issue',
                 value: issuesRes.html_url,
               },


### PR DESCRIPTION
#4329 対応漏れ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - フィードバック投稿時のDiscord埋め込みメッセージに「オートモード」欄が追加され、オートモードの状態（有効(1.0)、有効(2.0)、無効）が表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->