### PR TITLE
レイザーラモンHG

### DIFF
--- a/src/hooks/useAppleWatch.ts
+++ b/src/hooks/useAppleWatch.ts
@@ -50,9 +50,10 @@ export const useAppleWatch = (): void => {
   }, [isFullLoopLine, stations]);
 
   const boundStationName = useMemo(() => {
+    const enPrefix = 'For ';
     const jaSuffix = isFullLoopLine || isPartiallyLoopLine ? '方面' : 'ゆき';
 
-    return `${directionalStops
+    return `${isJapanese ? '' : enPrefix}${directionalStops
       .map((s) => (isJapanese ? s.name : s.nameRoman))
       .join(isJapanese ? '・' : '/')}${isJapanese ? jaSuffix : ''}`;
   }, [directionalStops, isFullLoopLine, isPartiallyLoopLine]);


### PR DESCRIPTION
#4382

コンプリケーションの英語版行き先に「For 」の接頭辞が付くようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 日本語以外の言語設定時に、駅名の前に「For 」という英語の接頭辞が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->