### PR TITLE
ストアレビュー通知実装

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -135,14 +135,14 @@ The Cloud Functions in this project handle various backend operations:
 - **App Store Review Notifier (`appStoreReviewNotifier`)** - App Storeの最新レビューをJSONフィードから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
     - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
-    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント
+    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。
       - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
       - 互換性のため環境変数名は`...RSS_URL`のままですが、JSON URLを指定してください
-    - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）
+    - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。バケットには少なくとも該当オブジェクトへの書込権限（例: `roles/storage.objectAdmin`）が必要です。
     - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得内容などの詳細ログを出力
-    - `REVIEW_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
 
 - **Google Play Review Notifier (`googlePlayReviewNotifier`)** - Google Playの最新レビューをAndroid Publisher APIから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
@@ -153,7 +153,7 @@ The Cloud Functions in this project handle various backend operations:
   - 認証: Cloud Functionsのサービスアカウントに「Android Publisher API」へのアクセス権を付与し、ADC（Application Default Credentials）で認証します。
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得/ページング/保存の詳細ログを出力
-    - `REVIEW_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
     - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
 
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -137,7 +137,6 @@ The Cloud Functions in this project handle various backend operations:
     - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
     - `APPSTORE_REVIEW_FEED_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。必ず末尾が `/json` のURLを指定してください（`/xml` は非対応）。
       - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
-      - 旧 `APPSTORE_REVIEW_RSS_URL` は非対応になりました（使用しないでください）。
     - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。必要最小の権限は該当オブジェクトへの読取/作成（例: `roles/storage.objectViewer` + `roles/storage.objectCreator`）。運用上の都合であれば `roles/storage.objectAdmin` でも可。
     - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
     - `REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC

--- a/functions/README.md
+++ b/functions/README.md
@@ -131,6 +131,32 @@ The Cloud Functions in this project handle various backend operations:
 - **Content Moderation** - Automated content review and filtering
 - **Data Processing** - Asynchronous data transformation tasks
 
+### Scheduled Jobs
+- **App Store Review Notifier (`appStoreReviewNotifier`)** - App Storeの最新レビューをJSONフィードから取得し、Discordへ通知します（既定: 毎時）。
+  - 環境変数:
+    - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
+    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント
+      - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
+      - 互換性のため環境変数名は`...RSS_URL`のままですが、JSON URLを指定してください
+    - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）
+    - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
+  - デバッグ用（任意）:
+    - `REVIEWS_DEBUG=1`: 取得内容などの詳細ログを出力
+    - `REVIEW_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+
+- **Google Play Review Notifier (`googlePlayReviewNotifier`)** - Google Playの最新レビューをAndroid Publisher APIから取得し、Discordへ通知します（既定: 毎時）。
+  - 環境変数:
+    - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
+    - `GOOGLE_PLAY_PACKAGE_NAME`: パッケージ名（既定: `me.tinykitten.trainlcd`）
+    - `GOOGLEPLAY_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/googleplay-reviews.json`）
+    - `PLAY_REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
+  - 認証: Cloud Functionsのサービスアカウントに「Android Publisher API」へのアクセス権を付与し、ADC（Application Default Credentials）で認証します。
+  - デバッグ用（任意）:
+    - `REVIEWS_DEBUG=1`: 取得/ページング/保存の詳細ログを出力
+    - `REVIEW_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
+
+
 ### Firestore Triggers
 - Database change reactions
 - Data validation

--- a/functions/README.md
+++ b/functions/README.md
@@ -135,9 +135,9 @@ The Cloud Functions in this project handle various backend operations:
 - **App Store Review Notifier (`appStoreReviewNotifier`)** - App Storeの最新レビューをJSONフィードから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
     - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
-    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。必ず末尾が `/json` のURLを指定してください（`/xml` は非対応）。
+    - `APPSTORE_REVIEW_FEED_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。必ず末尾が `/json` のURLを指定してください（`/xml` は非対応）。
       - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
-      - 互換性のため環境変数名は `...RSS_URL` のままですが、実体は JSON フィードです。将来的に `APPSTORE_REVIEW_FEED_URL` への改名を検討し、従来名は後方互換として読み替え予定です。
+      - 旧 `APPSTORE_REVIEW_RSS_URL` は非対応になりました（使用しないでください）。
     - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。必要最小の権限は該当オブジェクトへの読取/作成（例: `roles/storage.objectViewer` + `roles/storage.objectCreator`）。運用上の都合であれば `roles/storage.objectAdmin` でも可。
     - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
     - `REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC

--- a/functions/README.md
+++ b/functions/README.md
@@ -135,14 +135,16 @@ The Cloud Functions in this project handle various backend operations:
 - **App Store Review Notifier (`appStoreReviewNotifier`)** - App Storeの最新レビューをJSONフィードから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
     - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
-    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。
+    - `APPSTORE_REVIEW_RSS_URL`: App StoreレビューのJSONフィードURL（任意）。未設定時は既定のJSONエンドポイント（日本向け `/jp/`）。国・言語を変更したい場合はこのURLの地域コードを差し替えてください。必ず末尾が `/json` のURLを指定してください（`/xml` は非対応）。
       - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
-      - 互換性のため環境変数名は`...RSS_URL`のままですが、JSON URLを指定してください
-    - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。バケットには少なくとも該当オブジェクトへの書込権限（例: `roles/storage.objectAdmin`）が必要です。
+      - 互換性のため環境変数名は `...RSS_URL` のままですが、実体は JSON フィードです。将来的に `APPSTORE_REVIEW_FEED_URL` への改名を検討し、従来名は後方互換として読み替え予定です。
+    - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。必要最小の権限は該当オブジェクトへの読取/作成（例: `roles/storage.objectViewer` + `roles/storage.objectCreator`）。運用上の都合であれば `roles/storage.objectAdmin` でも可。
     - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
+    - `REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得内容などの詳細ログを出力
-    - `REVIEWS_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_FORCE_LATEST_COUNT`: 整数N。既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
 
 - **Google Play Review Notifier (`googlePlayReviewNotifier`)** - Google Playの最新レビューをAndroid Publisher APIから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
