### PR TITLE
interpret-as="address"と終着放送追加

### DIFF
--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -9,7 +9,6 @@ import type { LineDirection } from '~/models/Bound';
 import type { HeaderStoppingState } from '~/models/HeaderTransitionState';
 import type { AppTheme } from '~/models/Theme';
 import lineState from '~/store/atoms/line';
-import navigationState from '~/store/atoms/navigation';
 import stationState from '~/store/atoms/station';
 import { TOEI_SHINJUKU_LINE_LOCAL } from '../../__mocks__/fixture/line';
 import { TOEI_SHINJUKU_LINE_STATIONS } from '../../__mocks__/fixture/station';
@@ -35,7 +34,6 @@ const useTTSTextWithJotaiAndNumbering = (
 ) => {
   const setLineState = useSetAtom(lineState);
   const setStationState = useSetAtom(stationState);
-  const _setNaivgationState = useSetAtom(navigationState);
 
   useEffect(() => {
     const station = TOEI_SHINJUKU_LINE_STATIONS[0];
@@ -128,7 +126,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -140,7 +138,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -155,7 +153,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -167,7 +165,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at Shinjuku-sanchome S 2.',
+        'We will soon make a brief stop at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2.',
       ]);
     });
   });
@@ -182,7 +180,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -194,7 +192,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -209,7 +207,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -221,7 +219,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、次は、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon be making a brief stop at Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
+        'We will soon be making a brief stop at <say-as interpret-as="address">Shinjuku-sanchome</say-as> station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving <say-as interpret-as="address">Shinjuku-sanchome</say-as>, We will be stopping at <say-as interpret-as="address">Akebonobashi</say-as>.',
       ]);
     });
   });
