### PR TITLE
hotfix: Fix submodule URLs in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "proto"]
 	path = proto
-	url = https://github.com/TrainLCD/gRPCProto
+	url = https://github.com/TrainLCD/gRPCProto.git
 [submodule "ios/Fonts"]
 	path = ios/Fonts
-	url = https://github.com/TrainLCD/MobileAppFonts
+	url = https://github.com/TrainLCD/MobileAppFonts.git
 [submodule "android/app/src/main/assets/fonts"]
 	path = android/app/src/main/assets/fonts
-	url = https://github.com/TrainLCD/MobileAppFonts
+	url = https://github.com/TrainLCD/MobileAppFonts.git


### PR DESCRIPTION
Updated submodule URLs to include '.git' suffix.