### PR TITLE
路線を選んでない時はコンプリケーションをリセットする

### DIFF
--- a/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
+++ b/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
@@ -41,6 +41,32 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
     
     DispatchQueue.main.async {
       do {
+        guard let selectedLineDic = message["selectedLine"] as? Dictionary<String, Any> else {
+          defaults?.set(false, forKey: "loaded")
+          WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
+          return
+        }
+        guard let selectedLineData = try? JSONSerialization.data(withJSONObject: selectedLineDic, options: []) else {
+          defaults?.set(false, forKey: "loaded")
+          WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
+          return
+        }
+        guard let selectedLine = try? decoder.decode(Line.self, from: selectedLineData) else {
+          defaults?.set(false, forKey: "loaded")
+          WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
+          return
+        }
+        
+        self.selectedLine = selectedLine
+        
+        defaults?.set(selectedLine.lineColorC, forKey: "lineColor")
+        defaults?.set(selectedLine.name, forKey: "lineName")
+        defaults?.set(selectedLine.lineSymbol, forKey: "lineSymbol")
+        defaults?.set(message["boundStationName"], forKey: "boundStationName")
+        defaults?.set(true, forKey: "loaded")
+        
+        WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
+
         guard let stationDic = message["station"] as? Dictionary<String, Any> else {
           return
         }
@@ -63,22 +89,6 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
         default:
           break
         }
-        
-        guard let selectedLineDic = message["selectedLine"] as? Dictionary<String, Any> else {
-          return
-        }
-        guard let selectedLineData = try? JSONSerialization.data(withJSONObject: selectedLineDic, options: []) else {
-          return
-        }
-        self.selectedLine = try decoder.decode(Line.self, from: selectedLineData)
-        
-        defaults?.set(self.selectedLine?.lineColorC, forKey: "lineColor")
-        defaults?.set(self.selectedLine?.name, forKey: "lineName")
-        defaults?.set(self.selectedLine?.lineSymbol, forKey: "lineSymbol")
-        defaults?.set(message["boundStationName"], forKey: "boundStationName")
-        defaults?.set(true, forKey: "loaded")
-        
-        WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
         
         guard let stationListDic = message["stationList"] as? [Dictionary<String, Any>] else {
           return

--- a/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
+++ b/ios/WatchApp Extension/ViewModel/ConnectivityProvider.swift
@@ -41,7 +41,7 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
     
     DispatchQueue.main.async {
       do {
-        guard let selectedLineDic = message["selectedLine"] as? Dictionary<String, Any> else {
+        guard let selectedLineDic = message["selectedLine"] as? [String: Any] else {
           defaults?.set(false, forKey: "loaded")
           WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
           return
@@ -67,7 +67,7 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
         
         WidgetCenter.shared.reloadTimelines(ofKind: "WatchWidget")
 
-        guard let stationDic = message["station"] as? Dictionary<String, Any> else {
+        guard let stationDic = message["station"] as? [String: Any] else {
           return
         }
         guard let data = try? JSONSerialization.data(withJSONObject: stationDic, options: []) else {
@@ -90,7 +90,7 @@ class ConnectivityProvider: NSObject, WCSessionDelegate, ObservableObject {
           break
         }
         
-        guard let stationListDic = message["stationList"] as? [Dictionary<String, Any>] else {
+        guard let stationListDic = message["stationList"] as? [[String: Any]] else {
           return
         }
         guard let stationListData = try? JSONSerialization.data(withJSONObject: stationListDic, options: []) else {

--- a/ios/WatchWidget/WatchWidget.swift
+++ b/ios/WatchWidget/WatchWidget.swift
@@ -37,19 +37,37 @@ struct Provider: AppIntentTimelineProvider {
       return SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
     }
     
-    let lineColor = defaults.string(forKey: "lineColor") ?? "277BC0"
-    let lineName = defaults.string(forKey: "lineName") ?? String(localized: "lineNotSet")
-    let lineSymbol = defaults.string(forKey: "lineSymbol") ?? "?"
-    let boundFor = defaults.string(forKey: "boundStationName") ?? String(localized: "destinationNotSet")
     let loaded = defaults.bool(forKey: "loaded")
     
+    if (!loaded) {
+      var newIntent: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.lineColor = "277BC0"
+        intent.lineName = String(localized: "lineNotSet")
+        intent.lineSymbol = "?"
+        intent.boundFor = String(localized: "destinationNotSet")
+        intent.loaded = false
+        return intent
+      }
+      
+      return SimpleEntry (
+        date: Date(),
+        configuration: newIntent
+      )
+    }
+    
+    let lineColor = defaults.string(forKey: "lineColor") ?? ""
+    let lineName = defaults.string(forKey: "lineName") ?? ""
+    let lineSymbol = defaults.string(forKey: "lineSymbol") ?? ""
+    let boundFor = defaults.string(forKey: "boundStationName") ?? ""
+
     var newIntent: ConfigurationAppIntent {
       let intent = ConfigurationAppIntent()
       intent.lineColor = lineColor
       intent.lineName = lineName
       intent.lineSymbol = lineSymbol
       intent.boundFor = boundFor
-      intent.loaded = loaded
+      intent.loaded = true
       return intent
     }
     

--- a/src/hooks/useAppleWatch.ts
+++ b/src/hooks/useAppleWatch.ts
@@ -46,7 +46,7 @@ export const useAppleWatch = (): void => {
 
   const message = useMemo(() => {
     if (!switchedStation || !currentLine) {
-      return;
+      return {};
     }
 
     const switchedStations =
@@ -99,18 +99,14 @@ export const useAppleWatch = (): void => {
   ]);
 
   const sendMessagesToWatch = useCallback(async (): Promise<void> => {
-    if (message) {
-      sendMessage(message, console.log, (err) => {
-        console.error(err);
-        updateApplicationContext(message);
-      });
-    }
+    sendMessage(message, console.log, (err) => {
+      console.error(err);
+      updateApplicationContext(message);
+    });
   }, [message]);
 
   const updateWatchApplicationContext = useCallback(() => {
-    if (message) {
-      updateApplicationContext(message);
-    }
+    updateApplicationContext(message);
   }, [message]);
 
   useEffect(() => {


### PR DESCRIPTION
#4162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * Apple Watchアプリとウィジェットで「selectedLine」や関連データの管理方法を整理し、処理の重複を解消しました。
  * ウィジェットは「loaded」フラグを確認し、未設定時はデフォルト値を表示するようになりました。
  * Apple Watch連携処理の条件分岐を簡素化し、常にメッセージ送信処理が行われるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->