### PR TITLE
JRWテーマのTTSの終点文言漏れ修正

### DIFF
--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -531,7 +531,7 @@ export const useTTSText = (
                       )}から先は、後ほどご案内いたします。`
                 }`
               : ''
-          }次は、${nextStation?.id === selectedBound?.id && !isLoopLine ? '終点、' : ''}${
+          }次は、${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? '終点、' : ''}${
             replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
             ''
           }、${
@@ -709,8 +709,8 @@ export const useTTSText = (
       selectedBound,
       transferLines,
       viaStation,
-      nextStation?.id,
-      selectedBound?.id,
+      nextStation?.groupId,
+      selectedBound?.groupId,
     ]);
 
   const englishTemplate: Record<AppTheme, { [key: string]: string }> | null =
@@ -933,7 +933,7 @@ export const useTTSText = (
                       } will be announced later. `
                 }`
               : ''
-          }The next stop is ${nextStation?.nameRoman}${nextStation?.id === selectedBound?.id && !isLoopLine ? ' terminal.' : ''}${
+          }The next stop is ${nextStation?.nameRoman}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal.' : ''}${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -1032,8 +1032,8 @@ export const useTTSText = (
       isAfterNextStopTerminus,
       isLoopLine,
       isNextStopTerminus,
-      nextStation?.id,
-      selectedBound?.id,
+      nextStation?.groupId,
+      selectedBound?.groupId,
       nextStation?.nameRoman,
       nextStationNumber?.lineSymbol.length,
       nextStationNumberText,

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -531,7 +531,7 @@ export const useTTSText = (
                       )}から先は、後ほどご案内いたします。`
                 }`
               : ''
-          }次は、${
+          }次は、${nextStation?.id === selectedBound?.id && !isLoopLine ? '終点、' : ''}${
             replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
             ''
           }、${
@@ -709,6 +709,8 @@ export const useTTSText = (
       selectedBound,
       transferLines,
       viaStation,
+      nextStation?.id,
+      selectedBound?.id,
     ]);
 
   const englishTemplate: Record<AppTheme, { [key: string]: string }> | null =
@@ -931,7 +933,7 @@ export const useTTSText = (
                       } will be announced later. `
                 }`
               : ''
-          }The next stop is ${nextStation?.nameRoman}${
+          }The next stop is ${nextStation?.nameRoman}${nextStation?.id === selectedBound?.id && !isLoopLine ? ' terminal.' : ''}${
             nextStationNumber?.lineSymbol.length
               ? ` station number ${nextStationNumberText}`
               : ''
@@ -1030,6 +1032,8 @@ export const useTTSText = (
       isAfterNextStopTerminus,
       isLoopLine,
       isNextStopTerminus,
+      nextStation?.id,
+      selectedBound?.id,
       nextStation?.nameRoman,
       nextStationNumber?.lineSymbol.length,
       nextStationNumberText,


### PR DESCRIPTION
#4389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * JR西日本テーマで、次駅が終点の場合にTTS文に「終点、」または "terminal." を自動挿入するようになりました（日本語・英語両方対応）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->