### PR TITLE
SelectBoundModalでboundStationsがある場合はOUTBOUNDボタンを表示するように修正

### DIFF
--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -308,6 +308,107 @@ describe('SelectBoundModal - onCloseAnimationEnd', () => {
   });
 });
 
+describe('SelectBoundModal - renderButton 表示条件', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('boundStationsが空の場合、ボタンは非表示になる', () => {
+    const boundStations: Station[] = [];
+    const direction = 'OUTBOUND';
+    const isLoopLine = false;
+    const currentIndex = 0;
+    const stationsLength = 5;
+
+    // renderButtonの条件をシミュレート
+    const shouldHideButton =
+      !boundStations.length ||
+      (direction === 'INBOUND' &&
+        !isLoopLine &&
+        currentIndex === stationsLength - 1);
+
+    expect(shouldHideButton).toBe(true);
+  });
+
+  it('boundStationsがある場合、currentIndex === 0でもOUTBOUNDボタンは表示される', () => {
+    const boundStations = [
+      { id: 9930138, groupId: 9930138, name: '光が丘' },
+    ] as unknown as Station[];
+    const direction = 'OUTBOUND';
+    const isLoopLine = false;
+    const currentIndex = 0;
+    const stationsLength = 5;
+
+    // renderButtonの条件をシミュレート
+    const shouldHideButton =
+      !boundStations.length ||
+      (direction === 'INBOUND' &&
+        !isLoopLine &&
+        currentIndex === stationsLength - 1);
+
+    // boundStationsがあるのでOUTBOUNDボタンは表示される
+    expect(shouldHideButton).toBe(false);
+  });
+
+  it('INBOUNDで終点（currentIndex === stations.length - 1）の場合、ボタンは非表示になる', () => {
+    const boundStations = [
+      { id: 1, groupId: 1, name: '東京' },
+    ] as unknown as Station[];
+    const direction = 'INBOUND';
+    const isLoopLine = false;
+    const currentIndex = 4;
+    const stationsLength = 5;
+
+    // renderButtonの条件をシミュレート
+    const shouldHideButton =
+      !boundStations.length ||
+      (direction === 'INBOUND' &&
+        !isLoopLine &&
+        currentIndex === stationsLength - 1);
+
+    expect(shouldHideButton).toBe(true);
+  });
+
+  it('ループ線の場合、終点でもINBOUNDボタンは表示される', () => {
+    const boundStations = [
+      { id: 1, groupId: 1, name: '東京' },
+    ] as unknown as Station[];
+    const direction = 'INBOUND';
+    const isLoopLine = true;
+    const currentIndex = 4;
+    const stationsLength = 5;
+
+    // renderButtonの条件をシミュレート
+    const shouldHideButton =
+      !boundStations.length ||
+      (direction === 'INBOUND' &&
+        !isLoopLine &&
+        currentIndex === stationsLength - 1);
+
+    // ループ線なのでINBOUNDボタンは表示される
+    expect(shouldHideButton).toBe(false);
+  });
+
+  it('大江戸線の都庁前駅でboundStationsがある場合、OUTBOUNDボタンは表示される', () => {
+    // 都庁前駅が配列の先頭（currentIndex === 0）でも、
+    // boundStationsに光が丘があれば表示される
+    const boundStations = [
+      { id: 9930138, groupId: 9930138, name: '光が丘' },
+    ] as unknown as Station[];
+    const direction = 'OUTBOUND';
+    const isLoopLine = false;
+    const currentIndex = 0; // 都庁前が配列の先頭
+
+    // renderButtonの条件をシミュレート
+    const shouldHideButton =
+      !boundStations.length ||
+      (direction === 'INBOUND' && !isLoopLine && currentIndex === 0);
+
+    // boundStationsがあるのでOUTBOUNDボタンは表示される
+    expect(shouldHideButton).toBe(false);
+  });
+});
+
 describe('SelectBoundModal - 保存済み経路の検索ロジック', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from 'jotai';
 import type { Station } from '~/@types/graphql';
+import type { LineDirection } from '../models/Bound';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 
@@ -309,8 +310,6 @@ describe('SelectBoundModal - onCloseAnimationEnd', () => {
 });
 
 describe('SelectBoundModal - renderButton 表示条件', () => {
-  type LineDirection = 'INBOUND' | 'OUTBOUND';
-
   // renderButtonの非表示条件をシミュレートするヘルパー関数
   const shouldHideButton = (
     boundStationsLength: number,

--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -309,103 +309,56 @@ describe('SelectBoundModal - onCloseAnimationEnd', () => {
 });
 
 describe('SelectBoundModal - renderButton 表示条件', () => {
+  type LineDirection = 'INBOUND' | 'OUTBOUND';
+
+  // renderButtonの非表示条件をシミュレートするヘルパー関数
+  const shouldHideButton = (
+    boundStationsLength: number,
+    direction: LineDirection,
+    isLoopLine: boolean,
+    currentIndex: number,
+    stationsLength: number
+  ): boolean => {
+    return (
+      !boundStationsLength ||
+      (direction === 'INBOUND' &&
+        !isLoopLine &&
+        currentIndex === stationsLength - 1)
+    );
+  };
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('boundStationsが空の場合、ボタンは非表示になる', () => {
-    const boundStations: Station[] = [];
-    const direction = 'OUTBOUND';
-    const isLoopLine = false;
-    const currentIndex = 0;
-    const stationsLength = 5;
-
-    // renderButtonの条件をシミュレート
-    const shouldHideButton =
-      !boundStations.length ||
-      (direction === 'INBOUND' &&
-        !isLoopLine &&
-        currentIndex === stationsLength - 1);
-
-    expect(shouldHideButton).toBe(true);
+    const result = shouldHideButton(0, 'OUTBOUND', false, 0, 5);
+    expect(result).toBe(true);
   });
 
   it('boundStationsがある場合、currentIndex === 0でもOUTBOUNDボタンは表示される', () => {
-    const boundStations = [
-      { id: 9930138, groupId: 9930138, name: '光が丘' },
-    ] as unknown as Station[];
-    const direction = 'OUTBOUND';
-    const isLoopLine = false;
-    const currentIndex = 0;
-    const stationsLength = 5;
-
-    // renderButtonの条件をシミュレート
-    const shouldHideButton =
-      !boundStations.length ||
-      (direction === 'INBOUND' &&
-        !isLoopLine &&
-        currentIndex === stationsLength - 1);
-
+    const result = shouldHideButton(1, 'OUTBOUND', false, 0, 5);
     // boundStationsがあるのでOUTBOUNDボタンは表示される
-    expect(shouldHideButton).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('INBOUNDで終点（currentIndex === stations.length - 1）の場合、ボタンは非表示になる', () => {
-    const boundStations = [
-      { id: 1, groupId: 1, name: '東京' },
-    ] as unknown as Station[];
-    const direction = 'INBOUND';
-    const isLoopLine = false;
-    const currentIndex = 4;
-    const stationsLength = 5;
-
-    // renderButtonの条件をシミュレート
-    const shouldHideButton =
-      !boundStations.length ||
-      (direction === 'INBOUND' &&
-        !isLoopLine &&
-        currentIndex === stationsLength - 1);
-
-    expect(shouldHideButton).toBe(true);
+    const result = shouldHideButton(1, 'INBOUND', false, 4, 5);
+    expect(result).toBe(true);
   });
 
   it('ループ線の場合、終点でもINBOUNDボタンは表示される', () => {
-    const boundStations = [
-      { id: 1, groupId: 1, name: '東京' },
-    ] as unknown as Station[];
-    const direction = 'INBOUND';
-    const isLoopLine = true;
-    const currentIndex = 4;
-    const stationsLength = 5;
-
-    // renderButtonの条件をシミュレート
-    const shouldHideButton =
-      !boundStations.length ||
-      (direction === 'INBOUND' &&
-        !isLoopLine &&
-        currentIndex === stationsLength - 1);
-
+    const result = shouldHideButton(1, 'INBOUND', true, 4, 5);
     // ループ線なのでINBOUNDボタンは表示される
-    expect(shouldHideButton).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('大江戸線の都庁前駅でboundStationsがある場合、OUTBOUNDボタンは表示される', () => {
     // 都庁前駅が配列の先頭（currentIndex === 0）でも、
     // boundStationsに光が丘があれば表示される
-    const boundStations = [
-      { id: 9930138, groupId: 9930138, name: '光が丘' },
-    ] as unknown as Station[];
-    const direction = 'OUTBOUND';
-    const isLoopLine = false;
-    const currentIndex = 0; // 都庁前が配列の先頭
-
-    // renderButtonの条件をシミュレート
-    const shouldHideButton =
-      !boundStations.length ||
-      (direction === 'INBOUND' && !isLoopLine && currentIndex === 0);
-
+    const result = shouldHideButton(1, 'OUTBOUND', false, 0, 5);
     // boundStationsがあるのでOUTBOUNDボタンは表示される
-    expect(shouldHideButton).toBe(false);
+    expect(result).toBe(false);
   });
 });
 

--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -351,14 +351,6 @@ describe('SelectBoundModal - renderButton 表示条件', () => {
     // ループ線なのでINBOUNDボタンは表示される
     expect(result).toBe(false);
   });
-
-  it('大江戸線の都庁前駅でboundStationsがある場合、OUTBOUNDボタンは表示される', () => {
-    // 都庁前駅が配列の先頭（currentIndex === 0）でも、
-    // boundStationsに光が丘があれば表示される
-    const result = shouldHideButton(1, 'OUTBOUND', false, 0, 5);
-    // boundStationsがあるのでOUTBOUNDボタンは表示される
-    expect(result).toBe(false);
-  });
 });
 
 describe('SelectBoundModal - 保存済み経路の検索ロジック', () => {

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -342,8 +342,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         !boundStations.length ||
         (direction === 'INBOUND' &&
           !isLoopLine &&
-          currentIndex === stations.length - 1) ||
-        (direction === 'OUTBOUND' && !isLoopLine && !currentIndex)
+          currentIndex === stations.length - 1)
       ) {
         return <></>;
       }


### PR DESCRIPTION
#4982 の不備

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 最終駅到達時に「Inbound」ボタンが表示されないよう修正。
  * 「Outbound」ボタンの表示制御を緩和し、非端でも表示されるケースを許可。
  * 対応する駅がない場合は該当する乗り越しオプションボタンが表示されないよう修正。

* **テスト**
  * ボタン表示条件を網羅するテストを追加し、複数シナリオで可視性を検証。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->