### PR TITLE
経路検索画面にウォークスルー機能を追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -255,5 +255,11 @@
   "walkthroughSwipeHint": "Swipe to navigate",
   "walkthroughSkipHint": "Skip the walkthrough and get started",
   "walkthroughGoToStepHint": "Go to this step",
-  "walkthroughNextHint": "Proceed to the next step"
+  "walkthroughNextHint": "Proceed to the next step",
+  "routeSearchWalkthroughTitle1": "Route Search",
+  "routeSearchWalkthroughDescription1": "On this screen, you can search for a destination station and find a route.",
+  "routeSearchWalkthroughTitle2": "Enter Station Name",
+  "routeSearchWalkthroughDescription2": "Enter the name of your destination station here and tap the search button to see the available options.",
+  "routeSearchWalkthroughTitle3": "Select a Route",
+  "routeSearchWalkthroughDescription3": "Tap a destination from the search results to see the route to that station. Routes are color-coded by line, so you can choose the line you want to take."
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -256,5 +256,11 @@
   "walkthroughSwipeHint": "スワイプで前後に移動できます",
   "walkthroughSkipHint": "ウォークスルーをスキップして開始します",
   "walkthroughGoToStepHint": "このステップに移動します",
-  "walkthroughNextHint": "次のステップに進みます"
+  "walkthroughNextHint": "次のステップに進みます",
+  "routeSearchWalkthroughTitle1": "経路検索",
+  "routeSearchWalkthroughDescription1": "この画面では、目的地の駅を検索して経路を見つけることができます。",
+  "routeSearchWalkthroughTitle2": "駅名を入力",
+  "routeSearchWalkthroughDescription2": "ここに目的地の駅名を入力して検索ボタンをタップすると、候補が表示されます。",
+  "routeSearchWalkthroughTitle3": "経路を選択",
+  "routeSearchWalkthroughDescription3": "検索結果から目的地をタップすると、その駅までの経路が表示されます。路線ごとに色分けされているので、乗りたい路線を選んでください。"
 }

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -31,7 +31,10 @@ export type WalkthroughStepId =
   | 'changeLocation'
   | 'savedRoutes'
   | 'selectLine'
