### PR TITLE
Dynamic Islandのミニマルビューを駅ナンバリング進捗ゲージに変更

### DIFF
--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -239,7 +239,14 @@ struct RideSessionWidget: Widget {
         .frame(maxWidth: .infinity)
         .padding(.trailing, 8)
       } minimal: {
-        Image(systemName: "tram")
+        Gauge(
+          value: Double(context.state.stationIndex),
+          in: 0...Double(max(context.state.totalStations - 1, 1))
+        ) {
+          Image(systemName: "tram")
+        }
+        .gaugeStyle(.accessoryCircularCapacity)
+        .tint(Color(hex: context.state.lineColor))
       }
     }
     .supplementalActivityFamiliesIfAvailable()

--- a/ios/RideSessionActivity/RideSessionAttributes.swift
+++ b/ios/RideSessionActivity/RideSessionAttributes.swift
@@ -28,5 +28,7 @@ struct RideSessionAttributes: ActivityAttributes {
     var isNextLastStop: Bool
     var lineColor: String
     var lineName: String
+    var stationIndex: Int
+    var totalStations: Int
   }
 }

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -177,6 +177,13 @@ export const useUpdateLiveActivities = (): void => {
     [approachingFromState]
   );
 
+  const stationIndex = useMemo(() => {
+    const index = stations.findIndex((s) => s.id === stoppedStation?.id);
+    return index >= 0 ? index : 0;
+  }, [stations, stoppedStation?.id]);
+
+  const totalStations = useMemo(() => stations.length, [stations.length]);
+
   const activityState = useMemo(
     () => ({
       stationName,
@@ -194,6 +201,8 @@ export const useUpdateLiveActivities = (): void => {
       lineName,
       passingStationName,
       passingStationNumber,
+      stationIndex,
+      totalStations,
     }),
     [
       approaching,
@@ -207,9 +216,11 @@ export const useUpdateLiveActivities = (): void => {
       nextStationNumber,
       passingStationName,
       passingStationNumber,
+      stationIndex,
       stationName,
       stationNumber,
       stopped,
+      totalStations,
       trainTypeName,
     ]
   );

--- a/src/utils/native/ios/liveActivityModule.ts
+++ b/src/utils/native/ios/liveActivityModule.ts
@@ -14,6 +14,8 @@ type LiveActivityWidgetState = {
   lineColor: string;
   passingStationName: string;
   passingStationNumber: string;
+  stationIndex: number;
+  totalStations: number;
 };
 
 export const startLiveActivity = (state?: LiveActivityWidgetState) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ライブアクティビティに駅の進捗インジケーターを追加しました。乗車セッション中の現在位置を動的に表示するゲージが、従来の静的アイコンに代わり表示されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->