### PR TITLE
TTS IPA追加

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -92,6 +92,60 @@ exports.tts = onCall({ region: 'asia-northeast1' }, async (req) => {
       /Fukiage/gi,
       '<phoneme alphabet="ipa" ph="ɸɯkʲiaɡe">ふきあげ</phoneme>'
     )
+    // 新橋
+    .replace(
+      /Shimbashi/gi,
+      '<phoneme alphabet="ipa" ph="ɕimbaɕi">しんばし</phoneme>'
+    )
+    // 渋谷
+    .replace(
+      /Shibuya/gi,
+      '<phoneme alphabet="ipa" ph="ɕibɯja">しぶや</phoneme>'
+    )
+    // 品川
+    .replace(
+      /Shinagawa/gi,
+      '<phoneme alphabet="ipa" ph="ɕinaɡawa">しながわ</phoneme>'
+    )
+    // 上野
+    .replace(/Ueno/gi, '<phoneme alphabet="ipa" ph="ɯeno">うえの</phoneme>')
+    // 池袋
+    .replace(
+      /Ikebukuro/gi,
+      '<phoneme alphabet="ipa" ph="ikebɯkɯɾo">いけぶくろ</phoneme>'
+    )
+    // 新宿
+    .replace(
+      /Shinjuku/gi,
+      '<phoneme alphabet="ipa" ph="ɕiɲdʑɯkɯ">しんじゅく</phoneme>'
+    )
+    // 大阪
+    .replace(
+      /Osaka/gi,
+      '<phoneme alphabet="ipa" ph="oːsaka">おおさか</phoneme>'
+    )
+    // 京都
+    .replace(
+      /Kyoto/gi,
+      '<phoneme alphabet="ipa" ph="kʲoːto">きょうと</phoneme>'
+    )
+    // 横浜
+    .replace(
+      /Yokohama/gi,
+      '<phoneme alphabet="ipa" ph="jokohama">よこはま</phoneme>'
+    )
+    // 千葉
+    .replace(/Chiba/gi, '<phoneme alphabet="ipa" ph="t͡ɕiba">ちば</phoneme>')
+    // 川崎
+    .replace(
+      /Kawasaki/gi,
+      '<phoneme alphabet="ipa" ph="kawasakʲi">かわさき</phoneme>'
+    )
+    // 鶴見
+    .replace(
+      /Tsurumi/gi,
+      '<phoneme alphabet="ipa" ph="t͡sɯɾɯmi">つるみ</phoneme>'
+    )
     // 日本語はjoを「ホ」と読まない
     .replace(/jo/gi, '<phoneme alphabet="ipa" ph="ʤo">じょ</phoneme>')
     .replace(/JR/gi, 'J-R')

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -90,7 +90,7 @@ exports.tts = onCall({ region: 'asia-northeast1' }, async (req) => {
     // 吹上駅
     .replace(
       /Fukiage/gi,
-      '<phoneme alphabet="ipa" ph="ɸɯkiaɡe">ふきあげ</phoneme>'
+      '<phoneme alphabet="ipa" ph="ɸɯkʲiaɡe">ふきあげ</phoneme>'
     )
     // 日本語はjoを「ホ」と読まない
     .replace(/jo/gi, '<phoneme alphabet="ipa" ph="ʤo">じょ</phoneme>')

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -87,6 +87,11 @@ exports.tts = onCall({ region: 'asia-northeast1' }, async (req) => {
       /Toride/gi,
       '<phoneme alphabet="ipa" ph="toɾʲide">とりで</phoneme>'
     )
+    // 吹上駅
+    .replace(
+      /Fukiage/gi,
+      '<phoneme alphabet="ipa" ph="ɸɯkiaɡe">ふきあげ</phoneme>'
+    )
     // 日本語はjoを「ホ」と読まない
     .replace(/jo/gi, '<phoneme alphabet="ipa" ph="ʤo">じょ</phoneme>')
     .replace(/JR/gi, 'J-R')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 英語音声合成で「Fukiage」をはじめ、「Shimbashi」「Shibuya」「Shinagawa」「Ueno」「Ikebukuro」「Shinjuku」「Osaka」「Kyoto」「Yokohama」「Chiba」「Kawasaki」「Tsurumi」などの駅名が日本語の発音記号付きで正しく読み上げられるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->