@@ -150,10 +152,11 @@ The Cloud Functions in this project handle various backend operations:
     - `GOOGLE_PLAY_PACKAGE_NAME`: パッケージ名（既定: `me.tinykitten.trainlcd`）
     - `GOOGLEPLAY_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/googleplay-reviews.json`）
     - `PLAY_REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
+    - `PLAY_REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC
   - 認証: Cloud Functionsのサービスアカウントに「Android Publisher API」へのアクセス権を付与し、ADC（Application Default Credentials）で認証します。
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得/ページング/保存の詳細ログを出力
-    - `REVIEWS_FORCE_LATEST_COUNT=1`: 既読に関わらず最新N件を強制送信（検証用途）
+    - `REVIEWS_FORCE_LATEST_COUNT`: 整数N。既読に関わらず最新N件を強制送信（検証用途）
     - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
 
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -139,24 +139,26 @@ The Cloud Functions in this project handle various backend operations:
       - 既定値: `https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json`
     - `APPSTORE_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/appstore-reviews.json`）[本番必須]。必要最小の権限は該当オブジェクトへの読取/作成（例: `roles/storage.objectViewer` + `roles/storage.objectCreator`）。運用上の都合であれば `roles/storage.objectAdmin` でも可。
     - `REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
-    - `REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC
+    - `REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC（注: `every N minutes` のような相対指定ではタイムゾーンの影響は事実上ありません。特定時刻運用時は cron 式を推奨）
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得内容などの詳細ログを出力
     - `REVIEWS_FORCE_LATEST_COUNT`: 整数N。既読に関わらず最新N件を強制送信（検証用途）
     - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
+    - 注意: 大量送信時は Discord Webhook のレート制限（HTTP 429）が発生し得ます。必要に応じてバッチ処理や送信間隔の調整を行ってください。
 
 - **Google Play Review Notifier (`googlePlayReviewNotifier`)** - Google Playの最新レビューをAndroid Publisher APIから取得し、Discordへ通知します（既定: 毎時）。
   - 環境変数:
     - `DISCORD_REVIEW_WEBHOOK_URL`: DiscordのWebhook URL（必須）
     - `GOOGLE_PLAY_PACKAGE_NAME`: パッケージ名（既定: `me.tinykitten.trainlcd`）
-    - `GOOGLEPLAY_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/googleplay-reviews.json`）
+    - `GOOGLEPLAY_REVIEW_STATE_GCS_URI`: 既読状態を保存するGCSパス（例: `gs://<bucket>/states/googleplay-reviews.json`）。必要最小の権限は該当オブジェクトへの読取/作成（例: `roles/storage.objectViewer` + `roles/storage.objectCreator`）。運用都合であれば `roles/storage.objectAdmin` でも可。
     - `PLAY_REVIEWS_CRON_SCHEDULE`: スケジュール（例: `every 60 minutes`）。未設定時は毎時実行
