### PR TITLE
２駅目から日本語TTS再生完了を待たずに英語TTSが流れるバグを修正

### DIFF
--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -65,6 +65,10 @@ export const useTTS = (): void => {
           jaRemoveListener?.remove();
           soundJa.remove();
           soundEn.play();
+        } else if ('error' in jaStatus && jaStatus.error) {
+          jaRemoveListener?.remove();
+          soundJa.remove();
+          playingRef.current = false;
         }
       }
     );
@@ -76,12 +80,21 @@ export const useTTS = (): void => {
           enRemoveListener?.remove();
           soundEn.remove();
           playingRef.current = false;
+        } else if ('error' in enStatus && enStatus.error) {
+          enRemoveListener?.remove();
+          soundEn.remove();
+          playingRef.current = false;
         }
       }
     );
 
     return () => {
+      jaRemoveListener.remove();
+      enRemoveListener.remove();
+
+      soundJa.pause();
       soundJa.remove();
+      soundEn.pause();
       soundEn.remove();
     };
   }, []);

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -167,11 +167,7 @@ export const useTTS = (): void => {
 
     const { id, pathJa, pathEn } = fetched;
 
-    store(
-      id,
-      { text: textJa, path: fetched.pathJa },
-      { text: textEn, path: fetched.pathEn }
-    );
+    store(id, { text: textJa, path: pathJa }, { text: textEn, path: pathEn });
 
     await speakFromPath(pathJa, pathEn);
   }, [fetchSpeech, getByText, speakFromPath, store, textEn, textJa]);

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -58,8 +58,10 @@ export const useTTS = (): void => {
       uri: pathEn,
     });
 
-    soundJa.play();
+    soundJaRef.current = soundJa;
+    soundEnRef.current = soundEn;
     playingRef.current = true;
+    soundJa.play();
 
     const enRemoveListener = soundEn.addListener(
       'playbackStatusUpdate',
@@ -115,11 +117,6 @@ export const useTTS = (): void => {
         }
       }
     );
