### PR TITLE
ToggleButton上下中央

### DIFF
--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
     borderColor: '#fff',
     borderRadius: 8,
     justifyContent: 'center',
+    alignItems: 'center',
     flexDirection: 'row',
   },
   buttonLED: {


### PR DESCRIPTION
iOS版でToggleButtonのレイアウトが崩れている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * トグルボタン内のコンテンツの配置を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->