### PR TITLE
列車種別があるプリセットを削除できないことがあるバグを修正

### DIFF
--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -101,14 +101,13 @@ export const useSavedRoutes = () => {
     }): SavedRoute | null => {
       return (
         routes.find((r) => {
-          if (r.lineId !== lineId) return false;
-
           if (trainTypeId !== null) {
-            // 種別指定で検索する場合、hasTrainType: true かつ trainTypeId が一致する必要がある
+            // 種別指定で検索する場合、trainTypeId（lineGroupId）のみで一意に識別できる
+            // lineIdは経路の中間駅で異なる可能性があるため比較しない
             return r.hasTrainType && r.trainTypeId === trainTypeId;
           }
-          // trainTypeId === null の場合、hasTrainType: false の経路のみを検索
-          return !r.hasTrainType;
+          // trainTypeId === null の場合、lineId が一致し、hasTrainType: false の経路を検索
+          return r.lineId === lineId && !r.hasTrainType;
         }) ?? null
       );
     },

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -99,17 +99,20 @@ export const useSavedRoutes = () => {
       lineId: number | null;
       trainTypeId: number | null;
     }): SavedRoute | null => {
-      return (
-        routes.find((r) => {
-          if (trainTypeId !== null) {
-            // 種別指定で検索する場合、trainTypeId（lineGroupId）のみで一意に識別できる
-            // lineIdは経路の中間駅で異なる可能性があるため比較しない
-            return r.hasTrainType && r.trainTypeId === trainTypeId;
-          }
-          // trainTypeId === null の場合、lineId が一致し、hasTrainType: false の経路を検索
-          return r.lineId === lineId && !r.hasTrainType;
-        }) ?? null
-      );
+      if (trainTypeId !== null) {
+        // 種別指定で検索する場合、trainTypeId（lineGroupId）のみで一意に識別できる
+        // lineIdは経路の中間駅で異なる可能性があるため比較しない
+        return (
+          routes.find((r) => r.hasTrainType && r.trainTypeId === trainTypeId) ??
+          null
+        );
+      }
+      // trainTypeId === null の場合は lineId が必須
+      if (lineId === null) {
+        return null;
+      }
+      // lineId が一致し、hasTrainType: false の経路を検索
+      return routes.find((r) => r.lineId === lineId && !r.hasTrainType) ?? null;
     },
     [routes]
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 訓練タイプIDによるルート検索ロジックを改良し、同一の訓練タイプIDを持つルートを異なるラインIDにまたがって正しく検出するようにしました。

* **Tests**
  * 訓練タイプIDでの複数ラインID検索を検証するテストケースを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->