### PR TITLE
Marqueeの速度がなるべく文字数に比例しないように修正

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -22,8 +22,13 @@ const Marquee = ({ children }: Props) => {
 
   const startScroll = useCallback(
     (width: number) => {
+      const screenWidth = Dimensions.get('screen').width;
+      const totalDistance = screenWidth + width;
+      const pixelsPerSecond = 400;
+      const duration = (totalDistance / pixelsPerSecond) * 1000;
+
       offsetX.value = withRepeat(
-        withTiming(-width, { duration: 8500, easing: Easing.linear }),
+        withTiming(-width, { duration, easing: Easing.linear }),
         -1
       );
     },

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -16,13 +16,14 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
 });
 
+const screenWidth = Dimensions.get('screen').width;
+
 const Marquee = ({ children }: Props) => {
   const wrapperViewRef = useRef<View>(null);
-  const offsetX = useSharedValue(Dimensions.get('screen').width);
+  const offsetX = useSharedValue(screenWidth);
 
   const startScroll = useCallback(
     (width: number) => {
-      const screenWidth = Dimensions.get('screen').width;
       const totalDistance = screenWidth + width;
       const pixelsPerSecond = 400;
       const duration = (totalDistance / pixelsPerSecond) * 1000;
@@ -57,7 +58,7 @@ const Marquee = ({ children }: Props) => {
   const animatedViewStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateX: offsetX.get(),
+        translateX: offsetX.value,
       },
     ],
   }));

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -16,6 +16,8 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
 });
 
+const PIXELS_PER_SECOND = 400;
+
 const screenWidth = Dimensions.get('screen').width;
 
 const Marquee = ({ children }: Props) => {
@@ -25,8 +27,7 @@ const Marquee = ({ children }: Props) => {
   const startScroll = useCallback(
     (width: number) => {
       const totalDistance = screenWidth + width;
-      const pixelsPerSecond = 400;
-      const duration = (totalDistance / pixelsPerSecond) * 1000;
+      const duration = (totalDistance / PIXELS_PER_SECOND) * 1000;
 
       offsetX.value = withRepeat(
         withTiming(-width, { duration, easing: Easing.linear }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - スクロールアニメーションの速度が、画面サイズとコンテンツ幅に応じて自動調整されるようになりました。これにより、さまざまなデバイスやコンテンツ長でも一貫したスクロール体験が得られます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->