-  | 'customize';
+  | 'customize'
+  | 'routeSearchIntro'
+  | 'routeSearchBar'
+  | 'routeSearchResults';
 
 export type WalkthroughStep = {
   id: WalkthroughStepId;

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -18,6 +18,8 @@ export const ASYNC_STORAGE_KEYS = {
   PARTIALLY_PASS_ALERT_DISMISSED: '@TrainLCD:partiallyPassAlertDismissed',
   TELEMETRY_ENABLED: '@TrainLCD:telemetryEnabled',
   WALKTHROUGH_COMPLETED: '@TrainLCD:walkthroughCompleted',
+  ROUTE_SEARCH_WALKTHROUGH_COMPLETED:
+    '@TrainLCD:routeSearchWalkthroughCompleted',
 } as const;
 
 export type AsyncStorageKeys =

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -51,6 +51,7 @@ export { usePreviousStation } from './usePreviousStation';
 export { useRefreshLeftStations } from './useRefreshLeftStations';
 export { useRefreshStation } from './useRefreshStation';
 export { useResetMainState } from './useResetMainState';
+export { useRouteSearchWalkthrough } from './useRouteSearchWalkthrough';
 export { useSavedRoutes } from './useSavedRoutes';
 export { useShouldHideTypeChange } from './useShouldHideTypeChange';
 export { useSimulationMode } from './useSimulationMode';

--- a/src/hooks/useRouteSearchWalkthrough.ts
+++ b/src/hooks/useRouteSearchWalkthrough.ts
@@ -1,0 +1,137 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  WalkthroughStep,
+  WalkthroughStepId,
+} from '../components/WalkthroughOverlay';
+import { ASYNC_STORAGE_KEYS } from '../constants/asyncStorage';
+
+const ROUTE_SEARCH_WALKTHROUGH_STEPS: WalkthroughStep[] = [
+  {
+    id: 'routeSearchIntro',
+    titleKey: 'routeSearchWalkthroughTitle1',
+    descriptionKey: 'routeSearchWalkthroughDescription1',
+    tooltipPosition: 'bottom',
+  },
+  {
+    id: 'routeSearchBar',
+    titleKey: 'routeSearchWalkthroughTitle2',
+    descriptionKey: 'routeSearchWalkthroughDescription2',
+    tooltipPosition: 'bottom',
+  },
+  {
+    id: 'routeSearchResults',
+    titleKey: 'routeSearchWalkthroughTitle3',
+    descriptionKey: 'routeSearchWalkthroughDescription3',
+    tooltipPosition: 'top',
+  },
+];
+
+type UseRouteSearchWalkthroughResult = {
+  isWalkthroughCompleted: boolean | null;
+  isWalkthroughActive: boolean;
+  currentStepIndex: number;
+  currentStepId: WalkthroughStepId | null;
+  currentStep: WalkthroughStep | null;
+  totalSteps: number;
+  nextStep: () => void;
+  goToStep: (index: number) => void;
+  skipWalkthrough: () => Promise<void>;
+  setSpotlightArea: (area: WalkthroughStep['spotlightArea']) => void;
+};
+
+export const useRouteSearchWalkthrough =
+  (): UseRouteSearchWalkthroughResult => {
+    const [isWalkthroughCompleted, setIsWalkthroughCompleted] = useState<
+      boolean | null
+    >(null);
+    const [currentStepIndex, setCurrentStepIndex] = useState(0);
+    const [spotlightArea, setSpotlightAreaState] =
+      useState<WalkthroughStep['spotlightArea']>(undefined);
+
+    useEffect(() => {
+      const checkWalkthroughCompleted = async () => {
+        try {
+          const completed = await AsyncStorage.getItem(
+            ASYNC_STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED
+          );
+          setIsWalkthroughCompleted(completed === 'true');
+        } catch (error) {
+          console.error(
+            'Failed to check route search walkthrough completion status:',
+            error
+          );
+          setIsWalkthroughCompleted(false);
+        }
+      };
+      checkWalkthroughCompleted();
+    }, []);
+
+    const completeWalkthrough = useCallback(async () => {
+      setIsWalkthroughCompleted(true);
+      try {
+        await AsyncStorage.setItem(
+          ASYNC_STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED,
+          'true'
+        );
+      } catch (error) {
+        console.error(
+          'Failed to save route search walkthrough completion status:',
+          error
+        );
+      }
+    }, []);
+
+    const nextStep = useCallback(() => {
+      if (currentStepIndex < ROUTE_SEARCH_WALKTHROUGH_STEPS.length - 1) {
+        setCurrentStepIndex((prev) => prev + 1);
+        setSpotlightAreaState(undefined);
+      } else {
+        completeWalkthrough();
+      }
+    }, [currentStepIndex, completeWalkthrough]);
+
+    const goToStep = useCallback((index: number) => {
+      if (index >= 0 && index < ROUTE_SEARCH_WALKTHROUGH_STEPS.length) {
+        setCurrentStepIndex(index);
+        setSpotlightAreaState(undefined);
+      }
+    }, []);
+
+    const skipWalkthrough = useCallback(async () => {
+      await completeWalkthrough();
+    }, [completeWalkthrough]);
+
+    const setSpotlightArea = useCallback(
+      (area: WalkthroughStep['spotlightArea']) => {
+        setSpotlightAreaState(area);
+      },
+      []
+    );
+
+    const isWalkthroughActive =
+      isWalkthroughCompleted === false &&
+      currentStepIndex < ROUTE_SEARCH_WALKTHROUGH_STEPS.length;
+
+    const currentStep = isWalkthroughActive
+      ? {
+          ...ROUTE_SEARCH_WALKTHROUGH_STEPS[currentStepIndex],
+          spotlightArea,
+        }
+      : null;
+
+    const currentStepId = currentStep?.id ?? null;
+
+    return {
+      isWalkthroughCompleted,
+      isWalkthroughActive,
+      currentStepIndex,
+      currentStepId,
+      currentStep,
+      totalSteps: ROUTE_SEARCH_WALKTHROUGH_STEPS.length,
+      nextStep,
+      goToStep,
+      skipWalkthrough,
+      setSpotlightArea,
+    };
+  };

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -1,7 +1,13 @@
 import { useLazyQuery } from '@apollo/client/react';
 import { Orientation } from 'expo-screen-orientation';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { SEARCH_STATION_RESULT_LIMIT } from 'react-native-dotenv';
 import Animated, {
@@ -20,7 +26,9 @@ import { NowHeader } from '~/components/NowHeader';
 import { SearchBar } from '~/components/SearchBar';
 import { SelectBoundModal } from '~/components/SelectBoundModal';
 import { TrainTypeListModal } from '~/components/TrainTypeListModal';
+import WalkthroughOverlay from '~/components/WalkthroughOverlay';
 import { useDeviceOrientation } from '~/hooks/useDeviceOrientation';
+import { useRouteSearchWalkthrough } from '~/hooks/useRouteSearchWalkthrough';
 import {
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
@@ -136,6 +144,34 @@ const RouteSearchScreen = () => {
   const { pendingLine } = lineAtom;
 
   const scrollY = useSharedValue(0);
+
+  // ウォークスルー関連
+  const {
+    isWalkthroughActive,
+    currentStepIndex,
+    currentStepId,
+    currentStep,
+    totalSteps,
+    nextStep,
+    goToStep,
+    skipWalkthrough,
+    setSpotlightArea,
+  } = useRouteSearchWalkthrough();
+
+  const searchBarRef = useRef<View>(null);
+  const searchResultsRef = useRef<View>(null);
+  const [searchBarLayout, setSearchBarLayout] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
+  const [searchResultsLayout, setSearchResultsLayout] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
 
   // 駅グループが変更されたら検索結果をクリア
   // biome-ignore lint/correctness/useExhaustiveDependencies: station?.groupId の変更を意図的に監視
@@ -481,6 +517,52 @@ const RouteSearchScreen = () => {
     [station, pendingLine, routeTypesData?.routeTypes]
   );
 
+  // ウォークスルーのレイアウト計測
+  const handleSearchBarLayout = useCallback(() => {
+    if (searchBarRef.current) {
+      searchBarRef.current.measureInWindow(
+        (x: number, y: number, width: number, height: number) => {
+          setSearchBarLayout({ x, y, width, height });
+        }
+      );
+    }
+  }, []);
+
+  const handleSearchResultsLayout = useCallback(() => {
+    if (searchResultsRef.current) {
+      searchResultsRef.current.measureInWindow(
+        (x: number, y: number, width: number, height: number) => {
+          setSearchResultsLayout({ x, y, width, height });
+        }
+      );
+    }
+  }, []);
+
+  // ウォークスルーのスポットライト設定
+  useEffect(() => {
+    if (currentStepId === 'routeSearchBar' && searchBarLayout) {
+      setSpotlightArea({
+        x: searchBarLayout.x,
+        y: searchBarLayout.y,
+        width: searchBarLayout.width,
+        height: searchBarLayout.height,
+        borderRadius: 8,
+      });
+    }
+  }, [currentStepId, searchBarLayout, setSpotlightArea]);
+
+  useEffect(() => {
+    if (currentStepId === 'routeSearchResults' && searchResultsLayout) {
+      setSpotlightArea({
+        x: searchResultsLayout.x,
+        y: searchResultsLayout.y,
+        width: searchResultsLayout.width,
+        height: Math.min(searchResultsLayout.height, 200),
+        borderRadius: 12,
+      });
+    }
+  }, [currentStepId, searchResultsLayout, setSpotlightArea]);
+
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.nonLEDBg]}>
@@ -494,7 +576,11 @@ const RouteSearchScreen = () => {
           ]}
         >
           <View style={styles.listHeaderContainer}>
