### PR TITLE
TTS文言修正

### DIFF
--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -126,7 +126,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -138,7 +138,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -153,7 +153,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。',
-        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'The next station is Shinjuku-sanchome S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -164,8 +164,8 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2.',
+        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
+        'We will soon make a brief stop at Shinjuku-sanchome S 2.',
       ]);
     });
   });
@@ -180,7 +180,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -192,7 +192,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -207,7 +207,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -219,7 +219,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、次は、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon be making a brief stop at <say-as interpret-as="address">Shinjuku-sanchome</say-as> station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving <say-as interpret-as="address">Shinjuku-sanchome</say-as>, We will be stopping at <say-as interpret-as="address">Akebonobashi</say-as>.',
+        'We will soon be making a brief stop at Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
       ]);
     });
   });
@@ -234,7 +234,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -246,7 +246,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -261,7 +261,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。 <sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。この電車は、各駅停車、<sub alias="もとやわた">本八幡</sub>ゆきです。',
-        'This is the Local train bound for <say-as interpret-as="address">Motoyawata</say-as>. The next station is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -273,7 +273,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'We will soon be arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'We will soon be arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -288,7 +288,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -300,7 +300,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at <say-as interpret-as="address">Shinjuku-sanchome</say-as> S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -165,7 +165,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at Shinjuku-sanchome S 2.',
+        'We will soon make a brief stop at Shinjuku-sanchome S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
   });

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -801,6 +801,16 @@ export const useTTSText = (
           } ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           }${
+            transferLines.length
+              ? ` Passengers changing to ${transferLines
+                  .map((l, i, a) =>
+                    a.length > 1 && a.length - 1 === i
+                      ? `and the ${l.nameRoman}`
+                      : `the ${l.nameRoman}`
+                  )
+                  .join(', ')}, Please transfer at this station.`
+              : ''
+          }${
             currentTrainType && afterNextStation
               ? ` The stop after ${nextStation?.nameRoman}, will be ${
                   afterNextStation.nameRoman

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -388,6 +388,12 @@ export const useTTSText = (
             replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
             ''
           }${isNextStopTerminus ? '、終点' : ''}です。${
+            transferLines.length
+              ? `${transferLines
+                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
+                  .join('、')}をご利用のお客様はお乗り換えです。`
+              : ''
+          }${
             afterNextStation
               ? `${replaceJapaneseText(
                   nextStation?.name,
@@ -419,7 +425,7 @@ export const useTTSText = (
           }、${
             replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
             ''
-          }。${
+          }${isNextStopTerminus ? '、終点です' : ''}。${
             transferLines.length
               ? `${transferLines
                   .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
@@ -538,29 +544,55 @@ export const useTTSText = (
                   .join('、')}はお乗り換えです。`
               : ''
           }`,
-          ARRIVING: `まもなく、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }です。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }${
-            afterNextStation
-              ? `${replaceJapaneseText(
+          ARRIVING: isNextStopTerminus
+            ? `ご乗車ありがとうございました。まもなく${
+                replaceJapaneseText(
                   nextStation?.name,
                   nextStation?.nameKatakana
-                )}を出ますと、次は、${replaceJapaneseText(
-                  afterNextStation.name,
-                  afterNextStation.nameKatakana
-                )}に停まります。`
-              : ''
-          }`,
+                ) ?? ''
+              }、${
+                replaceJapaneseText(
+                  nextStation?.name,
+                  nextStation?.nameKatakana
+                ) ?? ''
+              }です。${
+                transferLines.length
+                  ? `${transferLines
+                      .map((l) =>
+                        replaceJapaneseText(l.nameShort, l.nameKatakana)
+                      )
+                      .join('、')}はお乗り換えです。`
+                  : ''
+              }今日も${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございました。${replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana)}、${replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana)}です。`
+            : `まもなく、${
+                replaceJapaneseText(
+                  nextStation?.name,
+                  nextStation?.nameKatakana
+                ) ?? ''
+              }、${
+                replaceJapaneseText(
+                  nextStation?.name,
+                  nextStation?.nameKatakana
+                ) ?? ''
+              }です。${
+                transferLines.length
+                  ? `${transferLines
+                      .map((l) =>
+                        replaceJapaneseText(l.nameShort, l.nameKatakana)
+                      )
+                      .join('、')}はお乗り換えです。`
+                  : ''
+              }${
+                afterNextStation
+                  ? `${replaceJapaneseText(
+                      nextStation?.name,
+                      nextStation?.nameKatakana
+                    )}を出ますと、次は、${replaceJapaneseText(
+                      afterNextStation.name,
+                      afterNextStation.nameKatakana
+                    )}に停まります。`
+                  : ''
+              }`,
         },
         [APP_THEME.TOEI]: {
           NEXT: `${

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -138,8 +138,8 @@ export const useTTSText = (
   const boundForEn = useMemo(
     () =>
       isLoopLine
-        ? `<say-as interpret-as="address">${loopLineBoundEn?.boundFor.replaceAll('&', ' and ')}</say-as>`
-        : `<say-as interpret-as="address">${directionalStops?.map((s) => s?.nameRoman).join(' and ')}</say-as>`,
+        ? `${loopLineBoundEn?.boundFor.replaceAll('&', ' and ')}`
+        : `${directionalStops?.map((s) => s?.nameRoman).join(' and ')}`,
 
     [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
   );
@@ -719,9 +719,7 @@ export const useTTSText = (
 
       const map = {
         [APP_THEME.TOKYO_METRO]: {
-          NEXT: `The next stop is <say-as interpret-as="address">${
-            nextStation?.nameRoman
-          }</say-as>${
+          NEXT: `The next stop is ${nextStation?.nameRoman}${
             nextStationNumberText.length ? ` ${nextStationNumberText}` : '.'
           }${
             transferLines.length
@@ -741,11 +739,9 @@ export const useTTSText = (
                   currentLine.nameRoman
                 } bound for ${boundForEn}. ${
                   currentTrainType && afterNextStation
-                    ? `The next stop after <say-as interpret-as="address">${
-                        nextStation?.nameRoman
-                      }</say-as>${`, is <say-as interpret-as="address">${
+                    ? `The next stop after ${nextStation?.nameRoman}${`, is ${
                         afterNextStation?.nameRoman
-                      }</say-as>${isAfterNextStopTerminus ? ' terminal.' : ''}`}.`
+                      }${isAfterNextStopTerminus ? ' terminal.' : ''}`}.`
                     : ''
                 }${
                   betweenNextStation.length
@@ -754,9 +750,9 @@ export const useTTSText = (
                 }`
               : ''
           }`,
-          ARRIVING: `Arriving at <say-as interpret-as="address">${
+          ARRIVING: `Arriving at ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop.' : ''
           } ${
             transferLines.length
@@ -785,9 +781,9 @@ export const useTTSText = (
                     : ''
                 } to ${boundForEn}. `
               : ''
-          }The next station is <say-as interpret-as="address">${
+          }The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           } ${
             transferLines.length
@@ -800,17 +796,15 @@ export const useTTSText = (
                   .join(', ')}, Please transfer at this station.`
               : ''
           }`,
-          ARRIVING: `We will soon make a brief stop at <say-as interpret-as="address">${
+          ARRIVING: `We will soon make a brief stop at ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after <say-as interpret-as="address">${
-                  nextStation?.nameRoman
-                }</say-as>, will be <say-as interpret-as="address">${
+              ? ` The stop after ${nextStation?.nameRoman}, will be ${
                   afterNextStation.nameRoman
-                }</say-as>${isNextStopTerminus ? ' the last stop' : ''}.`
+                }${isNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${
             isNextStopTerminus
@@ -823,9 +817,9 @@ export const useTTSText = (
             firstSpeech
               ? `This is the ${currentLine.nameRoman} train bound for ${boundForEn}. `
               : ''
-          }The next station is <say-as interpret-as="address">${
+          }The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText} ${
+          } ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -836,9 +830,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `The next station is <say-as interpret-as="address">${
+          ARRIVING: `The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', terminal.' : ''
           } ${
             transferLines.length
@@ -866,9 +860,9 @@ export const useTTSText = (
             firstSpeech
               ? `This is the ${currentLine.nameRoman} train bound for ${boundForEn}. `
               : ''
-          }The next station is <say-as interpret-as="address">${
+          }The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', terminal.' : ''
           } ${
             transferLines.length
@@ -881,9 +875,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `The next station is <say-as interpret-as="address">${
+          ARRIVING: `The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText}${
+          } ${nextStationNumberText}${
             isNextStopTerminus ? ', terminal.' : ''
           } ${
             transferLines.length
@@ -905,15 +899,13 @@ export const useTTSText = (
           NEXT: `${
             firstSpeech
               ? `Thank you for using ${currentLine?.company?.nameEnglishShort}. This is the ${currentTrainType?.nameRoman ?? 'Local'} Service bound for ${boundForEn} ${
-                  viaStation
-                    ? `via <say-as interpret-as="address">${viaStation.nameRoman}</say-as>`
-                    : ''
+                  viaStation ? `via ${viaStation.nameRoman}` : ''
                 }. We will be stopping at ${allStops
                   .slice(0, 5)
                   .map((s) =>
                     s.id === selectedBound?.id && !isLoopLine
-                      ? `<say-as interpret-as="address">${s.nameRoman}</say-as> terminal`
-                      : `<say-as interpret-as="address">${s.nameRoman}</say-as>`
+                      ? `${s.nameRoman} terminal`
+                      : `${s.nameRoman}`
                   )
                   .join(', ')}. ${
                   allStops
@@ -929,9 +921,7 @@ export const useTTSText = (
                       } will be announced later. `
                 }`
               : ''
-          }The next stop is <say-as interpret-as="address">${
-            nextStation?.nameRoman
-          }</say-as>${
+          }The next stop is ${nextStation?.nameRoman}${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -946,9 +936,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `We will soon be making a brief stop at <say-as interpret-as="address">${
+          ARRIVING: `We will soon be making a brief stop at ${
             nextStation?.nameRoman
-          }</say-as>${
+          }${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -964,11 +954,9 @@ export const useTTSText = (
               : ''
           } ${
             afterNextStation
-              ? `After leaving <say-as interpret-as="address">${
+              ? `After leaving ${
                   nextStation?.nameRoman
-                }</say-as>, We will be stopping at <say-as interpret-as="address">${
-                  afterNextStation.nameRoman
-                }</say-as>.`
+                }, We will be stopping at ${afterNextStation.nameRoman}.`
               : ''
           }`,
         },
@@ -977,9 +965,9 @@ export const useTTSText = (
             firstSpeech
               ? `Thank you for using the ${currentLine.nameRoman}. `
               : ''
-          }This is the ${currentTrainType?.nameRoman ?? 'Local'} train bound for ${boundForEn}. The next station is <say-as interpret-as="address">${
+          }This is the ${currentTrainType?.nameRoman ?? 'Local'} train bound for ${boundForEn}. The next station is ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText} ${
+          } ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -990,9 +978,9 @@ export const useTTSText = (
                   .join(' ')}`
               : ''
           }`,
-          ARRIVING: `We will soon be arriving at <say-as interpret-as="address">${
+          ARRIVING: `We will soon be arriving at ${
             nextStation?.nameRoman
-          }</say-as> ${nextStationNumberText} ${
+          } ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
@@ -1004,11 +992,9 @@ export const useTTSText = (
               : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after <say-as interpret-as="address">${
-                  nextStation?.nameRoman
-                }</say-as>, will be <say-as interpret-as="address">${
+              ? ` The stop after ${nextStation?.nameRoman}, will be ${
                   afterNextStation.nameRoman
-                }</say-as>${isNextStopTerminus ? ' the last stop' : ''}.`
+                }${isNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${
             isNextStopTerminus


### PR DESCRIPTION
#4389
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * なし

* **バグ修正**
  * 英語TTS出力からSSMLタグ（`<say-as interpret-as="address">`）を削除し、駅名や路線名がプレーンテキストで読み上げられるようになりました。
  * 日本語TTS出力のフレーズや句読点を一部調整し、乗換案内や終点案内の表現が改善されました。

* **テスト**
  * 英語TTS出力のテスト期待値からSSMLタグを削除し、内容を現仕様に合わせて修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->