### PR TITLE
一時的にDOを無効化できるようにした

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -178,5 +178,6 @@
   "autoModeV2AlertText": "Auto mode has been updated. It will operate according to the distance between stations. If the distance between stations is long, it may take a while to switch. You can return to the original auto mode in the settings.",
   "updateRequiredForReport": "Please update the app to send a feedback.",
   "updateApp": "Update app",
-  "jrKyushuLike": "JR Kyushu"
+  "jrKyushuLike": "JR Kyushu",
+  "disableDevOverlay": "Disable developer overlay"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -179,5 +179,6 @@
   "autoModeV2AlertText": "オートモードが新しくなりました。駅間距離に応じて動作しますので、駅間距離が長い場合は切り替わりが遅くなる場合があります。設定画面で元のオートモードに戻すことができます。",
   "updateRequiredForReport": "フィードバックを送信するにはアプリをアップデートしてください。",
   "updateApp": "アプリをアップデート",
-  "jrKyushuLike": "JR九州風"
+  "jrKyushuLike": "JR九州風",
+  "disableDevOverlay": "開発者オーバレイを無効化する"
 }

--- a/src/components/LEDThemeSwitch.tsx
+++ b/src/components/LEDThemeSwitch.tsx
@@ -9,7 +9,7 @@ import {
 import Typography from './Typography';
 
 type Props = {
-  style: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
   value: boolean;
   onValueChange: (value: boolean) => void;
 };

--- a/src/components/LEDThemeSwitch.tsx
+++ b/src/components/LEDThemeSwitch.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { type ComponentProps, useCallback } from 'react';
 import {
   type StyleProp,
   StyleSheet,
+  type Switch,
   TouchableOpacity,
   View,
   type ViewStyle,
@@ -12,7 +13,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   value: boolean;
   onValueChange: (value: boolean) => void;
-};
+} & ComponentProps<typeof Switch>;
 
 const styles = StyleSheet.create({
   container: {
@@ -34,7 +35,12 @@ const styles = StyleSheet.create({
   },
 });
 
-const LEDThemeSwitch = ({ style, value, onValueChange }: Props) => {
+const LEDThemeSwitch = ({
+  style,
+  value,
+  onValueChange,
+  accessibilityLabel,
+}: Props) => {
   const handleContainerPress = useCallback(
     () => onValueChange(!value),
     [onValueChange, value]
@@ -44,9 +50,13 @@ const LEDThemeSwitch = ({ style, value, onValueChange }: Props) => {
       activeOpacity={1}
       onPress={handleContainerPress}
       style={[
-        { ...styles.container, borderColor: value ? '#fff' : '#555' },
+        styles.container,
+        { borderColor: value ? '#fff' : '#555' },
         style,
       ]}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value }}
+      accessibilityLabel={accessibilityLabel}
     >
       <View
         style={[
@@ -57,7 +67,11 @@ const LEDThemeSwitch = ({ style, value, onValueChange }: Props) => {
           },
         ]}
       >
-        <Typography style={styles.label}>{value ? 'ON' : 'OFF'}</Typography>
+        <Typography
+          style={[styles.label, { color: value ? '#212121' : '#fff' }]}
+        >
+          {value ? 'ON' : 'OFF'}
+        </Typography>
       </View>
     </TouchableOpacity>
   );

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -451,7 +451,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.root}>
-          {isDevApp && !devOverlayEnabled && <DevOverlay />}
+          {isDevApp && devOverlayEnabled && <DevOverlay />}
           <Header />
           {children}
           <NullableWarningPanel />

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -62,7 +62,7 @@ type Props = {
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { selectedBound } = useAtomValue(stationState);
-  const { toggleDevOverlayEnabled } = useAtomValue(tuningState);
+  const { devOverlayEnabled } = useAtomValue(tuningState);
   const setNavigation = useSetAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
   const [reportModalShow, setReportModalShow] = useState(false);
@@ -451,7 +451,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.root}>
-          {isDevApp && !toggleDevOverlayEnabled && <DevOverlay />}
+          {isDevApp && !devOverlayEnabled && <DevOverlay />}
           <Header />
           {children}
           <NullableWarningPanel />

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -18,6 +18,7 @@ import {
 import { LongPressGestureHandler, State } from 'react-native-gesture-handler';
 import Share from 'react-native-share';
 import ViewShot from 'react-native-view-shot';
+import tuningState from '~/store/atoms/tuning';
 import {
   ALL_AVAILABLE_LANGUAGES,
   APP_STORE_URL,
@@ -47,7 +48,6 @@ import DevOverlay from './DevOverlay';
 import Header from './Header';
 import NewReportModal from './NewReportModal';
 import WarningPanel from './WarningPanel';
-import tuningState from '~/store/atoms/tuning';
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -47,6 +47,7 @@ import DevOverlay from './DevOverlay';
 import Header from './Header';
 import NewReportModal from './NewReportModal';
 import WarningPanel from './WarningPanel';
+import tuningState from '~/store/atoms/tuning';
 
 const styles = StyleSheet.create({
   root: {
@@ -61,6 +62,7 @@ type Props = {
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { selectedBound } = useAtomValue(stationState);
+  const { disableDevOverlay } = useAtomValue(tuningState);
   const setNavigation = useSetAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
   const [reportModalShow, setReportModalShow] = useState(false);
@@ -449,7 +451,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.root}>
-          {isDevApp && <DevOverlay />}
+          {isDevApp && !disableDevOverlay && <DevOverlay />}
           <Header />
           {children}
           <NullableWarningPanel />

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -62,7 +62,7 @@ type Props = {
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { selectedBound } = useAtomValue(stationState);
-  const { disableDevOverlay } = useAtomValue(tuningState);
+  const { toggleDevOverlayEnabled } = useAtomValue(tuningState);
   const setNavigation = useSetAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
   const [reportModalShow, setReportModalShow] = useState(false);
@@ -451,7 +451,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.root}>
-          {isDevApp && !disableDevOverlay && <DevOverlay />}
+          {isDevApp && !toggleDevOverlayEnabled && <DevOverlay />}
           <Header />
           {children}
           <NullableWarningPanel />

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -209,17 +209,23 @@ const TuningSettings: React.FC = () => {
             <LEDThemeSwitch
               value={!settings.devOverlayEnabled}
               onValueChange={toggleDevOverlayEnabled}
+              accessibilityLabel={translate('tuningItemDisableDevOverlay')}
             />
           ) : (
             <Switch
               value={!settings.devOverlayEnabled}
               onValueChange={toggleDevOverlayEnabled}
               ios_backgroundColor={'#fff'}
+              accessibilityLabel={translate('tuningItemDisableDevOverlay')}
             />
           )}
 
-          <Typography style={styles.switchSettingItemText}>
-            開発者オーバレイを無効化する
+          <Typography
+            style={styles.switchSettingItemText}
+            onPress={toggleDevOverlayEnabled}
+            accessibilityRole="button"
+          >
+            {translate('disableDevOverlay')}
           </Typography>
         </View>
       </ScrollView>

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -21,8 +21,8 @@ import { translate } from '~/translation';
 import { RFValue } from '~/utils/rfValue';
 import FAB from './FAB';
 import { Heading } from './Heading';
-import Typography from './Typography';
 import LEDThemeSwitch from './LEDThemeSwitch';
+import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'baseline',
   },
-  radioSettingItem: {
+  switchSettingItem: {
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: 12,
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     borderColor: '#aaa',
     paddingHorizontal: 10,
   },
-  radioSettingItemText: {
+  switchSettingItemText: {
     marginLeft: 8,
     fontWeight: 'bold',
   },
@@ -203,14 +203,14 @@ const TuningSettings: React.FC = () => {
           <Typography style={styles.settingItemUnit}>ms</Typography>
         </View>
 
-        <View style={styles.radioSettingItem}>
+        <View style={styles.switchSettingItem}>
           <Switch
             value={!settings.devOverlayEnabled}
             onValueChange={toggleDevOverlayEnabled}
             ios_backgroundColor={'#fff'}
           />
 
-          <Typography style={styles.radioSettingItemText}>
+          <Typography style={styles.switchSettingItemText}>
             開発者オーバレイを無効化する
           </Typography>
         </View>

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -22,6 +22,7 @@ import { RFValue } from '~/utils/rfValue';
 import FAB from './FAB';
 import { Heading } from './Heading';
 import Typography from './Typography';
+import LEDThemeSwitch from './LEDThemeSwitch';
 
 const styles = StyleSheet.create({
   root: {
@@ -204,11 +205,18 @@ const TuningSettings: React.FC = () => {
         </View>
 
         <View style={styles.switchSettingItem}>
-          <Switch
-            value={!settings.devOverlayEnabled}
-            onValueChange={toggleDevOverlayEnabled}
-            ios_backgroundColor={'#fff'}
-          />
+          {isLEDTheme ? (
+            <LEDThemeSwitch
+              value={!settings.devOverlayEnabled}
+              onValueChange={toggleDevOverlayEnabled}
+            />
+          ) : (
+            <Switch
+              value={!settings.devOverlayEnabled}
+              onValueChange={toggleDevOverlayEnabled}
+              ios_backgroundColor={'#fff'}
+            />
+          )}
 
           <Typography style={styles.switchSettingItemText}>
             開発者オーバレイを無効化する

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -126,10 +126,10 @@ const TuningSettings: React.FC = () => {
       ),
     }));
 
-  const toggleDevOverlayDisabled = () =>
+  const toggleDevOverlayEnabled = () =>
     setSettings((prev) => ({
       ...prev,
-      disableDevOverlay: !prev.disableDevOverlay,
+      devOverlayEnabled: !prev.devOverlayEnabled,
     }));
 
   return (
@@ -205,8 +205,8 @@ const TuningSettings: React.FC = () => {
 
         <View style={styles.radioSettingItem}>
           <Switch
-            value={settings.disableDevOverlay}
-            onValueChange={toggleDevOverlayDisabled}
+            value={!settings.devOverlayEnabled}
+            onValueChange={toggleDevOverlayEnabled}
             ios_backgroundColor={'#fff'}
           />
 

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
   ScrollView,
   StyleSheet,
+  Switch,
   TextInput,
   View,
 } from 'react-native';
@@ -31,6 +32,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'baseline',
   },
+  radioSettingItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 12,
+  },
   settingItemGroupTitle: {
     fontSize: RFValue(14),
     fontWeight: 'bold',
@@ -49,6 +55,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#aaa',
     paddingHorizontal: 10,
+  },
+  radioSettingItemText: {
+    marginLeft: 8,
+    fontWeight: 'bold',
   },
 });
 
@@ -114,6 +124,12 @@ const TuningSettings: React.FC = () => {
         prev.bottomTransitionInterval,
         text
       ),
+    }));
+
+  const toggleDevOverlayDisabled = () =>
+    setSettings((prev) => ({
+      ...prev,
+      disableDevOverlay: !prev.disableDevOverlay,
     }));
 
   return (
@@ -185,6 +201,18 @@ const TuningSettings: React.FC = () => {
             keyboardType="number-pad"
           />
           <Typography style={styles.settingItemUnit}>ms</Typography>
+        </View>
+
+        <View style={styles.radioSettingItem}>
+          <Switch
+            value={settings.disableDevOverlay}
+            onValueChange={toggleDevOverlayDisabled}
+            ios_backgroundColor={'#fff'}
+          />
+
+          <Typography style={styles.radioSettingItemText}>
+            開発者オーバレイを無効化する
+          </Typography>
         </View>
       </ScrollView>
       <FAB onPress={onPressBack} icon="close" />

--- a/src/store/atoms/tuning.ts
+++ b/src/store/atoms/tuning.ts
@@ -9,12 +9,14 @@ export type TuningState = {
   headerTransitionInterval: number;
   headerTransitionDelay: number;
   bottomTransitionInterval: number;
+  disableDevOverlay: boolean;
 };
 
 const tuningState = atom<TuningState>({
   headerTransitionInterval: DEFAULT_HEADER_TRANSITION_INTERVAL,
   headerTransitionDelay: DEFAULT_HEADER_TRANSITION_DELAY,
   bottomTransitionInterval: DEFAULT_BOTTOM_TRANSITION_INTERVAL,
+  disableDevOverlay: false,
 });
 
 export default tuningState;

--- a/src/store/atoms/tuning.ts
+++ b/src/store/atoms/tuning.ts
@@ -9,14 +9,14 @@ export type TuningState = {
   headerTransitionInterval: number;
   headerTransitionDelay: number;
   bottomTransitionInterval: number;
-  disableDevOverlay: boolean;
+  devOverlayEnabled: boolean;
 };
 
 const tuningState = atom<TuningState>({
   headerTransitionInterval: DEFAULT_HEADER_TRANSITION_INTERVAL,
   headerTransitionDelay: DEFAULT_HEADER_TRANSITION_DELAY,
   bottomTransitionInterval: DEFAULT_BOTTOM_TRANSITION_INTERVAL,
-  disableDevOverlay: false,
+  devOverlayEnabled: true,
 });
 
 export default tuningState;


### PR DESCRIPTION
close #4437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  * 設定に「開発者オーバレイを無効化する」トグルを追加。オンにするとオーバレイが表示されなくなります（初期表示はオフ）。
* 変更
  * 開発者オーバレイの表示条件をトグルの状態に応じて切替えるよう更新。
  * スイッチ系コンポーネントのスタイル指定が省略可能になり、テーマ用スイッチとネイティブスイッチを適切に使い分けます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->