### PR TITLE
到着フラグの初期値を試験的にtrueに変更

### DIFF
--- a/src/store/atoms/station.ts
+++ b/src/store/atoms/station.ts
@@ -13,7 +13,7 @@ export interface StationState {
 }
 
 const initialStationState: StationState = {
-  arrived: false,
+  arrived: true,
   approaching: false,
   station: null,
   stations: [],


### PR DESCRIPTION
#4167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 駅の到着状態の初期値が「到着済み」に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->