### PR TITLE
ウォークスルーのツールチップにmaxWidth: 640を追加してタブレット対応

### DIFF
--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -174,14 +174,17 @@ const WalkthroughOverlay: React.FC<Props> = ({
   }, [currentStepIndex, spotlightArea?.y, screenHeight]);
 
   // タブレットで中央揃えになるよう左位置を計算
-  const tooltipWidth = Math.min(screenWidth - 48, 640);
+  const tooltipWidth = Math.min(Math.max(0, screenWidth - 48), 640);
   const tooltipLeft = (screenWidth - tooltipWidth) / 2;
 
-  const animatedTooltipStyle = useAnimatedStyle(() => ({
-    top: animatedY.value,
-    left: tooltipLeft,
-    width: tooltipWidth,
-  }));
+  const animatedTooltipStyle = useAnimatedStyle(
+    () => ({
+      top: animatedY.value,
+      left: tooltipLeft,
+      width: tooltipWidth,
+    }),
+    [tooltipLeft, tooltipWidth]
+  );
 
   if (!visible) {
     return null;

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -63,8 +63,7 @@ const styles = StyleSheet.create({
   },
   tooltipContainer: {
     position: 'absolute',
-    left: 24,
-    right: 24,
+    maxWidth: 640,
     backgroundColor: '#fff',
     borderRadius: 12,
     padding: 20,
@@ -174,8 +173,14 @@ const WalkthroughOverlay: React.FC<Props> = ({
     animatedY.value = withTiming(targetY, { duration: ANIMATION_DURATION });
   }, [currentStepIndex, spotlightArea?.y, screenHeight]);
 
+  // タブレットで中央揃えになるよう左位置を計算
+  const tooltipWidth = Math.min(screenWidth - 48, 640);
+  const tooltipLeft = (screenWidth - tooltipWidth) / 2;
+
   const animatedTooltipStyle = useAnimatedStyle(() => ({
     top: animatedY.value,
+    left: tooltipLeft,
+    width: tooltipWidth,
   }));
 
   if (!visible) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * ツールチップの横位置が固定からレスポンシブな中央配置に変更され、画面幅に応じて幅が自動調整されます。既存の縦方向アニメーションはそのまま保持されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->