### PR TITLE
常磐快速線と常磐緩行線でアイコンを分けた

### DIFF
--- a/src/lineSymbolImage.ts
+++ b/src/lineSymbolImage.ts
@@ -79,10 +79,9 @@ const getLineSymbolImageWithColor = (line: Line): LineSymbolImage | null => {
     case 11229: // JR常磐線(取手～いわき)
       return { signPath: require('../assets/marks/jre/jj.webp') };
     case 11320: // JR常磐線(上野～取手)
-      return {
-        signPath: require('../assets/marks/jre/jl.webp'),
-        subSignPath: require('../assets/marks/jre/jj.webp'),
-      };
+      return { signPath: require('../assets/marks/jre/jj.webp') };
+    case 11344: // JR常磐線(緩行線)
+      return { signPath: require('../assets/marks/jre/jl.webp') };
     case 11326: // 京葉線
       return { signPath: require('../assets/marks/jre/je.webp') };
     case 11305: // 武蔵野線

--- a/src/lineSymbolImage.ts
+++ b/src/lineSymbolImage.ts
@@ -596,10 +596,9 @@ const getLineSymbolImageGrayscaleImage = (
     case 11321: // 埼京線
       return { signPath: require('../assets/marks/jre/ja_g.webp') };
     case 11320: // 常磐線
-      return {
-        signPath: require('../assets/marks/jre/jl_g.webp'),
-        subSignPath: require('../assets/marks/jre/jj_g.webp'),
-      };
+      return { signPath: require('../assets/marks/jre/jl_g.webp') };
+    case 11344: // JR常磐線(緩行線)
+      return { signPath: require('../assets/marks/jre/jj_g.webp') };
     case 11326: // 京葉線
       return { signPath: require('../assets/marks/jre/je_g.webp') };
     case 11305: // 武蔵野線


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * JR常磐線(上野～取手)の路線シンボル表示を最適化しました（表示されるシンボルが整理されます）。
  * JR常磐線(緩行線)の路線シンボル表示に対応しました（新しいシンボルが表示されます）。
  * シンボルの標準表示とモノクロ表示の両方を更新し、見た目の一貫性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->