### PR TITLE
最大許容位置情報誤差の閾値を2kmから4kmに拡大 & 速度が0m/sの時に速度を加味した停車判定から外れるバグを修正

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 30;
 export const LOCATION_TIME_INTERVAL = 5000;
 
-export const MAX_PERMIT_ACCURACY = 2000;
+export const MAX_PERMIT_ACCURACY = 4000;
 
 export const LOCATION_TASK_OPTIONS: Location.LocationTaskOptions = {
   accuracy: LOCATION_ACCURACY,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 位置情報の速度と精度が無効な場合の到着判定ロジックを改善し、より正確な判定が行われるようになりました。

* **その他**
  * 位置情報の精度許容値が2000から4000に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->