### PR TITLE
路線リストに都営バス見出し追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -221,5 +221,6 @@
   "ekidatajp": "Ekidata.jp",
   "toei": "Bureau of Transportation, Tokyo Metropolitan Government",
   "ccby": "CC BY 4.0 (Data has been modified)",
-  "otherOss": "Other Open Source Software"
+  "otherOss": "Other Open Source Software",
+  "toeiBusStopsNearby": "Nearby bus routes (Toei Bus)"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -222,5 +222,6 @@
   "ekidatajp": "駅データ.jp",
   "toei": "東京都交通局",
   "ccby": "CC BY 4.0(加工して利用)",
-  "otherOss": "その他オープンソースソフトウェア"
+  "otherOss": "その他オープンソースソフトウェア",
+  "toeiBusStopsNearby": "周辺のバス路線（都営バス）"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 路線選択画面に都営バスの周辺バス路線情報を表示する新しいセクションを追加しました。鉄道路線の下に、近隣のバス路線を一覧で確認できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->