### PR TITLE
Androidカナリア版はcanaryブランチから出す

### DIFF
--- a/.github/workflows/deploy_android_canary.yml
+++ b/.github/workflows/deploy_android_canary.yml
@@ -3,7 +3,7 @@ name: Deploy Android Canary App
 on:
   push:
     branches:
-      - dev
+      - canary
     paths:
       - "android/app/build.gradle"
       - "android/wearable/build.gradle.kts"


### PR DESCRIPTION
close #4501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Androidカナリー版の自動デプロイ対象ブランチをdevからcanaryへ変更。
  * パス条件やデプロイ手順は従来どおりで、運用フローに合わせて配信タイミングが調整されます。
  * アプリの機能やUIに変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->