### PR TITLE
expo-avでオーディオダッキングを有効化し、再生終了後にunduckするよう修正

### DIFF
--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -159,10 +159,12 @@ export const useTTS = (): void => {
           try {
             await soundJa.unloadAsync();
           } catch {}
+          await unduck();
           return;
         }
       } catch (e) {
         console.error('[useTTS] Failed to create soundJa:', e);
+        await unduck();
         return;
       }
 

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,5 +1,10 @@
 import { getIdToken } from '@react-native-firebase/auth';
-import { Audio, type AVPlaybackStatus } from 'expo-av';
+import {
+  Audio,
+  type AVPlaybackStatus,
+  InterruptionModeAndroid,
+  InterruptionModeIOS,
+} from 'expo-av';
 import type { Sound } from 'expo-av/build/Audio';
 import { File, Paths } from 'expo-file-system';
 import { useAtomValue } from 'jotai';
@@ -83,6 +88,8 @@ export const useTTS = (): void => {
           allowsRecordingIOS: false,
           staysActiveInBackground: backgroundEnabled,
           playsInSilentModeIOS: true,
+          interruptionModeIOS: InterruptionModeIOS.DuckOthers,
+          interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
           shouldDuckAndroid: true,
           playThroughEarpieceAndroid: false,
         });
@@ -179,6 +186,17 @@ export const useTTS = (): void => {
         }
         soundEnRef.current = null;
         playingRef.current = false;
