### PR TITLE
バスの場合日本語バス停名もカッコを消す

### DIFF
--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -42,6 +42,7 @@ const LineBoard: React.FC<Props> = ({ hasTerminus = false }: Props) => {
     () =>
       leftStations.slice(0, 8).map((sta) => ({
         ...sta,
+        name: isBus ? sta.name?.replace(parenthesisRegexp, '') : sta.name,
         nameRoman: isBus
           ? sta.nameRoman?.replace(parenthesisRegexp, '')
           : sta.nameRoman,


### PR DESCRIPTION
https://github.com/TrainLCD/MobileApp/pull/4890/changes#r2657135266

上記レビューの指摘対応。最初指摘の意味を理解できていなかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* バス路線の名前表示から括弧が削除されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->