### PR TITLE
プリセットを削除できないことがあるバグを修正

### DIFF
--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -1,4 +1,5 @@
 import { useAtom } from 'jotai';
+import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 
 // Mock jotai
@@ -96,5 +97,83 @@ describe('SelectBoundModal - wantedDestinationロジック', () => {
     }));
 
     expect(mockSetStationState).toHaveBeenCalledWith(expect.any(Function));
+  });
+});
+
+describe('SelectBoundModal - 保存済み経路の検索ロジック', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pendingTrainType.groupId を使用して保存済み経路を検索する', () => {
+    const mockNavigationState = {
+      pendingTrainType: { id: 1, groupId: 100, name: '快速' },
+      fetchedTrainTypes: [{ id: 1, groupId: 100, name: '快速' }],
+      trainType: null, // trainType ではなく pendingTrainType を使用すべき
+      presetsFetched: true,
+      presetRoutes: [],
+    };
+
+    (useAtom as jest.Mock).mockReturnValue([mockNavigationState, jest.fn()]);
+
+    const [state] = useAtom(navigationState);
+
+    // 保存済み経路の検索には pendingTrainType.groupId を使用する
+    expect(state.pendingTrainType?.groupId).toBe(100);
+    // trainType ではなく pendingTrainType を使用することを確認
+    expect(state.trainType).toBeNull();
+  });
+
+  it('pendingTrainType が null の場合、trainTypeId: null で検索する', () => {
+    const mockNavigationState = {
+      pendingTrainType: null,
+      fetchedTrainTypes: [],
+      trainType: null,
+      presetsFetched: true,
+      presetRoutes: [],
+    };
+
+    (useAtom as jest.Mock).mockReturnValue([mockNavigationState, jest.fn()]);
+
+    const [state] = useAtom(navigationState);
+
+    // pendingTrainType が null の場合、trainTypeId: null で検索する
+    expect(state.pendingTrainType?.groupId ?? null).toBeNull();
+  });
+
+  it('種別変更時に pendingTrainType が更新され、保存済み経路の検索条件が変わる', () => {
+    const mockSetNavigationState = jest.fn();
+    const initialState = {
+      pendingTrainType: null,
+      fetchedTrainTypes: [
+        { id: 1, groupId: 100, name: '快速' },
+        { id: 2, groupId: 200, name: '急行' },
+      ],
+      trainType: null,
+      presetsFetched: true,
+      presetRoutes: [],
+    };
+
+    (useAtom as jest.Mock).mockReturnValue([
+      initialState,
+      mockSetNavigationState,
+    ]);
+
+    // 種別選択時の処理をシミュレート
+    const selectedTrainType = { id: 2, groupId: 200, name: '急行' };
+    mockSetNavigationState((prev: typeof initialState) => ({
+      ...prev,
+      pendingTrainType: selectedTrainType,
+    }));
+
+    expect(mockSetNavigationState).toHaveBeenCalledWith(expect.any(Function));
+
+    const updateFunction = mockSetNavigationState.mock.calls[0][0];
+    const updatedState = updateFunction(initialState);
+
+    // pendingTrainType が更新されている
+    expect(updatedState.pendingTrainType).toEqual(selectedTrainType);
+    // これにより検索条件が trainTypeId: 200 に変わる
+    expect(updatedState.pendingTrainType?.groupId).toBe(200);
   });
 });

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -115,7 +115,7 @@ export const SelectBoundModal: React.FC<Props> = ({
     wantedDestination,
   } = stationAtom;
   const [
-    { autoModeEnabled, trainType, fetchedTrainTypes, pendingTrainType },
+    { autoModeEnabled, fetchedTrainTypes, pendingTrainType },
     setNavigationState,
   ] = useAtom(navigationState);
   const [lineAtom, setLineState] = useAtom(lineState);
@@ -141,10 +141,10 @@ export const SelectBoundModal: React.FC<Props> = ({
 
     const route = findSavedRoute({
       lineId: line.id ?? 0,
-      trainTypeId: trainType?.groupId ?? null,
+      trainTypeId: pendingTrainType?.groupId ?? null,
     });
     setSavedRoute(route ?? null);
-  }, [findSavedRoute, line, trainType?.groupId, isRoutesDBInitialized]);
+  }, [findSavedRoute, line, pendingTrainType?.groupId, isRoutesDBInitialized]);
 
   const currentIndex = stations.findIndex(
     (s) => s.groupId === station?.groupId

--- a/src/hooks/useSavedRoutes.test.tsx
+++ b/src/hooks/useSavedRoutes.test.tsx
@@ -346,7 +346,21 @@ describe('useSavedRoutes', () => {
       ).toBe(withTrainType);
     });
 
