### PR TITLE
NumberingIconSquareのiOSレイアウト崩れ修正

### DIFF
--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -129,7 +129,7 @@ const NumberingIconSquare: React.FC<Props> = ({
   threeLetterCode,
   allowScaling,
   size,
-  transformOrigin = 'center',
+  transformOrigin = Platform.OS === 'android' ? 'center' : 'bottom',
   withOutline,
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * NumberingIconSquareコンポーネントのデフォルト表示位置をプラットフォーム別に調整しました。Android端末とその他のデバイスで一貫した表示になるよう改善されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->