### PR TITLE
ヘッダーの処理からsetStateを減らす

### DIFF
--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -431,13 +431,12 @@ const HeaderJRKyushu: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
+  }, [selectedBound]);
+
+  useEffect(() => {
     fade();
-  }, [fade, selectedBound]);
+  }, [fade]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -392,13 +392,12 @@ const HeaderSaikyo: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
+  }, [selectedBound]);
+
+  useEffect(() => {
     fade();
-  }, [fade, selectedBound]);
+  }, [fade]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -419,13 +419,12 @@ const HeaderTY: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
+  }, [selectedBound]);
+
+  useEffect(() => {
     fade();
-  }, [fade, selectedBound]);
+  }, [fade]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -428,13 +428,12 @@ const HeaderTokyoMetro: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
+  }, [selectedBound]);
+
+  useEffect(() => {
     fade();
-  }, [fade, selectedBound]);
+  }, [fade]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,


### PR DESCRIPTION
#4422 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* リファクタリング
  * JR九州・埼京・TY・東京メトロの各ヘッダーでフェード状態の更新と依存関係を整理・簡素化。
  * 選択変更時のフェード挙動がより滑らかで一貫し、不要な再実行が減少して操作感が向上。
  * フリッカーの抑制やわずかな遅延の低減に寄与。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->