### PR TITLE
behaviorをpadding固定でAndroid版でもKeyboardAvoidingViewを使う

### DIFF
--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -118,7 +118,7 @@ export const CustomModal: React.FC<Props> = ({
         />
         <Toast />
 
-        {avoidKeyboard && Platform.OS === 'ios' ? (
+        {avoidKeyboard ? (
           <KeyboardAvoidingView
             style={[StyleSheet.absoluteFill, styles.center, containerStyle]}
             behavior="padding"


### PR DESCRIPTION
なぜか #4846 で対応できてなかった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* モーダルのキーボード回避動作がすべてのプラットフォームで一貫して動作するよう改善されました。従来はiOSに限定されていましたが、キーボード回避機能が有効に設定された場合、Androidおよびその他のすべてのプラットフォームにおいても適切にキーボード回避動作が適用されるようになりました。これによりクロスプラットフォーム間でのユーザーエクスペリエンスが向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->