### PR TITLE
一旦テーマ画像外枠のelevationを撤去

### DIFF
--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -311,7 +311,6 @@ const ThemeSettingsScreen: React.FC = () => {
             </Typography>
             <View
               style={{
-                elevation: 1,
                 shadowColor: '#333',
                 shadowOpacity: 0.25,
                 shadowOffset: {


### PR DESCRIPTION
Androidだけ描画がおかしい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
  * テーマ設定画面のUIコンポーネントのシャドウエフェクトを調整し、ビジュアルデザインを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->