### PR TITLE
THQにnoteフィールドを送信

### DIFF
--- a/src/hooks/useTelemetrySender.disabled.test.ts
+++ b/src/hooks/useTelemetrySender.disabled.test.ts
@@ -10,16 +10,59 @@ jest.mock('expo-device', () => ({
   modelName: 'TestDevice',
 }));
 
+jest.mock('expo-network', () => ({
+  NetworkStateType: {
+    WIFI: 'WIFI',
+    CELLULAR: 'CELLULAR',
+    NONE: 'NONE',
+  },
+  useNetworkState: jest.fn(() => ({
+    type: 'WIFI',
+    isConnected: true,
+    isInternetReachable: true,
+  })),
+}));
+
 jest.mock('jotai', () => ({
   atom: jest.fn(),
-  useAtomValue: jest.fn(() => ({
-    arrived: false,
-    approaching: true,
-  })),
+  useAtomValue: jest.fn((atom) => {
+    // stationState の場合は完全なステート構造を返す
+    if (
+      atom?.toString?.().includes('station') ||
+      atom === require('~/store/atoms/station').default
+    ) {
+      return {
+        arrived: false,
+        approaching: true,
+        station: null,
+        stations: [],
+        selectedDirection: null,
+        selectedBound: null,
+        wantedDestination: null,
+      };
+    }
+    // その他の atom の場合はデフォルト値を返す
+    return {
+      arrived: false,
+      approaching: true,
+    };
+  }),
 }));
 
 jest.mock('~/hooks/useIsPassing', () => ({
   useIsPassing: jest.fn(() => false),
+}));
+
+jest.mock('~/hooks/useCurrentStation', () => ({
+  useCurrentStation: jest.fn(() => null),
+}));
+
+jest.mock('~/hooks/useNextStation', () => ({
+  useNextStation: jest.fn(() => null),
+}));
+
+jest.mock('~/utils/native/android/gnssModule', () => ({
+  subscribeGnss: jest.fn(() => () => {}),
 }));
 
 jest.mock('~/hooks/useLocationStore', () => ({

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -15,9 +15,9 @@ import {
 } from '~/utils/native/android/gnssModule';
 import { isTelemetryEnabled } from '~/utils/telemetryConfig';
 import stationState from '../store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
 import { useIsPassing } from './useIsPassing';
 import { useLocationStore } from './useLocationStore';
-import { useCurrentStation } from './useCurrentStation';
 import { useNextStation } from './useNextStation';
 
 const MovingState = z.enum(['arrived', 'approaching', 'passing', 'moving']);

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -17,6 +17,8 @@ import { isTelemetryEnabled } from '~/utils/telemetryConfig';
 import stationState from '../store/atoms/station';
 import { useIsPassing } from './useIsPassing';
 import { useLocationStore } from './useLocationStore';
+import { useCurrentStation } from './useCurrentStation';
+import { useNextStation } from './useNextStation';
 
 const MovingState = z.enum(['arrived', 'approaching', 'passing', 'moving']);
 type MovingState = z.infer<typeof MovingState>;
@@ -61,6 +63,7 @@ const TelemetryPayload = z.object({
     })
     .nullable()
     .optional(),
+  note: z.string().optional(),
   timestamp: z.number(),
 });
 
@@ -73,6 +76,9 @@ export const useTelemetrySender = (
   const gnssRef = useRef<GnssState | null>(null);
   const telemetryQueueRef = useRef<string[]>([]);
   const messageQueueRef = useRef<string[]>([]);
+
+  const currentStation = useCurrentStation(false);
+  const nextStation = useNextStation(false);
 
   useEffect(
     () =>
@@ -166,6 +172,7 @@ export const useTelemetrySender = (
       radio: {
         isWifiConnected,
       },
+      note: `${currentStation?.name} - ${nextStation?.name}`,
       timestamp: now,
     });
 
@@ -191,7 +198,14 @@ export const useTelemetrySender = (
         enqueueMessage(telemetryQueueRef.current, stringifiedData);
       }
     }
-  }, [coords, state, enqueueMessage, isWifiConnected]);
+  }, [
+    coords,
+    state,
+    enqueueMessage,
+    isWifiConnected,
+    currentStation?.name,
+    nextStation?.name,
+  ]);
 
   useEffect(() => {
     let reconnectAttempts = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - テレメトリー送信に現在駅・次駅の情報を注記として追加し、運行状況の把握精度を向上。
  - 駅名の変化に応じて送信が再実行されるよう送信タイミングを最適化。

- Tests
  - テストを分離・安定化するため、ネットワーク・駅情報・GNSS周りのモックを強化。

- Documentation
  - 公開インターフェースに変更なし。内部データにオプションの注記フィールドを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->