### PR TITLE
Revert "SelectBoundModalでboundStationsがある場合はOUTBOUNDボタンを表示するように修正"

### DIFF
--- a/src/components/SelectBoundModal.test.tsx
+++ b/src/components/SelectBoundModal.test.tsx
@@ -1,6 +1,5 @@
 import { useAtom } from 'jotai';
 import type { Station } from '~/@types/graphql';
-import type { LineDirection } from '../models/Bound';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 
@@ -306,50 +305,6 @@ describe('SelectBoundModal - onCloseAnimationEnd', () => {
 
     expect(props).toHaveProperty('targetDestination');
     expect(props.targetDestination).toEqual(targetStation);
-  });
-});
-
-describe('SelectBoundModal - renderButton 表示条件', () => {
-  // renderButtonの非表示条件をシミュレートするヘルパー関数
-  const shouldHideButton = (
-    boundStationsLength: number,
-    direction: LineDirection,
-    isLoopLine: boolean,
-    currentIndex: number,
-    stationsLength: number
-  ): boolean => {
-    return (
-      !boundStationsLength ||
-      (direction === 'INBOUND' &&
-        !isLoopLine &&
-        currentIndex === stationsLength - 1)
-    );
-  };
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('boundStationsが空の場合、ボタンは非表示になる', () => {
-    const result = shouldHideButton(0, 'OUTBOUND', false, 0, 5);
-    expect(result).toBe(true);
-  });
-
-  it('boundStationsがある場合、currentIndex === 0でもOUTBOUNDボタンは表示される', () => {
-    const result = shouldHideButton(1, 'OUTBOUND', false, 0, 5);
-    // boundStationsがあるのでOUTBOUNDボタンは表示される
-    expect(result).toBe(false);
-  });
-
-  it('INBOUNDで終点（currentIndex === stations.length - 1）の場合、ボタンは非表示になる', () => {
-    const result = shouldHideButton(1, 'INBOUND', false, 4, 5);
-    expect(result).toBe(true);
-  });
-
-  it('ループ線の場合、終点でもINBOUNDボタンは表示される', () => {
-    const result = shouldHideButton(1, 'INBOUND', true, 4, 5);
-    // ループ線なのでINBOUNDボタンは表示される
-    expect(result).toBe(false);
   });
 });
 

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -342,7 +342,8 @@ export const SelectBoundModal: React.FC<Props> = ({
         !boundStations.length ||
         (direction === 'INBOUND' &&
           !isLoopLine &&
-          currentIndex === stations.length - 1)
+          currentIndex === stations.length - 1) ||
+        (direction === 'OUTBOUND' && !isLoopLine && !currentIndex)
       ) {
         return <></>;
       }


### PR DESCRIPTION
Reverts TrainLCD/MobileApp#4985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ループラインではない場合、最初の駅でアウトバウンド方向選択ボタンが表示されないよう表示制御ロジックを改善しました。

* **テスト**
  * ボタン表示条件に関連する不要なテストスイートを削除し、テストコード全体を整理しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->