### PR TITLE
バスは乗換情報に使わない

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -8,7 +8,6 @@ import {
   View,
 } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
-import { isBusLine } from '~/utils/line';
 import { NUMBERING_ICON_SIZE, parenthesisRegexp } from '../constants';
 import {
   useCurrentStation,
@@ -140,7 +139,6 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
       if (!station) {
         return null;
       }
-      const isBus = isBusLine(line);
       const lineMark = getLineMarkFunc({
         line,
       });
@@ -254,21 +252,22 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
                   }}
                 >
                   <Typography style={styles.lineName}>
-                    {`${line.station?.name?.replace(parenthesisRegexp, '')}${isBus ? '' : '駅'}`}
+                    {`${line.station?.name?.replace(parenthesisRegexp, '')}駅`}
                   </Typography>
                   <Typography style={styles.lineNameEn}>
                     {`${(line.station?.nameRoman ?? '').replace(
                       parenthesisRegexp,
                       ''
-                    )}${isBus ? '' : ' Sta.'}`}
+                    )} Sta.`}
                   </Typography>
                   <Typography style={styles.lineNameEn}>
                     {`${(line.station?.nameChinese ?? '').replace(
                       parenthesisRegexp,
                       ''
-                    )}${isBus ? '' : '站'} / ${(
-                      line.station?.nameKorean ?? ''
-                    ).replace(parenthesisRegexp, '')}${isBus ? '' : '역'}`}
+                    )}站 / ${(line.station?.nameKorean ?? '').replace(
+                      parenthesisRegexp,
+                      ''
+                    )}역`}
                   </Typography>
                 </TouchableOpacity>
               )}

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -5,7 +5,7 @@ import { File, Paths } from 'expo-file-system';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { DEV_TTS_API_URL, PRODUCTION_TTS_API_URL } from 'react-native-dotenv';
-import { TransportType } from '~/@types/graphql';
+import { isBusLine } from '~/utils/line';
 import speechState from '../store/atoms/speech';
 import { isDevApp } from '../utils/isDevApp';
 import { useBusTTSText } from './useBusTTSText';
