### PR TITLE
駅リストでバス停以外はバス停の乗換案内を隠す

### DIFF
--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -9,6 +9,7 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import dropEitherJunctionStation from '~/utils/dropJunctionStation';
 import isTablet from '~/utils/isTablet';
+import { filterBusLinesForNonBusStation } from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
 import Button from './Button';
 import { CommonCard } from './CommonCard';
@@ -105,7 +106,8 @@ export const RouteInfoModal = ({
 
   const renderItem = useCallback(
     ({ item }: { item: Station }) => {
-      const { line, lines } = item;
+      const { line, lines: linesRaw } = item;
+      const lines = filterBusLinesForNonBusStation(line, linesRaw);
       if (!line) return null;
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;

--- a/src/components/StationSearchModal.tsx
+++ b/src/components/StationSearchModal.tsx
@@ -19,6 +19,7 @@ import { locationAtom } from '~/store/atoms/location';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
+import { filterBusLinesForNonBusStation } from '~/utils/line';
 import Button from './Button';
 import { CommonCard } from './CommonCard';
 import { CustomModal } from './CustomModal';
@@ -157,7 +158,8 @@ export const StationSearchModal = ({ visible, onClose, onSelect }: Props) => {
 
   const renderItem = useCallback(
     ({ item }: { item: Station }) => {
-      const { line, lines } = item;
+      const { line, lines: linesRaw } = item;
+      const lines = filterBusLinesForNonBusStation(line, linesRaw);
       if (!line) return null;
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;

--- a/src/utils/line.test.ts
+++ b/src/utils/line.test.ts
@@ -1,5 +1,5 @@
 import { TransportType } from '~/@types/graphql';
-import { isBusLine } from './line';
+import { filterBusLinesForNonBusStation, isBusLine } from './line';
 
 describe('isBusLine', () => {
   it('should return true for Bus transport type', () => {
@@ -30,5 +30,68 @@ describe('isBusLine', () => {
 
   it('should return false for null transportType', () => {
     expect(isBusLine({ transportType: null })).toBe(false);
+  });
+});
+
+describe('filterBusLinesForNonBusStation', () => {
+  const railLine = { transportType: TransportType.Rail };
+  const busLine = { transportType: TransportType.Bus };
+  const railAndBusLine = { transportType: TransportType.RailAndBus };
+
+  it('should filter out bus lines when current line is rail', () => {
+    const lines = [railLine, busLine, railAndBusLine];
+    const result = filterBusLinesForNonBusStation(railLine, lines);
+    expect(result).toEqual([railLine, railAndBusLine]);
+  });
+
+  it('should keep all lines when current line is bus', () => {
+    const lines = [railLine, busLine, railAndBusLine];
+    const result = filterBusLinesForNonBusStation(busLine, lines);
+    expect(result).toEqual([railLine, busLine, railAndBusLine]);
+  });
+
+  it('should filter out bus lines when current line is RailAndBus', () => {
+    const lines = [railLine, busLine, railAndBusLine];
+    const result = filterBusLinesForNonBusStation(railAndBusLine, lines);
+    expect(result).toEqual([railLine, railAndBusLine]);
+  });
+
+  it('should return empty array when lines is null', () => {
+    const result = filterBusLinesForNonBusStation(railLine, null);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when lines is undefined', () => {
+    const result = filterBusLinesForNonBusStation(railLine, undefined);
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out bus lines when current line is null', () => {
+    const lines = [railLine, busLine, railAndBusLine];
+    const result = filterBusLinesForNonBusStation(null, lines);
+    expect(result).toEqual([railLine, railAndBusLine]);
+  });
+
+  it('should filter out bus lines when current line is undefined', () => {
+    const lines = [railLine, busLine, railAndBusLine];
+    const result = filterBusLinesForNonBusStation(undefined, lines);
+    expect(result).toEqual([railLine, railAndBusLine]);
+  });
+
+  it('should return empty array when both current line and lines are null', () => {
+    const result = filterBusLinesForNonBusStation(null, null);
+    expect(result).toEqual([]);
+  });
+
+  it('should keep only rail lines from mixed array when current is rail', () => {
+    const lines = [busLine, busLine, railLine];
+    const result = filterBusLinesForNonBusStation(railLine, lines);
+    expect(result).toEqual([railLine]);
+  });
+
+  it('should return all bus lines when current line is bus', () => {
+    const lines = [busLine, busLine, busLine];
+    const result = filterBusLinesForNonBusStation(busLine, lines);
+    expect(result).toEqual([busLine, busLine, busLine]);
   });
 });

--- a/src/utils/line.ts
+++ b/src/utils/line.ts
@@ -34,3 +34,17 @@ export const getNextStationLinesWithoutCurrentLine = (
   forceStationIndex?: number
 ): Line[] =>
   filterWithoutCurrentLine(stations, selectedLine, forceStationIndex ?? 1);
+
+/**
+ * バス停以外の駅ではバス路線を除外してフィルタリングする
+ * バス停の場合はすべての路線を表示
+ */
+export const filterBusLinesForNonBusStation = <
+  T extends Pick<Line, 'transportType'>,
+>(
+  currentLine: Pick<Line, 'transportType'> | null | undefined,
+  lines: T[] | null | undefined
+): T[] => {
+  if (!lines) return [];
+  return lines.filter((l) => isBusLine(currentLine) || !isBusLine(l));
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善点**
  * バス駅以外での路線情報表示を最適化しました。関連するバス路線のみが表示されるようになります。

* **テスト**
  * 路線フィルタリング機能のテストケースを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->