-    it('trainTypeId が不一致でも lineId が一致すればルートを返す', async () => {
+    it('trainTypeId が指定されている場合、hasTrainType: false のルートは返さない', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      // trainTypeId を指定して検索した場合、hasTrainType: false のルートは一致しない
+      expect(
+        result.current.find({
+          lineId: withoutTrainType.lineId,
+          trainTypeId: 999,
+        })
+      ).toBeNull();
+    });
+
+    it('trainTypeId が null の場合、hasTrainType: false のルートを返す', async () => {
       const { result, store } = renderWithPresetRoutes();
       await waitFor(() =>
         expect(store.get(navigationState).presetsFetched).toBe(true)
@@ -354,7 +368,7 @@ describe('useSavedRoutes', () => {
       expect(
         result.current.find({
           lineId: withoutTrainType.lineId,
-          trainTypeId: 999,
+          trainTypeId: null,
         })
       ).toBe(withoutTrainType);
     });
@@ -367,6 +381,95 @@ describe('useSavedRoutes', () => {
       expect(
         result.current.find({ lineId: 9999, trainTypeId: 8888 })
       ).toBeNull();
+    });
+
+    it('trainTypeId が指定されている場合、hasTrainType: true でも trainTypeId が一致しなければ null を返す', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      // lineId は一致するが trainTypeId が異なる
+      expect(
+        result.current.find({
+          lineId: withTrainType.lineId,
+          trainTypeId: 999, // 実際の trainTypeId は 7
+        })
+      ).toBeNull();
+    });
+
+    it('trainTypeId が null の場合、hasTrainType: true のルートは返さない', async () => {
+      const { result, store } = renderWithPresetRoutes();
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+      // lineId は一致するが trainTypeId: null で検索
+      expect(
+        result.current.find({
+          lineId: withTrainType.lineId,
+          trainTypeId: null,
+        })
+      ).toBeNull();
+    });
+
+    it('同じ lineId で異なる trainTypeId の経路が複数ある場合、正しい経路を返す', async () => {
+      const route1: SavedRoute = {
+        id: 'route-1',
+        hasTrainType: true,
+        lineId: 300,
+        trainTypeId: 10,
+        name: 'Route 1',
+        createdAt: new Date('2025-01-05T00:00:00.000Z'),
+      };
+      const route2: SavedRoute = {
+        id: 'route-2',
+        hasTrainType: true,
+        lineId: 300,
+        trainTypeId: 20,
+        name: 'Route 2',
+        createdAt: new Date('2025-01-06T00:00:00.000Z'),
+      };
+      const routeNoTrainType: SavedRoute = {
+        id: 'route-3',
+        hasTrainType: false,
+        lineId: 300,
+        trainTypeId: null,
+        name: 'Route 3 (no train type)',
+        createdAt: new Date('2025-01-07T00:00:00.000Z'),
+      };
+
+      const store = createStore();
+      store.set(navigationState, {
+        ...initialNavigationState,
+        presetRoutes: [route1, route2, routeNoTrainType],
+      });
+      const { result } = renderHook(
+        () => require('./useSavedRoutes').useSavedRoutes(),
+        {
+          wrapper: withJotaiProvider(store),
+        }
+      );
+
+      await waitFor(() =>
+        expect(store.get(navigationState).presetsFetched).toBe(true)
+      );
+
+      // trainTypeId: 10 で検索 → route1 を返す
+      expect(result.current.find({ lineId: 300, trainTypeId: 10 })).toBe(
+        route1
+      );
+
+      // trainTypeId: 20 で検索 → route2 を返す
+      expect(result.current.find({ lineId: 300, trainTypeId: 20 })).toBe(
+        route2
+      );
+
+      // trainTypeId: null で検索 → routeNoTrainType を返す
+      expect(result.current.find({ lineId: 300, trainTypeId: null })).toBe(
+        routeNoTrainType
+      );
+
+      // trainTypeId: 30 で検索 → 該当なし
+      expect(result.current.find({ lineId: 300, trainTypeId: 30 })).toBeNull();
     });
   });
 });

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -100,11 +100,16 @@ export const useSavedRoutes = () => {
       trainTypeId: number | null;
     }): SavedRoute | null => {
       return (
-        routes.find((r) =>
-          r.hasTrainType
-            ? r.trainTypeId === trainTypeId && r.lineId === lineId
-            : r.lineId === lineId
-        ) ?? null
+        routes.find((r) => {
+          if (r.lineId !== lineId) return false;
+
+          if (trainTypeId !== null) {
+            // 種別指定で検索する場合、hasTrainType: true かつ trainTypeId が一致する必要がある
+            return r.hasTrainType && r.trainTypeId === trainTypeId;
+          }
+          // trainTypeId === null の場合、hasTrainType: false の経路のみを検索
+          return !r.hasTrainType;
+        }) ?? null
       );
     },
     [routes]

