### PR TITLE
バス使用時のHeaderとLineBoardではカッコで囲われたバス停名を非表示にする

### DIFF
--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -1,7 +1,9 @@
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useCurrentStation } from '../hooks';
+import { TransportType } from '~/@types/graphql';
+import { parenthesisRegexp } from '~/constants';
+import { useCurrentLine, useCurrentStation } from '../hooks';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import { themeAtom } from '../store/atoms/theme';
@@ -34,10 +36,18 @@ const LineBoard: React.FC<Props> = ({ hasTerminus = false }: Props) => {
   const theme = useAtomValue(themeAtom);
   const { leftStations } = useAtomValue(navigationState);
   const station = useCurrentStation();
+  const currentLine = useCurrentLine();
+  const isBus = currentLine?.transportType === TransportType.Bus;
 
   const slicedLeftStations = useMemo(
-    () => leftStations.slice(0, 8),
-    [leftStations]
+    () =>
+      leftStations.slice(0, 8).map((sta) => ({
+        ...sta,
+        nameRoman: isBus
+          ? sta.nameRoman?.replace(parenthesisRegexp, '')
+          : sta.nameRoman,
+      })),
+    [leftStations, isBus]
   );
 
   const currentStationIndex = useMemo(

--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { TransportType } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
-import { useCurrentLine, useCurrentStation } from '../hooks';
+import { useCurrentStation } from '../hooks';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import { themeAtom } from '../store/atoms/theme';
@@ -36,8 +36,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus = false }: Props) => {
   const theme = useAtomValue(themeAtom);
   const { leftStations } = useAtomValue(navigationState);
   const station = useCurrentStation();
-  const currentLine = useCurrentLine();
-  const isBus = currentLine?.transportType === TransportType.Bus;
+  const isBus = station?.line?.transportType === TransportType.Bus;
 
   const slicedLeftStations = useMemo(
     () =>

--- a/src/hooks/useHeaderStationText.ts
+++ b/src/hooks/useHeaderStationText.ts
@@ -1,10 +1,12 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import type { Station } from '~/@types/graphql';
+import { type Station, TransportType } from '~/@types/graphql';
+import { parenthesisRegexp } from '~/constants';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import katakanaToHiragana from '../utils/kanaToHiragana';
+import { useCurrentLine } from './useCurrentLine';
 
 type UseHeaderStationTextOptions = {
   currentStation: Station | undefined;
@@ -22,7 +24,10 @@ export const useHeaderStationText = ({
   const { headerState } = useAtomValue(navigationState);
   const { selectedBound } = useAtomValue(stationState);
 
-  return useMemo<string>(() => {
+  const currentLine = useCurrentLine();
+  const isBus = currentLine?.transportType === TransportType.Bus;
+
+  const rawText = useMemo<string>(() => {
     if (!selectedBound) {
       return currentStation?.name ?? '';
     }
@@ -101,4 +106,6 @@ export const useHeaderStationText = ({
     firstStop,
     headerLangState,
   ]);
+
+  return isBus ? rawText.replace(parenthesisRegexp, '') : rawText;
 };

--- a/src/hooks/useHeaderStationText.ts
+++ b/src/hooks/useHeaderStationText.ts
@@ -6,7 +6,6 @@ import type { HeaderLangState } from '../models/HeaderTransitionState';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import katakanaToHiragana from '../utils/kanaToHiragana';
-import { useCurrentLine } from './useCurrentLine';
 
 type UseHeaderStationTextOptions = {
   currentStation: Station | undefined;
@@ -24,8 +23,7 @@ export const useHeaderStationText = ({
   const { headerState } = useAtomValue(navigationState);
   const { selectedBound } = useAtomValue(stationState);
 
-  const currentLine = useCurrentLine();
-  const isBus = currentLine?.transportType === TransportType.Bus;
+  const isBus = currentStation?.line?.transportType === TransportType.Bus;
 
   const rawText = useMemo<string>(() => {
     if (!selectedBound) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * バス路線の駅名表示から括弧を自動で削除し、ヘッダーと駅一覧で一貫した表示にしました。
  * 駅一覧は表示数を制限して見やすさを向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->