### PR TITLE
LineBoard幅計算処理のデグレ修正

### DIFF
--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -76,7 +76,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'flex-end',
     bottom: isTablet ? 84 : undefined,
-    width: `${100 / 9}%`,
   },
   stationNameMapContainer: {
     flex: 1,
@@ -495,7 +494,14 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   return (
     <>
-      <View style={styles.stationNameContainer}>
+      <View
+        style={[
+          styles.stationNameContainer,
+          {
+            width: dim.width / 9,
+          },
+        ]}
+      >
         <View
           style={[
             styles.nameCommon,

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -77,7 +77,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'flex-end',
     bottom: isTablet ? 84 : undefined,
-    width: `${100 / 9}%`,
   },
   stationNameMapContainer: {
     flex: 1,
@@ -558,6 +557,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
+            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -550,14 +550,13 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   return (
     <>
-      <View style={styles.stationNameContainer}>
+      <View style={[styles.stationNameContainer, { width: dim.width / 9 }]}>
         <View
           style={[
             styles.nameCommon,
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
-            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -458,14 +458,13 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   return (
     <>
-      <View style={styles.stationNameContainer}>
+      <View style={[styles.stationNameContainer, { width: dim.width / 9 }]}>
         <View
           style={[
             styles.nameCommon,
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
-            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -76,7 +76,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'flex-end',
     bottom: isTablet ? 84 : undefined,
-    width: `${100 / 9}%`,
   },
   stationNameMapContainer: {
     flex: 1,
@@ -466,6 +465,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
+            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -526,14 +526,13 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   return (
     <>
-      <View style={styles.stationNameContainer}>
+      <View style={[styles.stationNameContainer, { width: dim.width / 9 }]}>
         <View
           style={[
             styles.nameCommon,
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
-            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -77,7 +77,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'flex-end',
     bottom: isTablet ? 84 : undefined,
-    width: `${100 / 9}%`,
   },
   stationName: {
     fontSize: RFValue(18),
@@ -534,6 +533,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             isEn || includesLongStationName
               ? styles.longOrEnName
               : styles.jaName,
+            { width: dim.width / 9 },
           ]}
         >
           <StationName

--- a/src/components/LineBoardWest.tsx
+++ b/src/components/LineBoardWest.tsx
@@ -88,7 +88,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     bottom: isTablet ? 110 : undefined,
     paddingBottom: 0,
-    width: `${100 / 9}%`,
   },
   stationName: {
     width: isTablet ? 48 : 32,
@@ -430,6 +429,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 }: StationNameCellProps) => {
   const { stations: allStations } = useAtomValue(stationState);
   const isEn = useAtomValue(isEnAtom);
+  const { width: windowWidth } = useWindowDimensions();
 
   const transferLines = useTransferLinesFromStation(stationInLoop, {
     omitJR: true,
@@ -483,6 +483,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
         styles.stationNameContainer,
         {
           paddingBottom,
+          width: windowWidth / 9,
         },
       ]}
     >

--- a/src/screens/SelectLineScreenPresets.tsx
+++ b/src/screens/SelectLineScreenPresets.tsx
@@ -24,7 +24,6 @@ const CARD_GAP = 12;
 const styles = StyleSheet.create({
   root: { marginHorizontal: -24 },
   horizontalMargin: { marginHorizontal: 24 },
-  noPresetsContainer: { height: 160, justifyContent: 'center' },
   itemSeparator: { width: CARD_GAP },
   contentContainer: { paddingHorizontal: 0, marginBottom: 48 },
 });
@@ -103,12 +102,9 @@ export const SelectLineScreenPresets = ({
             </SkeletonPlaceholder>
           ) : (
             <View
-              style={[
-                styles.noPresetsContainer,
-                {
-                  width: cardWidth,
-                },
-              ]}
+              style={{
+                width: cardWidth,
+              }}
             >
               <View style={styles.horizontalMargin}>
                 <NoPresetsCard />


### PR DESCRIPTION
#4585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ラインボード表示における駅名コンテナのレイアウトを改善しました。固定パーセント幅からウィンドウ幅に基づく動的幅へ変更し、画面サイズに応じて駅名ブロックの表示幅が自動調整されます。
  * プリセット未設定時のリスト表示で、従来の高さ・中央寄せスタイルを廃止し、カード幅のみを指定する簡素なラッパースタイルに変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->