-    - `PLAY_REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC
+    - `PLAY_REVIEWS_TIMEZONE`: タイムゾーン（例: `Asia/Tokyo`）。未設定時はUTC（注: `every N minutes` のような相対指定ではタイムゾーンの影響は事実上ありません。特定時刻運用時は cron 式を推奨）
   - 認証: Cloud Functionsのサービスアカウントに「Android Publisher API」へのアクセス権を付与し、ADC（Application Default Credentials）で認証します。
   - デバッグ用（任意）:
     - `REVIEWS_DEBUG=1`: 取得/ページング/保存の詳細ログを出力
     - `REVIEWS_FORCE_LATEST_COUNT`: 整数N。既読に関わらず最新N件を強制送信（検証用途）
     - `REVIEWS_DRY_RUN=1`: Discord送信をスキップし、送信予定の項目をログ表示
+    - 注意: 大量送信時は Discord Webhook のレート制限（HTTP 429）が発生し得ます。必要に応じてバッチ処理や送信間隔の調整を行ってください。
 
 
 ### Firestore Triggers

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,6 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   testEnvironment: "node",
+  watchman: false,
+  testPathIgnorePatterns: ["/node_modules/", "/lib/"],
   transform: {
     "^.+.tsx?$": ["ts-jest",{}],
   },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,9 +8,11 @@
       "dependencies": {
         "@google-cloud/pubsub": "^4.3.3",
         "@google-cloud/vertexai": "^1.10.0",
+        "@googleapis/androidpublisher": "^15.0.0",
         "dayjs": "^1.11.9",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^6.3.1"
+        "firebase-functions": "^6.3.1",
+        "google-auth-library": "^9.14.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -936,6 +938,18 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@googleapis/androidpublisher": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/androidpublisher/-/androidpublisher-15.1.0.tgz",
+      "integrity": "sha512-ZoIkjFt7RROsuWwxd/HfUGWb7JsP+8c5qh05JZEf2F8+OIoJsnVXxCMuybOPpILoDmWdGr8LEO571OUe4l2JGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2855,22 +2869,19 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3264,9 +3275,10 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.7.0.tgz",
-      "integrity": "sha512-I/AvzBiUXDzLOy4iIZ2W+Zq33W4lcukQv1nl7C8WUA6SQwyQwUwu3waNmWNAvzds//FG8SZ+DnKnW/2k6mQS8A==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -3299,6 +3311,23 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/gopd": {
@@ -5571,9 +5600,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
       "optional": true
     },
     "node_modules/stubs": {
@@ -5847,6 +5883,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,10 +4,12 @@
     "test": "jest",
     "lint": "biome check ./src",
     "format": "biome format ./src --write",
-    "build": "tsc",
-    "build:watch": "tsc --watch",
+    "build": "tsc -p tsconfig.build.json",
+    "build:watch": "tsc -p tsconfig.build.json --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
+    "shell:dev": "npm run build && firebase functions:shell --project trainlcd-dev",
+    "shell:prod": "npm run build && firebase functions:shell --project trainlcd-ea91e",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
@@ -19,6 +21,8 @@
   "dependencies": {
     "@google-cloud/pubsub": "^4.3.3",
     "@google-cloud/vertexai": "^1.10.0",
+    "@googleapis/androidpublisher": "^15.0.0",
+    "google-auth-library": "^9.14.2",
     "dayjs": "^1.11.9",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^6.3.1"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,8 +2,12 @@ import { enqueueFeedback } from './funcs/enqueueFeedback';
 import { tts } from './funcs/tts';
 import { ttsCachePubSub } from './funcs/ttsCachePubSub';
 import { feedbackTriageWorker } from './workers/feedback';
+import { appStoreReviewNotifier } from './workers/appStoreReviewNotifier';
+import { googlePlayReviewNotifier } from './workers/googlePlayReviews';
 
 exports.tts = tts;
 exports.ttsCachePubSub = ttsCachePubSub;
 exports.postFeedback = enqueueFeedback;
 exports.feedbackTriageWorker = feedbackTriageWorker;
+exports.appStoreReviewNotifier = appStoreReviewNotifier;
+exports.googlePlayReviewNotifier = googlePlayReviewNotifier;

--- a/functions/src/workers/__tests__/appStoreReviewNotifier.test.ts
+++ b/functions/src/workers/__tests__/appStoreReviewNotifier.test.ts
@@ -45,7 +45,7 @@ describe('appStoreReviewNotifier (JSON only)', () => {
     prevEnv = { ...process.env };
     process.env.REVIEWS_DEBUG = '1';
     process.env.DISCORD_REVIEW_WEBHOOK_URL = 'https://discord.test/webhook';
-    process.env.APPSTORE_REVIEW_RSS_URL = 'https://example.test/rss.json';
+    process.env.APPSTORE_REVIEW_FEED_URL = 'https://example.test/rss.json';
     process.env.APPSTORE_REVIEW_STATE_GCS_URI = 'gs://test-bucket/states/appstore.json';
   });
   let prevEnv: NodeJS.ProcessEnv;

--- a/functions/src/workers/__tests__/appStoreReviewNotifier.test.ts
+++ b/functions/src/workers/__tests__/appStoreReviewNotifier.test.ts
@@ -1,0 +1,129 @@
+// --- Mocks ---
+const gcsStore = new Map<string, string>();
+
+jest.mock('@google-cloud/storage', () => {
+  const store = gcsStore;
+  class File {
+    private key: string;
+    constructor(bucketName: string, fileName: string) {
+      this.key = `${bucketName}/${fileName}`;
+    }
+    async download(): Promise<[Buffer]> {
+      const v = store.get(this.key) ?? '';
+      return [Buffer.from(v)];
+    }
+    async save(data: string | Buffer) {
+      store.set(this.key, typeof data === 'string' ? data : data.toString('utf8'));
+    }
+  }
+  class Bucket {
+    constructor(private name: string) {}
+    file(fileName: string) {
+      return new File(this.name, fileName);
+    }
+  }
+  return {
+    Storage: class Storage {
+      bucket(name: string) {
+        return new Bucket(name);
+      }
+    },
+    __mockGcsStore: store,
+  };
+});
+
+// Global fetch mock (JSON feed and Discord)
+const fetchMock = jest.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+describe('appStoreReviewNotifier (JSON only)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    gcsStore.clear();
+    fetchMock.mockReset();
+    process.env.REVIEWS_DEBUG = '1';
+    process.env.DISCORD_REVIEW_WEBHOOK_URL = 'https://discord.test/webhook';
+    process.env.APPSTORE_REVIEW_RSS_URL = 'https://example.test/rss.json';
+    process.env.APPSTORE_REVIEW_STATE_GCS_URI = 'gs://test-bucket/states/appstore.json';
+  });
+
+  test('新着レビューのみ通知し、stateを更新する', async () => {
+    const feedJson = JSON.stringify({
+      feed: {
+        entry: [
+          {
+            id: { label: 'r1' },
+            updated: { label: '2025-09-03T10:00:00Z' },
+            title: { label: 'Great' },
+            content: { label: 'Awesome' },
+            'im:rating': { label: '5' },
+            'im:version': { label: '1.0' },
+            author: { name: { label: 'A' } },
+            link: { attributes: { href: 'https://example.com/r1' } },
+          },
+          {
+            id: { label: 'r2' },
+            updated: { label: '2025-09-04T10:00:00Z' },
+            title: { label: 'Bug' },
+            content: { label: 'Bad' },
+            'im:rating': { label: '2' },
+            'im:version': { label: '1.1' },
+            author: { name: { label: 'B' } },
+            link: { attributes: { href: 'https://example.com/r2' } },
+          },
+        ],
+      },
+    });
+
+    // fetch mock: 1) JSON, 2..3) Discord posts
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, text: async () => feedJson })
+      .mockResolvedValue({ ok: true, text: async () => '' });
+
+    const { runAppStoreReviewJob } = await import('../appStoreReviewNotifier');
+    await runAppStoreReviewJob();
+
+    // 1 (JSON) + 2 (Discord) = 3 calls
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // state saved
+    const saved = gcsStore.get('test-bucket/states/appstore.json');
+    expect(saved).toBeTruthy();
+    const json = JSON.parse(String(saved));
+    expect(new Date(json.lastUpdated).toISOString()).toBe('2025-09-04T10:00:00.000Z');
+    expect(Array.isArray(json.lastIds)).toBe(true);
+  });
+
+  test('新着なしならDiscordへ送信しない', async () => {
+    // 事前にstateを最新にしておく
+    gcsStore.set(
+      'test-bucket/states/appstore.json',
+      JSON.stringify({ lastUpdated: '2025-09-05T00:00:00.000Z', lastIds: ['rX'] })
+    );
+
+    const feedJson = JSON.stringify({
+      feed: {
+        entry: [
+          {
+            id: { label: 'r1' },
+            updated: { label: '2025-09-03T10:00:00Z' },
+            title: { label: 'Old' },
+            content: { label: 'Old' },
+            'im:rating': { label: '5' },
+            author: { name: { label: 'A' } },
+          },
+        ],
+      },
+    });
+
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, text: async () => feedJson })
+      .mockResolvedValue({ ok: true, text: async () => '' });
+
+    const { runAppStoreReviewJob } = await import('../appStoreReviewNotifier');
+    await runAppStoreReviewJob();
+
+    // JSONの1回のみ
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/functions/src/workers/__tests__/googlePlayReviews.test.ts
+++ b/functions/src/workers/__tests__/googlePlayReviews.test.ts
@@ -1,0 +1,152 @@
+// Mocks
+const gcsStore = new Map<string, string>();
+
+jest.mock('@google-cloud/storage', () => {
+  const store = gcsStore;
+  class File {
+    private key: string;
+    constructor(bucketName: string, fileName: string) {
+      this.key = `${bucketName}/${fileName}`;
+    }
+    async download(): Promise<[Buffer]> {
+      const v = store.get(this.key) ?? '';
+      return [Buffer.from(v)];
+    }
+    async save(data: string | Buffer) {
+      store.set(this.key, typeof data === 'string' ? data : data.toString('utf8'));
+    }
+  }
+  class Bucket {
+    constructor(private name: string) {}
+    file(fileName: string) {
+      return new File(this.name, fileName);
+    }
+  }
+  return {
+    Storage: class Storage {
+      bucket(name: string) {
+        return new Bucket(name);
+      }
+    },
+    __mockGcsStore: store,
+  };
+});
+
+const listMock = jest.fn();
+jest.mock('@googleapis/androidpublisher', () => {
+  return {
+    androidpublisher: () => ({ reviews: { list: listMock } }),
+    androidpublisher_v3: {},
+    __listMock: listMock,
+  };
+});
+
+// Mock fetch (Discord)
+const fetchMock = jest.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+describe('googlePlayReviewNotifier', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    gcsStore.clear();
+    fetchMock.mockReset();
+    listMock.mockReset();
+    process.env.DISCORD_REVIEW_WEBHOOK_URL = 'https://discord.test/webhook';
+    process.env.GOOGLEPLAY_REVIEW_STATE_GCS_URI = 'gs://test-bucket/states/googleplay.json';
+    process.env.GOOGLE_PLAY_PACKAGE_NAME = 'me.tinykitten.trainlcd';
+  });
+
+  test('新着レビューのみ通知し、stateを更新する', async () => {
+    // APIレスポンス（2レビュー）
+    listMock.mockResolvedValueOnce({
+      data: {
+        reviews: [
+          {
+            reviewId: 'rev1',
+            authorName: 'U1',
+            comments: [
+              {
+                userComment: {
+                  text: 'Good',
+                  starRating: 5,
+                  appVersionName: '1.0',
+                  reviewerLanguage: 'ja',
+                  lastModified: { seconds: 1693821600, nanos: 0 }, // 2023-09-04T12:00:00Z
+                },
+              },
+            ],
+          },
+          {
+            reviewId: 'rev2',
+            authorName: 'U2',
+            comments: [
+              {
+                userComment: {
+                  text: 'Bad',
+                  starRating: 2,
+                  appVersionName: '1.1',
+                  reviewerLanguage: 'en',
+                  lastModified: { seconds: 1756960800, nanos: 0 }, // 2025-09-04T10:00:00Z
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' });
+
+    const { runGooglePlayReviewJob } = await import('../googlePlayReviews');
+    await runGooglePlayReviewJob();
+
+    // Discordへ2件
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // state saved
+    const saved = gcsStore.get('test-bucket/states/googleplay.json');
+    expect(saved).toBeTruthy();
+    const json = JSON.parse(String(saved));
+    expect(new Date(json.lastUpdated).toISOString()).toBe(new Date(1756960800 * 1000).toISOString());
+    expect(Array.isArray(json.lastIds)).toBe(true);
+  });
+
+  test('既読状態により重複を通知しない', async () => {
+    const latestIso = '2025-09-04T10:00:00.000Z';
+    const latestId = `rev2:${latestIso}`;
+    gcsStore.set(
+      'test-bucket/states/googleplay.json',
+      JSON.stringify({ lastUpdated: latestIso, lastIds: [latestId] })
+    );
+
+    listMock.mockResolvedValueOnce({
+      data: {
+        reviews: [
+          {
+            reviewId: 'rev2',
+            authorName: 'U2',
+            comments: [
+              {
+                userComment: {
+                  text: 'Bad',
+                  starRating: 2,
+                  appVersionName: '1.1',
+                  reviewerLanguage: 'en',
+                  lastModified: { seconds: 1756960800, nanos: 0 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' });
+
+    const { runGooglePlayReviewJob } = await import('../googlePlayReviews');
+    await runGooglePlayReviewJob();
+
+    // 既読のためDiscord送信なし
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/functions/src/workers/appStoreReviewNotifier.ts
+++ b/functions/src/workers/appStoreReviewNotifier.ts
@@ -1,0 +1,242 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { Storage } from '@google-cloud/storage';
+import dayjs from 'dayjs';
+import type { DiscordEmbed } from '../models/common';
+
+type AppStoreReview = {
+  id: string;
+  updated: string; // ISO8601
+  title: string;
+  content: string;
+  rating: number; // 1..5
+  version?: string;
+  author?: string;
+  url?: string;
+};
+
+type ReviewState = {
+  lastUpdated?: string | null;
+  lastIds?: string[]; // optional ring buffer of recent ids
+};
+
+const storage = new Storage();
+
+function parseGsUri(uri: string | undefined | null): { bucket: string; file: string } | null {
+  if (!uri) return null;
+  const m = uri.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  const [, bucket, file] = m;
+  return { bucket, file };
+}
+
+async function loadState(uri: string | undefined | null): Promise<ReviewState> {
+  const loc = parseGsUri(uri);
+  if (!loc) return {};
+  try {
+    const buf = await storage.bucket(loc.bucket).file(loc.file).download();
+    const json = JSON.parse(buf[0].toString('utf8')) as ReviewState;
+    return json ?? {};
+  } catch {
+    return {};
+  }
+}
+
+async function saveState(uri: string | undefined | null, state: ReviewState) {
+  const loc = parseGsUri(uri);
+  if (!loc) return;
+  await storage
+    .bucket(loc.bucket)
+    .file(loc.file)
+    .save(JSON.stringify(state), { contentType: 'application/json' });
+}
+
+
+type JsonObj = Record<string, unknown>;
+
+function deepGet(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object' && key in (acc as JsonObj)) {
+      return (acc as JsonObj)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+function labelOf(v: unknown, d = ''): string {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object' && 'label' in (v as JsonObj)) {
+    const lv = (v as JsonObj)['label'];
+    if (typeof lv === 'string') return lv;
+  }
+  return d;
+}
+
+function hrefOf(link: unknown): string | undefined {
+  if (Array.isArray(link)) {
+    for (const it of link) {
+      const href = deepGet(it, 'attributes.href');
+      if (typeof href === 'string') return href;
+    }
+  }
+  const single = deepGet(link, 'attributes.href');
+  return typeof single === 'string' ? single : undefined;
+}
+
+function parseAppStoreJson(jsonText: string): AppStoreReview[] {
+  try {
+    const data = JSON.parse(jsonText) as unknown;
+    const entryNode = deepGet(data, 'feed.entry');
+    const entries: unknown[] = Array.isArray(entryNode)
+      ? entryNode
+      : entryNode != null
+        ? [entryNode]
+        : [];
+
+    const reviews: AppStoreReview[] = [];
+    for (const e of entries) {
+      const id = labelOf(deepGet(e, 'id'));
+      const updated = labelOf(deepGet(e, 'updated'));
+      const title = labelOf(deepGet(e, 'title'));
+      const content = labelOf(deepGet(e, 'content'));
+      const ratingStr = labelOf(deepGet(e, 'im:rating'));
+      const version = labelOf(deepGet(e, 'im:version')) || undefined;
+      const author = labelOf(deepGet(e, 'author.name')) || labelOf(deepGet(e, 'author')) || undefined;
+      const url = hrefOf(deepGet(e, 'link')) || id;
+      if (!id || !updated) continue;
+      const rating = Number(ratingStr) || 0;
+      reviews.push({ id, updated, title, content, rating, version, author, url });
+    }
+    return reviews;
+  } catch {
+    return [];
+  }
+}
+
+// for unit testing
+export const __test_parseAppStoreJson = parseAppStoreJson;
+
+async function postToDiscord(webhookUrl: string, reviews: AppStoreReview[]) {
+  if (!reviews.length) return;
+  for (const r of reviews) {
+    const embeds: DiscordEmbed[] = [
+      {
+        fields: [
+          { name: 'プラットフォーム', value: 'App Store' },
+          { name: '評価', value: `${'★'.repeat(Math.max(1, r.rating))}${'☆'.repeat(Math.max(0, 5 - r.rating))} (${r.rating}/5)` },
+          { name: 'タイトル', value: r.title || '(タイトルなし)' },
+          { name: '本文', value: r.content || '(本文なし)' },
+          { name: 'バージョン', value: r.version || '不明' },
+          { name: '投稿者', value: r.author || '不明' },
+          { name: '投稿日', value: dayjs(r.updated).format('YYYY/MM/DD HH:mm:ss') },
+          { name: 'リンク', value: r.url || r.id },
+        ],
+      },
+    ];
+
+    const content = '**📝 App Storeに新しいレビューが投稿されました**';
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, embeds }),
+    });
+    if (!res.ok) {
+      const msg = await res.text().catch(() => '');
+      console.error('Discord Review webhook failed', res.status, msg);
+    }
+  }
+}
+
+export async function runAppStoreReviewJob() {
+  const debug = process.env.REVIEWS_DEBUG === '1';
+  const forceCount = Number(process.env.REVIEW_FORCE_LATEST_COUNT ?? 0);
+  const defaultUrl = 'https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json';
+  const appStoreUrl = process.env.APPSTORE_REVIEW_RSS_URL || defaultUrl;
+  const stateUri = process.env.APPSTORE_REVIEW_STATE_GCS_URI; // e.g. gs://<bucket>/states/appstore-reviews.json
+  const discordWebhook = process.env.DISCORD_REVIEW_WEBHOOK_URL;
+
+  if (!discordWebhook) {
+    throw new Error('process.env.DISCORD_REVIEW_WEBHOOK_URL is not set');
+  }
+
+  if (debug) {
+    console.log('[AppStoreJob] start', { hasStateUri: Boolean(stateUri), hasWebhook: Boolean(discordWebhook), appStoreUrl });
+  }
+
+  // 1) Load last state
+  const state = await loadState(stateUri);
+  const lastUpdated = state.lastUpdated ? dayjs(state.lastUpdated) : null;
+  const lastIds = new Set(state.lastIds ?? []);
+  if (debug) {
+    console.log('[AppStoreJob] loaded state', { lastUpdated: state.lastUpdated ?? null, lastIdsSize: lastIds.size });
+  }
+
+  // 2) JSONフィードを取得（UA付与）
+  const r = await fetch(appStoreUrl, {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36',
+      Accept: 'application/json',
+    },
+  });
+  if (!r.ok) throw new Error(`App Store Reviews fetch failed: ${r.status}`);
+  const t = await r.text();
+  if (debug) {
+    type MaybeHeaders = { get(name: string): string | null };
+    const ct = (r.headers as MaybeHeaders | undefined)?.get('content-type') ?? '';
+    console.log('[AppStoreJob] json fetched', { url: appStoreUrl, contentType: ct, preview: t.slice(0, 200).replace(/\s+/g, ' ') });
+  }
+  const items = parseAppStoreJson(t);
+  if (debug) console.log('[AppStoreJob] json parsed', { count: items.length });
+  if (debug) {
+    console.log('[AppStoreJob] parsed items', { count: items.length });
+  }
+
+  // 3) Filter new items by updated timestamp and id dedupe
+  const newcomers = items
+    .filter((r) => !lastUpdated || dayjs(r.updated).isAfter(lastUpdated))
+    .filter((r) => !lastIds.has(r.id))
+    // Oldest first to post in order
+    .sort((a, b) => dayjs(a.updated).valueOf() - dayjs(b.updated).valueOf());
+
+  let postTargets = newcomers;
+  if (forceCount > 0 && items.length > 0) {
+    postTargets = items
+      .slice() // copy
+      .sort((a, b) => dayjs(a.updated).valueOf() - dayjs(b.updated).valueOf())
+      .slice(-Math.max(1, forceCount));
+    if (debug) {
+      console.log('[AppStoreJob] force mode enabled', { forceCount, actual: postTargets.length });
+    }
+  }
+
+  if (debug) {
+    console.log('[AppStoreJob] newcomers', { count: newcomers.length });
+  }
+
+  // 4) Post to Discord
+  await postToDiscord(discordWebhook, postTargets);
+
+  // 5) Update state
+  if (items.length) {
+    const newest = items.reduce((p, c) => (dayjs(c.updated).isAfter(dayjs(p.updated)) ? c : p), items[0]);
+    const updatedIds = [
+      ...Array.from(new Set([...(state.lastIds ?? []).slice(-20), ...items.slice(0, 5).map((r) => r.id)])),
+    ].slice(-40);
+    await saveState(stateUri, { lastUpdated: newest.updated, lastIds: updatedIds });
+    if (debug) {
+      console.log('[AppStoreJob] state saved', { lastUpdated: newest.updated, lastIds: updatedIds.length });
+    }
+  }
+}
+
+export const appStoreReviewNotifier = onSchedule(
+  {
+    schedule: process.env.REVIEWS_CRON_SCHEDULE || 'every 60 minutes',
+    timeZone: 'Asia/Tokyo',
+    region: 'asia-northeast1',
+    maxInstances: 1,
+  },
+  async () => {
+    await runAppStoreReviewJob();
+  }
+);

--- a/functions/src/workers/appStoreReviewNotifier.ts
+++ b/functions/src/workers/appStoreReviewNotifier.ts
@@ -157,7 +157,7 @@ export async function runAppStoreReviewJob() {
   const dryRun = process.env.REVIEWS_DRY_RUN === '1';
   const forceCount = Number(process.env.REVIEWS_FORCE_LATEST_COUNT ?? 0);
   const defaultUrl = 'https://itunes.apple.com/jp/rss/customerreviews/page=1/id=1486355943/sortBy=mostRecent/json';
-  const appStoreUrl = process.env.APPSTORE_REVIEW_RSS_URL || defaultUrl;
+  const appStoreUrl = process.env.APPSTORE_REVIEW_FEED_URL || defaultUrl;
   const stateUri = process.env.APPSTORE_REVIEW_STATE_GCS_URI; // e.g. gs://<bucket>/states/appstore-reviews.json
   const discordWebhook = process.env.DISCORD_REVIEW_WEBHOOK_URL;
 

--- a/functions/src/workers/googlePlayReviews.ts
+++ b/functions/src/workers/googlePlayReviews.ts
@@ -1,0 +1,227 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { Storage } from '@google-cloud/storage';
+import { GoogleAuth } from 'google-auth-library';
+import { androidpublisher, androidpublisher_v3 } from '@googleapis/androidpublisher';
+import dayjs from 'dayjs';
+import type { DiscordEmbed } from '../models/common';
+
+type ReviewState = {
+  lastUpdated?: string | null;
+  lastIds?: string[];
+};
+
+type PlayReview = {
+  id: string; // reviewId + lastModified
+  reviewId: string;
+  updated: string; // ISO8601 string
+  content: string;
+  rating: number;
+  versionName?: string;
+  author?: string;
+  language?: string;
+};
+
+const storage = new Storage();
+
+function parseGsUri(uri: string | undefined | null): { bucket: string; file: string } | null {
+  if (!uri) return null;
+  const m = uri.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  const [, bucket, file] = m;
+  return { bucket, file };
+}
+
+async function loadState(uri: string | undefined | null): Promise<ReviewState> {
+  const loc = parseGsUri(uri);
+  if (!loc) return {};
+  try {
+    const buf = await storage.bucket(loc.bucket).file(loc.file).download();
+    return JSON.parse(buf[0].toString('utf8')) as ReviewState;
+  } catch {
+    return {};
+  }
+}
+
+async function saveState(uri: string | undefined | null, state: ReviewState) {
+  const loc = parseGsUri(uri);
+  if (!loc) return;
+  await storage
+    .bucket(loc.bucket)
+    .file(loc.file)
+    .save(JSON.stringify(state), { contentType: 'application/json' });
+}
+
+function tsToIso(ts?: androidpublisher_v3.Schema$Timestamp | null): string | null {
+  if (!ts) return null;
+  // googleapis の Timestamp は seconds が string のことが多い
+  // 型定義に合わせて安全に数値化する
+  const secondsRaw = (ts as { seconds?: string | number | null }).seconds;
+  const nanosRaw = (ts as { nanos?: number | string | null }).nanos;
+  const sec = typeof secondsRaw === 'string' ? Number(secondsRaw) : Number(secondsRaw ?? 0);
+  const nanosNum = typeof nanosRaw === 'string' ? Number(nanosRaw) : Number(nanosRaw ?? 0);
+  const ms = sec * 1000 + Math.round(nanosNum / 1e6);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function toPlayReviews(rs?: androidpublisher_v3.Schema$ReviewsListResponse | null): PlayReview[] {
+  const out: PlayReview[] = [];
+  const reviews = rs?.reviews ?? [];
+  for (const r of reviews) {
+    const reviewId = r.reviewId ?? '';
+    const author = r.authorName ?? undefined;
+    const comments = r.comments ?? [];
+    // もっとも新しいユーザーコメント（開発者返信ではない）を採用
+    const userComments = comments
+      .map((c) => c.userComment)
+      .filter((u): u is NonNullable<typeof u> => !!u);
+    if (!reviewId || userComments.length === 0) continue;
+    const latest = userComments.reduce((p, c) => {
+      const pMs = dayjs(tsToIso(p.lastModified)).valueOf();
+      const cMs = dayjs(tsToIso(c.lastModified)).valueOf();
+      return cMs > pMs ? c : p;
+    });
+    const updated = tsToIso(latest.lastModified);
+    if (!updated) continue;
+    const language = latest.reviewerLanguage ?? undefined;
+    const versionName = latest.appVersionName ?? undefined;
+    const rating = Number(latest.starRating ?? 0) || 0;
+    const content = String(latest.text ?? '').trim();
+    const id = `${reviewId}:${updated}`;
+    out.push({ id, reviewId, updated, content, rating, versionName, author, language });
+  }
+  return out;
+}
+
+async function postToDiscord(webhookUrl: string, items: PlayReview[], packageName: string) {
+  for (const r of items) {
+    const star = `${'★'.repeat(Math.max(1, Math.min(5, r.rating)))}` +
+      `${'☆'.repeat(Math.max(0, 5 - Math.max(1, Math.min(5, r.rating))))}`;
+    const embeds: DiscordEmbed[] = [
+      {
+        fields: [
+          { name: 'プラットフォーム', value: 'Google Play' },
+          { name: '評価', value: `${star} (${r.rating}/5)` },
+          { name: '本文', value: r.content || '(本文なし)' },
+          { name: 'バージョン', value: r.versionName || '不明' },
+          { name: '言語', value: r.language || '不明' },
+          { name: '投稿者', value: r.author || '不明' },
+          { name: '投稿日', value: dayjs(r.updated).format('YYYY/MM/DD HH:mm:ss') },
+          { name: 'レビューID', value: r.reviewId },
+          { name: 'アプリページ', value: `https://play.google.com/store/apps/details?id=${packageName}` },
+        ],
+      },
+    ];
+
+    const content = '**📝 Google Playに新しいレビューが投稿されました**';
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, embeds }),
+    });
+    if (!res.ok) {
+      const msg = await res.text().catch(() => '');
+      console.error('Discord Review webhook failed (Play)', res.status, msg);
+    }
+  }
+}
+
+export async function runGooglePlayReviewJob() {
+  const debug = process.env.REVIEWS_DEBUG === '1';
+  const dryRun = process.env.REVIEWS_DRY_RUN === '1';
+  const forceCount = Number(process.env.REVIEW_FORCE_LATEST_COUNT ?? 0);
+  const packageName = process.env.GOOGLE_PLAY_PACKAGE_NAME || 'me.tinykitten.trainlcd';
+  const discordWebhook = process.env.DISCORD_REVIEW_WEBHOOK_URL;
+  const stateUri = process.env.GOOGLEPLAY_REVIEW_STATE_GCS_URI; // gs://<bucket>/states/googleplay-reviews.json
+  if (!discordWebhook) {
+    throw new Error('process.env.DISCORD_REVIEW_WEBHOOK_URL is not set');
+  }
+
+  const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/androidpublisher'] });
+  const api = androidpublisher({ version: 'v3', auth });
+
+  // 1) 既存状態の取得
+  const state = await loadState(stateUri);
+  const lastUpdated = state.lastUpdated ? dayjs(state.lastUpdated) : null;
+  const lastIds = new Set(state.lastIds ?? []);
+  if (debug) {
+    console.log('[PlayJob] start', { packageName, hasStateUri: Boolean(stateUri), lastUpdated: state.lastUpdated ?? null, lastIdsSize: lastIds.size });
+  }
+
+  // 2) レビューの取得（ページング）
+  const all: PlayReview[] = [];
+  let token: string | undefined = undefined;
+  for (let page = 0; page < 10; page++) {
+    try {
+      const response = (await api.reviews.list({ packageName, maxResults: 100, token })) as unknown as {
+        data: androidpublisher_v3.Schema$ReviewsListResponse;
+      };
+      const data = response.data;
+      const items = toPlayReviews(data);
+      all.push(...items);
+      if (debug) {
+        const rawCount = Array.isArray(data?.reviews) ? data.reviews.length : 0;
+        const hasNext = Boolean(data?.tokenPagination?.nextPageToken);
+        console.log('[PlayJob] page', { page, rawCount, parsed: items.length, hasNext });
+      }
+      token = data?.tokenPagination?.nextPageToken ?? undefined; // next page token
+      if (!token) break;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error('[PlayJob] reviews.list failed', msg);
+      throw e;
+    }
+  }
+  if (debug) console.log('[PlayJob] fetched total', { parsed: all.length });
+
+  // 3) フィルタ（新着かつ未処理）
+  const newcomers = all
+    .filter((r) => !lastUpdated || dayjs(r.updated).isAfter(lastUpdated))
+    .filter((r) => !lastIds.has(r.id))
+    .sort((a, b) => dayjs(a.updated).valueOf() - dayjs(b.updated).valueOf());
+
+  let postTargets = newcomers;
+  if (forceCount > 0 && all.length > 0) {
+    postTargets = all
+      .slice()
+      .sort((a, b) => dayjs(a.updated).valueOf() - dayjs(b.updated).valueOf())
+      .slice(-Math.max(1, forceCount));
+    if (debug) {
+      console.log('[PlayJob] force mode enabled', { forceCount, actual: postTargets.length });
+    }
+  }
+  if (debug) {
+    console.log('[PlayJob] newcomers', { count: newcomers.length, all: all.length });
+  }
+
+  // 4) Discord通知
+  if (dryRun) {
+    console.log('[PlayJob] DRY_RUN on. Will post (skipped):', postTargets.map((r) => ({ id: r.id, rating: r.rating, updated: r.updated })).slice(0, 5));
+  } else {
+    await postToDiscord(discordWebhook, postTargets, packageName);
+  }
+
+  // 5) 状態更新
+  if (all.length) {
+    const newest = all.reduce((p, c) => (dayjs(c.updated).isAfter(dayjs(p.updated)) ? c : p), all[0]);
+    const updatedIds = [
+      ...Array.from(new Set([...(state.lastIds ?? []).slice(-20), ...all.slice(0, 20).map((r) => r.id)])),
+    ].slice(-60);
+    await saveState(stateUri, { lastUpdated: newest.updated, lastIds: updatedIds });
+    if (debug) {
+      console.log('[PlayJob] state saved', { lastUpdated: newest.updated, lastIds: updatedIds.length });
+    }
+  }
+}
+
+export const googlePlayReviewNotifier = onSchedule(
+  {
+    schedule: process.env.PLAY_REVIEWS_CRON_SCHEDULE || 'every 60 minutes',
+    timeZone: 'Asia/Tokyo',
+    region: 'asia-northeast1',
+    maxInstances: 1,
+  },
+  async () => {
+    await runGooglePlayReviewJob();
+  }
+);

