### PR TITLE
終着駅指定のバグを修正

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -169,7 +169,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         station,
         stations: stops,
         selectedBound:
-          line?.id === TOEI_OEDO_LINE_ID && !stops.length
+          line?.id === TOEI_OEDO_LINE_ID && !terminateBySelectedStation
             ? oedoLineTerminus
             : direction === 'INBOUND'
               ? stops[stops.length - 1]

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -7,7 +7,7 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import Toast from 'react-native-toast-message';
 import type { Station, TrainType } from '~/@types/graphql';
 import { Heading } from '~/components/Heading';
-import { LED_THEME_BG_COLOR, TOEI_OEDO_LINE_ID } from '~/constants';
+import { LED_THEME_BG_COLOR } from '~/constants';
 import {
   useBounds,
   useGetStationsWithTermination,
@@ -153,8 +153,6 @@ export const SelectBoundModal: React.FC<Props> = ({
       direction: LineDirection,
       terminateBySelectedStation = false
     ) => {
-      const oedoLineTerminus =
-        direction === 'INBOUND' ? stations[stations.length - 1] : stations[0];
       const stops = terminateBySelectedStation
         ? getTerminatedStations(selectedStation, stations)
         : stations;
@@ -169,11 +167,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         station,
         stations: stops,
         selectedBound:
-          line?.id === TOEI_OEDO_LINE_ID && !terminateBySelectedStation
-            ? oedoLineTerminus
-            : direction === 'INBOUND'
-              ? stops[stops.length - 1]
-              : stops[0],
+          direction === 'INBOUND' ? stops[stops.length - 1] : stops[0],
         selectedDirection: direction,
         pendingStation: null,
         pendingStations: [],

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -155,6 +155,9 @@ export const SelectBoundModal: React.FC<Props> = ({
     ) => {
       const oedoLineTerminus =
         direction === 'INBOUND' ? stations[stations.length - 1] : stations[0];
+      const stops = terminateBySelectedStation
+        ? getTerminatedStations(selectedStation, stations)
+        : stations;
 
       setLineState((prev) => ({
         ...prev,
@@ -164,15 +167,13 @@ export const SelectBoundModal: React.FC<Props> = ({
       setStationState((prev) => ({
         ...prev,
         station,
-        stations: terminateBySelectedStation
-          ? getTerminatedStations(selectedStation, stations)
-          : stations,
+        stations: stops,
         selectedBound:
-          line?.id === TOEI_OEDO_LINE_ID && !terminateBySelectedStation
+          line?.id === TOEI_OEDO_LINE_ID && !stops.length
             ? oedoLineTerminus
             : direction === 'INBOUND'
-              ? stations[stations.length - 1]
-              : stations[0],
+              ? stops[stops.length - 1]
+              : stops[0],
         selectedDirection: direction,
         pendingStation: null,
         pendingStations: [],


### PR DESCRIPTION
fixes #4695
駅リストは指定終着駅から先の情報は切り捨てられていたが、行先が指定した終着駅になっていなかった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 終点指定時に表示・更新する駅一覧を一度だけ算出して再利用するようにし、重複計算を削減して処理効率と一貫性を向上させました。これにより終点に応じた表示切替や境界駅の選択動作がより安定します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->