### PR TITLE
PadLineMarks駅名表示修正

### DIFF
--- a/src/hooks/useIsDifferentStationName.ts
+++ b/src/hooks/useIsDifferentStationName.ts
@@ -38,7 +38,10 @@ export const useIsDifferentStationName = () => {
       }
 
       // nameだと市ヶ谷と市ケ谷の違い程度でも違うものとなってしまうのでよみがなで判別する
-      return station.nameKatakana !== line.station.nameKatakana;
+      return (
+        station.name !== line.station.name &&
+        station.nameKatakana !== line.station.nameKatakana
+      );
     },
     [isEn]
   );

--- a/src/hooks/useIsDifferentStationName.ts
+++ b/src/hooks/useIsDifferentStationName.ts
@@ -37,11 +37,7 @@ export const useIsDifferentStationName = () => {
         );
       }
 
-      // nameだと市ヶ谷と市ケ谷の違い程度でも違うものとなってしまうのでよみがなで判別する
-      return (
-        station.name !== line.station.name &&
-        station.nameKatakana !== line.station.nameKatakana
-      );
+      return station.name !== line.station.name;
     },
     [isEn]
   );


### PR DESCRIPTION
駅名変わらないのに [ 駅名 ] が無意味に表示されていた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 非日本語表示時の駅名差異判定を改善しました。カタカナのみではなく表示される駅名（フルネーム）を基に比較することで、異なる駅をより正確に検出します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->