-            <View style={styles.searchBarContainer}>
+            <View
+              ref={searchBarRef}
+              style={styles.searchBarContainer}
+              onLayout={handleSearchBarLayout}
+            >
               <SearchBar onSearch={handleSearch} />
             </View>
             <Heading style={styles.searchResultHeading}>
@@ -502,27 +588,29 @@ const RouteSearchScreen = () => {
             </Heading>
           </View>
 
-          {!searchResults.length ? (
-            <EmptyResult
-              loading={byNameLoading || fetchRouteTypesLoading}
-              hasSearched={hasSearched}
-            />
-          ) : (
-            Array.from({
-              length: Math.ceil(searchResults.length / numColumns),
-            }).map((_, rowIndex) => {
-              const rowStations = searchResults.slice(
-                rowIndex * numColumns,
-                (rowIndex + 1) * numColumns
-              );
-              const rowKey = rowStations.map((s) => s.id).join('-');
-              return (
-                <React.Fragment key={rowKey}>
-                  {renderStationRow(rowStations, rowIndex)}
-                </React.Fragment>
-              );
-            })
-          )}
+          <View ref={searchResultsRef} onLayout={handleSearchResultsLayout}>
+            {!searchResults.length ? (
+              <EmptyResult
+                loading={byNameLoading || fetchRouteTypesLoading}
+                hasSearched={hasSearched}
+              />
+            ) : (
+              Array.from({
+                length: Math.ceil(searchResults.length / numColumns),
+              }).map((_, rowIndex) => {
+                const rowStations = searchResults.slice(
+                  rowIndex * numColumns,
+                  (rowIndex + 1) * numColumns
+                );
+                const rowKey = rowStations.map((s) => s.id).join('-');
+                return (
+                  <React.Fragment key={rowKey}>
+                    {renderStationRow(rowStations, rowIndex)}
+                  </React.Fragment>
+                );
+              })
+            )}
+          </View>
 
           <EmptyLineSeparator />
         </Animated.ScrollView>
@@ -576,6 +664,18 @@ const RouteSearchScreen = () => {
           fetchRouteTypesLoading
         }
       />
+
+      {currentStep && (
+        <WalkthroughOverlay
+          visible={isWalkthroughActive}
+          step={currentStep}
+          currentStepIndex={currentStepIndex}
+          totalSteps={totalSteps}
+          onNext={nextStep}
+          onGoToStep={goToStep}
+          onSkip={skipWalkthrough}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
- useRouteSearchWalkthroughフックを新規作成
- WalkthroughStepIdに経路検索用のステップIDを追加
- 日本語/英語の翻訳キーを追加
- RouteSearchScreenにウォークスルーオーバーレイを統合
- AsyncStorageにウォークスルー完了状態の保存キーを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ルート検索画面にガイドウォークスルーを追加しました。段階的なチュートリアルにより、ユーザーが検索バーと検索結果の使い方を学べるようになります。ウォークスルーは多言語対応し、完了状態が保存されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->