### PR TITLE
RCTNewArchEnabled削除

### DIFF
--- a/ios/CanaryAppClip/Info.plist
+++ b/ios/CanaryAppClip/Info.plist
@@ -33,8 +33,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FrutigerNeueLTPro-Bold.ttf</string>

--- a/ios/ProdAppClip/Info.plist
+++ b/ios/ProdAppClip/Info.plist
@@ -33,8 +33,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FrutigerNeueLTPro-Bold.ttf</string>

--- a/ios/RideSessionActivity/Schemes/Dev/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Dev/Info.plist
@@ -7,7 +7,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/RideSessionActivity/Schemes/Prod/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Prod/Info.plist
@@ -7,7 +7,5 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -70,8 +70,6 @@
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
 	<true/>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FrutigerNeueLTPro-Bold.ttf</string>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -62,8 +62,6 @@
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
 	<true/>
-	<key>RCTNewArchEnabled</key>
-	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FrutigerNeueLTPro-Bold.ttf</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - iOS の複数ターゲットで内部設定を整理し、旧/新アーキテクチャ関連フラグを無効化。
  - App Clip、ウィジェット、拡張機能における実行時挙動の一貫性と互換性を改善。
  - 将来のビルド安定性と保守性を向上。
  - ユーザー影響: 機能変更はありませんが、全体の安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->