### PR TITLE
経路検索時に目的地方向のボタンしか表示しないように修正

### DIFF
--- a/src/components/CustomModal.test.tsx
+++ b/src/components/CustomModal.test.tsx
@@ -1,0 +1,166 @@
+import { render, waitFor } from '@testing-library/react-native';
+import type React from 'react';
+import { Text } from 'react-native';
+import { runOnJS, withTiming } from 'react-native-reanimated';
+import { CustomModal } from './CustomModal';
+
+// jotaiのモック
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+// @gorhom/portalのモック
+jest.mock('@gorhom/portal', () => ({
+  Portal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// react-native-reanimated のモックを拡張
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  const { View } = require('react-native');
+  return {
+    ...Reanimated,
+    useSharedValue: jest.fn((initial) => ({ value: initial })),
+    useAnimatedStyle: jest.fn(() => ({})),
+    withTiming: jest.fn((value, _config, callback) => {
+      if (callback) callback(true);
+      return value;
+    }),
+    runOnJS: jest.fn((fn) => fn),
+    cancelAnimation: jest.fn(),
+    interpolate: jest.fn((value, inputRange, outputRange) => {
+      const progress =
+        (value - inputRange[0]) / (inputRange[1] - inputRange[0]);
+      return outputRange[0] + progress * (outputRange[1] - outputRange[0]);
+    }),
+    createAnimatedComponent: jest.fn((component) => component),
+    default: {
+      View,
+      ScrollView: View,
+    },
+  };
+});
+
+describe('CustomModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('visible=true の場合、childrenがレンダリングされる', () => {
+    const { getByText } = render(
+      <CustomModal visible={true}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    expect(getByText('Test Content')).toBeTruthy();
+  });
+
+  it('visible=false の場合、初期状態ではレンダリングされない', () => {
+    const { queryByText } = render(
+      <CustomModal visible={false}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    expect(queryByText('Test Content')).toBeNull();
+  });
+
+  it('onClose が呼ばれた時にコールバックが実行される', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <CustomModal visible={true} onClose={onClose} testID="modal">
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // CustomModal はレンダリングされる
+    expect(getByTestId('modal')).toBeTruthy();
+  });
+});
+
+describe('CustomModal - onCloseAnimationEnd', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('onCloseAnimationEnd が prop として渡される', () => {
+    const onCloseAnimationEnd = jest.fn();
+
+    // コンポーネントが onCloseAnimationEnd を受け取ることを確認
+    const { rerender } = render(
+      <CustomModal visible={true} onCloseAnimationEnd={onCloseAnimationEnd}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // 初期状態では呼ばれない
+    expect(onCloseAnimationEnd).not.toHaveBeenCalled();
+
+    // visible を false に変更
+    rerender(
+      <CustomModal visible={false} onCloseAnimationEnd={onCloseAnimationEnd}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // withTiming が呼ばれることを確認
+    expect(withTiming).toHaveBeenCalled();
+  });
+
+  it('閉じるアニメーション完了後に onCloseAnimationEnd が呼ばれる', async () => {
+    const onCloseAnimationEnd = jest.fn();
+
+    // withTiming をモックしてコールバックを即座に実行
+    (withTiming as jest.Mock).mockImplementation((value, _config, callback) => {
+      if (callback) {
+        // finished=true, cancelled=false, visible=false の状態でコールバックを呼ぶ
+        callback(true);
+      }
+      return value;
+    });
+
+    const { rerender } = render(
+      <CustomModal visible={true} onCloseAnimationEnd={onCloseAnimationEnd}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // visible を false に変更してクローズアニメーションをトリガー
+    rerender(
+      <CustomModal visible={false} onCloseAnimationEnd={onCloseAnimationEnd}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // runOnJS が呼ばれたことを確認
+    await waitFor(() => {
+      expect(runOnJS).toHaveBeenCalled();
+    });
+  });
+
+  it('onCloseAnimationEnd が未指定の場合でもエラーにならない', () => {
+    (withTiming as jest.Mock).mockImplementation((value, _config, callback) => {
+      if (callback) {
+        callback(true);
+      }
+      return value;
+    });
+
+    const { rerender } = render(
+      <CustomModal visible={true}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    // onCloseAnimationEnd を渡さずに閉じてもエラーにならない
+    expect(() => {
+      rerender(
+        <CustomModal visible={false}>
+          <Text>Test Content</Text>
+        </CustomModal>
+      );
+    }).not.toThrow();
+  });
+});

--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -24,6 +24,8 @@ type Props = {
   visible: boolean;
   children: React.ReactNode;
   onClose?: () => void;
+  /** 閉じるアニメーションが完了した後に呼ばれるコールバック */
+  onCloseAnimationEnd?: () => void;
   dismissOnBackdropPress?: boolean;
   backdropStyle?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
@@ -40,6 +42,7 @@ export const CustomModal: React.FC<Props> = ({
   visible,
   children,
   onClose,
+  onCloseAnimationEnd,
   dismissOnBackdropPress = true,
   backdropStyle,
   containerStyle,
@@ -74,12 +77,17 @@ export const CustomModal: React.FC<Props> = ({
       };
     }
 
+    const handleCloseAnimationEnd = () => {
+      setIsMounted(false);
+      onCloseAnimationEnd?.();
+    };
+
     opacity.value = withTiming(
       0,
       { duration: animationDuration },
       (finished) => {
         if (finished && !cancelled && !visible) {
-          runOnJS(setIsMounted)(false);
+          runOnJS(handleCloseAnimationEnd)();
         }
       }
     );
@@ -88,7 +96,7 @@ export const CustomModal: React.FC<Props> = ({
       cancelled = true;
       cancelAnimation(opacity);
     };
-  }, [animationDuration, opacity, visible]);
+  }, [animationDuration, opacity, visible, onCloseAnimationEnd]);
 
   const handleBackdropPress = () => {
     Keyboard.dismiss();

--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -1,14 +1,7 @@
 import { useAtom } from 'jotai';
+import type { Station } from '~/@types/graphql';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
-
-// Station 型の定義
-interface Station {
-  id: number;
-  groupId: number;
-  name: string;
-  nameRoman?: string;
-}
 
 // Mock jotai
 jest.mock('jotai', () => ({
@@ -114,17 +107,17 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
   });
 
   it('targetDestination が null の場合、方向のフィルタリングは行われない', () => {
-    const stations: Station[] = [
+    const stations = [
       { id: 1, groupId: 1, name: '東京', nameRoman: 'Tokyo' },
       { id: 2, groupId: 2, name: '品川', nameRoman: 'Shinagawa' },
       { id: 3, groupId: 3, name: '横浜', nameRoman: 'Yokohama' },
-    ];
-    const currentStation: Station = {
+    ] as unknown as Station[];
+    const currentStation = {
       id: 1,
       groupId: 1,
       name: '東京',
       nameRoman: 'Tokyo',
-    };
+    } as unknown as Station;
 
     // targetDestination が null の場合は両方向を表示
     const targetDestination: Station | null = null;
@@ -140,25 +133,29 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
   });
 
   it('targetDestination が設定されている場合、INBOUND 方向が計算される', () => {
-    const stations: Station[] = [
+    const stations = [
       { id: 1, groupId: 1, name: '東京', nameRoman: 'Tokyo' },
       { id: 2, groupId: 2, name: '品川', nameRoman: 'Shinagawa' },
       { id: 3, groupId: 3, name: '横浜', nameRoman: 'Yokohama' },
-    ];
-    const currentStation: Station = {
+    ] as unknown as Station[];
+    const currentStation = {
       id: 1,
       groupId: 1,
       name: '東京',
       nameRoman: 'Tokyo',
-    };
+    } as unknown as Station;
 
     // targetDestination が現在の駅より後ろにある場合は INBOUND
-    const targetDestination: Station = { id: 3, groupId: 3, name: '横浜' };
+    const targetDestination = {
+      id: 3,
+      groupId: 3,
+      name: '横浜',
+    } as unknown as Station;
     const currentStationIndex = stations.findIndex(
-      (s: Station) => s.groupId === currentStation.groupId
+      (s) => s.groupId === currentStation.groupId
     );
     const targetStationIndex = stations.findIndex(
-      (s: Station) => s.groupId === targetDestination.groupId
+      (s) => s.groupId === targetDestination.groupId
     );
 
     const direction =
@@ -170,25 +167,29 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
   });
 
   it('targetDestination が設定されている場合、OUTBOUND 方向が計算される', () => {
-    const stations: Station[] = [
+    const stations = [
       { id: 1, groupId: 1, name: '東京', nameRoman: 'Tokyo' },
       { id: 2, groupId: 2, name: '品川', nameRoman: 'Shinagawa' },
       { id: 3, groupId: 3, name: '横浜', nameRoman: 'Yokohama' },
-    ];
-    const currentStation: Station = {
+    ] as unknown as Station[];
+    const currentStation = {
       id: 3,
       groupId: 3,
       name: '横浜',
       nameRoman: 'Yokohama',
-    };
+    } as unknown as Station;
 
     // targetDestination が現在の駅より前にある場合は OUTBOUND
-    const targetDestination: Station = { id: 1, groupId: 1, name: '東京' };
+    const targetDestination = {
+      id: 1,
+      groupId: 1,
+      name: '東京',
+    } as unknown as Station;
     const currentStationIndex = stations.findIndex(
-      (s: Station) => s.groupId === currentStation.groupId
+      (s) => s.groupId === currentStation.groupId
     );
     const targetStationIndex = stations.findIndex(
-      (s: Station) => s.groupId === targetDestination.groupId
+      (s) => s.groupId === targetDestination.groupId
     );
 
     const direction =
@@ -200,14 +201,22 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
   });
 
   it('wantedDestination が設定されている場合は targetDestination より優先される', () => {
-    const stations: Station[] = [
+    const stations = [
       { id: 1, groupId: 1, name: '東京', nameRoman: 'Tokyo' },
       { id: 2, groupId: 2, name: '品川', nameRoman: 'Shinagawa' },
       { id: 3, groupId: 3, name: '横浜', nameRoman: 'Yokohama' },
-    ];
+    ] as unknown as Station[];
 
-    const targetDestination: Station = { id: 3, groupId: 3, name: '横浜' };
-    const wantedDestination: Station = { id: 2, groupId: 2, name: '品川' };
+    const targetDestination = {
+      id: 3,
+      groupId: 3,
+      name: '横浜',
+    } as unknown as Station;
+    const wantedDestination = {
+      id: 2,
+      groupId: 2,
+      name: '品川',
+    } as unknown as Station;
 
     // 実装のロジック: targetDestination && !isLoopLine && !wantedDestination
     // wantedDestination が設定されている場合は targetDestination のフィルタリングは無視される
@@ -221,7 +230,11 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
 
   it('ループ線の場合は targetDestination によるフィルタリングは行われない', () => {
     const isLoopLine = true;
-    const targetDestination: Station = { id: 3, groupId: 3, name: '横浜' };
+    const targetDestination = {
+      id: 3,
+      groupId: 3,
+      name: '横浜',
+    } as unknown as Station;
     const wantedDestination: Station | null = null;
 
     // 実装のロジック: targetDestination && !isLoopLine && !wantedDestination
@@ -273,7 +286,11 @@ describe('SelectBoundModal - onCloseAnimationEnd', () => {
   });
 
   it('targetDestination prop が SelectBoundModal の Props 型に含まれる', () => {
-    const targetStation: Station = { id: 3, groupId: 3, name: '横浜' };
+    const targetStation = {
+      id: 3,
+      groupId: 3,
+      name: '横浜',
+    } as unknown as Station;
 
     const props = {
       visible: true,

--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -144,10 +144,10 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
     // targetDestination が現在の駅より後ろにある場合は INBOUND
     const targetDestination = { id: 3, groupId: 3, name: '横浜' };
     const currentStationIndex = stations.findIndex(
-      (s: { groupId: number }) => s.groupId === currentStation?.groupId
+      (s) => s.groupId === currentStation?.groupId
     );
     const targetStationIndex = stations.findIndex(
-      (s: { groupId: number }) => s.groupId === targetDestination.groupId
+      (s) => s.groupId === targetDestination.groupId
     );
 
     const direction =
@@ -181,10 +181,10 @@ describe('SelectBoundModal - targetDestination による方向フィルタリン
     // targetDestination が現在の駅より前にある場合は OUTBOUND
     const targetDestination = { id: 1, groupId: 1, name: '東京' };
     const currentStationIndex = stations.findIndex(
-      (s: { groupId: number }) => s.groupId === currentStation?.groupId
+      (s) => s.groupId === currentStation?.groupId
     );
     const targetStationIndex = stations.findIndex(
-      (s: { groupId: number }) => s.groupId === targetDestination.groupId
+      (s) => s.groupId === targetDestination.groupId
     );
 
     const direction =

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -81,19 +81,25 @@ type RenderButtonProps = {
 type Props = {
   visible: boolean;
   onClose: () => void;
+  /** 閉じるアニメーションが完了した後に呼ばれるコールバック */
+  onCloseAnimationEnd?: () => void;
   loading: boolean;
   error: Error | null;
   onTrainTypeSelect: (trainType: TrainType) => void;
   onBoundSelect: () => void;
+  /** 方面選択を片方向のみに絞るための目的地（終点としては扱わない） */
+  targetDestination?: Station | null;
 };
 
 export const SelectBoundModal: React.FC<Props> = ({
   visible,
   onClose,
+  onCloseAnimationEnd,
   loading,
   error,
   onTrainTypeSelect,
   onBoundSelect,
+  targetDestination,
 }) => {
   const [savedRoute, setSavedRoute] = useState<SavedRoute | null>(null);
   const [isTrainTypeModalVisible, setIsTrainTypeModalVisible] = useState(false);
@@ -286,6 +292,22 @@ export const SelectBoundModal: React.FC<Props> = ({
         return <></>;
       }
 
+      // targetDestination が設定されている場合、その方向のボタンのみ表示（終点としては扱わない）
+      if (targetDestination && !isLoopLine && !wantedDestination) {
+        const currentStationIndex = stations.findIndex(
+          (s) => s.groupId === station?.groupId
+        );
+        const targetStationIndex = stations.findIndex(
+          (s) => s.groupId === targetDestination.groupId
+        );
+        const dir: LineDirection =
+          currentStationIndex < targetStationIndex ? 'INBOUND' : 'OUTBOUND';
+
+        if (direction !== dir) {
+          return <></>;
+        }
+      }
+
       if (wantedDestination && !isLoopLine) {
         const currentStationIndex = stations.findIndex(
           (s) => s.groupId === station?.groupId
@@ -351,6 +373,7 @@ export const SelectBoundModal: React.FC<Props> = ({
       station?.groupId,
       stations,
       wantedDestination,
+      targetDestination,
       line,
       loopLineDirectionText,
       normalLineDirectionText,
@@ -485,6 +508,7 @@ export const SelectBoundModal: React.FC<Props> = ({
     <CustomModal
       visible={visible}
       onClose={onClose}
+      onCloseAnimationEnd={onCloseAnimationEnd}
       backdropStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
       contentContainerStyle={[
         styles.contentView,

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -113,6 +113,8 @@ const RouteSearchScreen = () => {
     useState(false);
   const [searchResults, setSearchResults] = useState<Station[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
+  const [selectedDestination, setSelectedDestination] =
+    useState<Station | null>(null);
 
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const orientation = useDeviceOrientation();
@@ -212,6 +214,7 @@ const RouteSearchScreen = () => {
   const handleLineSelected = useCallback(
     async (selectedStation: Station) => {
       setSelectBoundModalVisible(true);
+      setSelectedDestination(selectedStation);
 
       const newPendingLine = selectedStation.line ?? null;
 
@@ -538,6 +541,9 @@ const RouteSearchScreen = () => {
         onClose={() => {
           setSelectBoundModalVisible(false);
         }}
+        onCloseAnimationEnd={() => {
+          setSelectedDestination(null);
+        }}
         onBoundSelect={() => {
           setSelectBoundModalVisible(false);
           setTrainTypeListModalVisible(false);
@@ -554,6 +560,7 @@ const RouteSearchScreen = () => {
           null
         }
         onTrainTypeSelect={handleTrainTypeSelected}
+        targetDestination={selectedDestination}
       />
       <TrainTypeListModal
         visible={trainTypeListModalVisible}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 目的地に基づく方向フィルタで、モーダルの選択肢が現在地と目的地の関係に応じて自動で絞り込まれます。
  * 目的地選択がモーダルに渡され、モーダル閉鎖のアニメーション完了時に選択状態がクリアされます。
  * モーダル閉鎖のアニメーション完了時に任意で呼ばれるコールバックを追加しました。

* **Tests**
  * モーダル挙動、アニメーション完了コールバック、及び画面の状態遷移を網羅するテストスイートを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->