--- a/functions/src/workers/googlePlayReviews.ts
+++ b/functions/src/workers/googlePlayReviews.ts
@@ -219,7 +219,7 @@ export async function runGooglePlayReviewJob() {
 export const googlePlayReviewNotifier = onSchedule(
   {
     schedule: process.env.PLAY_REVIEWS_CRON_SCHEDULE || 'every 60 minutes',
-    timeZone: 'Asia/Tokyo',
+    timeZone: process.env.PLAY_REVIEWS_TIMEZONE || 'UTC',
     region: 'asia-northeast1',
     maxInstances: 1,
   },

--- a/functions/src/workers/googlePlayReviews.ts
+++ b/functions/src/workers/googlePlayReviews.ts
@@ -95,14 +95,16 @@ function toPlayReviews(rs?: androidpublisher_v3.Schema$ReviewsListResponse | nul
 
 async function postToDiscord(webhookUrl: string, items: PlayReview[], packageName: string) {
   for (const r of items) {
-    const star = `${'★'.repeat(Math.max(1, Math.min(5, r.rating)))}` +
-      `${'☆'.repeat(Math.max(0, 5 - Math.max(1, Math.min(5, r.rating))))}`;
+    const r5 = Math.max(0, Math.min(5, Math.floor(r.rating)));
+    const stars = '★'.repeat(r5) + '☆'.repeat(5 - r5);
+    const ratingText = r5 === 0 ? '評価なし (0/5)' : `${stars} (${r5}/5)`;
+    const contentVal = (r.content || '(本文なし)').slice(0, 1000);
     const embeds: DiscordEmbed[] = [
       {
         fields: [
           { name: 'プラットフォーム', value: 'Google Play' },
-          { name: '評価', value: `${star} (${r.rating}/5)` },
-          { name: '本文', value: r.content || '(本文なし)' },
+          { name: '評価', value: ratingText },
+          { name: '本文', value: contentVal },
           { name: 'バージョン', value: r.versionName || '不明' },
           { name: '言語', value: r.language || '不明' },
           { name: '投稿者', value: r.author || '不明' },
@@ -129,7 +131,7 @@ async function postToDiscord(webhookUrl: string, items: PlayReview[], packageNam
 export async function runGooglePlayReviewJob() {
   const debug = process.env.REVIEWS_DEBUG === '1';
   const dryRun = process.env.REVIEWS_DRY_RUN === '1';
-  const forceCount = Number(process.env.REVIEW_FORCE_LATEST_COUNT ?? 0);
+  const forceCount = Number(process.env.REVIEWS_FORCE_LATEST_COUNT ?? 0);
   const packageName = process.env.GOOGLE_PLAY_PACKAGE_NAME || 'me.tinykitten.trainlcd';
   const discordWebhook = process.env.DISCORD_REVIEW_WEBHOOK_URL;
   const stateUri = process.env.GOOGLEPLAY_REVIEW_STATE_GCS_URI; // gs://<bucket>/states/googleplay-reviews.json

--- a/functions/tsconfig.build.json
+++ b/functions/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/__tests__/**"
+  ]
+}
+


### PR DESCRIPTION
close #1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - App Store / Google Play の定期レビュー検出とDiscord通知を追加（重複防止、並び順制御、強制取得/ドライラン/デバッグ対応、スケジュール化）。
- **ドキュメント**
  - 定期ジョブのREADME追記：各ジョブの環境変数、既定値、デバッグ/認証手順、フィード変数名の更新。
- **テスト**
  - 各ワーカーの新着検出・通知・状態更新を検証するユニットテストを追加。
- **チョア/ビルド**
  - ビルド設定・スクリプト整備、Jest設定調整、Play API用依存の追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->