### PR TITLE
Revert "ヘッダーの処理からsetStateを減らす"

### DIFF
--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -431,11 +431,7 @@ const HeaderJRKyushu: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
     fade();
   }, [fade, selectedBound]);
 

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -431,12 +431,13 @@ const HeaderJRKyushu: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(!selectedBound);
-  }, [selectedBound]);
-
-  useEffect(() => {
+    if (!selectedBound) {
+      setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
+    }
     fade();
-  }, [fade]);
+  }, [fade, selectedBound]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -392,11 +392,7 @@ const HeaderSaikyo: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
     fade();
   }, [fade, selectedBound]);
 

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -392,12 +392,13 @@ const HeaderSaikyo: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(!selectedBound);
-  }, [selectedBound]);
-
-  useEffect(() => {
+    if (!selectedBound) {
+      setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
+    }
     fade();
-  }, [fade]);
+  }, [fade, selectedBound]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -419,11 +419,7 @@ const HeaderTY: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
     fade();
   }, [fade, selectedBound]);
 

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -419,12 +419,13 @@ const HeaderTY: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(!selectedBound);
-  }, [selectedBound]);
-
-  useEffect(() => {
+    if (!selectedBound) {
+      setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
+    }
     fade();
-  }, [fade]);
+  }, [fade, selectedBound]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -428,11 +428,7 @@ const HeaderTokyoMetro: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    if (!selectedBound) {
-      setFadeOutFinished(true);
-    } else {
-      setFadeOutFinished(false);
-    }
+    setFadeOutFinished(!selectedBound);
     fade();
   }, [fade, selectedBound]);
 

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -428,12 +428,13 @@ const HeaderTokyoMetro: React.FC = () => {
   }, [fadeIn, fadeOut]);
 
   useEffect(() => {
-    setFadeOutFinished(!selectedBound);
-  }, [selectedBound]);
-
-  useEffect(() => {
+    if (!selectedBound) {
+      setFadeOutFinished(true);
+    } else {
+      setFadeOutFinished(false);
+    }
     fade();
-  }, [fade]);
+  }, [fade, selectedBound]);
 
   const stateTopAnimatedStyles = useAnimatedStyle(() => ({
     opacity: 1 - stateOpacityAnim.value,


### PR DESCRIPTION
Reverts TrainLCD/MobileApp#4460

アニメーションが動かなくなった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 複数のヘッダーでフェード処理のタイミングを統一し、状態更新とアニメーション起動の同期を改善。
  * 選択状態の変化に対するアニメーションの一貫性と安定性を向上し、まれなチラつきを抑制。
  * 公開APIや外部挙動に変更はなく、ユーザー向けの見た目や操作は従来どおりです。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->