### PR TITLE
英語環境の不備修正

### DIFF
--- a/ios/Localizable/en.lproj/Localizable.strings
+++ b/ios/Localizable/en.lproj/Localizable.strings
@@ -13,7 +13,7 @@
 "next" = "Next";
 "nextLast" = "Next last stop";
 "nowStoppingAt" = "Now stopping at";
-"stop" = "Stopping at";
+"stop" = "Stop";
 "nextLast" = "Next last stop";
 "passingStation" = "Passing %@";
 "boundStation" = "Bound for %@";

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -22,11 +22,10 @@ func getRunningStateText(
   }
 
   if stopped {
-    if isDynamicIsland{
+    if isDynamicIsland {
       return String(localized: "stop")
-    } else {
-      return String(localized: "nowStoppingAt")
     }
+    return String(localized: "nowStoppingAt")
   }
 
   if approaching {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -12,7 +12,7 @@ import WidgetKit
 // NOTE: 通過中の値を追加するとなぜかライブアクティビティが死ぬので含めていない
 // ちなみにライブアクティビティにスピナーが表示され固まる
 func getRunningStateText(
-  approaching: Bool, stopped: Bool, isNextLastStop: Bool
+  approaching: Bool, stopped: Bool, isNextLastStop: Bool, isDynamicIsland: Bool = false
 ) -> String {
   if !stopped && !approaching {
     if isNextLastStop {
@@ -22,7 +22,11 @@ func getRunningStateText(
   }
 
   if stopped {
-    return String(localized: "stop")
+    if isDynamicIsland{
+      return String(localized: "stop")
+    } else {
+      return String(localized: "nowStoppingAt")
+    }
   }
 
   if approaching {
@@ -90,7 +94,8 @@ struct RideSessionWidget: Widget {
                 getRunningStateText(
                   approaching: context.state.approaching,
                   stopped: context.state.stopped,
-                  isNextLastStop: context.state.isNextLastStop
+                  isNextLastStop: context.state.isNextLastStop,
+                  isDynamicIsland: true
                 )
               )
               .bold()
@@ -112,7 +117,8 @@ struct RideSessionWidget: Widget {
                 getRunningStateText(
                   approaching: context.state.approaching,
                   stopped: context.state.stopped,
-                  isNextLastStop: context.state.isNextLastStop
+                  isNextLastStop: context.state.isNextLastStop,
+                  isDynamicIsland: true
                 )
               )
               .bold()
@@ -144,7 +150,8 @@ struct RideSessionWidget: Widget {
               getRunningStateText(
                 approaching: context.state.approaching,
                 stopped: context.state.stopped,
-                isNextLastStop: context.state.isNextLastStop
+                isNextLastStop: context.state.isNextLastStop,
+                isDynamicIsland: true
               )
             )
             .font(.caption)

--- a/src/utils/station.ts
+++ b/src/utils/station.ts
@@ -1,11 +1,12 @@
 import type { Line, Station } from '~/gen/proto/stationapi_pb';
+import { isJapanese } from '~/translation';
 
 export const getStationPrimaryCode = (
   s: Station | null | undefined
 ): string | null => s?.stationNumbers?.[0]?.stationNumber ?? null;
 
 export const getStationName = (s: Station | null | undefined): string | null =>
-  s?.name ?? null;
+  (isJapanese ? s?.name : s?.nameRoman) ?? null;
 
 export const getStationLineId = (
   s: Station | null | undefined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 端末の言語設定に応じて駅名表示を自動切替（日本語は日本語名、非日本語はローマ字）し、視認性を向上しました。

- 改善
  - Dynamic Islandおよびロック画面での走行状態表現をコンテキストに応じて切替え、表示がより適切かつ簡潔になりました。

- スタイル
  - 表示文言を「Stopping at」から「Stop」に短縮・統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->