### PR TITLE
経路検索画面で駅が変更された場合経路検索結果をクリアする

### DIFF
--- a/src/screens/RouteSearchScreen.test.tsx
+++ b/src/screens/RouteSearchScreen.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { useAtom, useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 
@@ -108,5 +109,126 @@ describe('RouteSearchScreen - wantedDestination の状態管理', () => {
     }));
 
     expect(mockSetStationState).toHaveBeenCalledWith(expect.any(Function));
+  });
+});
+
+describe('RouteSearchScreen - 駅グループ変更時の検索結果クリア', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('station.groupIdが変更されたら検索結果がクリアされる', () => {
+    const setSearchResults = jest.fn();
+    const setHasSearched = jest.fn();
+
+    // RouteSearchScreen内のuseEffectロジックを再現
+    const useResetSearchOnGroupChange = (groupId: number | undefined) => {
+      // biome-ignore lint/correctness/useExhaustiveDependencies: groupIdの変更を意図的に監視するテスト
+      useEffect(() => {
+        setSearchResults([]);
+        setHasSearched(false);
+      }, [groupId]);
+    };
+
+    const { rerender } = renderHook(
+      ({ groupId }) => useResetSearchOnGroupChange(groupId),
+      { initialProps: { groupId: 1 } }
+    );
+
+    // 初回レンダリングでクリアが呼ばれる
+    expect(setSearchResults).toHaveBeenCalledWith([]);
+    expect(setHasSearched).toHaveBeenCalledWith(false);
+
+    jest.clearAllMocks();
+
+    // groupIdを変更
+    rerender({ groupId: 2 });
+
+    // groupId変更後にクリアが呼ばれる
+    expect(setSearchResults).toHaveBeenCalledWith([]);
+    expect(setHasSearched).toHaveBeenCalledWith(false);
+  });
+
+  it('station.groupIdが同じ値の場合は検索結果がクリアされない', () => {
+    const setSearchResults = jest.fn();
+    const setHasSearched = jest.fn();
+
+    const useResetSearchOnGroupChange = (groupId: number | undefined) => {
+      // biome-ignore lint/correctness/useExhaustiveDependencies: groupIdの変更を意図的に監視するテスト
+      useEffect(() => {
+        setSearchResults([]);
+        setHasSearched(false);
+      }, [groupId]);
+    };
+
+    const { rerender } = renderHook(
+      ({ groupId }) => useResetSearchOnGroupChange(groupId),
+      { initialProps: { groupId: 1 } }
+    );
+
+    // 初回レンダリング分をクリア
+    jest.clearAllMocks();
+
+    // 同じgroupIdで再レンダリング
+    rerender({ groupId: 1 });
+
+    // 同じ値なのでクリアは呼ばれない
+    expect(setSearchResults).not.toHaveBeenCalled();
+    expect(setHasSearched).not.toHaveBeenCalled();
+  });
+
+  it('station.groupIdがundefinedからnumberに変更されたら検索結果がクリアされる', () => {
+    const setSearchResults = jest.fn();
+    const setHasSearched = jest.fn();
+
+    const useResetSearchOnGroupChange = (groupId: number | undefined) => {
+      // biome-ignore lint/correctness/useExhaustiveDependencies: groupIdの変更を意図的に監視するテスト
+      useEffect(() => {
+        setSearchResults([]);
+        setHasSearched(false);
+      }, [groupId]);
+    };
+
+    const { rerender } = renderHook(
+      ({ groupId }) => useResetSearchOnGroupChange(groupId),
+      { initialProps: { groupId: undefined as number | undefined } }
+    );
+
+    // 初回レンダリング分をクリア
+    jest.clearAllMocks();
+
+    // undefinedから数値に変更
+    rerender({ groupId: 1 });
+
+    // クリアが呼ばれる
+    expect(setSearchResults).toHaveBeenCalledWith([]);
+    expect(setHasSearched).toHaveBeenCalledWith(false);
+  });
+
+  it('検索結果とhasSearchedの両方がリセットされる', () => {
+    // useState を使用した実際の状態管理をシミュレート
+    const useSearchState = (groupId: number | undefined) => {
+      const [searchResults, setSearchResults] = useState<string[]>([
+        'result1',
+        'result2',
+      ]);
+      const [hasSearched, setHasSearched] = useState(true);
+
+      // biome-ignore lint/correctness/useExhaustiveDependencies: groupIdの変更を意図的に監視するテスト
+      useEffect(() => {
+        setSearchResults([]);
+        setHasSearched(false);
+      }, [groupId]);
+
+      return { searchResults, hasSearched };
+    };
+
+    const { result } = renderHook(({ groupId }) => useSearchState(groupId), {
+      initialProps: { groupId: 1 },
+    });
+
+    // 初回レンダリング後、useEffectによりクリアされている
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.hasSearched).toBe(false);
   });
 });

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -131,6 +131,13 @@ const RouteSearchScreen = () => {
 
   const scrollY = useSharedValue(0);
 
+  // 駅グループが変更されたら検索結果をクリア
+  // biome-ignore lint/correctness/useExhaustiveDependencies: station?.groupId の変更を意図的に監視
+  useEffect(() => {
+    setSearchResults([]);
+    setHasSearched(false);
+  }, [station?.groupId]);
+
   const [
     fetchRouteTypes,
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ステーション グループを切り替える際に、前の検索結果が自動的にリセットされるようになりました。新しいグループでの検索結果の精度が向上します。

* **テスト**
  * ステーション変更時に検索状態が正しくリセットされることを検証するテストが追加されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->