### PR TITLE
行先が両方面表示されなくなることがあるバグを修正

### DIFF
--- a/src/hooks/useBounds.ts
+++ b/src/hooks/useBounds.ts
@@ -72,14 +72,7 @@ export const useBounds = (): {
       }
     }
 
-    if (
-      inboundStation?.groupId !== currentStation?.groupId ||
-      outboundStation?.groupId !== currentStation?.groupId
-    ) {
-      return [[inboundStation], [outboundStation]];
-    }
-
-    return [[], []];
+    return [[inboundStation], [outboundStation]];
   }, [
     currentLine?.id,
     currentStation,


### PR DESCRIPTION
富山駅の富山地鉄３系統で発生

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 駅情報の取得処理が簡素化され、常に入境駅と出境駅が返されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->