### PR TITLE
到着通知の復活

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -192,5 +192,6 @@
   "stationNameSearchPlaceholder": "Where are you?",
   "routeSearchPlaceholder": "Where to?",
   "trainTypeIs": "Train type: %{trainTypeName}",
-  "trainTypesNotExist": "No train types available"
+  "trainTypesNotExist": "No train types available",
+  "enableNotificationMode": "Enable arrival notifications"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -193,5 +193,6 @@
   "stationNameSearchPlaceholder": "どこにいますか？",
   "routeSearchPlaceholder": "どこへ行きますか？",
   "trainTypeIs": "列車種別: %{trainTypeName}",
-  "trainTypesNotExist": "列車種別がありません"
+  "trainTypesNotExist": "列車種別がありません",
+  "enableNotificationMode": "到着通知を有効にする"
 }

--- a/src/components/StationSettingsModal.tsx
+++ b/src/components/StationSettingsModal.tsx
@@ -1,0 +1,116 @@
+import type React from 'react';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import type { Station } from '~/@types/graphql';
+import { APP_THEME } from '~/models/Theme';
+import isTablet from '~/utils/isTablet';
+import { RFValue } from '~/utils/rfValue';
+import Button from '../components/Button';
+import { Heading } from '../components/Heading';
+import { LED_THEME_BG_COLOR } from '../constants';
+import { useThemeStore } from '../hooks';
+import { isJapanese, translate } from '../translation';
+import { ToggleButton } from './ToggleButton';
+import Typography from './Typography';
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: 24,
+  },
+  contentView: {
+    width: '100%',
+    paddingVertical: 24,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    minHeight: 256,
+  },
+  buttonsContainer: {
+    gap: 8,
+    marginTop: 24,
+    width: '100%',
+  },
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButton: { marginTop: 24 },
+  closeButtonText: { fontWeight: 'bold' },
+  heading: { width: '100%' },
+  lineText: { width: '100%', fontWeight: 'bold', fontSize: RFValue(12) },
+});
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  station: Station | null;
+  notificationModeEnabled: boolean;
+  toggleNotificationModeEnabled: () => void;
+};
+
+export const StationSettingsModal: React.FC<Props> = ({
+  visible,
+  onClose,
+  station,
+  notificationModeEnabled,
+  toggleNotificationModeEnabled,
+}) => {
+  const isLEDTheme = useThemeStore((state) => state === APP_THEME.LED);
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={onClose}
+      supportedOrientations={['portrait', 'landscape']}
+    >
+      <Pressable style={styles.root} onPress={onClose}>
+        <Pressable
+          style={[
+            styles.contentView,
+            {
+              backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
+            },
+            isTablet && {
+              width: '80%',
+              maxHeight: '90%',
+              shadowOpacity: 0.25,
+              shadowColor: '#333',
+              borderRadius: 16,
+            },
+          ]}
+        >
+          <View style={styles.container}>
+            <Typography style={styles.lineText}>
+              {isJapanese ? station?.line?.nameShort : station?.line?.nameRoman}
+            </Typography>
+            <Heading style={styles.heading}>
+              {isJapanese ? station?.name : station?.nameRoman}
+              {translate('station')}
+            </Heading>
+
+            <View style={styles.buttonsContainer}>
+              <ToggleButton
+                outline
+                onToggle={toggleNotificationModeEnabled}
+                state={notificationModeEnabled}
+              >
+                {translate('enableNotificationMode')}
+              </ToggleButton>
+              <Button
+                style={styles.closeButton}
+                textStyle={styles.closeButtonText}
+                onPress={onClose}
+              >
+                {translate('close')}
+              </Button>
+            </View>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};


### PR DESCRIPTION
fixes #4642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 駅ごとに到着通知の有効・無効を切り替えられるようになりました。駅を選択すると、通知設定画面が表示され、そこで各駅の到着通知をカスタマイズできます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->