### PR TITLE
不要なEASビルド抑止

### DIFF
--- a/.eas/workflows/create-beta-builds.yml
+++ b/.eas/workflows/create-beta-builds.yml
@@ -12,6 +12,12 @@ jobs:
       profile: production
     steps:
       - uses: eas/checkout
+      - name: Ensure EAS_PROJECT is beta
+        run: |
+          if [ "${EAS_PROJECT:-}" != "beta" ]; then
+            echo "EAS_PROJECT must be 'beta' for this workflow; got '${EAS_PROJECT:-<unset>}'"
+            exit 1
+          fi
       - name: Checkout submodules
         run: |
           set -euo pipefail

--- a/.eas/workflows/create-development-builds.yml
+++ b/.eas/workflows/create-development-builds.yml
@@ -12,6 +12,12 @@ jobs:
       profile: development
     steps:
       - uses: eas/checkout
+      - name: Ensure EAS_PROJECT is canary
+        run: |
+          if [ "${EAS_PROJECT:-}" != "canary" ]; then
+            echo "EAS_PROJECT must be 'canary' for this workflow; got '${EAS_PROJECT:-<unset>}'"
+            exit 1
+          fi
       - name: Checkout submodules
         run: |
           set -euo pipefail
@@ -71,6 +77,12 @@ jobs:
       profile: development
     steps:
       - uses: eas/checkout
+      - name: Ensure EAS_PROJECT is canary
+        run: |
+          if [ "${EAS_PROJECT:-}" != "canary" ]; then
+            echo "EAS_PROJECT must be 'canary' for this workflow; got '${EAS_PROJECT:-<unset>}'"
+            exit 1
+          fi
       - name: Checkout submodules
         run: |
           set -euo pipefail

--- a/app.json
+++ b/app.json
@@ -26,7 +26,12 @@
     },
     "android": {
       "package": "me.tinykitten.trainlcd.dev",
-      "versionCode": 100000098
-    }
+      "versionCode": 100000098,
+      "permissions": [
+        "android.permission.RECORD_AUDIO",
+        "android.permission.MODIFY_AUDIO_SETTINGS"
+      ]
+    },
+    "owner": "trainlcd"
   }
 }


### PR DESCRIPTION
EASで同一リポジトリでEASプロジェクト切ってデプロイしているので、他の環境向けビルドが走った場合即停止させたい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドプロセスの安定性向上のため、検証ステップを追加しました。
  * アプリケーション設定を更新し、オーディオ機能に関連する権限（音声記録および音声設定変更）を追加しました。
  * プロジェクト構成情報を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->