### PR TITLE
WatchAppからRCTNewArchEnabledを削除

### DIFF
--- a/ios/WatchApp Extension/Schemes/Dev/Info.plist
+++ b/ios/WatchApp Extension/Schemes/Dev/Info.plist
@@ -32,7 +32,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/WatchApp Extension/Schemes/Prod/Info.plist
+++ b/ios/WatchApp Extension/Schemes/Prod/Info.plist
@@ -32,7 +32,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/WatchWidget/Schemes/Dev/Info.plist
+++ b/ios/WatchWidget/Schemes/Dev/Info.plist
@@ -9,7 +9,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/WatchWidget/Schemes/Prod/Info.plist
+++ b/ios/WatchWidget/Schemes/Prod/Info.plist
@@ -9,7 +9,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - WatchアプリおよびウィジェットのDev/Prodスキーム設定を整理・統一し、ビルドの一貫性と安定性を向上。
  - 不要なフラグを削除して設定を簡潔化。ユーザー向けの動作や UI への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->