### PR TITLE
タブレットでのプリセット表示調整

### DIFF
--- a/src/components/GlobalToast.tsx
+++ b/src/components/GlobalToast.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { useMemo } from 'react';
+import type { DimensionValue } from 'react-native';
 import type { ToastConfigParams } from 'react-native-toast-message';
 import Toast, { BaseToast, ErrorToast } from 'react-native-toast-message';
 import { FONTS, LED_THEME_BG_COLOR } from '~/constants';
@@ -17,7 +18,7 @@ export const GlobalToast: React.FC = () => {
       borderLeftWidth: 16,
       backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#333',
       borderRadius: isLEDTheme ? 0 : 6,
-      width: isTablet ? '50%' : '90%',
+      width: (isTablet ? '50%' : '90%') as DimensionValue,
     });
 
     const contentContainerStyle = {

--- a/src/components/GlobalToast.tsx
+++ b/src/components/GlobalToast.tsx
@@ -5,6 +5,7 @@ import type { ToastConfigParams } from 'react-native-toast-message';
 import Toast, { BaseToast, ErrorToast } from 'react-native-toast-message';
 import { FONTS, LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 
 export const GlobalToast: React.FC = () => {
@@ -16,6 +17,7 @@ export const GlobalToast: React.FC = () => {
       borderLeftWidth: 16,
       backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#333',
       borderRadius: isLEDTheme ? 0 : 6,
+      width: isTablet ? '50%' : '90%',
     });
 
     const contentContainerStyle = {

--- a/src/screens/SelectLineScreen.test.tsx
+++ b/src/screens/SelectLineScreen.test.tsx
@@ -434,9 +434,9 @@ describe('SelectLineScreenPresets', () => {
         />
       );
 
-      // ループデータは3倍になるので、3つのPresetCardが表示される
+      // プリセットが1件の場合はループしないので1つだけ表示される
       const presetCards = getAllByTestId('preset-card');
-      expect(presetCards.length).toBe(3);
+      expect(presetCards.length).toBe(1);
     });
 
     it('複数のプリセットがある場合、全てがループデータとして3倍表示される', () => {
@@ -602,7 +602,7 @@ describe('SelectLineScreenPresets - ループデータ生成', () => {
     expect(presetCards.length).toBe(9);
   });
 
-  it('1つのプリセットでも3倍に複製される', () => {
+  it('1つのプリセットはループしない', () => {
     const stations = [createMockStation(1, '駅A', 'Station A')];
     const carouselData = [createMockLoopItem(1, '単独プリセット', stations)];
 
@@ -614,6 +614,7 @@ describe('SelectLineScreenPresets - ループデータ生成', () => {
       />
     );
 
-    expect(getAllByTestId('preset-card').length).toBe(3);
+    // プリセットが1件の場合はループしないので1つだけ表示される
+    expect(getAllByTestId('preset-card').length).toBe(1);
   });
 });


### PR DESCRIPTION
fixes #5015
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * トースト通知がタブレットで適切な幅で表示されるようになりました
  * 単一プリセットが不必要に複製表示される問題を解消しました
* **改善**
  * プリセット選択画面のレイアウトと余白がタブレット／回転時に応じて最適化され、カード表示と空状態レイアウトが調整されました
* **テスト**
  * プリセット関連のテストが新しい表示挙動に合わせて更新されました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->