--- a/src/screens/SelectLineScreen.test.tsx
+++ b/src/screens/SelectLineScreen.test.tsx
@@ -117,3 +117,167 @@ describe('SelectLineScreen - pendingWantedDestination削除', () => {
     expect(result.current[0]).not.toHaveProperty('pendingWantedDestination');
   });
 });
+
+describe('SelectLineScreen - PresetCard押下時の状態リセット', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('openModalByLineId (hasTrainType: false のプリセット)', () => {
+    it('pendingTrainType と fetchedTrainTypes がリセットされる', () => {
+      const mockSetNavigationState = jest.fn();
+      const mockNavigationState = {
+        headerState: 'CURRENT',
+        leftStations: [],
+        trainType: null,
+        pendingTrainType: { id: 1, groupId: 100, name: '快速' }, // 前回の値が残っている
+        autoModeEnabled: true,
+        stationForHeader: null,
+        arrived: false,
+        approaching: false,
+        isLEDTheme: false,
+        fetchedTrainTypes: [{ id: 1, groupId: 100, name: '快速' }], // 前回の値が残っている
+        headerTransitionDelay: false,
+        targetAutoModeStation: null,
+        firstStop: true,
+        presetsFetched: true,
+        presetRoutes: [],
+      };
+
+      (useAtom as jest.Mock).mockReturnValue([
+        mockNavigationState,
+        mockSetNavigationState,
+      ]);
+
+      // openModalByLineId で行われる setNavigationState をシミュレート
+      mockSetNavigationState((prev: typeof mockNavigationState) => ({
+        ...prev,
+        fetchedTrainTypes: [],
+        pendingTrainType: null,
+      }));
+
+      expect(mockSetNavigationState).toHaveBeenCalledWith(expect.any(Function));
+
+      const updateFunction = mockSetNavigationState.mock.calls[0][0];
+      const updatedState = updateFunction(mockNavigationState);
+
+      // pendingTrainType が null にリセットされている
+      expect(updatedState.pendingTrainType).toBeNull();
+      // fetchedTrainTypes が空配列にリセットされている
+      expect(updatedState.fetchedTrainTypes).toEqual([]);
+    });
+
+    it('stationState の selectedDirection と wantedDestination がリセットされる', () => {
+      const mockSetStationState = jest.fn();
+      const mockStationState = {
+        station: null,
+        stations: [],
+        pendingStation: null,
+        pendingStations: [],
+        selectedDirection: 'INBOUND', // 前回の値が残っている
+        wantedDestination: { id: 1, groupId: 1, name: '東京' }, // 前回の値が残っている
+      };
+
+      (useAtom as jest.Mock).mockReturnValue([
+        mockStationState,
+        mockSetStationState,
+      ]);
+
+      // openModalByLineId で行われる setStationState をシミュレート
+      mockSetStationState((prev: typeof mockStationState) => ({
+        ...prev,
+        selectedDirection: null,
+        pendingStation: { id: 2, name: '渋谷' },
+        pendingStations: [{ id: 2, name: '渋谷' }],
+        wantedDestination: null,
+      }));
+
+      expect(mockSetStationState).toHaveBeenCalledWith(expect.any(Function));
+
+      const updateFunction = mockSetStationState.mock.calls[0][0];
+      const updatedState = updateFunction(mockStationState);
+
+      expect(updatedState.selectedDirection).toBeNull();
+      expect(updatedState.wantedDestination).toBeNull();
+    });
+  });
+
+  describe('openModalByTrainTypeId (hasTrainType: true のプリセット)', () => {
+    it('stationState の selectedDirection と wantedDestination がリセットされる', () => {
+      const mockSetStationState = jest.fn();
+      const mockStationState = {
+        station: null,
+        stations: [],
+        pendingStation: null,
+        pendingStations: [],
+        selectedDirection: 'OUTBOUND', // 前回の値が残っている
+        wantedDestination: { id: 1, groupId: 1, name: '品川' }, // 前回の値が残っている
+      };
+
+      (useAtom as jest.Mock).mockReturnValue([
+        mockStationState,
+        mockSetStationState,
+      ]);
+
+      // openModalByTrainTypeId で行われる setStationState をシミュレート
+      mockSetStationState((prev: typeof mockStationState) => ({
+        ...prev,
+        selectedDirection: null,
+        pendingStation: { id: 3, name: '新宿' },
+        pendingStations: [{ id: 3, name: '新宿' }],
+        wantedDestination: null,
+      }));
+
+      expect(mockSetStationState).toHaveBeenCalledWith(expect.any(Function));
+
+      const updateFunction = mockSetStationState.mock.calls[0][0];
+      const updatedState = updateFunction(mockStationState);
+
+      expect(updatedState.selectedDirection).toBeNull();
+      expect(updatedState.wantedDestination).toBeNull();
+    });
+
+    it('pendingTrainType が正しく設定される', () => {
+      const mockSetNavigationState = jest.fn();
+      const mockNavigationState = {
+        headerState: 'CURRENT',
+        leftStations: [],
+        trainType: null,
+        pendingTrainType: null,
+        autoModeEnabled: true,
+        stationForHeader: null,
+        arrived: false,
+        approaching: false,
+        isLEDTheme: false,
+        fetchedTrainTypes: [],
+        headerTransitionDelay: false,
+        targetAutoModeStation: null,
+        firstStop: true,
+        presetsFetched: true,
+        presetRoutes: [],
+      };
+
+      const expectedTrainType = { id: 5, groupId: 200, name: '急行' };
+
+      (useAtom as jest.Mock).mockReturnValue([
+        mockNavigationState,
+        mockSetNavigationState,
+      ]);
+
+      // openModalByTrainTypeId で行われる setNavigationState をシミュレート
+      mockSetNavigationState((prev: typeof mockNavigationState) => ({
+        ...prev,
+        pendingTrainType: expectedTrainType,
+        fetchedTrainTypes: [expectedTrainType],
+      }));
+
+      expect(mockSetNavigationState).toHaveBeenCalledWith(expect.any(Function));
+
+      const updateFunction = mockSetNavigationState.mock.calls[0][0];
+      const updatedState = updateFunction(mockNavigationState);
+
+      expect(updatedState.pendingTrainType).toEqual(expectedTrainType);
+      expect(updatedState.fetchedTrainTypes).toContainEqual(expectedTrainType);
+    });
+  });
+});

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -534,8 +534,20 @@ const SelectLineScreen = () => {
         ...prev,
         pendingLine: (station.line as Line) ?? null,
       }));
+      setNavigationState((prev) => ({
+        ...prev,
+        fetchedTrainTypes: [],
+        pendingTrainType: null,
+      }));
     },
-    [fetchStationsByLineId, latitude, longitude, setStationState, setLineState]
+    [
+      fetchStationsByLineId,
+      latitude,
+      longitude,
+      setStationState,
+      setLineState,
+      setNavigationState,
+    ]
   );
 
   // PresetCard押下時のモーダル表示ロジック
@@ -581,8 +593,10 @@ const SelectLineScreen = () => {
 
       setStationState((prev) => ({
         ...prev,
+        selectedDirection: null,
         pendingStation: station,
         pendingStations: stations,
+        wantedDestination: null,
       }));
       setLineState((prev) => ({
         ...prev,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 保存済み経路の検索ロジックを改善し、列車タイプ選択時の動作を正確化
  * プリセットカード使用時のUI状態リセット処理を改善

* **Tests**
  * 保存済み経路検索と列車タイプ処理に関するテストケースを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->