### PR TITLE
乗換パネルから他路線に乗り換えた時にstationsが0駅になるバグを修正

### DIFF
--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -4,7 +4,6 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import {
   Keyboard,
   KeyboardAvoidingView,
-  Platform,
   Pressable,
   StyleSheet,
   View,

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -115,7 +115,7 @@ export const SelectBoundModal: React.FC<Props> = ({
     wantedDestination,
   } = stationAtom;
   const [
-    { autoModeEnabled, trainType, fetchedTrainTypes },
+    { autoModeEnabled, trainType, fetchedTrainTypes, pendingTrainType },
     setNavigationState,
   ] = useAtom(navigationState);
   const [lineAtom, setLineState] = useAtom(lineState);
@@ -176,7 +176,11 @@ export const SelectBoundModal: React.FC<Props> = ({
         pendingStations: [],
         wantedDestination: null,
       }));
-      setNavigationState((prev) => ({ ...prev, leftStations: [] }));
+      setNavigationState((prev) => ({
+        ...prev,
+        leftStations: [],
+        trainType: pendingTrainType,
+      }));
       onBoundSelect();
       requestAnimationFrame(() => {
         navigation.navigate('Main' as never);
@@ -185,11 +189,12 @@ export const SelectBoundModal: React.FC<Props> = ({
     [
       navigation,
       station,
+      stations,
       line,
+      pendingTrainType,
       setLineState,
       setStationState,
       setNavigationState,
-      stations,
       onBoundSelect,
       getTerminatedStations,
     ]
@@ -397,16 +402,16 @@ export const SelectBoundModal: React.FC<Props> = ({
       ? `${stations[0]?.name ?? ''}〜${stations[stations.length - 1]?.name ?? ''}`
       : `${stations[0]?.nameRoman ?? ''} - ${stations[stations.length - 1]?.nameRoman ?? ''}`;
 
-    if (trainType?.groupId) {
+    if (pendingTrainType?.groupId) {
       const trainTypeName =
-        (isJapanese ? trainType.name : trainType.nameRoman) ?? '';
+        (isJapanese ? pendingTrainType.name : pendingTrainType.nameRoman) ?? '';
       const newRoute: SavedRouteWithTrainTypeInput = {
         hasTrainType: true,
         name: wantedDestination
           ? `${lineName} ${trainTypeName} ${edgeStationNames} ${isJapanese ? `${wantedDestination.name}ゆき` : `for ${wantedDestination.nameRoman}`}`.trim()
           : `${lineName} ${trainTypeName} ${edgeStationNames}`.trim(),
         lineId: line.id ?? 0,
-        trainTypeId: trainType?.groupId,
+        trainTypeId: pendingTrainType?.groupId,
         createdAt: new Date(),
       };
       setSavedRoute(await saveCurrentRoute(newRoute));
@@ -444,7 +449,7 @@ export const SelectBoundModal: React.FC<Props> = ({
     saveCurrentRoute,
     wantedDestination,
     line,
-    trainType,
+    pendingTrainType,
     stations,
   ]);
 
@@ -478,16 +483,16 @@ export const SelectBoundModal: React.FC<Props> = ({
       return translate('trainTypesNotExist');
     }
 
-    if (!trainType) {
+    if (!pendingTrainType) {
       return translate('trainTypeSettings');
     }
 
     return translate('trainTypeIs', {
       trainTypeName: isJapanese
-        ? (trainType.name ?? '')
-        : (trainType.nameRoman ?? ''),
+        ? (pendingTrainType.name ?? '')
+        : (pendingTrainType.nameRoman ?? ''),
     });
-  }, [fetchedTrainTypes, trainType]);
+  }, [fetchedTrainTypes, pendingTrainType]);
 
   const stationsWithoutPass = useMemo(
     () => stations.filter((s) => !getIsPass(s)),
@@ -578,7 +583,7 @@ export const SelectBoundModal: React.FC<Props> = ({
 
       <RouteInfoModal
         visible={routeInfoModalVisible}
-        trainType={trainType}
+        trainType={pendingTrainType}
         stations={stationsWithoutPass}
         onClose={() => setRouteInfoModalVisible(false)}
         onSelect={handleStationSelected}

--- a/src/hooks/useBounds.ts
+++ b/src/hooks/useBounds.ts
@@ -20,7 +20,7 @@ export const useBounds = (
   directionalStops: Station[];
 } => {
   const { selectedDirection, selectedBound } = useAtomValue(stationState);
-  const { trainType } = useAtomValue(navigationState);
+  const { pendingTrainType } = useAtomValue(navigationState);
   const currentStation = useCurrentStation();
 
   const {
@@ -71,7 +71,7 @@ export const useBounds = (
       return [oedoLineInboundStops, oedoLineOutboundStops];
     }
 
-    if (!trainType || getIsLocal(trainType)) {
+    if (!pendingTrainType || getIsLocal(pendingTrainType)) {
       if (isLoopLine) {
         return [inboundStationsForLoopLine, outboundStationsForLoopLine];
       }
@@ -85,7 +85,7 @@ export const useBounds = (
     stations,
     outboundStationsForLoopLine,
     isOedoLine,
-    trainType,
+    pendingTrainType,
   ]);
 
   const directionalStops = useMemo(() => {

--- a/src/hooks/useOpenRouteFromLink.test.tsx
+++ b/src/hooks/useOpenRouteFromLink.test.tsx
@@ -135,7 +135,7 @@ describe('useOpenRouteFromLink', () => {
     return { mockFetchByGroup, mockFetchByLine };
   };
 
-  beforeEach(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/src/hooks/useOpenRouteFromLink.test.tsx
+++ b/src/hooks/useOpenRouteFromLink.test.tsx
@@ -85,6 +85,7 @@ const createNavigationState = (
   firstStop: true,
   presetsFetched: false,
   presetRoutes: [],
+  pendingTrainType: null,
   ...overrides,
 });
 
@@ -171,14 +172,14 @@ describe('useOpenRouteFromLink', () => {
 
     const stationSetter = mockSetStationState.mock.calls[0][0];
     const stationResult = stationSetter(createStationState());
-    expect(stationResult.station?.groupId).toBe(1);
-    expect(stationResult.stations).toEqual(stations);
+    expect(stationResult.pendingStation?.groupId).toBe(1);
+    expect(stationResult.pendingStations).toEqual(stations);
     expect(stationResult.selectedDirection).toBe<LineDirection>('INBOUND');
     expect(stationResult.selectedBound?.groupId).toBe(2);
 
     const navigationSetter = mockSetNavigationState.mock.calls[0][0];
     const navigationResult = navigationSetter(createNavigationState());
-    expect(navigationResult.trainType?.typeId).toBe('local');
+    expect(navigationResult.pendingTrainType?.typeId).toBe('local');
     expect(navigationResult.stationForHeader?.groupId).toBe(1);
 
     const lineSetter = mockSetLineState.mock.calls[0][0];

--- a/src/hooks/useOpenRouteFromLink.ts
+++ b/src/hooks/useOpenRouteFromLink.ts
@@ -65,14 +65,14 @@ export const useOpenRouteFromLink = () => {
       setLineState((prev) => ({ ...prev, selectedLine: line }));
       setNavigationState((prev) => ({
         ...prev,
-        trainType: (station.trainType ?? null) as TrainType | null,
+        pendingTrainType: (station.trainType ?? null) as TrainType | null,
         leftStations: [],
         stationForHeader: station,
       }));
       setStationState((prev) => ({
         ...prev,
-        station,
-        stations,
+        pendingStation: station,
+        pendingStations: stations,
         selectedDirection: direction,
         selectedBound:
           direction === 'INBOUND' ? stations[stations.length - 1] : stations[0],

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -42,6 +42,7 @@ export const gqlClient = new ApolloClient({
       StationNested: { keyFields: false },
       TrainTypeNested: { keyFields: false },
       TrainType: { keyFields: false },
+      Station: { keyFields: false },
     },
   }),
 });

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -156,7 +156,7 @@ const MainScreen: React.FC = () => {
       }));
       setNavigationState((prev) => ({
         ...prev,
-        trainType,
+        pendingTrainType: trainType,
       }));
     },
     [fetchStationsByLineGroupId, setStationState, setNavigationState]
@@ -529,6 +529,7 @@ const MainScreen: React.FC = () => {
         variables: { lineId: selectedLine.id, stationId: selectedStation.id },
       });
 
+      setNavigationState((prev) => ({ ...prev, pendingTrainType: null }));
       setLineState((prev) => ({ ...prev, pendingLine: selectedLine }));
       setStationState((prev) => ({
         ...prev,
@@ -536,7 +537,7 @@ const MainScreen: React.FC = () => {
         pendingStations: data?.lineStations ?? [],
       }));
     },
-    [setStationState, setLineState, fetchStationsByLineId]
+    [setStationState, setLineState, fetchStationsByLineId, setNavigationState]
   );
 
   const handleTransferPress = useCallback(

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -272,7 +272,7 @@ const RouteSearchScreen = () => {
       setNavigationState((prev) => ({
         ...prev,
         fetchedTrainTypes,
-        trainType: prev.trainType ?? localTrainType,
+        pendingTrainType: prev.pendingTrainType ?? localTrainType,
       }));
     },
     [
@@ -369,7 +369,7 @@ const RouteSearchScreen = () => {
 
       setNavigationState((prev) => ({
         ...prev,
-        trainType,
+        pendingTrainType: trainType,
       }));
 
       fetchStationsByLineGroupIdClient.cache.evict({

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -594,7 +594,7 @@ const SelectLineScreen = () => {
 
       setNavigationState((prev) => ({
         ...prev,
-        trainType: station.trainType ?? null,
+        pendingTrainType: station.trainType ?? null,
         fetchedTrainTypes: trainTypes,
       }));
     },

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -415,15 +415,15 @@ const SelectLineScreen = () => {
       const result = await fetchStationsByLineId({
         variables: { lineId, stationId: lineStationId },
       });
-      const pendingStations = result.data?.lineStations ?? [];
+      const fetchedStations = result.data?.lineStations ?? [];
 
       const pendingStation =
-        pendingStations.find((s) => s.id === lineStationId) ?? null;
+        fetchedStations.find((s) => s.id === lineStationId) ?? null;
 
       setStationState((prev) => ({
         ...prev,
         pendingStation,
-        pendingStations,
+        pendingStations: fetchedStations,
         selectedDirection: null,
         wantedDestination: null,
         selectedBound: null,
@@ -436,6 +436,7 @@ const SelectLineScreen = () => {
         ...prev,
         fetchedTrainTypes: [],
         trainType: null,
+        pendingTrainType: null,
       }));
 
       if (line.station?.hasTrainTypes) {
@@ -446,7 +447,7 @@ const SelectLineScreen = () => {
         });
         const fetchedTrainTypes = result.data?.stationTrainTypes ?? [];
         const designatedTrainTypeId =
-          pendingStations.find((s) => s.id === lineStationId)?.trainType?.id ??
+          fetchedStations.find((s) => s.id === lineStationId)?.trainType?.id ??
           null;
         const designatedTrainType =
           fetchedTrainTypes.find((tt) => tt.id === designatedTrainTypeId) ??
@@ -454,7 +455,7 @@ const SelectLineScreen = () => {
         setNavigationState((prev) => ({
           ...prev,
           fetchedTrainTypes,
-          trainType: designatedTrainType as TrainType | null,
+          pendingTrainType: designatedTrainType as TrainType | null,
         }));
       }
     },
@@ -481,7 +482,7 @@ const SelectLineScreen = () => {
       }));
       setNavigationState((prev) => ({
         ...prev,
-        trainType,
+        pendingTrainType: trainType,
       }));
     },
     [fetchStationsByLineGroupId, setStationState, setNavigationState]
@@ -529,20 +530,8 @@ const SelectLineScreen = () => {
         ...prev,
         pendingLine: (station.line as Line) ?? null,
       }));
-      setNavigationState((prev) => ({
-        ...prev,
-        fetchedTrainTypes: [],
-        trainType: null,
-      }));
     },
-    [
-      fetchStationsByLineId,
-      latitude,
-      longitude,
-      setNavigationState,
-      setStationState,
-      setLineState,
-    ]
+    [fetchStationsByLineId, latitude, longitude, setStationState, setLineState]
   );
 
   // PresetCard押下時のモーダル表示ロジック
@@ -594,11 +583,6 @@ const SelectLineScreen = () => {
       setLineState((prev) => ({
         ...prev,
         pendingLine: station?.line ?? null,
-      }));
-      setNavigationState((prev) => ({
-        ...prev,
-        fetchedTrainTypes: [],
-        trainType: null,
       }));
 
       const fetchedTrainTypesData = await fetchTrainTypes({

--- a/src/store/atoms/navigation.ts
+++ b/src/store/atoms/navigation.ts
@@ -15,6 +15,7 @@ export type LoopItem = (SavedRoute & { stations: Station[] }) & {
 
 export interface NavigationState {
   leftStations: Station[];
+  pendingTrainType: TrainType | null;
   trainType: TrainType | null;
   headerState: HeaderTransitionState;
   bottomState: BottomTransitionState;
@@ -33,6 +34,7 @@ export interface NavigationState {
 
 export const initialNavigationState: NavigationState = {
   headerState: (isJapanese ? 'CURRENT' : 'CURRENT_EN') as HeaderTransitionState,
+  pendingTrainType: null,
   trainType: null,
   bottomState: 'LINE' as BottomTransitionState,
   leftStations: [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * ナビゲーション状態に「pendingTrainType」フィールドを追加し、選択・保存・表示フローで trainType を置換して挙動を一貫化
  * 選択・リンク開閉・ルート保存など関連画面・フックで pendingTrainType に基づく処理へ変更
  * Apollo キャッシュ設定に駅データ(Station)のポリシー追加で取得動作を最適化

* **Chores**
  * 不要なインポートを削除（コードの軽微整理）

* **Tests**
  * 状態名変更に合わせてテストを更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->