### PR TITLE
プリセット機能のバグを修正と仕様変更

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -136,16 +136,9 @@ export const SelectBoundModal: React.FC<Props> = ({
     const route = findSavedRoute({
       lineId: line.id ?? 0,
       trainTypeId: trainType?.groupId ?? null,
-      destinationStationId: pendingWantedDestination?.id ?? null,
     });
     setSavedRoute(route ?? null);
-  }, [
-    findSavedRoute,
-    line,
-    trainType?.groupId,
-    pendingWantedDestination?.id,
-    isRoutesDBInitialized,
-  ]);
+  }, [findSavedRoute, line, trainType?.groupId, isRoutesDBInitialized]);
 
   const currentIndex = stations.findIndex(
     (s) => s.groupId === station?.groupId
@@ -397,7 +390,6 @@ export const SelectBoundModal: React.FC<Props> = ({
           : `${lineName} ${trainTypeName} ${edgeStationNames}`.trim(),
         lineId: line.id ?? 0,
         trainTypeId: trainType?.groupId,
-        destinationStationId: pendingWantedDestination?.id ?? null,
         createdAt: new Date(),
       };
       setSavedRoute(await saveCurrentRoute(newRoute));
@@ -421,7 +413,6 @@ export const SelectBoundModal: React.FC<Props> = ({
         : `${lineName} Local ${edgeStationNames}${destinationName ? ` for ${destinationName}` : ''}`.trim(),
       lineId: line.id ?? 0,
       trainTypeId: null,
-      destinationStationId: pendingWantedDestination?.id ?? null,
       createdAt: new Date(),
     };
 

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -250,10 +250,9 @@ describe('useSavedRoutes', () => {
       );
 
       await waitFor(() => expect(result.current.routes.length).toBe(2));
-      expect(result.current.routes.map((route: SavedRoute) => route.id)).toEqual([
-        saved2Defined.id,
-        saved1Defined.id,
-      ]);
+      expect(
+        result.current.routes.map((route: SavedRoute) => route.id)
+      ).toEqual([saved2Defined.id, saved1Defined.id]);
     });
 
     it('remove: 指定 ID を削除し routes からも取り除く', async () => {

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
-import type { ReactNode } from 'react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
+import type { ReactNode } from 'react';
 import type {
   SavedRoute,
   SavedRouteWithoutTrainTypeInput,

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -209,7 +209,10 @@ describe('useSavedRoutes', () => {
       });
 
       expect(saved1).toBeDefined();
-      const saved1Defined = saved1!;
+      if (!saved1) {
+        throw new Error('save should return route with train type');
+      }
+      const saved1Defined: SavedRoute = saved1;
       expect(saved1Defined.id).toMatch(
         /^550e8400-e29b-41d4-a716-4466554400001$/
       );
@@ -234,7 +237,10 @@ describe('useSavedRoutes', () => {
         saved2 = await result.current.save(withoutType);
       });
       expect(saved2).toBeDefined();
-      const saved2Defined = saved2!;
+      if (!saved2) {
+        throw new Error('save should return route without train type');
+      }
+      const saved2Defined: SavedRoute = saved2;
       expect(saved2Defined.hasTrainType).toBe(false);
       expect(saved2Defined.trainTypeId).toBeNull();
       expect(mockDb.runAsync).toHaveBeenCalledWith(
@@ -273,7 +279,10 @@ describe('useSavedRoutes', () => {
         saved = await result.current.save(withType);
       });
       expect(saved).toBeDefined();
-      const savedDefined = saved!;
+      if (!saved) {
+        throw new Error('save should return route before removing');
+      }
+      const savedDefined: SavedRoute = saved;
       await waitFor(() => expect(result.current.routes.length).toBe(1));
 
       await act(async () => {
@@ -327,7 +336,7 @@ describe('useSavedRoutes', () => {
       );
       expect(
         result.current.find({
-          lineId: null,
+          lineId: withTrainType.lineId,
           trainTypeId: withTrainType.trainTypeId,
         })
       ).toBe(withTrainType);

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -203,48 +203,56 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      let saved1: SavedRoute;
+      let saved1: SavedRoute | undefined;
       await act(async () => {
         saved1 = await result.current.save(withType);
       });
 
-      expect(saved1.id).toMatch(/^550e8400-e29b-41d4-a716-4466554400001$/);
+      expect(saved1).toBeDefined();
+      const saved1Defined = saved1!;
+      expect(saved1Defined.id).toMatch(
+        /^550e8400-e29b-41d4-a716-4466554400001$/
+      );
       expect(mockDb.runAsync).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO saved_routes'),
         [
-          saved1.id,
+          saved1Defined.id,
           withType.name,
           withType.lineId,
           withType.trainTypeId,
           1,
-          saved1.createdAt.toISOString(),
+          saved1Defined.createdAt.toISOString(),
         ]
       );
 
-      await waitFor(() => expect(result.current.routes[0]?.id).toBe(saved1.id));
+      await waitFor(() =>
+        expect(result.current.routes[0]?.id).toBe(saved1Defined.id)
+      );
 
-      let saved2: SavedRoute;
+      let saved2: SavedRoute | undefined;
       await act(async () => {
         saved2 = await result.current.save(withoutType);
       });
-      expect(saved2.hasTrainType).toBe(false);
-      expect(saved2.trainTypeId).toBeNull();
+      expect(saved2).toBeDefined();
+      const saved2Defined = saved2!;
+      expect(saved2Defined.hasTrainType).toBe(false);
+      expect(saved2Defined.trainTypeId).toBeNull();
       expect(mockDb.runAsync).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO saved_routes'),
         expect.arrayContaining([
-          saved2.id,
+          saved2Defined.id,
           withoutType.name,
           withoutType.lineId,
           null,
           0,
-          saved2.createdAt.toISOString(),
+          saved2Defined.createdAt.toISOString(),
         ])
       );
 
       await waitFor(() => expect(result.current.routes.length).toBe(2));
-      expect(result.current.routes.map((route) => route.id)).toEqual([
-        saved2.id,
-        saved1.id,
+      expect(result.current.routes.map((route: SavedRoute) => route.id)).toEqual([
+        saved2Defined.id,
+        saved1Defined.id,
       ]);
     });
 
@@ -261,18 +269,20 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      let saved: SavedRoute;
+      let saved: SavedRoute | undefined;
       await act(async () => {
         saved = await result.current.save(withType);
       });
+      expect(saved).toBeDefined();
+      const savedDefined = saved!;
       await waitFor(() => expect(result.current.routes.length).toBe(1));
 
       await act(async () => {
-        await result.current.remove(saved.id);
+        await result.current.remove(savedDefined.id);
       });
       expect(mockDb.runAsync).toHaveBeenCalledWith(
         'DELETE FROM saved_routes WHERE id = ?',
-        [saved.id]
+        [savedDefined.id]
       );
       await waitFor(() => expect(result.current.routes.length).toBe(0));
     });

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { createStore, Provider as JotaiProvider } from 'jotai';
 import type {
+  SavedRoute,
   SavedRouteWithoutTrainTypeInput,
   SavedRouteWithTrainTypeInput,
 } from '~/models/SavedRoute';
@@ -49,12 +50,9 @@ describe('useSavedRoutes', () => {
   });
 
   describe('initialization', () => {
-    it('DB 初期化を行い isInitialized を true にする', async () => {
+    it('DB 初期化でテーブルとインデックスを作成し presetsFetched を true にする', async () => {
       const store = createStore();
-      store.set(navigationState, {
-        ...initialNavigationState,
-        presetsFetched: true,
-      });
+      store.set(navigationState, initialNavigationState);
       const { result } = renderHook(
         () => require('./useSavedRoutes').useSavedRoutes(),
         {
@@ -62,10 +60,32 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      expect(mockDb.execAsync).toHaveBeenCalledWith(
+      await waitFor(() => expect(mockDb.execAsync).toHaveBeenCalledTimes(4));
+      expect(mockDb.execAsync).toHaveBeenNthCalledWith(
+        1,
         expect.stringContaining('CREATE TABLE IF NOT EXISTS saved_routes')
       );
-      expect(result.current.isInitialized).toBe(true);
+      expect(mockDb.execAsync).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(
+          'CREATE INDEX IF NOT EXISTS idx_saved_routes_createdAt'
+        )
+      );
+      expect(mockDb.execAsync).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining(
+          'CREATE INDEX IF NOT EXISTS idx_saved_routes_line_dest_has'
+        )
+      );
+      expect(mockDb.execAsync).toHaveBeenNthCalledWith(
+        4,
+        expect.stringContaining(
+          'CREATE INDEX IF NOT EXISTS idx_saved_routes_ttype_dest_has'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+      expect(store.get(navigationState).presetsFetched).toBe(true);
     });
   });
 
@@ -77,7 +97,6 @@ describe('useSavedRoutes', () => {
           name: 'With TrainType',
           lineId: 10,
           trainTypeId: 5,
-          destinationStationId: 100,
           hasTrainType: 1,
           createdAt: '2025-01-01T00:00:00.000Z',
         },
@@ -86,7 +105,6 @@ describe('useSavedRoutes', () => {
           name: 'Without TrainType',
           lineId: 11,
           trainTypeId: 999,
-          destinationStationId: 101,
           hasTrainType: 0,
           createdAt: '2025-01-02T00:00:00.000Z',
         },
@@ -105,7 +123,9 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      await result.current.updateRoutes();
+      await act(async () => {
+        await result.current.updateRoutes();
+      });
 
       await waitFor(() => expect(result.current.routes.length).toBe(2));
       const [r1, r2] = result.current.routes;
@@ -128,7 +148,6 @@ describe('useSavedRoutes', () => {
           name: 'Invalid',
           lineId: 1,
           trainTypeId: null,
-          destinationStationId: null,
           hasTrainType: 1,
           createdAt: '2025-01-01T00:00:00.000Z',
         },
@@ -146,135 +165,11 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      await result.current.updateRoutes();
+      await act(async () => {
+        await result.current.updateRoutes();
+      });
 
       await waitFor(() => expect(result.current.routes).toEqual([]));
-    });
-  });
-
-  describe('find', () => {
-    it('destinationStationId が null の場合は trainTypeId または lineId が一致する最初の要素を返す', async () => {
-      mockDb.getAllAsync.mockResolvedValue([
-        {
-          id: 'a',
-          name: 'A',
-          lineId: 100,
-          trainTypeId: 50,
-          destinationStationId: null,
-          hasTrainType: 1,
-          createdAt: '2025-01-01T00:00:00.000Z',
-        },
-        {
-          id: 'b',
-          name: 'B',
-          lineId: 200,
-          trainTypeId: null,
-          destinationStationId: null,
-          hasTrainType: 0,
-          createdAt: '2025-01-02T00:00:00.000Z',
-        },
-      ] as unknown[]);
-
-      const store = createStore();
-      store.set(navigationState, {
-        ...initialNavigationState,
-        presetsFetched: true,
-      });
-      const { result } = renderHook(
-        () => require('./useSavedRoutes').useSavedRoutes(),
-        {
-          wrapper: withJotaiProvider(store),
-        }
-      );
-      await result.current.updateRoutes();
-
-      // trainTypeId でマッチ
-      await waitFor(() =>
-        expect(
-          result.current.find({
-            lineId: 999,
-            destinationStationId: null,
-            trainTypeId: 50,
-          })?.id
-        ).toBe('a')
-      );
-      // lineId でマッチ
-      await waitFor(() =>
-        expect(
-          result.current.find({
-            lineId: 200,
-            destinationStationId: null,
-            trainTypeId: null,
-          })?.id
-        ).toBe('b')
-      );
-    });
-
-    it('destinationStationId が指定されている場合は (trainTypeId, dest) または (lineId, dest) で一致', async () => {
-      mockDb.getAllAsync.mockResolvedValue([
-        {
-          id: 'c',
-          name: 'C',
-          lineId: 300,
-          trainTypeId: 10,
-          destinationStationId: 123,
-          hasTrainType: 1,
-          createdAt: '2025-01-03T00:00:00.000Z',
-        },
-        {
-          id: 'd',
-          name: 'D',
-          lineId: 400,
-          trainTypeId: null,
-          destinationStationId: 123,
-          hasTrainType: 0,
-          createdAt: '2025-01-04T00:00:00.000Z',
-        },
-      ] as unknown[]);
-
-      const store = createStore();
-      store.set(navigationState, {
-        ...initialNavigationState,
-        presetsFetched: true,
-      });
-      const { result } = renderHook(
-        () => require('./useSavedRoutes').useSavedRoutes(),
-        {
-          wrapper: withJotaiProvider(store),
-        }
-      );
-      await result.current.updateRoutes();
-
-      // (trainTypeId, destinationStationId) で一致
-      await waitFor(() =>
-        expect(
-          result.current.find({
-            lineId: null,
-            destinationStationId: 123,
-            trainTypeId: 10,
-          })?.id
-        ).toBe('c')
-      );
-      // (lineId, destinationStationId) で一致
-      await waitFor(() =>
-        expect(
-          result.current.find({
-            lineId: 400,
-            destinationStationId: 123,
-            trainTypeId: null,
-          })?.id
-        ).toBe('d')
-      );
-      // 見つからない
-      await waitFor(() =>
-        expect(
-          result.current.find({
-            lineId: 999,
-            destinationStationId: 555,
-            trainTypeId: null,
-          })
-        ).toBeNull()
-      );
     });
   });
 
@@ -283,7 +178,6 @@ describe('useSavedRoutes', () => {
       hasTrainType: true,
       lineId: 1,
       trainTypeId: 9,
-      destinationStationId: 10,
       name: 'WithType',
       createdAt: new Date('2025-01-01T00:00:00.000Z'),
     };
@@ -291,7 +185,6 @@ describe('useSavedRoutes', () => {
       hasTrainType: false,
       lineId: 2,
       trainTypeId: null,
-      destinationStationId: 20,
       name: 'WithoutType',
       createdAt: new Date('2025-01-02T00:00:00.000Z'),
     };
@@ -309,7 +202,10 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      const saved1 = await result.current.save(withType);
+      let saved1: SavedRoute;
+      await act(async () => {
+        saved1 = await result.current.save(withType);
+      });
 
       expect(saved1.id).toMatch(/^550e8400-e29b-41d4-a716-4466554400001$/);
       expect(mockDb.runAsync).toHaveBeenCalledWith(
@@ -319,7 +215,6 @@ describe('useSavedRoutes', () => {
           withType.name,
           withType.lineId,
           withType.trainTypeId,
-          withType.destinationStationId,
           1,
           saved1.createdAt.toISOString(),
         ]
@@ -327,7 +222,10 @@ describe('useSavedRoutes', () => {
 
       await waitFor(() => expect(result.current.routes[0]?.id).toBe(saved1.id));
 
-      const saved2 = await result.current.save(withoutType);
+      let saved2: SavedRoute;
+      await act(async () => {
+        saved2 = await result.current.save(withoutType);
+      });
       expect(saved2.hasTrainType).toBe(false);
       expect(saved2.trainTypeId).toBeNull();
       expect(mockDb.runAsync).toHaveBeenCalledWith(
@@ -337,13 +235,16 @@ describe('useSavedRoutes', () => {
           withoutType.name,
           withoutType.lineId,
           null,
-          withoutType.destinationStationId,
           0,
           saved2.createdAt.toISOString(),
         ])
       );
 
       await waitFor(() => expect(result.current.routes.length).toBe(2));
+      expect(result.current.routes.map((route) => route.id)).toEqual([
+        saved2.id,
+        saved1.id,
+      ]);
     });
 
     it('remove: 指定 ID を削除し routes からも取り除く', async () => {
@@ -359,15 +260,90 @@ describe('useSavedRoutes', () => {
         }
       );
 
-      const saved = await result.current.save(withType);
+      let saved: SavedRoute;
+      await act(async () => {
+        saved = await result.current.save(withType);
+      });
       await waitFor(() => expect(result.current.routes.length).toBe(1));
 
-      await expect(result.current.remove(saved.id)).resolves.toBeUndefined();
+      await act(async () => {
+        await result.current.remove(saved.id);
+      });
       expect(mockDb.runAsync).toHaveBeenCalledWith(
         'DELETE FROM saved_routes WHERE id = ?',
         [saved.id]
       );
       await waitFor(() => expect(result.current.routes.length).toBe(0));
+    });
+  });
+
+  describe('find', () => {
+    const withTrainType: SavedRoute = {
+      id: 'route-with',
+      hasTrainType: true,
+      lineId: 100,
+      trainTypeId: 7,
+      name: 'With Train Type',
+      createdAt: new Date('2025-01-03T00:00:00.000Z'),
+    };
+    const withoutTrainType: SavedRoute = {
+      id: 'route-without',
+      hasTrainType: false,
+      lineId: 200,
+      trainTypeId: null,
+      name: 'Without Train Type',
+      createdAt: new Date('2025-01-04T00:00:00.000Z'),
+    };
+
+    const renderWithPresetRoutes = () => {
+      const store = createStore();
+      store.set(navigationState, {
+        ...initialNavigationState,
+        presetRoutes: [withTrainType, withoutTrainType],
+      });
+      const { result } = renderHook(
+        () => require('./useSavedRoutes').useSavedRoutes(),
+        {
+          wrapper: withJotaiProvider(store),
+        }
+      );
+      return { result, store };
+    };
+
+    it('trainTypeId が一致するルートを返す', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      expect(
+        result.current.find({
+          lineId: null,
+          trainTypeId: withTrainType.trainTypeId,
+        })
+      ).toBe(withTrainType);
+    });
+
+    it('trainTypeId が不一致でも lineId が一致すればルートを返す', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      expect(
+        result.current.find({
+          lineId: withoutTrainType.lineId,
+          trainTypeId: 999,
+        })
+      ).toBe(withoutTrainType);
+    });
+
+    it('一致するルートがなければ null を返す', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      expect(
+        result.current.find({ lineId: 9999, trainTypeId: 8888 })
+      ).toBeNull();
     });
   });
 });

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
 import type {
   SavedRoute,
@@ -36,7 +37,7 @@ jest.mock('expo-sqlite', () => ({
 
 // 各テストを独立させるため Jotai のストアを毎回作り直す
 const withJotaiProvider = (store: ReturnType<typeof createStore>) =>
-  function Wrapper({ children }: { children: React.ReactNode }) {
+  function Wrapper({ children }: { children: ReactNode }) {
     return <JotaiProvider store={store}>{children}</JotaiProvider>;
   };
 

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -11,7 +11,6 @@ interface SavedRouteRow {
   name: string;
   lineId: number;
   trainTypeId: number | null;
-  destinationStationId: number | null;
   hasTrainType: number; // SQLiteではBOOLEANが数値として保存される
   createdAt: string; // SQLiteでは日時が文字列として保存される
 }
@@ -32,7 +31,6 @@ const convertRowToSavedRoute = (row: SavedRouteRow): SavedRoute | null => {
       name: row.name,
       lineId: row.lineId,
       trainTypeId: row.trainTypeId,
-      destinationStationId: row.destinationStationId,
       hasTrainType: true,
       createdAt: new Date(row.createdAt),
     };
@@ -42,7 +40,6 @@ const convertRowToSavedRoute = (row: SavedRouteRow): SavedRoute | null => {
     name: row.name,
     lineId: row.lineId,
     trainTypeId: null,
-    destinationStationId: row.destinationStationId,
     hasTrainType: false,
     createdAt: new Date(row.createdAt),
   };
@@ -62,7 +59,6 @@ export const useSavedRoutes = () => {
         name TEXT NOT NULL,
         lineId INTEGER NOT NULL,
         trainTypeId INTEGER,
-        destinationStationId INTEGER,
         hasTrainType INTEGER NOT NULL CHECK (hasTrainType IN (0,1)),
         createdAt TEXT NOT NULL,
         CHECK ((hasTrainType = 1 AND trainTypeId IS NOT NULL) OR (hasTrainType = 0 AND trainTypeId IS NULL))
@@ -73,10 +69,10 @@ export const useSavedRoutes = () => {
         'CREATE INDEX IF NOT EXISTS idx_saved_routes_createdAt ON saved_routes(createdAt DESC);'
       );
       await db.execAsync(
-        'CREATE INDEX IF NOT EXISTS idx_saved_routes_line_dest_has ON saved_routes(lineId, destinationStationId, hasTrainType, createdAt DESC);'
+        'CREATE INDEX IF NOT EXISTS idx_saved_routes_line_dest_has ON saved_routes(lineId, hasTrainType, createdAt DESC);'
       );
       await db.execAsync(
-        'CREATE INDEX IF NOT EXISTS idx_saved_routes_ttype_dest_has ON saved_routes(trainTypeId, destinationStationId, hasTrainType, createdAt DESC);'
+        'CREATE INDEX IF NOT EXISTS idx_saved_routes_ttype_dest_has ON saved_routes(trainTypeId, hasTrainType, createdAt DESC);'
       );
       setNavigationAtom((prev) => ({ ...prev, presetsFetched: true }));
     };
@@ -99,27 +95,13 @@ export const useSavedRoutes = () => {
     ({
       lineId,
       trainTypeId,
-      destinationStationId,
     }: {
       lineId: number | null;
-      destinationStationId: number | null;
       trainTypeId: number | null;
     }): SavedRoute | null => {
-      if (!destinationStationId) {
-        return (
-          routes.find(
-            (r) => r.trainTypeId === trainTypeId || r.lineId === lineId
-          ) ?? null
-        );
-      }
-
       return (
         routes.find(
-          (r) =>
-            (r.trainTypeId === trainTypeId &&
-              r.destinationStationId === destinationStationId) ||
-            (r.lineId === lineId &&
-              r.destinationStationId === destinationStationId)
+          (r) => r.trainTypeId === trainTypeId || r.lineId === lineId
         ) ?? null
       );
     },
@@ -140,14 +122,13 @@ export const useSavedRoutes = () => {
 
       await db.runAsync(
         `INSERT INTO saved_routes 
-         (id, name, lineId, trainTypeId, destinationStationId, hasTrainType, createdAt)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+         (id, name, lineId, trainTypeId, hasTrainType, createdAt)
+         VALUES (?, ?, ?, ?, ?, ?)`,
         [
           newRoute.id,
           newRoute.name,
           newRoute.lineId,
           newRoute.trainTypeId ?? null,
-          newRoute.destinationStationId ?? null,
           newRoute.hasTrainType ? 1 : 0,
           newRoute.createdAt.toISOString(),
         ]

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -100,8 +100,10 @@ export const useSavedRoutes = () => {
       trainTypeId: number | null;
     }): SavedRoute | null => {
       return (
-        routes.find(
-          (r) => r.trainTypeId === trainTypeId || r.lineId === lineId
+        routes.find((r) =>
+          r.hasTrainType
+            ? r.trainTypeId === trainTypeId && r.lineId === lineId
+            : r.lineId === lineId
         ) ?? null
       );
     },

--- a/src/models/SavedRoute.ts
+++ b/src/models/SavedRoute.ts
@@ -5,7 +5,6 @@ export const SavedRouteWithTrainTypeSchema = z.object({
   hasTrainType: z.literal(true),
   lineId: z.number().int().nonnegative(),
   trainTypeId: z.number().int().nonnegative(),
-  destinationStationId: z.number().int().nonnegative().nullish(),
   name: z.string().min(1).max(100),
   createdAt: z.date(),
 });
@@ -19,7 +18,6 @@ export const SavedRouteWithoutTrainTypeSchema = z.object({
   hasTrainType: z.literal(false),
   lineId: z.number().int().nonnegative(),
   trainTypeId: z.null(),
-  destinationStationId: z.number().int().nonnegative().nullish(),
   name: z.string().min(1).max(100),
   createdAt: z.date(),
 });

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -4,6 +4,7 @@ import { Effect, pipe } from 'effect';
 import * as Location from 'expo-location';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import findNearest from 'geolib/es/findNearest';
+import orderByDistance from 'geolib/es/orderByDistance';
 import { useAtom, useSetAtom } from 'jotai';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, StyleSheet } from 'react-native';
@@ -460,44 +461,26 @@ const SelectLineScreen = () => {
 
   // PresetCard押下時のモーダル表示ロジック
   const openModalByLineId = useCallback(
-    async (lineId: number, destinationStationId: number | null) => {
-      if (!destinationStationId) return;
+    async (lineId: number) => {
       const result = await fetchStationsByLineId({
-        variables: { lineId, stationId: destinationStationId },
+        variables: { lineId },
       });
       const stations = result.data?.lineStations ?? [];
       if (!stations.length) return;
 
-      const wantedDestination =
-        stations.find((sta: Station) => sta.id === destinationStationId) ??
-        null;
-
-      // Filter stations with valid coordinates
-      const stationsWithCoords = stations.filter(
-        (sta: Station) => sta.latitude != null && sta.longitude != null
-      );
-
-      if (!stationsWithCoords.length) {
-        // No stations have coordinates, cannot determine nearest
-        return;
-      }
-
-      // Determine reference coordinates: user location or first station with coords
-      const referenceCoords =
-        latitude != null && longitude != null
-          ? { latitude, longitude }
-          : {
-              latitude: stationsWithCoords[0].latitude as number,
-              longitude: stationsWithCoords[0].longitude as number,
-            };
-
-      const nearestCoordinates = findNearest(
-        referenceCoords,
-        stationsWithCoords.map((sta: Station) => ({
-          latitude: sta.latitude as number,
-          longitude: sta.longitude as number,
-        }))
-      ) as { latitude: number; longitude: number };
+      const nearestCoordinates =
+        latitude && longitude
+          ? (findNearest(
+              { latitude, longitude },
+              stations.map((sta: Station) => ({
+                latitude: sta.latitude as number,
+                longitude: sta.longitude as number,
+              }))
+            ) as { latitude: number; longitude: number })
+          : stations.map((s) => ({
+              latitude: s.latitude,
+              longitude: s.longitude,
+            }))[0];
 
       const station = stations.find(
         (sta: Station) =>
@@ -518,7 +501,6 @@ const SelectLineScreen = () => {
       }));
       setNavigationState((prev) => ({
         ...prev,
-        pendingWantedDestination: wantedDestination,
         fetchedTrainTypes: [],
         trainType: null,
       }));
@@ -533,49 +515,36 @@ const SelectLineScreen = () => {
     ]
   );
 
+  // PresetCard押下時のモーダル表示ロジック
   const openModalByTrainTypeId = useCallback(
-    async (lineGroupId: number, destinationStationId: number | null) => {
+    async (lineGroupId: number) => {
       const result = await fetchStationsByLineGroupId({
         variables: { lineGroupId },
       });
       const stations = result.data?.lineGroupStations ?? [];
       if (!stations.length) return;
 
-      const wantedDestination =
-        stations.find((sta: Station) => sta.id === destinationStationId) ??
-        null;
-
-      // Filter stations with valid coordinates
-      const stationsWithCoords = stations.filter(
-        (sta: Station) => sta.latitude != null && sta.longitude != null
-      );
-
-      if (!stationsWithCoords.length) {
-        // No stations have coordinates, cannot determine nearest
-        return;
-      }
-
-      // Determine reference coordinates: user location or first station with coords
-      const referenceCoords =
-        latitude != null && longitude != null
-          ? { latitude, longitude }
-          : {
-              latitude: stationsWithCoords[0].latitude as number,
-              longitude: stationsWithCoords[0].longitude as number,
-            };
-
-      const nearestCoordinates = findNearest(
-        referenceCoords,
-        stationsWithCoords.map((sta: Station) => ({
-          latitude: sta.latitude as number,
-          longitude: sta.longitude as number,
-        }))
-      ) as { latitude: number; longitude: number };
+      const sortedStationCoords =
+        latitude && longitude
+          ? (orderByDistance(
+              { lat: latitude, lon: longitude },
+              stations.map((sta) => ({
+                latitude: sta.latitude as number,
+                longitude: sta.longitude as number,
+              }))
+            ) as { latitude: number; longitude: number }[])
+          : stations;
 
       const station = stations.find(
         (sta: Station) =>
-          sta.latitude === nearestCoordinates.latitude &&
-          sta.longitude === nearestCoordinates.longitude
+          sta.trainType?.groupId === lineGroupId &&
+          (latitude && longitude
+            ? sortedStationCoords.some(
+                (coords) =>
+                  coords.latitude === sta.latitude &&
+                  coords.longitude === sta.longitude
+              )
+            : true)
       );
 
       if (!station) return;
@@ -591,24 +560,22 @@ const SelectLineScreen = () => {
       }));
       setNavigationState((prev) => ({
         ...prev,
-        pendingWantedDestination: wantedDestination,
         fetchedTrainTypes: [],
         trainType: null,
       }));
 
-      if (station?.hasTrainTypes && station?.id != null) {
-        const result = await fetchTrainTypes({
-          variables: {
-            stationId: station.id,
-          },
-        });
-        const trainTypes = result.data?.stationTrainTypes ?? [];
+      const fetchedTrainTypesData = await fetchTrainTypes({
+        variables: {
+          stationId: station.id as number,
+        },
+      });
+      const trainTypes = fetchedTrainTypesData.data?.stationTrainTypes ?? [];
 
-        setNavigationState((prev) => ({
-          ...prev,
-          fetchedTrainTypes: trainTypes,
-        }));
-      }
+      setNavigationState((prev) => ({
+        ...prev,
+        trainType: station.trainType ?? null,
+        fetchedTrainTypes: trainTypes,
+      }));
     },
     [
       fetchStationsByLineGroupId,
@@ -625,15 +592,9 @@ const SelectLineScreen = () => {
     async (route: SavedRoute) => {
       setIsSelectBoundModalOpen(true);
       if (route.hasTrainType) {
-        await openModalByTrainTypeId(
-          route.trainTypeId,
-          route.destinationStationId ?? null
-        );
+        await openModalByTrainTypeId(route.trainTypeId);
       } else {
-        await openModalByLineId(
-          route.lineId,
-          route.destinationStationId ?? null
-        );
+        await openModalByLineId(route.lineId);
       }
     },
     [openModalByLineId, openModalByTrainTypeId]

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -533,18 +533,25 @@ const SelectLineScreen = () => {
                 longitude: sta.longitude as number,
               }))
             ) as { latitude: number; longitude: number }[])
-          : stations;
+          : stations.map((sta) => ({
+              latitude: sta.latitude,
+              longitude: sta.longitude,
+            }));
 
-      const station = stations.find(
-        (sta: Station) =>
-          sta.trainType?.groupId === lineGroupId &&
-          (latitude && longitude
-            ? sortedStationCoords.some(
-                (coords) =>
-                  coords.latitude === sta.latitude &&
-                  coords.longitude === sta.longitude
-              )
-            : true)
+      const sortedStations = stations.slice().sort((a, b) => {
+        const aIndex = sortedStationCoords.findIndex(
+          (coord) =>
+            coord.latitude === a.latitude && coord.longitude === a.longitude
+        );
+        const bIndex = sortedStationCoords.findIndex(
+          (coord) =>
+            coord.latitude === b.latitude && coord.longitude === b.longitude
+        );
+        return aIndex - bIndex;
+      });
+
+      const station = sortedStations.find(
+        (sta: Station) => sta.trainType?.groupId === lineGroupId
       );
 
       if (!station) return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 保存されたルートで目的地駅IDが不要になりました（ルートは路線と列車種別のみで扱います）。

* **改善**
  * 駅一覧を距離順で並び替え、位置情報がある場合は近い駅を優先して選択。位置情報がない場合は最初の駅をデフォルト選択します。
  * ルートの検索・保存・削除時の挙動を簡素化・安定化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->