### PR TITLE
canary

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,13 +142,13 @@ android {
             dimension "environment"
             applicationId "me.tinykitten.trainlcd.dev"
             versionNameSuffix "-dev"
-            versionCode 100000127
-            versionName "10.0.47"
+            versionCode 100000128
+            versionName "10.0.48"
         }
         prod {
             dimension "environment"
-            versionCode 100000127
-            versionName "10.0.47"
+            versionCode 100000128
+            versionName "10.0.48"
         }
     }
 }

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TrainLCD",
     "slug": "trainlcd",
-    "version": "10.0.47",
+    "version": "10.0.48",
     "plugins": [
       "expo-font",
       "expo-localization",
@@ -16,18 +16,18 @@
         "projectId": "dad36dde-0056-4760-8eda-37f05e7c9c6c"
       },
       "versioning": {
-        "androidMinVersionCode": 100000127
+        "androidMinVersionCode": 100000128
       }
     },
     "ios": {
       "bundleIdentifier": "me.tinykitten.trainlcd.dev",
       "scheme": "CanaryTrainLCD",
-      "buildNumber": "2340",
+      "buildNumber": "2341",
       "supportsTablet": true
     },
     "android": {
       "package": "me.tinykitten.trainlcd.dev",
-      "versionCode": 100000127,
+      "versionCode": 100000128,
       "permissions": [
         "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS"

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -2515,7 +2515,7 @@
 				CODE_SIGN_ENTITLEMENTS = TrainLCD/trainlcd.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2340;
+				CURRENT_PROJECT_VERSION = 2341;
 				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -2571,7 +2571,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 10.0.47;
+				MARKETING_VERSION = 10.0.48;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
@@ -2621,7 +2621,7 @@
 				CODE_SIGN_ENTITLEMENTS = TrainLCD/trainlcd.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2340;
+				CURRENT_PROJECT_VERSION = 2341;
 				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -2673,7 +2673,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 10.0.47;
+				MARKETING_VERSION = 10.0.48;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
@@ -3610,7 +3610,7 @@
 				CODE_SIGN_ENTITLEMENTS = CanaryAppClip/CanaryAppClip.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2340;
+				CURRENT_PROJECT_VERSION = 2341;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -3633,7 +3633,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 10.0.47;
+				MARKETING_VERSION = 10.0.48;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -3666,7 +3666,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2340;
+				CURRENT_PROJECT_VERSION = 2341;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -3685,7 +3685,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 10.0.47;
+				MARKETING_VERSION = 10.0.48;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PODS_ROOT = "${SRCROOT}/Pods";

--- a/package.json
+++ b/package.json
@@ -146,5 +146,5 @@
     }
   },
   "name": "trainlcd",
-  "version": "10.0.47"
+  "version": "10.0.48"
 }


### PR DESCRIPTION
* フィードバックモーダルで日本語入力ができない問題を修正

- NewReportModalからPressable onPress={Keyboard.dismiss}を削除
- CustomModalのAnimated.ViewにpointerEvents="auto"を追加
- TextInputを完全に非制御コンポーネント化（refで値を管理）
- 文字数カウントのみを状態で管理し、入力中の再レンダリングを最小化

* CodeRabbitの指摘に対応

- onSubmitのシグネチャを変更し、descriptionを直接引数として渡すように修正
- 状態更新のタイミング問題を解消（onDescriptionChangeを削除）
- useEffectの依存配列からdescriptionを削除し、visibleのみに変更
- Permitted.tsxからreportDescription状態を削除し、handleReportSendで直接引数を使用

* モーダル再表示時にTextInputをクリアする処理を追加

---------