@@ -66,10 +66,8 @@ export const useTTS = (): void => {
   const { store, getByText } = useTTSCache();
   const trainTTSText = useTTSText(firstSpeechRef.current, enabled);
   const busTTSText = useBusTTSText(firstSpeechRef.current, enabled);
-  const ttsText =
-    currentLine?.transportType === TransportType.Bus
-      ? busTTSText
-      : trainTTSText;
+  const isBus = isBusLine(currentLine);
+  const ttsText = isBus ? busTTSText : trainTTSText;
   const [prevTextJa, prevTextEn] = usePrevious(ttsText);
   const [textJa, textEn] = ttsText;
 

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
-import { type Station, TransportType } from '~/@types/graphql';
+import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '../constants';
 import { APP_THEME, type AppTheme } from '../models/Theme';
 import stationState from '../store/atoms/station';
@@ -46,7 +46,7 @@ export const useTTSText = (
   const station = useCurrentStation();
   const currentLineOrigin = useCurrentLine();
 
-  const connectedLinesOrigin = useConnectedLines();
+  const connectedLines = useConnectedLines();
   const transferLines = useTransferLines();
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false);
@@ -177,14 +177,6 @@ export const useTTSText = (
         : 'Station Number '
     }${symbol} ${num}.`;
   }, [nextStationNumber, theme]);
-
-  const connectedLines = useMemo(
-    () =>
-      connectedLinesOrigin?.filter(
-        (l) => l.station?.transportType === TransportType.Rail
-      ),
-    [connectedLinesOrigin]
-  );
 
   const nextStation = useMemo(
     () =>

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -47,7 +47,7 @@ export const useTTSText = (
   const currentLineOrigin = useCurrentLine();
 
   const connectedLinesOrigin = useConnectedLines();
-  const transferLinesOriginal = useTransferLines();
+  const transferLines = useTransferLines();
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false);
   const loopLineBoundEn = useLoopLineBound(false, 'EN');
@@ -91,14 +91,6 @@ export const useTTSText = (
         ? `<sub alias="かくえきていしゃ">各駅停車</sub>`
         : `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`,
     []
-  );
-
-  const transferLines = useMemo(
-    () =>
-      transferLinesOriginal.filter(
-        (l) => l.station?.transportType === TransportType.Rail
-      ),
-    [transferLinesOriginal]
   );
 
   const currentLine = useMemo(

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -47,7 +47,7 @@ export const useTTSText = (
   const currentLineOrigin = useCurrentLine();
 
   const connectedLinesOrigin = useConnectedLines();
-  const transferLinesOriginal = useTransferLines();
+  const transferLinesOriginal = useTransferLines({ hideBuses: false });
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false);
   const loopLineBoundEn = useLoopLineBound(false, 'EN');

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -47,7 +47,7 @@ export const useTTSText = (
   const currentLineOrigin = useCurrentLine();
 
   const connectedLinesOrigin = useConnectedLines();
-  const transferLinesOriginal = useTransferLines({ hideBuses: false });
+  const transferLinesOriginal = useTransferLines();
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false);
   const loopLineBoundEn = useLoopLineBound(false, 'EN');

--- a/src/hooks/useTransferLines.test.tsx
+++ b/src/hooks/useTransferLines.test.tsx
@@ -31,7 +31,7 @@ jest.mock('../utils/isPass', () => ({
 }));
 
 const TestComponent: React.FC<{
-  options?: { omitJR?: boolean; hideBuses?: boolean };
+  options?: { omitJR?: boolean };
 }> = ({ options }) => {
   const lines = useTransferLines(options);
   return <Text testID="transferLines">{JSON.stringify(lines)}</Text>;
@@ -149,9 +149,8 @@ describe('useTransferLines', () => {
     expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(
       currentStation,
       {
-        omitRepeatingLine: undefined,
+        omitRepeatingLine: false,
         omitJR: false,
-        hideBuses: true,
       }
     );
     expect(getByTestId('transferLines').props.children).toContain('metro');
@@ -172,7 +171,6 @@ describe('useTransferLines', () => {
       {
         omitRepeatingLine: undefined,
         omitJR: true,
-        hideBuses: undefined,
       }
     );
   });
@@ -185,53 +183,8 @@ describe('useTransferLines', () => {
     render(<TestComponent />);
 
     expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
-      omitRepeatingLine: undefined,
+      omitRepeatingLine: false,
       omitJR: false,
-      hideBuses: true,
     });
-  });
-
-  it('hideBuses: falseを指定するとバス路線も含めて渡す', () => {
-    const currentStation = createStation(30);
-    const transferLines = [
-      createLine({ id: 200, nameShort: 'metro' }),
-      createLine({ id: 201, nameShort: 'bus' }),
-    ];
-    stationAtomValue.arrived = true;
-    currentStationValue = currentStation;
-    nextStationValue = createStation(31);
-    mockUseTransferLinesFromStation.mockReturnValue(transferLines);
-
-    const { getByTestId } = render(
-      <TestComponent options={{ hideBuses: false }} />
-    );
-
-    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(
-      currentStation,
-      {
-        omitRepeatingLine: undefined,
-        omitJR: undefined,
-        hideBuses: false,
-      }
-    );
-    expect(getByTestId('transferLines').props.children).toContain('bus');
-  });
-
-  it('hideBuses: trueを明示的に指定するとバス路線を除外する', () => {
-    const currentStation = createStation(40);
-    stationAtomValue.arrived = true;
-    currentStationValue = currentStation;
-    nextStationValue = createStation(41);
-
-    render(<TestComponent options={{ hideBuses: true }} />);
-
-    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(
-      currentStation,
-      {
-        omitRepeatingLine: undefined,
-        omitJR: undefined,
-        hideBuses: true,
-      }
-    );
   });
 });

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -10,7 +10,6 @@ import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
-  hideBuses?: boolean;
 };
 
 export const useTransferLines = (options?: Option): Line[] => {
@@ -25,16 +24,14 @@ export const useTransferLines = (options?: Option): Line[] => {
     [arrived, currentStation, nextStation]
   );
 
-  const { omitRepeatingLine, omitJR, hideBuses } = options ?? {
-    omitRepeatingLines: false,
+  const { omitRepeatingLine, omitJR } = options ?? {
+    omitRepeatingLine: false,
     omitJR: false,
-    hideBuses: true,
   };
 
   const transferLines = useTransferLinesFromStation(targetStation, {
     omitRepeatingLine,
     omitJR,
-    hideBuses,
   });
 
   return transferLines;

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -7,7 +7,11 @@ import { useCurrentStation } from './useCurrentStation';
 import { useNextStation } from './useNextStation';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 
-type Option = { omitRepeatingLine?: boolean; omitJR?: boolean };
+type Option = {
+  omitRepeatingLine?: boolean;
+  omitJR?: boolean;
+  hideBuses?: boolean;
+};
 
 export const useTransferLines = (options?: Option): Line[] => {
   const { arrived } = useAtomValue(stationState);
@@ -21,14 +25,16 @@ export const useTransferLines = (options?: Option): Line[] => {
     [arrived, currentStation, nextStation]
   );
 
-  const { omitRepeatingLine, omitJR } = options ?? {
+  const { omitRepeatingLine, omitJR, hideBuses } = options ?? {
     omitRepeatingLines: false,
     omitJR: false,
+    hideBuses: true,
   };
 
   const transferLines = useTransferLinesFromStation(targetStation, {
     omitRepeatingLine,
     omitJR,
+    hideBuses,
   });
 
   return transferLines;

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -3,13 +3,13 @@ import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { Text } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
-import type { LineNested } from '~/@types/graphql.d';
 import {
   LineType,
   OperationStatus,
   StopCondition,
   TransportType,
 } from '~/@types/graphql';
+import type { LineNested } from '~/@types/graphql.d';
 import stationState from '../store/atoms/station';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 
@@ -33,9 +33,7 @@ const TestComponent: React.FC<TestComponentProps> = ({ station, options }) => {
   return <Text testID="transferLines">{JSON.stringify(lines)}</Text>;
 };
 
-const createLineNested = (
-  overrides: Partial<LineNested> = {}
-): LineNested => ({
+const createLineNested = (overrides: Partial<LineNested> = {}): LineNested => ({
   __typename: 'LineNested',
   averageDistance: null,
   color: '#123456',

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -2,14 +2,13 @@ import { render } from '@testing-library/react-native';
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { Text } from 'react-native';
-import type { Line, Station } from '~/@types/graphql';
+import type { Line, LineNested, Station } from '~/@types/graphql';
 import {
   LineType,
   OperationStatus,
   StopCondition,
   TransportType,
 } from '~/@types/graphql';
-import type { LineNested } from '~/@types/graphql.d';
 import stationState from '../store/atoms/station';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 
@@ -24,7 +23,6 @@ type TestComponentProps = {
   options?: {
     omitRepeatingLine?: boolean;
     omitJR?: boolean;
-    hideBuses?: boolean;
   };
 };
 
@@ -108,13 +106,11 @@ describe('useTransferLinesFromStation', () => {
   });
 
   it('station が undefined の場合は空配列を返す', () => {
-    const { getByTestId } = render(
-      <TestComponent station={undefined} options={{ hideBuses: true }} />
-    );
+    const { getByTestId } = render(<TestComponent station={undefined} />);
     expect(getByTestId('transferLines').props.children).toBe('[]');
   });
 
-  it('デフォルトでバス路線を除外する', () => {
+  it('バス路線を除外する', () => {
     const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
     const railLine = createLineNested({
       id: 2,
@@ -141,63 +137,6 @@ describe('useTransferLinesFromStation', () => {
     expect(lines.find((l: Line) => l.id === 3)).toBeUndefined();
   });
 
-  it('hideBuses: false を指定するとバス路線も含める', () => {
-    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
-    const railLine = createLineNested({
-      id: 2,
-      nameShort: '山手線',
-      transportType: TransportType.Rail,
-    });
-    const busLine = createLineNested({
-      id: 3,
-      nameShort: 'バス',
-      transportType: TransportType.Bus,
-    });
-    const station = createStation(100, {
-      line: currentLine,
-      lines: [currentLine, railLine, busLine],
-    });
-    stationAtomValue.stations = [station];
-
-    const { getByTestId } = render(
-      <TestComponent station={station} options={{ hideBuses: false }} />
-    );
-    const lines = JSON.parse(
-      getByTestId('transferLines').props.children as string
-    );
-
-    expect(lines.map((l: Line) => l.id)).toEqual([2, 3]);
-  });
-
-  it('hideBuses: true を明示的に指定してもバス路線を除外する', () => {
-    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
-    const railLine = createLineNested({
-      id: 2,
-      nameShort: '山手線',
-      transportType: TransportType.Rail,
-    });
-    const busLine = createLineNested({
-      id: 3,
-      nameShort: 'バス',
-      transportType: TransportType.Bus,
-    });
-    const station = createStation(100, {
-      line: currentLine,
-      lines: [currentLine, railLine, busLine],
-    });
-    stationAtomValue.stations = [station];
-
-    const { getByTestId } = render(
-      <TestComponent station={station} options={{ hideBuses: true }} />
-    );
-    const lines = JSON.parse(
-      getByTestId('transferLines').props.children as string
-    );
-
-    expect(lines.map((l: Line) => l.id)).toEqual([2]);
-    expect(lines.find((l: Line) => l.id === 3)).toBeUndefined();
-  });
-
   it('現在路線は除外する', () => {
     const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
     const otherLine = createLineNested({ id: 2, nameShort: '山手線' });
@@ -207,9 +146,7 @@ describe('useTransferLinesFromStation', () => {
     });
     stationAtomValue.stations = [station];
 
-    const { getByTestId } = render(
-      <TestComponent station={station} options={{ hideBuses: true }} />
-    );
+    const { getByTestId } = render(<TestComponent station={station} />);
     const lines = JSON.parse(
       getByTestId('transferLines').props.children as string
     );
@@ -234,9 +171,7 @@ describe('useTransferLinesFromStation', () => {
     });
     stationAtomValue.stations = [station];
 
-    const { getByTestId } = render(
-      <TestComponent station={station} options={{ hideBuses: true }} />
-    );
+    const { getByTestId } = render(<TestComponent station={station} />);
     const lines = JSON.parse(
       getByTestId('transferLines').props.children as string
     );

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -179,4 +179,295 @@ describe('useTransferLinesFromStation', () => {
     expect(lines.map((l: Line) => l.id)).toEqual([3]);
     expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
   });
+
+  it('omitRepeatingLine が true の場合、前後の駅に同一路線がある並走路線を除外する', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const parallelLine = createLineNested({ id: 2, nameShort: '総武線' });
+    const uniqueLine = createLineNested({ id: 3, nameShort: '丸ノ内線' });
+
+    const prevStation = createStation(99, {
+      line: currentLine,
+      lines: [currentLine, parallelLine],
+    });
+    const currentStation = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, parallelLine, uniqueLine],
+    });
+    const nextStation = createStation(101, {
+      line: currentLine,
+      lines: [currentLine, parallelLine],
+    });
+
+    stationAtomValue.stations = [prevStation, currentStation, nextStation];
+
+    const { getByTestId } = render(
+      <TestComponent
+        station={currentStation}
+        options={{ omitRepeatingLine: true }}
+      />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([3]);
+    expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
+  });
+
+  it('omitRepeatingLine が true でも次の駅で直通運転している場合は並走路線を除外しない', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const throughServiceLine = createLineNested({ id: 4, nameShort: '東西線' });
+    const parallelLine = createLineNested({ id: 2, nameShort: '総武線' });
+
+    const prevStation = createStation(99, {
+      line: currentLine,
+      lines: [currentLine, parallelLine],
+    });
+    const currentStation = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, parallelLine],
+    });
+    const nextStation = createStation(101, {
+      line: throughServiceLine,
+      lines: [throughServiceLine, parallelLine],
+    });
+
+    stationAtomValue.stations = [prevStation, currentStation, nextStation];
+
+    const { getByTestId } = render(
+      <TestComponent
+        station={currentStation}
+        options={{ omitRepeatingLine: true }}
+      />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toContain(2);
+  });
+
+  it('omitJR が true で JR路線が閾値以上の場合、JR線として集約される', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '丸ノ内線' });
+    const jrLine1 = createLineNested({
+      id: 101,
+      nameShort: '山手線',
+      company: {
+        __typename: 'Company',
+        id: 2,
+        railroadId: 1,
+        type: undefined,
+        status: undefined,
+        name: 'JR東日本',
+        nameShort: 'JR東',
+        nameFull: 'JR東日本',
+        nameKatakana: 'ジェイアールヒガシニホン',
+        nameEnglishShort: 'JR East',
+        nameEnglishFull: 'JR East',
+        url: undefined,
+      },
+    });
+    const jrLine2 = createLineNested({
+      id: 102,
+      nameShort: '京浜東北線',
+      company: {
+        __typename: 'Company',
+        id: 2,
+        railroadId: 1,
+        type: undefined,
+        status: undefined,
+        name: 'JR東日本',
+        nameShort: 'JR東',
+        nameFull: 'JR東日本',
+        nameKatakana: 'ジェイアールヒガシニホン',
+        nameEnglishShort: 'JR East',
+        nameEnglishFull: 'JR East',
+        url: undefined,
+      },
+    });
+    const jrLine3 = createLineNested({
+      id: 103,
+      nameShort: '中央線',
+      company: {
+        __typename: 'Company',
+        id: 2,
+        railroadId: 1,
+        type: undefined,
+        status: undefined,
+        name: 'JR東日本',
+        nameShort: 'JR東',
+        nameFull: 'JR東日本',
+        nameKatakana: 'ジェイアールヒガシニホン',
+        nameEnglishShort: 'JR East',
+        nameEnglishFull: 'JR East',
+        url: undefined,
+      },
+    });
+    const nonJRLine = createLineNested({
+      id: 200,
+      nameShort: '銀座線',
+      company: {
+        __typename: 'Company',
+        id: 100,
+        railroadId: 100,
+        type: undefined,
+        status: undefined,
+        name: '東京メトロ',
+        nameShort: 'メトロ',
+        nameFull: '東京メトロ',
+        nameKatakana: 'トウキョウメトロ',
+        nameEnglishShort: 'Tokyo Metro',
+        nameEnglishFull: 'Tokyo Metro',
+        url: undefined,
+      },
+    });
+
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, jrLine1, jrLine2, jrLine3, nonJRLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ omitJR: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    const jrUnionLine = lines.find((l: Line) => l.nameShort === 'JR線');
+    expect(jrUnionLine).toBeDefined();
+    expect(lines.find((l: Line) => l.id === 101)).toBeUndefined();
+    expect(lines.find((l: Line) => l.id === 102)).toBeUndefined();
+    expect(lines.find((l: Line) => l.id === 103)).toBeUndefined();
+    expect(lines.find((l: Line) => l.nameShort === '銀座線')).toBeDefined();
+  });
+
+  it('omitJR が true でも JR路線が閾値未満の場合、個別路線が返される', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '丸ノ内線' });
+    const jrLine1 = createLineNested({
+      id: 101,
+      nameShort: '山手線',
+      company: {
+        __typename: 'Company',
+        id: 2,
+        railroadId: 1,
+        type: undefined,
+        status: undefined,
+        name: 'JR東日本',
+        nameShort: 'JR東',
+        nameFull: 'JR東日本',
+        nameKatakana: 'ジェイアールヒガシニホン',
+        nameEnglishShort: 'JR East',
+        nameEnglishFull: 'JR East',
+        url: undefined,
+      },
+    });
+    const jrLine2 = createLineNested({
+      id: 102,
+      nameShort: '京浜東北線',
+      company: {
+        __typename: 'Company',
+        id: 2,
+        railroadId: 1,
+        type: undefined,
+        status: undefined,
+        name: 'JR東日本',
+        nameShort: 'JR東',
+        nameFull: 'JR東日本',
+        nameKatakana: 'ジェイアールヒガシニホン',
+        nameEnglishShort: 'JR East',
+        nameEnglishFull: 'JR East',
+        url: undefined,
+      },
+    });
+    const nonJRLine = createLineNested({
+      id: 200,
+      nameShort: '銀座線',
+      company: {
+        __typename: 'Company',
+        id: 100,
+        railroadId: 100,
+        type: undefined,
+        status: undefined,
+        name: '東京メトロ',
+        nameShort: 'メトロ',
+        nameFull: '東京メトロ',
+        nameKatakana: 'トウキョウメトロ',
+        nameEnglishShort: 'Tokyo Metro',
+        nameEnglishFull: 'Tokyo Metro',
+        url: undefined,
+      },
+    });
+
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, jrLine1, jrLine2, nonJRLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ omitJR: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.find((l: Line) => l.nameShort === 'JR線')).toBeUndefined();
+    expect(lines.find((l: Line) => l.nameShort === '山手線')).toBeDefined();
+    expect(lines.find((l: Line) => l.nameShort === '京浜東北線')).toBeDefined();
+    expect(lines.find((l: Line) => l.nameShort === '銀座線')).toBeDefined();
+  });
+
+  it('返される路線の nameShort と nameRoman からカッコ内の文字が除去される', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const lineWithParentheses = createLineNested({
+      id: 2,
+      nameShort: '総武線(各駅停車)',
+      nameRoman: 'Sobu Line (Local)',
+    });
+
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, lineWithParentheses],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(<TestComponent station={station} />);
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    const resultLine = lines.find((l: Line) => l.id === 2);
+    expect(resultLine).toBeDefined();
+    expect(resultLine.nameShort).toBe('総武線');
+    expect(resultLine.nameRoman).toBe('Sobu Line ');
+  });
+
+  it('omitJR が true の場合でもカッコ内の文字が除去される', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '丸ノ内線' });
+    const lineWithParentheses = createLineNested({
+      id: 2,
+      nameShort: '銀座線(渋谷方面)',
+      nameRoman: 'Ginza Line (Shibuya)',
+    });
+
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, lineWithParentheses],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ omitJR: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    const resultLine = lines.find((l: Line) => l.id === 2);
+    expect(resultLine).toBeDefined();
+    expect(resultLine.nameShort).toBe('銀座線');
+    expect(resultLine.nameRoman).toBe('Ginza Line ');
+  });
 });

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -1,0 +1,249 @@
+import { render } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import { Text } from 'react-native';
+import type { Line, Station } from '~/@types/graphql';
+import type { LineNested } from '~/@types/graphql.d';
+import {
+  LineType,
+  OperationStatus,
+  StopCondition,
+  TransportType,
+} from '~/@types/graphql';
+import stationState from '../store/atoms/station';
+import { useTransferLinesFromStation } from './useTransferLinesFromStation';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  useAtomValue: jest.fn(),
+  atom: jest.fn(),
+}));
+
+type TestComponentProps = {
+  station: Station | undefined;
+  options?: {
+    omitRepeatingLine?: boolean;
+    omitJR?: boolean;
+    hideBuses?: boolean;
+  };
+};
+
+const TestComponent: React.FC<TestComponentProps> = ({ station, options }) => {
+  const lines = useTransferLinesFromStation(station, options);
+  return <Text testID="transferLines">{JSON.stringify(lines)}</Text>;
+};
+
+const createLineNested = (
+  overrides: Partial<LineNested> = {}
+): LineNested => ({
+  __typename: 'LineNested',
+  averageDistance: null,
+  color: '#123456',
+  company: null,
+  id: 1,
+  lineSymbols: [],
+  lineType: LineType.Normal,
+  nameChinese: null,
+  nameFull: 'Line',
+  nameKatakana: 'ライン',
+  nameKorean: '라인',
+  nameRoman: 'Line',
+  nameShort: 'Line',
+  station: null,
+  status: OperationStatus.InOperation,
+  trainType: null,
+  transportType: TransportType.Rail,
+  ...overrides,
+});
+
+const createStation = (
+  id: number,
+  overrides: Partial<Station> = {}
+): Station => ({
+  __typename: 'Station',
+  address: null,
+  closedAt: null,
+  distance: null,
+  groupId: id,
+  hasTrainTypes: false,
+  id,
+  latitude: null,
+  line: null,
+  lines: [],
+  longitude: null,
+  name: `Station${id}`,
+  nameChinese: null,
+  nameKatakana: `ステーション${id}`,
+  nameKorean: null,
+  nameRoman: `Station${id}`,
+  openedAt: null,
+  postalCode: null,
+  prefectureId: null,
+  stationNumbers: [],
+  status: OperationStatus.InOperation,
+  stopCondition: StopCondition.All,
+  threeLetterCode: null,
+  trainType: null,
+  transportType: null,
+  ...overrides,
+});
+
+describe('useTransferLinesFromStation', () => {
+  const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+    typeof useAtomValue
+  >;
+
+  let stationAtomValue: { stations: Station[] };
+
+  beforeEach(() => {
+    stationAtomValue = { stations: [] };
+    mockUseAtomValue.mockImplementation((atom) => {
+      if (atom === stationState) {
+        return stationAtomValue;
+      }
+      throw new Error('unknown atom');
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('station が undefined の場合は空配列を返す', () => {
+    const { getByTestId } = render(
+      <TestComponent station={undefined} options={{ hideBuses: true }} />
+    );
+    expect(getByTestId('transferLines').props.children).toBe('[]');
+  });
+
+  it('デフォルトでバス路線を除外する', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const railLine = createLineNested({
+      id: 2,
+      nameShort: '山手線',
+      transportType: TransportType.Rail,
+    });
+    const busLine = createLineNested({
+      id: 3,
+      nameShort: 'バス',
+      transportType: TransportType.Bus,
+    });
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, railLine, busLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(<TestComponent station={station} />);
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([2]);
+    expect(lines.find((l: Line) => l.id === 3)).toBeUndefined();
+  });
+
+  it('hideBuses: false を指定するとバス路線も含める', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const railLine = createLineNested({
+      id: 2,
+      nameShort: '山手線',
+      transportType: TransportType.Rail,
+    });
+    const busLine = createLineNested({
+      id: 3,
+      nameShort: 'バス',
+      transportType: TransportType.Bus,
+    });
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, railLine, busLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ hideBuses: false }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([2, 3]);
+  });
+
+  it('hideBuses: true を明示的に指定してもバス路線を除外する', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const railLine = createLineNested({
+      id: 2,
+      nameShort: '山手線',
+      transportType: TransportType.Rail,
+    });
+    const busLine = createLineNested({
+      id: 3,
+      nameShort: 'バス',
+      transportType: TransportType.Bus,
+    });
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, railLine, busLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ hideBuses: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([2]);
+    expect(lines.find((l: Line) => l.id === 3)).toBeUndefined();
+  });
+
+  it('現在路線は除外する', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '中央線' });
+    const otherLine = createLineNested({ id: 2, nameShort: '山手線' });
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, otherLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ hideBuses: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([2]);
+    expect(lines.find((l: Line) => l.id === 1)).toBeUndefined();
+  });
+
+  it('カッコを除いて同名の路線は除外する', () => {
+    const currentLine = createLineNested({
+      id: 1,
+      nameShort: 'JR神戸線(大阪～神戸)',
+    });
+    const sameLine = createLineNested({
+      id: 2,
+      nameShort: 'JR神戸線(神戸～姫路)',
+    });
+    const otherLine = createLineNested({ id: 3, nameShort: '山手線' });
+    const station = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, sameLine, otherLine],
+    });
+    stationAtomValue.stations = [station];
+
+    const { getByTestId } = render(
+      <TestComponent station={station} options={{ hideBuses: true }} />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([3]);
+    expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
+  });
+});

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -4,19 +4,22 @@ import type { Line, Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '../constants';
 import stationState from '../store/atoms/station';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
+import { isBusLine } from '~/utils/line';
 
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
+  hideBuses?: boolean;
 };
 
 export const useTransferLinesFromStation = (
   station: Station | undefined,
   option?: Option
 ): Line[] => {
-  const { omitRepeatingLine, omitJR } = option ?? {
+  const { omitRepeatingLine, omitJR, hideBuses } = option ?? {
     omitRepeatingLine: false,
     omitJR: false,
+    hideBuses: true,
   };
 
   const { stations } = useAtomValue(stationState);
@@ -24,6 +27,7 @@ export const useTransferLinesFromStation = (
   const transferLines = useMemo(
     () =>
       station?.lines
+        ?.filter((line) => !(hideBuses && isBusLine(line)))
         ?.filter((line) => line.id !== station.line?.id)
         // カッコを除いて路線名が同じということは、
         // データ上の都合で路線が分かれているだけなので除外する
@@ -71,6 +75,7 @@ export const useTransferLinesFromStation = (
       station?.line?.nameShort,
       station?.lines,
       stations,
+      hideBuses,
     ]
   );
 

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -1,10 +1,10 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import type { Line, Station } from '~/@types/graphql';
+import { isBusLine } from '~/utils/line';
 import { parenthesisRegexp } from '../constants';
 import stationState from '../store/atoms/station';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
-import { isBusLine } from '~/utils/line';
 
 type Option = {
   omitRepeatingLine?: boolean;

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -9,17 +9,15 @@ import omitJRLinesIfThresholdExceeded from '../utils/jr';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
-  hideBuses?: boolean;
 };
 
 export const useTransferLinesFromStation = (
   station: Station | undefined,
   option?: Option
 ): Line[] => {
-  const { omitRepeatingLine, omitJR, hideBuses } = option ?? {
+  const { omitRepeatingLine, omitJR } = option ?? {
     omitRepeatingLine: false,
     omitJR: false,
-    hideBuses: true,
   };
 
   const { stations } = useAtomValue(stationState);
@@ -27,7 +25,7 @@ export const useTransferLinesFromStation = (
   const transferLines = useMemo(
     () =>
       station?.lines
-        ?.filter((line) => !(hideBuses && isBusLine(line)))
+        ?.filter((line) => !isBusLine(line))
         ?.filter((line) => line.id !== station.line?.id)
         // カッコを除いて路線名が同じということは、
         // データ上の都合で路線が分かれているだけなので除外する
@@ -75,7 +73,6 @@ export const useTransferLinesFromStation = (
       station?.line?.nameShort,
       station?.lines,
       stations,
-      hideBuses,
     ]
   );
 

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -38,6 +38,7 @@ import {
 } from '~/lib/graphql/queries';
 import type { SavedRoute } from '~/models/SavedRoute';
 import isTablet from '~/utils/isTablet';
+import { isBusLine } from '~/utils/line';
 import FooterTabBar, { FOOTER_BASE_HEIGHT } from '../components/FooterTabBar';
 import { Heading } from '../components/Heading';
 import { ASYNC_STORAGE_KEYS, LOCATION_TASK_NAME } from '../constants';
@@ -185,8 +186,7 @@ const SelectLineScreen = () => {
 
   const stationLines = useMemo<Line[]>(() => {
     return (station?.lines ?? []).filter(
-      (line): line is LineNested =>
-        line?.id != null && line.transportType === TransportType.Rail
+      (line): line is LineNested => line?.id != null && !isBusLine(line)
     );
   }, [station?.lines]);
   const busesLines = useMemo<Line[]>(() => {

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -18,13 +18,7 @@ import {
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import {
-  type Line,
-  type LineNested,
-  type Station,
-  type TrainType,
-  TransportType,
-} from '~/@types/graphql';
+import type { Line, LineNested, Station, TrainType } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
 import { EmptyLineSeparator } from '~/components/EmptyLineSeparator';
 import { NowHeader } from '~/components/NowHeader';
@@ -191,8 +185,7 @@ const SelectLineScreen = () => {
   }, [station?.lines]);
   const busesLines = useMemo<Line[]>(() => {
     return (station?.lines ?? []).filter(
-      (line): line is LineNested =>
-        line?.id != null && line.transportType === TransportType.Bus
+      (line): line is LineNested => line?.id != null && isBusLine(line)
     );
   }, [station?.lines]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 駅名表示を統一し、全路線で各言語の接尾辞（日本語「駅」、英語「Sta.」、中国語「站」、韓国語「역」）を常に表示するように修正
  * 乗り換え候補の既定挙動を明確化し、繰り返し路線を省略しない設定をデフォルト化
  * 案内音声（TTS）の路線判定と文言選択処理を安定化

* **Tests**
  * 乗り換え候補の表示振る舞いやバスの扱い、重複除外などを検証する包括的なテストを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->