### PR TITLE
駅ナンバリングゲージに路線記号を含めて表示

### DIFF
--- a/ios/Modules/LiveActivity/LiveActivityModule.swift
+++ b/ios/Modules/LiveActivity/LiveActivityModule.swift
@@ -26,7 +26,7 @@ class LiveActivityModule: NSObject {
       isNextLastStop: state["isNextLastStop"] as? Bool ?? false,
       lineColor: state["lineColor"] as? String ?? "#000000",
       lineName: state["lineName"] as? String ?? "",
-      progress: 0.0
+      progress: state["progress"] as? Double ?? 0.3
     )
   }
   

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -52,11 +52,12 @@ struct StationNumberGaugeView: View {
         Text(displayNumber)
           .font(.system(size: 10, weight: .bold, design: .rounded))
           .minimumScaleFactor(0.5)
+          .frame(width: 16, height: 16)
       } else {
         Image("AppIcon")
           .resizable()
           .scaledToFit()
-          .frame(width: 14, height: 14)
+          .frame(width: 12, height: 12)
       }
     }
     .frame(width: 24, height: 24)

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -42,7 +42,7 @@ struct StationNumberGaugeView: View {
 
       // プログレスの円弧
       Circle()
-        .trim(from: 0, to: progress)
+        .trim(from: 0, to: 1.0)  // TODO: デバッグ用 - progressを1.0に固定
         .stroke(
           gaugeColor,
           style: StrokeStyle(lineWidth: 3, lineCap: .round)

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -16,13 +16,17 @@ struct StationNumberGaugeView: View {
   let progress: Double
   let stopped: Bool
 
-  private var displayNumber: String {
+  private var displayNumberParts: (symbol: String, number: String)? {
     let number = stopped ? stationNumber : nextStationNumber
     if number.isEmpty {
-      return ""
+      return nil
     }
-    // ハイフンを改行に置換して路線記号と番号を2行で表示（例: E-31 → E\n31）
-    return number.replacingOccurrences(of: "-", with: "\n")
+    let parts = number.split(separator: "-", maxSplits: 1)
+    if parts.count == 2 {
+      return (symbol: String(parts[0]), number: String(parts[1]))
+    }
+    // ハイフンがない場合はそのまま表示
+    return (symbol: "", number: number)
   }
 
   private var gaugeColor: Color {
@@ -48,12 +52,17 @@ struct StationNumberGaugeView: View {
         .rotationEffect(.degrees(-90))
 
       // 中央の駅ナンバー表示
-      if !displayNumber.isEmpty {
-        Text(displayNumber)
-          .font(.system(size: 10, weight: .bold, design: .rounded))
-          .multilineTextAlignment(.center)
-          .minimumScaleFactor(0.5)
-          .frame(width: 16, height: 16)
+      if let parts = displayNumberParts {
+        VStack(spacing: 0) {
+          if !parts.symbol.isEmpty {
+            Text(parts.symbol)
+              .font(.system(size: 8, weight: .bold, design: .rounded))
+          }
+          Text(parts.number)
+            .font(.system(size: 8, weight: .bold, design: .rounded))
+        }
+        .minimumScaleFactor(0.5)
+        .frame(width: 16, height: 16)
       } else {
         Image("AppIcon")
           .resizable()

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -26,11 +26,12 @@ struct StationNumberGaugeView: View {
   }
 
   private var gaugeColor: Color {
-    // デバッグ: lineColorが空の場合は白にフォールバック
-    if lineColor.isEmpty {
-      return .white
-    }
-    return Color(hex: lineColor)
+    // TODO: デバッグ用 - 赤色で表示されるか確認後に削除
+    return .red
+    // if lineColor.isEmpty {
+    //   return .white
+    // }
+    // return Color(hex: lineColor)
   }
 
   var body: some View {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -51,7 +51,7 @@ struct StationNumberGaugeView: View {
         )
         .rotationEffect(.degrees(-90))
 
-      // 中央の駅ナンバー表示
+      // 中央の駅ナンバー表示（ナンバリングがない場合は空）
       if let parts = displayNumberParts {
         VStack(spacing: 0) {
           if !parts.symbol.isEmpty {
@@ -63,11 +63,6 @@ struct StationNumberGaugeView: View {
         }
         .minimumScaleFactor(0.5)
         .frame(width: 16, height: 16)
-      } else {
-        Image("AppIcon")
-          .resizable()
-          .scaledToFit()
-          .frame(width: 12, height: 12)
       }
     }
     .frame(width: 24, height: 24)

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -26,12 +26,10 @@ struct StationNumberGaugeView: View {
   }
 
   private var gaugeColor: Color {
-    // TODO: デバッグ用 - 赤色で表示されるか確認後に削除
-    return .red
-    // if lineColor.isEmpty {
-    //   return .white
-    // }
-    // return Color(hex: lineColor)
+    if lineColor.isEmpty {
+      return .white
+    }
+    return Color(hex: lineColor)
   }
 
   var body: some View {
@@ -42,11 +40,12 @@ struct StationNumberGaugeView: View {
 
       // プログレスの円弧
       Circle()
-        .trim(from: 0, to: 1.0)  // TODO: デバッグ用 - progressを1.0に固定
+        .trim(from: 0, to: progress)
         .stroke(
           gaugeColor,
           style: StrokeStyle(lineWidth: 3, lineCap: .round)
         )
+        .rotationEffect(.degrees(-90))
 
       // 中央の駅ナンバー表示
       if !displayNumber.isEmpty {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -21,8 +21,8 @@ struct StationNumberGaugeView: View {
     if number.isEmpty {
       return ""
     }
-    // ハイフンを削除して路線記号+番号を表示（例: E-31 → E31）
-    return number.replacingOccurrences(of: "-", with: "")
+    // ハイフンを改行に置換して路線記号と番号を2行で表示（例: E-31 → E\n31）
+    return number.replacingOccurrences(of: "-", with: "\n")
   }
 
   private var gaugeColor: Color {
@@ -51,6 +51,7 @@ struct StationNumberGaugeView: View {
       if !displayNumber.isEmpty {
         Text(displayNumber)
           .font(.system(size: 10, weight: .bold, design: .rounded))
+          .multilineTextAlignment(.center)
           .minimumScaleFactor(0.5)
           .frame(width: 16, height: 16)
       } else {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -21,13 +21,8 @@ struct StationNumberGaugeView: View {
     if number.isEmpty {
       return ""
     }
-    // 駅ナンバーが長い場合は数字部分のみ抽出して表示
-    let digits = number.filter { $0.isNumber }
-    if digits.count <= 2 {
-      return digits
-    }
-    // 3桁以上の場合は最後の2桁を表示
-    return String(digits.suffix(2))
+    // ハイフンを削除して路線記号+番号を表示（例: E-31 → E31）
+    return number.replacingOccurrences(of: "-", with: "")
   }
 
   private var gaugeColor: Color {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -47,7 +47,6 @@ struct StationNumberGaugeView: View {
           gaugeColor,
           style: StrokeStyle(lineWidth: 3, lineCap: .round)
         )
-        .rotationEffect(.degrees(-90))
 
       // 中央の駅ナンバー表示
       if !displayNumber.isEmpty {

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -26,7 +26,11 @@ struct StationNumberGaugeView: View {
   }
 
   private var gaugeColor: Color {
-    Color(hex: lineColor)
+    // デバッグ: lineColorが空の場合は白にフォールバック
+    if lineColor.isEmpty {
+      return .white
+    }
+    return Color(hex: lineColor)
   }
 
   var body: some View {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 駅／路線番号でハイフンを分割して縦表示に対応（例：上段: 記号／下段: 番号）。空文字は非表示扱いに変更。
  * 線色が未指定のときは白を使用し、指定があればその色を反映。
  * 進捗値を外部状態からDoubleで取得し、未指定時の既定値を0.3に変更。

* **変更**
  * 番号表示の配置・縮小挙動を調整（縦2行対応、最小縮小率、16×16内で表示）。
  * 番号なし時のアイコン代替表示を削除（中央は空き領域となる）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->