@@ -236,7 +234,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -248,7 +246,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -263,7 +261,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。 <sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。この電車は、各駅停車、<sub alias="もとやわた">本八幡</sub>ゆきです。',
-        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'This is the Local train bound for <say-as interpret-as="address">Motoyawata</say-as>. The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -275,7 +273,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'We will soon be arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'We will soon be arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -290,7 +288,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -302,7 +300,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -129,8 +129,8 @@ export const useTTSText = (
   const boundForEn = useMemo(
     () =>
       isLoopLine
-        ? loopLineBoundEn?.boundFor.replaceAll('&', ' and ')
-        : directionalStops?.map((s) => s?.nameRoman).join(' and '),
+        ? `<say-as interpret-as="address">${loopLineBoundEn?.boundFor.replaceAll('&', ' and ')}</say-as>`
+        : `<say-as interpret-as="address">${directionalStops?.map((s) => s?.nameRoman).join(' and ')}</say-as>`,
 
     [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
   );
@@ -390,6 +390,13 @@ export const useTTSText = (
                   afterNextStation.nameKatakana
                 )}に停まります。`
               : ''
+          }${
+            isNextStopTerminus
+              ? ` ${replaceJapaneseText(
+                  currentLine?.nameShort,
+                  currentLine?.nameKatakana
+                )}をご利用くださいまして、ありがとうございました。`
+              : ''
           }`,
         },
         [APP_THEME.YAMANOTE]: {
@@ -628,6 +635,13 @@ export const useTTSText = (
                   .map((s) => replaceJapaneseText(s.name, s.nameKatakana))
                   .join('、')}へおいでの方はお乗り換えです。`
               : ''
+          }${
+            isNextStopTerminus
+              ? ` ${replaceJapaneseText(
+                  currentLine?.nameShort,
+                  currentLine?.nameKatakana
+                )}をご利用くださいまして、ありがとうございました。`
+              : ''
           }`,
         },
         [APP_THEME.LED]: {
@@ -664,7 +678,9 @@ export const useTTSText = (
 
       const map = {
         [APP_THEME.TOKYO_METRO]: {
-          NEXT: `The next stop is ${nextStation?.nameRoman}${
+          NEXT: `The next stop is <say-as interpret-as="address">${
+            nextStation?.nameRoman
+          }</say-as>${
             nextStationNumberText.length ? ` ${nextStationNumberText}` : '.'
           }${
             transferLines.length
@@ -684,9 +700,11 @@ export const useTTSText = (
                   currentLine.nameRoman
                 } bound for ${boundForEn}. ${
                   currentTrainType && afterNextStation
-                    ? `The next stop after ${nextStation?.nameRoman}${`, is ${
+                    ? `The next stop after <say-as interpret-as="address">${
+                        nextStation?.nameRoman
+                      }</say-as>${`, is <say-as interpret-as="address">${
                         afterNextStation?.nameRoman
-                      }${isAfterNextStopTerminus ? ' terminal' : ''}`}.`
+                      }</say-as>${isAfterNextStopTerminus ? ' terminal.' : ''}`}.`
                     : ''
                 }${
                   betweenNextStation.length
@@ -695,9 +713,9 @@ export const useTTSText = (
                 }`
               : ''
           }`,
-          ARRIVING: `Arriving at ${
+          ARRIVING: `Arriving at <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText}${
+          }</say-as> ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop.' : ''
           } ${
             transferLines.length
@@ -708,6 +726,10 @@ export const useTTSText = (
                       : `the ${l.nameRoman}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
+              : ''
+          }${
+            isNextStopTerminus
+              ? ` Thank you for using the ${currentLine?.nameRoman}.`
               : ''
           }`,
         },
@@ -722,9 +744,9 @@ export const useTTSText = (
                     : ''
                 } to ${boundForEn}. `
               : ''
-          }The next station is ${
+          }The next station is <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText}${
+          }</say-as> ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           } ${
             transferLines.length
@@ -737,15 +759,21 @@ export const useTTSText = (
                   .join(', ')}, Please transfer at this station.`
               : ''
           }`,
-          ARRIVING: `We will soon make a brief stop at ${
+          ARRIVING: `We will soon make a brief stop at <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText}${
+          }</say-as> ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after ${nextStation?.nameRoman}, will be ${
+              ? ` The stop after <say-as interpret-as="address">${
+                  nextStation?.nameRoman
+                }</say-as>, will be <say-as interpret-as="address">${
                   afterNextStation.nameRoman
-                }${isNextStopTerminus ? ' the last stop' : ''}.`
+                }</say-as>${isNextStopTerminus ? ' the last stop' : ''}.`
+              : ''
+          }${
+            isNextStopTerminus
+              ? ` Thank you for using the ${currentLine?.nameRoman}.`
               : ''
           }`,
         },
@@ -754,9 +782,9 @@ export const useTTSText = (
             firstSpeech
               ? `This is the ${currentLine.nameRoman} train bound for ${boundForEn}. `
               : ''
-          }The next station is ${
+          }The next station is <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText} ${
+          }</say-as> ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -767,11 +795,13 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `The next station is ${nextStation?.nameRoman}${
-            isNextStopTerminus ? ', terminal' : ''
-          } ${nextStationNumberText}${
+          ARRIVING: `The next station is <say-as interpret-as="address">${
+            nextStation?.nameRoman
+          }</say-as> ${nextStationNumberText}${
+            isNextStopTerminus ? ', terminal.' : ''
+          } ${
             transferLines.length
-              ? ` Please change here for ${transferLines
+              ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${l.nameRoman}.`
@@ -795,9 +825,11 @@ export const useTTSText = (
             firstSpeech
               ? `This is the ${currentLine.nameRoman} train bound for ${boundForEn}. `
               : ''
-          }The next station is ${nextStation?.nameRoman}${
-            isNextStopTerminus ? ', terminal' : ''
-          } ${nextStationNumberText} ${
+          }The next station is <say-as interpret-as="address">${
+            nextStation?.nameRoman
+          }</say-as> ${nextStationNumberText}${
+            isNextStopTerminus ? ', terminal.' : ''
+          } ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -808,11 +840,13 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `The next station is ${nextStation?.nameRoman}${
-            isNextStopTerminus ? ', terminal' : ''
-          } ${nextStationNumberText}${
+          ARRIVING: `The next station is <say-as interpret-as="address">${
+            nextStation?.nameRoman
+          }</say-as> ${nextStationNumberText}${
+            isNextStopTerminus ? ', terminal.' : ''
+          } ${
             transferLines.length
-              ? ` Please change here for ${transferLines
+              ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${l.nameRoman}.`
@@ -830,13 +864,15 @@ export const useTTSText = (
           NEXT: `${
             firstSpeech
               ? `Thank you for using ${currentLine?.company?.nameEnglishShort}. This is the ${currentTrainType?.nameRoman ?? 'Local'} Service bound for ${boundForEn} ${
-                  viaStation ? `via ${viaStation.nameRoman}` : ''
+                  viaStation
+                    ? `via <say-as interpret-as="address">${viaStation.nameRoman}</say-as>`
+                    : ''
                 }. We will be stopping at ${allStops
                   .slice(0, 5)
                   .map((s) =>
                     s.id === selectedBound?.id && !isLoopLine
-                      ? `${s.nameRoman} terminal`
-                      : s.nameRoman
+                      ? `<say-as interpret-as="address">${s.nameRoman}</say-as> terminal`
+                      : `<say-as interpret-as="address">${s.nameRoman}</say-as>`
                   )
                   .join(', ')}. ${
                   allStops
@@ -852,7 +888,9 @@ export const useTTSText = (
                       } will be announced later. `
                 }`
               : ''
-          }The next stop is ${nextStation?.nameRoman}${
+          }The next stop is <say-as interpret-as="address">${
+            nextStation?.nameRoman
+          }</say-as>${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -867,9 +905,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `We will soon be making a brief stop at ${
+          ARRIVING: `We will soon be making a brief stop at <say-as interpret-as="address">${
             nextStation?.nameRoman
-          }${
+          }</say-as>${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -885,7 +923,11 @@ export const useTTSText = (
               : ''
           } ${
             afterNextStation
-              ? `After leaving ${nextStation?.nameRoman}, We will be stopping at ${afterNextStation.nameRoman}.`
+              ? `After leaving <say-as interpret-as="address">${
+                  nextStation?.nameRoman
+                }</say-as>, We will be stopping at <say-as interpret-as="address">${
+                  afterNextStation.nameRoman
+                }</say-as>.`
               : ''
           }`,
         },
@@ -894,9 +936,9 @@ export const useTTSText = (
             firstSpeech
               ? `Thank you for using the ${currentLine.nameRoman}. `
               : ''
-          }This is the ${currentTrainType?.nameRoman ?? 'Local'} train bound for ${boundForEn}. The next station is ${
+          }This is the ${currentTrainType?.nameRoman ?? 'Local'} train bound for ${boundForEn}. The next station is <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText} ${
+          }</say-as> ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -907,9 +949,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `We will soon be arriving at ${
+          ARRIVING: `We will soon be arriving at <say-as interpret-as="address">${
             nextStation?.nameRoman
-          } ${nextStationNumberText} ${
+          }</say-as> ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -921,9 +963,15 @@ export const useTTSText = (
               : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after ${nextStation?.nameRoman}, will be ${
+              ? ` The stop after <say-as interpret-as="address">${
+                  nextStation?.nameRoman
+                }</say-as>, will be <say-as interpret-as="address">${
                   afterNextStation.nameRoman
-                }${isNextStopTerminus ? ' the last stop' : ''}.`
+                }</say-as>${isNextStopTerminus ? ' the last stop' : ''}.`
+              : ''
+          }${
+            isNextStopTerminus
+              ? ` Thank you for using the ${currentLine?.nameRoman}.`
               : ''
           }`,
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 英語の駅名や路線名のTTS出力が、SSMLの`<say-as interpret-as="address">`タグでラップされ、発音が向上しました。
  * 一部テーマの日本語TTSで、終点到着時に丁寧なお礼フレーズが追加されました。

* **テスト**
  * テストケースの期待値が新しいSSMLタグ付き出力に更新されました。
  * 未使用のテスト用インポートが削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->