### PR TITLE
一つのPRに対してbump versionのPR自動作成は１回だけにする

### DIFF
--- a/.github/workflows/bump_version_on_pr.yml
+++ b/.github/workflows/bump_version_on_pr.yml
@@ -1,8 +1,9 @@
 name: Bump Version on Canary PR
 
 on:
+  workflow_dispatch:
   pull_request:
-    types: [opened, synchronize]
+    types: opened
     branches:
       - canary
 

--- a/.github/workflows/bump_version_on_pr.yml
+++ b/.github/workflows/bump_version_on_pr.yml
@@ -1,7 +1,6 @@
 name: Bump Version on Canary PR
 
 on:
-  workflow_dispatch:
   pull_request:
     types: opened
     branches:


### PR DESCRIPTION
…uests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted automated workflow to run only when a pull request is opened (no longer triggered by PR updates), reducing workflow runs from PR synchronizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->