### PR TITLE
英語環境で英語路線名がない場合は日本語にフォールバック（都営バス等を想定）

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -194,7 +194,7 @@ export const CommonCard: React.FC<Props> = ({
   const titleOrLineName = useMemo(() => {
     return isJapanese
       ? (title ?? line.nameShort ?? '')
-      : (title ?? line.nameRoman ?? '');
+      : (title ?? (line.nameRoman || line.nameShort) ?? '');
   }, [title, line.nameShort, line.nameRoman]);
 
   const targetStationNumber = targetStation?.stationNumbers?.[0]?.stationNumber;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 非日本語環境での路線名表示ロジックの改善 - 路線表示名の選択時に空の値が適切に処理されるようになり、より正確なフォールバック値が表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->