### PR TITLE
シェア時に一時的にOrientationロック解除

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -186,7 +186,14 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           url: urlString,
           type: 'image/png',
         };
-        return Share.open(options);
+
+        ScreenOrientation.unlockAsync().catch(console.error);
+
+        return Share.open(options).finally(() => {
+          ScreenOrientation.lockAsync(
+            ScreenOrientation.OrientationLock.LANDSCAPE
+          ).catch(console.error);
+        });
       }),
       Effect.runPromise
     );

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -168,7 +168,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           catch: captureError,
         })
       ),
-      Effect.andThen((base64) => {
+      Effect.andThen(async (base64) => {
         const urlString = `data:image/jpeg;base64,${base64}`;
 
         const message = isJapanese
@@ -186,14 +186,11 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           url: urlString,
           type: 'image/png',
         };
-
-        ScreenOrientation.unlockAsync().catch(console.error);
-
-        return Share.open(options).finally(() => {
-          ScreenOrientation.lockAsync(
-            ScreenOrientation.OrientationLock.LANDSCAPE
-          ).catch(console.error);
-        });
+        await ScreenOrientation.unlockAsync().catch(console.error);
+        await Share.open(options).catch(console.warn);
+        return ScreenOrientation.lockAsync(
+          ScreenOrientation.OrientationLock.LANDSCAPE
+        ).catch(console.error);
       }),
       Effect.runPromise
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * シェア機能のフローで画面向きの制御を改善しました。シェア前に向きを解除し、シェア完了後（成功・失敗いずれでも）に横向きへ再ロックすることで、向きが固定されたままになる問題を防止します。
  * 非同期処理とエラー処理を強化し、安定性を向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->