### PR TITLE
JR九州Chevron色修正

### DIFF
--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -169,7 +169,7 @@ interface StationNameCellProps {
   line: Line;
   lineColors: (string | null | undefined)[];
   hasTerminus: boolean;
-  chevronColor: 'RED' | 'BLACK' | 'WHITE';
+  chevronColor: 'BLUE' | 'BLACK' | 'WHITE';
 }
 
 const StationName: React.FC<StationNameProps> = ({
@@ -564,7 +564,7 @@ const LineBoardJRKyushu: React.FC<Props> = ({
   hasTerminus,
   lineColors,
 }: Props) => {
-  const [chevronColor, setChevronColor] = useState<'RED' | 'BLACK'>('BLACK');
+  const [chevronColor, setChevronColor] = useState<'BLUE' | 'BLACK'>('BLACK');
   const { selectedLine } = useAtomValue(lineState);
   const currentLine = useCurrentLine();
 
@@ -574,7 +574,7 @@ const LineBoardJRKyushu: React.FC<Props> = ({
   );
 
   const intervalStep = useCallback(
-    () => setChevronColor((prev) => (prev === 'RED' ? 'BLACK' : 'RED')),
+    () => setChevronColor((prev) => (prev === 'BLUE' ? 'BLACK' : 'BLUE')),
     []
   );
 


### PR DESCRIPTION
赤->黒じゃなくて青->黒

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チェブロンインジケーターの色が「赤」から「青」に変更され、「青」と「黒」の間で切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->