### PR TITLE
テーマ説明文の翻訳をgetThemeInfo呼び出し時に遅延評価するように修正

### DIFF
--- a/src/utils/themeInfo.ts
+++ b/src/utils/themeInfo.ts
@@ -7,58 +7,70 @@ export type ThemeInfo = {
   tabletImage: number;
 };
 
-const APP_THEME_INFO_MAP: Record<AppTheme, ThemeInfo> = {
+type ThemeInfoData = {
+  descriptionKey: string;
+  spImage: number;
+  tabletImage: number;
+};
+
+const APP_THEME_INFO_MAP: Record<AppTheme, ThemeInfoData> = {
   [APP_THEME.TOKYO_METRO]: {
-    description: translate('themeDescriptionTokyoMetro'),
+    descriptionKey: 'themeDescriptionTokyoMetro',
     spImage: require('../../assets/images/themes/tokyo-metro-sp.webp'),
     tabletImage: require('../../assets/images/themes/tokyo-metro-tablet.webp'),
   },
   [APP_THEME.TOEI]: {
-    description: translate('themeDescriptionToei'),
+    descriptionKey: 'themeDescriptionToei',
     spImage: require('../../assets/images/themes/toei-sp.webp'),
     tabletImage: require('../../assets/images/themes/toei-tablet.webp'),
   },
   [APP_THEME.YAMANOTE]: {
-    description: translate('themeDescriptionYamanote'),
+    descriptionKey: 'themeDescriptionYamanote',
     spImage: require('../../assets/images/themes/yamanote-sp.webp'),
     tabletImage: require('../../assets/images/themes/yamanote-tablet.webp'),
   },
   [APP_THEME.JR_WEST]: {
-    description: translate('themeDescriptionJrWest'),
+    descriptionKey: 'themeDescriptionJrWest',
     spImage: require('../../assets/images/themes/jr-west-sp.webp'),
     tabletImage: require('../../assets/images/themes/jr-west-tablet.webp'),
   },
   [APP_THEME.TY]: {
-    description: translate('themeDescriptionTy'),
+    descriptionKey: 'themeDescriptionTy',
     spImage: require('../../assets/images/themes/ty-sp.webp'),
     tabletImage: require('../../assets/images/themes/ty-tablet.webp'),
   },
   [APP_THEME.SAIKYO]: {
-    description: translate('themeDescriptionSaikyo'),
+    descriptionKey: 'themeDescriptionSaikyo',
     spImage: require('../../assets/images/themes/saikyo-sp.webp'),
     tabletImage: require('../../assets/images/themes/saikyo-tablet.webp'),
   },
   [APP_THEME.LED]: {
-    description: translate('themeDescriptionLed'),
+    descriptionKey: 'themeDescriptionLed',
     spImage: require('../../assets/images/themes/led-sp.webp'),
     tabletImage: require('../../assets/images/themes/led-tablet.webp'),
   },
   [APP_THEME.JO]: {
-    description: translate('themeDescriptionJo'),
+    descriptionKey: 'themeDescriptionJo',
     spImage: require('../../assets/images/themes/jo-sp.webp'),
     tabletImage: require('../../assets/images/themes/jo-tablet.webp'),
   },
   [APP_THEME.JL]: {
-    description: translate('themeDescriptionJl'),
+    descriptionKey: 'themeDescriptionJl',
     spImage: require('../../assets/images/themes/jl-sp.webp'),
     tabletImage: require('../../assets/images/themes/jl-tablet.webp'),
   },
   [APP_THEME.JR_KYUSHU]: {
-    description: translate('themeDescriptionJrKyushu'),
+    descriptionKey: 'themeDescriptionJrKyushu',
     spImage: require('../../assets/images/themes/jr-kyushu-sp.webp'),
     tabletImage: require('../../assets/images/themes/jr-kyushu-tablet.webp'),
   },
 } as const;
 
-export const getThemeInfo = (theme: AppTheme): ThemeInfo =>
-  APP_THEME_INFO_MAP[theme];
+export const getThemeInfo = (theme: AppTheme): ThemeInfo => {
+  const { descriptionKey, spImage, tabletImage } = APP_THEME_INFO_MAP[theme];
+  return {
+    description: translate(descriptionKey),
+    spImage,
+    tabletImage,
+  };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **内部改善**
  * テーマ情報の内部処理を最適化しました。公開API の動作に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->