### PR TITLE
WatchAppからRCTNewArchEnabledを削除

### DIFF
--- a/ios/WatchApp/Info.plist
+++ b/ios/WatchApp/Info.plist
@@ -20,8 +20,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/WatchApp/Schemes/Dev/Info.plist
+++ b/ios/WatchApp/Schemes/Dev/Info.plist
@@ -20,8 +20,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/WatchApp/Schemes/Prod/Info.plist
+++ b/ios/WatchApp/Schemes/Prod/Info.plist
@@ -20,8 +20,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - Watch Appの設定を更新し、新アーキテクチャ関連フラグ項目を本体およびDev/ProdスキームのInfo.plistから削除。
  - ユーザー向けの挙動や機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->