### PR TITLE
座標検索クエリからtransportType: TransportType.Railを削除

### DIFF
--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -347,7 +347,6 @@ const SelectLineScreen = () => {
         latitude: location.coords.latitude,
         longitude: location.coords.longitude,
         limit: 1,
-        transportType: TransportType.Rail,
       });
       const stationFromAPI = data.data?.stationsNearby[0] ?? null;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 近くの駅検索機能がすべての交通機関の種類に対応するようになりました。これまでレール（鉄道）のみに限定されていた検索結果が、より広範な交通機関オプションを含むようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->