### PR TITLE
Android版ビルド失敗したのでreact-native-track-playerにパッチ当て

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     }
   },
   "name": "trainlcd",
-  "version": "10.0.96",
+  "version": "10.0.97",
   "pnpm": {
     "patchedDependencies": {
       "react-native-track-player@4.1.2": "patches/react-native-track-player@4.1.2.patch"

--- a/package.json
+++ b/package.json
@@ -143,5 +143,10 @@
     }
   },
   "name": "trainlcd",
-  "version": "10.0.97"
+  "version": "10.0.96",
+  "pnpm": {
+    "patchedDependencies": {
+      "react-native-track-player@4.1.2": "patches/react-native-track-player@4.1.2.patch"
+    }
+  }
 }

--- a/patches/react-native-track-player@4.1.2.patch
+++ b/patches/react-native-track-player@4.1.2.patch
@@ -1,0 +1,21 @@
+diff --git a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
++++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+@@ -545,7 +545,7 @@ class MusicModule(reactContext: ReactApplicationContext) :
+         if (verifyServiceBoundOrReject(callback)) return@launch
+ 
+         if (index >= 0 && index < musicService.tracks.size) {
+-            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem))
++            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem!!))
+         } else {
+             callback.resolve(null)
+         }
+@@ -585,7 +585,7 @@ class MusicModule(reactContext: ReactApplicationContext) :
+         callback.resolve(
+             if (musicService.tracks.isEmpty()) null
+             else Arguments.fromBundle(
+-                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem
++                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem!!
+             )
+         )
+     }

--- a/patches/react-native-track-player@4.1.2.patch
+++ b/patches/react-native-track-player@4.1.2.patch
@@ -1,21 +1,29 @@
 diff --git a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
 --- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
 +++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
-@@ -545,7 +545,7 @@ class MusicModule(reactContext: ReactApplicationContext) :
+@@ -545,7 +545,10 @@ class MusicModule(reactContext: ReactApplicationContext) :
          if (verifyServiceBoundOrReject(callback)) return@launch
- 
+
          if (index >= 0 && index < musicService.tracks.size) {
 -            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem))
-+            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem!!))
++            musicService.tracks[index].originalItem?.let {
++                callback.resolve(Arguments.fromBundle(it))
++            } ?: callback.resolve(null)
          } else {
              callback.resolve(null)
          }
-@@ -585,7 +585,7 @@ class MusicModule(reactContext: ReactApplicationContext) :
-         callback.resolve(
-             if (musicService.tracks.isEmpty()) null
-             else Arguments.fromBundle(
+@@ -585,7 +588,10 @@ class MusicModule(reactContext: ReactApplicationContext) :
+-        callback.resolve(
+-            if (musicService.tracks.isEmpty()) null
+-            else Arguments.fromBundle(
 -                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem
-+                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem!!
-             )
-         )
+-            )
+-        )
++        if (musicService.tracks.isEmpty()) {
++            callback.resolve(null)
++        } else {
++            musicService.tracks[musicService.getCurrentTrackIndex()].originalItem?.let {
++                callback.resolve(Arguments.fromBundle(it))
++            } ?: callback.resolve(null)
++        }
      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-native-track-player@4.1.2:
+    hash: 8fcd040d06f9b56699ba41411d3deb81e4a36e890cf87631d365abd3b88466db
+    path: patches/react-native-track-player@4.1.2.patch
+
 importers:
 
   .:
@@ -202,7 +207,7 @@ importers:
         version: 2.3.3(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native-track-player:
         specifier: ^4.1.2
-        version: 4.1.2(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+        version: 4.1.2(patch_hash=8fcd040d06f9b56699ba41411d3deb81e4a36e890cf87631d365abd3b88466db)(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native-version-check:
         specifier: ^3.4.7
         version: 3.5.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))
@@ -13120,7 +13125,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0)
 
-  react-native-track-player@4.1.2(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
+  react-native-track-player@4.1.2(patch_hash=8fcd040d06f9b56699ba41411d3deb81e4a36e890cf87631d365abd3b88466db)(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.27.1)(@react-native-community/cli@20.0.2(typescript@5.9.2))(@react-native/metro-config@0.81.1(@babel/core@7.27.1))(@types/react@19.1.13)(react@19.1.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * React Nativeトラックプレーヤーの依存にローカルパッチを適用しました（パッケージ設定にパッチ指定を追加）。
* **Bug Fixes**
  * Android側のトラック取得処理でのヌル参照を回避する安全性向上を導入し、安定性とクラッシュ低減を図りました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->