+
+        // Unduck: 他のアプリの音量を元に戻す
+        try {
+          await Audio.setAudioModeAsync({
+            interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+            interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+            shouldDuckAndroid: false,
+          });
+        } catch (e) {
+          console.warn('[useTTS] Failed to unduck:', e);
+        }
       }
     };
 

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -155,7 +155,38 @@ export const useTTS = (): void => {
       soundEnRef.current = soundEn;
       playingRef.current = true;
 
-      const onPlaybackStatusUpdateJa = async (status: AVPlaybackStatus) => {
+      const handlePlaybackStatusUpdateEn = async (status: AVPlaybackStatus) => {
+        if (!status.isLoaded) {
+          if (status.error) {
+            console.warn('[useTTS] soundEn error:', status.error);
+            try {
+              await soundEn.unloadAsync();
+            } catch {}
+            soundEnRef.current = null;
+            playingRef.current = false;
+            await unduck();
+          }
+          return;
+        }
+
+        if (status.didJustFinish) {
+          soundEn.setOnPlaybackStatusUpdate(null);
+          try {
+            await soundEn.unloadAsync();
+          } catch (e) {
+            console.warn('[useTTS] Failed to unload soundEn:', e);
+          }
+          soundEnRef.current = null;
+          playingRef.current = false;
+          await unduck();
+        }
+      };
+
+      const onPlaybackStatusUpdateEn = (status: AVPlaybackStatus) => {
+        void handlePlaybackStatusUpdateEn(status).catch(console.error);
+      };
+
+      const handlePlaybackStatusUpdateJa = async (status: AVPlaybackStatus) => {
         if (!status.isLoaded) {
           if (status.error) {
             console.warn('[useTTS] soundJa error:', status.error);
@@ -196,31 +227,8 @@ export const useTTS = (): void => {
         }
       };
 
-      const onPlaybackStatusUpdateEn = async (status: AVPlaybackStatus) => {
-        if (!status.isLoaded) {
-          if (status.error) {
-            console.warn('[useTTS] soundEn error:', status.error);
-            try {
-              await soundEn.unloadAsync();
-            } catch {}
-            soundEnRef.current = null;
-            playingRef.current = false;
-            await unduck();
-          }
-          return;
-        }
-
-        if (status.didJustFinish) {
-          soundEn.setOnPlaybackStatusUpdate(null);
-          try {
-            await soundEn.unloadAsync();
-          } catch (e) {
-            console.warn('[useTTS] Failed to unload soundEn:', e);
-          }
-          soundEnRef.current = null;
-          playingRef.current = false;
-          await unduck();
-        }
+      const onPlaybackStatusUpdateJa = (status: AVPlaybackStatus) => {
+        void handlePlaybackStatusUpdateJa(status).catch(console.error);
       };
 
       try {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -97,7 +97,7 @@ export const useTTS = (): void => {
     try {
       await Audio.setAudioModeAsync({
         interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
-        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
         shouldDuckAndroid: false,
       });
     } catch (e) {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -112,9 +112,9 @@ export const useTTS = (): void => {
           allowsRecordingIOS: false,
           staysActiveInBackground: backgroundEnabled,
           playsInSilentModeIOS: true,
-          interruptionModeIOS: InterruptionModeIOS.DuckOthers,
-          interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
-          shouldDuckAndroid: true,
+          interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+          interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
+          shouldDuckAndroid: false,
           playThroughEarpieceAndroid: false,
         });
       } catch (e) {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -376,15 +376,8 @@ export const useTTS = (): void => {
         soundJaRef.current = null;
         soundEnRef.current = null;
         playingRef.current = false;
-        // Unduck on unmount
-        try {
-          await Audio.setAudioModeAsync({
-            interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
-            interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
-            shouldDuckAndroid: false,
-          });
-        } catch {}
+        await unduck();
       })();
     };
-  }, []);
+  }, [unduck]);
 };

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -81,6 +81,18 @@ export const useTTS = (): void => {
   const soundJaRef = useRef<Sound | null>(null);
   const soundEnRef = useRef<Sound | null>(null);
 
+  const duck = useCallback(async () => {
+    try {
+      await Audio.setAudioModeAsync({
+        interruptionModeIOS: InterruptionModeIOS.DuckOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+        shouldDuckAndroid: true,
+      });
+    } catch (e) {
+      console.warn('[useTTS] Failed to duck:', e);
+    }
+  }, []);
+
   const unduck = useCallback(async () => {
     try {
       await Audio.setAudioModeAsync({
@@ -118,6 +130,9 @@ export const useTTS = (): void => {
       }
 
       firstSpeechRef.current = false;
+
+      // 再生前にダッキングを有効化
+      await duck();
 
       // 既存のサウンドをクリーンアップ
       try {
@@ -248,7 +263,7 @@ export const useTTS = (): void => {
         await unduck();
       }
     },
-    [unduck]
+    [duck, unduck]
   );
 
   const ttsApiUrl = useMemo(() => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -131,8 +131,25 @@ export const useTTS = (): void => {
       soundJaRef.current = null;
       soundEnRef.current = null;
 
-      const { sound: soundJa } = await Audio.Sound.createAsync({ uri: pathJa });
-      const { sound: soundEn } = await Audio.Sound.createAsync({ uri: pathEn });
+      let soundJa: Sound;
+      let soundEn: Sound;
+      try {
+        const resultJa = await Audio.Sound.createAsync({ uri: pathJa });
+        soundJa = resultJa.sound;
+        try {
+          const resultEn = await Audio.Sound.createAsync({ uri: pathEn });
+          soundEn = resultEn.sound;
+        } catch (e) {
+          console.error('[useTTS] Failed to create soundEn:', e);
+          try {
+            await soundJa.unloadAsync();
+          } catch {}
+          return;
+        }
+      } catch (e) {
+        console.error('[useTTS] Failed to create soundJa:', e);
+        return;
+      }
 
       soundJaRef.current = soundJa;
       soundEnRef.current = soundEn;

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -81,6 +81,18 @@ export const useTTS = (): void => {
   const soundJaRef = useRef<Sound | null>(null);
   const soundEnRef = useRef<Sound | null>(null);
 
+  const unduck = useCallback(async () => {
+    try {
+      await Audio.setAudioModeAsync({
+        interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+        shouldDuckAndroid: false,
+      });
+    } catch (e) {
+      console.warn('[useTTS] Failed to unduck:', e);
+    }
+  }, []);
+
   useEffect(() => {
     (async () => {
       try {
@@ -138,6 +150,7 @@ export const useTTS = (): void => {
           soundJaRef.current = null;
           soundEnRef.current = null;
           playingRef.current = false;
+          await unduck();
         }
         return;
       }
@@ -160,6 +173,7 @@ export const useTTS = (): void => {
           } catch {}
           soundEnRef.current = null;
           playingRef.current = false;
+          await unduck();
         }
       }
     };
@@ -173,6 +187,7 @@ export const useTTS = (): void => {
           } catch {}
           soundEnRef.current = null;
           playingRef.current = false;
+          await unduck();
         }
         return;
       }
@@ -186,17 +201,7 @@ export const useTTS = (): void => {
         }
         soundEnRef.current = null;
         playingRef.current = false;
-
-        // Unduck: 他のアプリの音量を元に戻す
-        try {
-          await Audio.setAudioModeAsync({
-            interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
-            interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
-            shouldDuckAndroid: false,
-          });
-        } catch (e) {
-          console.warn('[useTTS] Failed to unduck:', e);
-        }
+        await unduck();
       }
     };
 
@@ -214,8 +219,9 @@ export const useTTS = (): void => {
       soundJaRef.current = null;
       soundEnRef.current = null;
       playingRef.current = false;
+      await unduck();
     }
-  }, []);
+  }, [unduck]);
 
   const ttsApiUrl = useMemo(() => {
     return isDevApp ? DEV_TTS_API_URL : PRODUCTION_TTS_API_URL;
@@ -367,6 +373,14 @@ export const useTTS = (): void => {
         soundJaRef.current = null;
         soundEnRef.current = null;
         playingRef.current = false;
+        // Unduck on unmount
+        try {
+          await Audio.setAudioModeAsync({
+            interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+            interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+            shouldDuckAndroid: false,
+          });
+        } catch {}
       })();
     };
   }, []);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * iOS/Androidの割り込みモード設定を明確化し、再生前の「duck」と再生完了・エラー・アンマウント時の確実な「unduck」を追加して音声フォーカスの安定性を向上しました。
  * 再生失敗時や終了時の復旧処理とエラーメッセージを改善しました。

* **リファクタ**
  * 日本語→英語の連続再生フローを整理し、再生中のクリーンアップ、リソース解放、状態管理を安定化しました。

* **その他**
  * 再生・読み上げ処理のログ出力を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->