-
-    soundJa.play();
-
-    soundJaRef.current = soundJa;
-    soundEnRef.current = soundEn;
   }, []);
 
   const ttsApiUrl = useMemo(() => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -24,9 +24,6 @@ export const useTTS = (): void => {
 
   const user = useCachedInitAnonymousUser();
 
-  const soundJaRef = useRef<AudioPlayer | null>(null);
-  const soundEnRef = useRef<AudioPlayer | null>(null);
-
   useEffect(() => {
     (async () => {
       try {
@@ -51,37 +48,42 @@ export const useTTS = (): void => {
 
     firstSpeechRef.current = false;
 
-    soundJaRef.current = createAudioPlayer({
+    const soundJa = createAudioPlayer({
       uri: pathJa,
     });
-    soundEnRef.current = createAudioPlayer({
+    const soundEn = createAudioPlayer({
       uri: pathEn,
     });
 
-    soundJaRef.current.play();
+    soundJa.play();
     playingRef.current = true;
 
-    const jaRemoveListener = soundJaRef.current.addListener(
+    const jaRemoveListener = soundJa.addListener(
       'playbackStatusUpdate',
       (jaStatus) => {
         if (jaStatus.didJustFinish) {
           jaRemoveListener?.remove();
-          soundJaRef.current = null;
-          soundEnRef.current?.play();
+          soundJa.remove();
+          soundEn.play();
         }
       }
     );
 
-    const enRemoveListener = soundEnRef.current.addListener(
+    const enRemoveListener = soundEn.addListener(
       'playbackStatusUpdate',
       (enStatus) => {
         if (enStatus.didJustFinish) {
           enRemoveListener?.remove();
-          soundEnRef.current = null;
+          soundEn.remove();
           playingRef.current = false;
         }
       }
     );
+
+    return () => {
+      soundJa.remove();
+      soundEn.remove();
+    };
   }, []);
 
   const ttsApiUrl = useMemo(() => {
@@ -187,10 +189,6 @@ export const useTTS = (): void => {
   useEffect(() => {
     return () => {
       isLoadableRef.current = false;
-      soundJaRef.current?.remove();
-      soundEnRef.current?.remove();
-      soundJaRef.current = null;
-      soundEnRef.current = null;
     };
   }, []);
 };

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -165,8 +165,8 @@ export const useTTS = (): void => {
     const cache = getByText(textJa);
 
     if (cache) {
-      await speakFromPath(cache.ja.path, cache.en.path);
-      return;
+      const cleanup = await speakFromPath(cache.ja.path, cache.en.path);
+      return cleanup;
     }
 
     const fetched = await fetchSpeech();
@@ -182,7 +182,9 @@ export const useTTS = (): void => {
       { text: textEn, path: fetched.pathEn }
     );
 
-    await speakFromPath(pathJa, pathEn);
+    const cleanup = await speakFromPath(pathJa, pathEn);
+
+    return cleanup;
   }, [fetchSpeech, getByText, speakFromPath, store, textEn, textJa]);
 
   useEffect(() => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -61,6 +61,7 @@ export const useTTS = (): void => {
     soundJaRef.current = soundJa;
     soundEnRef.current = soundEn;
     playingRef.current = true;
+
     soundJa.play();
 
     const enRemoveListener = soundEn.addListener(

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -58,21 +58,6 @@ export const useTTS = (): void => {
     soundJa.play();
     playingRef.current = true;
 
-    const jaRemoveListener = soundJa.addListener(
-      'playbackStatusUpdate',
-      (jaStatus) => {
-        if (jaStatus.didJustFinish) {
-          jaRemoveListener?.remove();
-          soundJa.remove();
-          soundEn.play();
-        } else if ('error' in jaStatus && jaStatus.error) {
-          jaRemoveListener?.remove();
-          soundJa.remove();
-          playingRef.current = false;
-        }
-      }
-    );
-
     const enRemoveListener = soundEn.addListener(
       'playbackStatusUpdate',
       (enStatus) => {
@@ -83,6 +68,25 @@ export const useTTS = (): void => {
         } else if ('error' in enStatus && enStatus.error) {
           enRemoveListener?.remove();
           soundEn.remove();
+          playingRef.current = false;
+        }
+      }
+    );
+
+    const jaRemoveListener = soundJa.addListener(
+      'playbackStatusUpdate',
+      (jaStatus) => {
+        if (jaStatus.didJustFinish) {
+          jaRemoveListener?.remove();
+          soundJa.remove();
+          soundEn.play();
+        } else if ('error' in jaStatus && jaStatus.error) {
+          jaRemoveListener?.remove();
+          soundJa.remove();
+
+          enRemoveListener?.remove();
+          soundEn.remove();
+
           playingRef.current = false;
         }
       }

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -67,6 +67,7 @@ export const useTTS = (): void => {
         if (enStatus.didJustFinish) {
           enRemoveListener?.remove();
           soundEn.remove();
+          soundEnRef.current = null;
           playingRef.current = false;
         } else if ('error' in enStatus && enStatus.error) {
           // 英語側エラー時も確実に終了
@@ -74,6 +75,7 @@ export const useTTS = (): void => {
           try {
             soundEn.remove();
           } catch {}
+          soundEnRef.current = null;
           playingRef.current = false;
         }
       }
@@ -85,6 +87,7 @@ export const useTTS = (): void => {
         if (jaStatus.didJustFinish) {
           jaRemoveListener?.remove();
           soundJa.remove();
+          soundJaRef.current = null;
           if (isLoadableRef.current) {
             soundEn.play();
           } else {
@@ -93,6 +96,7 @@ export const useTTS = (): void => {
             try {
               soundEn.remove();
             } catch {}
+            soundEnRef.current = null;
             playingRef.current = false;
           }
         } else if ('error' in jaStatus && jaStatus.error) {
@@ -101,10 +105,12 @@ export const useTTS = (): void => {
           try {
             soundJa.remove();
           } catch {}
+          soundJaRef.current = null;
           enRemoveListener?.remove();
           try {
             soundEn.remove();
           } catch {}
+          soundEnRef.current = null;
           playingRef.current = false;
         }
       }
@@ -215,10 +221,18 @@ export const useTTS = (): void => {
   useEffect(() => {
     return () => {
       isLoadableRef.current = false;
-      soundJaRef.current?.pause();
-      soundEnRef.current?.pause();
-      soundJaRef.current?.remove();
-      soundEnRef.current?.remove();
+      try {
+        soundJaRef.current?.pause();
+      } catch {}
+      try {
+        soundEnRef.current?.pause();
+      } catch {}
+      try {
+        soundJaRef.current?.remove();
+      } catch {}
+      try {
+        soundEnRef.current?.remove();
+      } catch {}
       soundJaRef.current = null;
       soundEnRef.current = null;
     };

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -51,24 +51,12 @@ export const useTTS = (): void => {
 
     firstSpeechRef.current = false;
 
-    if (!soundJaRef.current) {
-      soundJaRef.current = createAudioPlayer({
-        uri: pathJa,
-      });
-    } else {
-      soundJaRef.current.replace({
-        uri: pathJa,
-      });
-    }
-    if (!soundEnRef.current) {
-      soundEnRef.current = createAudioPlayer({
-        uri: pathEn,
-      });
-    } else {
-      soundEnRef.current.replace({
-        uri: pathEn,
-      });
-    }
+    soundJaRef.current = createAudioPlayer({
+      uri: pathJa,
+    });
+    soundEnRef.current = createAudioPlayer({
+      uri: pathEn,
+    });
 
     soundJaRef.current.play();
     playingRef.current = true;
@@ -76,8 +64,9 @@ export const useTTS = (): void => {
     const jaRemoveListener = soundJaRef.current.addListener(
       'playbackStatusUpdate',
       (jaStatus) => {
-        if (jaStatus.isLoaded && jaStatus.didJustFinish) {
+        if (jaStatus.didJustFinish) {
           jaRemoveListener?.remove();
+          soundJaRef.current = null;
           soundEnRef.current?.play();
         }
       }
@@ -86,8 +75,9 @@ export const useTTS = (): void => {
     const enRemoveListener = soundEnRef.current.addListener(
       'playbackStatusUpdate',
       (enStatus) => {
-        if (enStatus.isLoaded && enStatus.didJustFinish) {
+        if (enStatus.didJustFinish) {
           enRemoveListener?.remove();
+          soundEnRef.current = null;
           playingRef.current = false;
         }
       }

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -62,8 +62,6 @@ export const useTTS = (): void => {
     soundEnRef.current = soundEn;
     playingRef.current = true;
 
-    soundJa.play();
-
     const enRemoveListener = soundEn.addListener(
       'playbackStatusUpdate',
       (enStatus) => {
@@ -118,6 +116,8 @@ export const useTTS = (): void => {
         }
       }
     );
+
+    soundJa.play();
   }, []);
 
   const ttsApiUrl = useMemo(() => {
@@ -233,6 +233,7 @@ export const useTTS = (): void => {
       } catch {}
       soundJaRef.current = null;
       soundEnRef.current = null;
+      playingRef.current = false;
     };
   }, []);
 };


### PR DESCRIPTION
#4469 のデグレ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - 日→英の連続再生で英語再生が確実に開始されるよう安定化。
  - 再生中の二重再生や途中停止、再生状態が戻らない問題を解消。
  - 再生エラー時に両言語の再生処理を確実に解除するよう改善。
- パフォーマンス
  - アンマウント時と再生後の明示的なクリーンアップでリソース解放を強化。
- その他
  - 言語ごとの再生ライフサイクル管理を導入し挙動の安定化を実施。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->