### PR TITLE
fix(LineBoardToei): restore correct Korean font size in vertical mode

### DIFF
--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -139,7 +139,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
       <View style={styles.splittedStationName}>
         {(station.nameKorean ?? '').split('').map((c, j) => (
           <Typography
-            style={[styles.stationName, passed ? styles.grayColor : null]}
+            style={[styles.stationNameExtra, passed ? styles.grayColor : null]}
             key={`${station.id}-ko-${j}`}
           >
             {c}


### PR DESCRIPTION
Fixes regression introduced in PR #4792 where Korean station names in vertical mode were using the same font size as Japanese names instead of the smaller stationNameExtra style.

## Issue

In vertical display mode, Korean station names (nameKorean) were incorrectly using `styles.stationName` (same size as Japanese text) instead of `styles.stationNameExtra` (smaller font matching Chinese text).

## Fix

Changed Korean text style from:
- `styles.stationName` (incorrect) to:
- `styles.stationNameExtra` (correct)

This restores the original behavior where Korean and Chinese station names use RFValue(10) font size in vertical mode, while Japanese names use the larger default size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 駅名の韓国語表記のビジュアル表示を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->