### PR TITLE
Xcode Cloud向けスクリプト修正

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-\. "$HOME/.nvm/nvm.sh"
-nvm install 24
+brew install node@24
 npm install -g pnpm@10
 pnpm approve-builds
 pnpm i


### PR DESCRIPTION
```
Can't find the 'node' binary to build the React Native bundle. If you have a non-standard Node.js installation, select your project in Xcode, find 'Build Phases' - 'Bundle React Native code and images' and change NODE_BINARY to an absolute path to your node executable. You can find it by invoking 'which node' in the terminal.
```

nvmだとビルドが通らなかった🥺

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * CI ビルドプロセスにおける Node.js インストール方法を Homebrew に最適化しました。これにより、ビルドパイプラインの効率性と信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->