### PR TITLE
Android版ではモーダルでKeyboardAvoidingViewを使用しない

### DIFF
--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -118,10 +118,10 @@ export const CustomModal: React.FC<Props> = ({
         />
         <Toast />
 
-        {avoidKeyboard ? (
+        {avoidKeyboard && Platform.OS === 'ios' ? (
           <KeyboardAvoidingView
             style={[StyleSheet.absoluteFill, styles.center, containerStyle]}
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            behavior="padding"
             pointerEvents="box-none"
           >
             <Animated.View


### PR DESCRIPTION
fixes #4842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- モーダルコンポーネントのキーボード回避ビューをiOSプラットフォーム限定で表示するよう改善しました。
- キーボードパディング動作を統一化し、プラットフォーム間での一貫性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->