### PR TITLE
iOS側でwatchOS向け英語文言指定

### DIFF
--- a/ios/WatchApp Extension/Model/Line.swift
+++ b/ios/WatchApp Extension/Model/Line.swift
@@ -12,6 +12,5 @@ struct Line: Decodable, Identifiable {
   let id: Int
   let lineColorC: String?
   let name: String
-  let nameR: String
   let lineSymbol: String
 }

--- a/ios/WatchApp Extension/Model/Station.swift
+++ b/ios/WatchApp Extension/Model/Station.swift
@@ -9,7 +9,6 @@
 struct Station: Decodable, Identifiable {
   let id: Int
   let name: String
-  let nameR: String
   let lines: [Line]
   let stationNumber: String?
   let pass: Bool

--- a/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
+++ b/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
@@ -85,7 +85,6 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
         
         defaults?.set(self.selectedLine?.lineColorC, forKey: "lineColor")
         defaults?.set(self.selectedLine?.name, forKey: "lineName")
-        defaults?.set(self.selectedLine?.nameR, forKey: "lineNameR")
         defaults?.set(self.selectedLine?.lineSymbol, forKey: "lineSymbol")
         
         if let boundStationName = message["boundStationName"] as? String {

--- a/ios/WatchApp Extension/Views/RootView.swift
+++ b/ios/WatchApp Extension/Views/RootView.swift
@@ -12,14 +12,12 @@ struct RootView: View {
   let state: String
   let station: Station
   
-  let isJa = Locale.current.languageCode == "ja"
-  
   var body: some View {
     VStack{
       Text(state)
         .multilineTextAlignment(.center)
         .font(.subheadline)
-      Text(isJa ? station.name : station.nameR)
+      Text(station.name)
         .multilineTextAlignment(.center)
         .font(.title2)
       if let stationNumber = station.stationNumber {
@@ -31,7 +29,7 @@ struct RootView: View {
       }
       List {
         ForEach(station.lines) { line in
-          Text(isJa ? line.name : line.nameR)
+          Text(line.name)
             .listRowPlatterColor(Color(hex: line.lineColorC ?? "000"))
         }
       }

--- a/ios/WatchApp Extension/Views/StationListView.swift
+++ b/ios/WatchApp Extension/Views/StationListView.swift
@@ -11,9 +11,7 @@ struct StationListView: View {
   let currentStation: Station
   let stations: [Station]
   let selectedLine: Line?
-  
-  let isJa = Locale.current.languageCode == "ja"
-  
+
   @ViewBuilder
   var body: some View {
     NavigationView {

--- a/ios/WatchApp Extension/Views/StationListView.swift
+++ b/ios/WatchApp Extension/Views/StationListView.swift
@@ -26,10 +26,10 @@ struct StationListView: View {
           List {
             ForEach(stations) { station in
               if let stationNumber = station.stationNumber {
-                Text("\(isJa ? station.name : station.nameR)(\(stationNumber))")
+                Text("\(station.name)(\(stationNumber))")
                   .opacity(station.pass ? 0.25 : 1)
               } else {
-                Text("\(isJa ? station.name : station.nameR)")
+                Text(station.name)
                   .opacity(station.pass ? 0.25 : 1)
               }
             }
@@ -42,7 +42,7 @@ struct StationListView: View {
         }
       }
     }
-    .navigationBarTitle(Text((isJa ? selectedLine?.name : selectedLine?.nameR) ?? ""))
+    .navigationBarTitle(Text(selectedLine?.name ?? ""))
     
   }
 }

--- a/src/hooks/useAppleWatch.ts
+++ b/src/hooks/useAppleWatch.ts
@@ -66,15 +66,15 @@ export const useAppleWatch = (): void => {
       state: stoppingState,
       station: {
         id: switchedStation.id,
-        name: switchedStation.name,
-        nameR: switchedStation.nameRoman,
+        name: isJapanese ? switchedStation.name : switchedStation.nameRoman,
         lines: switchedStation.lines
           .filter((l) => l.id !== currentLine?.id)
           .map((l) => ({
             id: l.id,
             lineColorC: l.color,
-            name: l.nameShort.replace(parenthesisRegexp, ''),
-            nameR: l.nameRoman?.replace(parenthesisRegexp, ''),
+            name: isJapanese
+              ? l.nameShort.replace(parenthesisRegexp, '')
+              : l.nameRoman?.replace(parenthesisRegexp, ''),
             lineSymbol: currentNumbering?.lineSymbol ?? '',
           })),
         stationNumber: currentNumbering?.stationNumber,
@@ -94,15 +94,15 @@ export const useAppleWatch = (): void => {
     return {
       stationList: switchedStations.map((s) => ({
         id: s.id,
-        name: s.name,
-        nameR: s.nameRoman,
+        name: isJapanese ? s.name : s.nameRoman,
         lines: s.lines
           .filter((l) => l.id !== currentLine.id)
           .map((l) => ({
             id: l.id,
             lineColorC: l.color,
-            name: l.nameShort.replace(parenthesisRegexp, ''),
-            nameR: l.nameRoman?.replace(parenthesisRegexp, ''),
+            name: isJapanese
+              ? l.nameShort.replace(parenthesisRegexp, '')
+              : l.nameRoman?.replace(parenthesisRegexp, ''),
             lineSymbol: currentNumbering?.lineSymbol ?? '',
           })),
         stationNumber: s?.stationNumbers?.[0]?.stationNumber,
@@ -110,8 +110,9 @@ export const useAppleWatch = (): void => {
       })),
       selectedLine: {
         id: currentLine.id,
-        name: currentLine.nameShort.replace(parenthesisRegexp, ''),
-        nameR: currentLine.nameRoman?.replace(parenthesisRegexp, ''),
+        name: isJapanese
+          ? currentLine.nameShort.replace(parenthesisRegexp, '')
+          : currentLine.nameRoman?.replace(parenthesisRegexp, ''),
         lineColorC: currentLine.color,
         lineSymbol: currentNumbering?.lineSymbol ?? '',
       },


### PR DESCRIPTION
#4382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 駅名や路線名の表示が常に日本語表記になりました。端末の言語設定に関係なく、日本語名のみが表示されます。
  * Apple Watchへのデータ送信時、言語設定に応じて日本語またはローマ字表記を選択して送信するようになりました。  
* **その他**
  * 不要なローマ字表記用プロパティが削除されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->