### PR TITLE
英語環境でバス路線名が空欄になるバグを修正

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -6,7 +6,7 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { Path, Svg } from 'react-native-svg';
 import type { Line, Station } from '~/@types/graphql';
 import isTablet from '~/utils/isTablet';
-import { isBusLine } from '~/utils/line';
+import { getLocalizedLineName, isBusLine } from '~/utils/line';
 import { MARK_SHAPE, NUMBERING_ICON_SIZE } from '../constants';
 import { useBounds, useGetLineMark } from '../hooks';
 import { isLEDThemeAtom } from '../store/atoms/theme';
@@ -192,10 +192,8 @@ export const CommonCard: React.FC<Props> = ({
   }, [bounds, stations]);
 
   const titleOrLineName = useMemo(() => {
-    return isJapanese
-      ? (title ?? line.nameShort ?? '')
-      : (title ?? (line.nameRoman || line.nameShort) ?? '');
-  }, [title, line.nameShort, line.nameRoman]);
+    return title ?? getLocalizedLineName(line, isJapanese);
+  }, [title, line]);
 
   const targetStationNumber = targetStation?.stationNumbers?.[0]?.stationNumber;
   const targetStationColor =

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -111,7 +111,11 @@ export const RouteInfoModal = ({
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;
       const subtitle = Array.from(
-        new Set((lines ?? []).map((l) => getLocalizedLineName(l, isJapanese)))
+        new Set(
+          (lines ?? [])
+            .map((l) => getLocalizedLineName(l, isJapanese))
+            .filter(Boolean)
+        )
       ).join(isJapanese ? '・' : ', ');
 
       return (

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -97,7 +97,7 @@ export const RouteInfoModal = ({
   const { pendingLine } = useAtomValue(lineState);
   const lineName = isJapanese
     ? (pendingLine?.nameShort ?? '')
-    : (pendingLine?.nameRoman ?? '');
+    : ((pendingLine?.nameRoman || pendingLine?.nameShort) ?? '');
   const trainTypeName = isJapanese
     ? (trainType?.name ?? '普通/各駅停車')
     : (trainType?.nameRoman ?? 'Local');
@@ -111,7 +111,9 @@ export const RouteInfoModal = ({
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;
       const subtitle = isJapanese
         ? Array.from(new Set((lines ?? []).map((l) => l.nameShort))).join('・')
-        : Array.from(new Set((lines ?? []).map((l) => l.nameRoman))).join(', ');
+        : Array.from(
+            new Set((lines ?? []).map((l) => l.nameRoman || l.nameShort))
+          ).join(', ');
 
       return (
         <CommonCard

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -9,7 +9,10 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import dropEitherJunctionStation from '~/utils/dropJunctionStation';
 import isTablet from '~/utils/isTablet';
-import { filterBusLinesForNonBusStation } from '~/utils/line';
+import {
+  filterBusLinesForNonBusStation,
+  getLocalizedLineName,
+} from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
 import Button from './Button';
 import { CommonCard } from './CommonCard';
@@ -95,9 +98,7 @@ export const RouteInfoModal = ({
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   const { pendingLine } = useAtomValue(lineState);
-  const lineName = isJapanese
-    ? (pendingLine?.nameShort ?? '')
-    : ((pendingLine?.nameRoman || pendingLine?.nameShort) ?? '');
+  const lineName = getLocalizedLineName(pendingLine, isJapanese);
   const trainTypeName = isJapanese
     ? (trainType?.name ?? '普通/各駅停車')
     : (trainType?.nameRoman ?? 'Local');
@@ -109,11 +110,9 @@ export const RouteInfoModal = ({
       if (!line) return null;
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;
-      const subtitle = isJapanese
-        ? Array.from(new Set((lines ?? []).map((l) => l.nameShort))).join('・')
-        : Array.from(
-            new Set((lines ?? []).map((l) => l.nameRoman || l.nameShort))
-          ).join(', ');
+      const subtitle = Array.from(
+        new Set((lines ?? []).map((l) => getLocalizedLineName(l, isJapanese)))
+      ).join(isJapanese ? '・' : ', ');
 
       return (
         <CommonCard

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -271,13 +271,14 @@ export const SelectBoundModal: React.FC<Props> = ({
       ) => {
         const lineName = isJapanese
           ? lineForCard.nameShort
-          : lineForCard.nameRoman;
-        const trainTypeName = trainTypeForCard
-          ? isJapanese
-            ? trainTypeForCard.name
-            : trainTypeForCard.nameRoman
-          : '';
-        return `${lineName} ${!isLoopLine && trainTypeName ? trainTypeName : ''}`.trim();
+          : lineForCard.nameRoman || lineForCard.nameShort;
+        if (!trainTypeForCard) {
+          return lineName;
+        }
+        const trainTypeName = isJapanese
+          ? trainTypeForCard.name
+          : trainTypeForCard.nameRoman;
+        return `${lineName} ${!isLoopLine && trainTypeName ? trainTypeName : ''}`;
       };
       const finalStop =
         wantedDestination ??
@@ -322,7 +323,7 @@ export const SelectBoundModal: React.FC<Props> = ({
           const title = isLoopLine
             ? loopLineDirectionText(direction)
             : normalLineDirectionText(boundStations);
-          const subtitle = buildSubtitle(lineForCard, trainTypeForCard);
+          const subtitle = buildSubtitle(lineForCard, trainTypeForCard) ?? '';
           return (
             <CommonCard
               line={lineForCard ?? line}
@@ -354,7 +355,7 @@ export const SelectBoundModal: React.FC<Props> = ({
       const title = isLoopLine
         ? loopLineDirectionText(direction)
         : normalLineDirectionText(boundStations);
-      const subtitle = buildSubtitle(lineForCard, trainTypeForCard);
+      const subtitle = buildSubtitle(lineForCard, trainTypeForCard) ?? '';
 
       return (
         <CommonCard

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -24,7 +24,7 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import getIsPass from '~/utils/isPass';
 import isTablet from '~/utils/isTablet';
-import { isBusLine } from '~/utils/line';
+import { getLocalizedLineName, isBusLine } from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
 import { showToast } from '~/utils/toast';
 import Button from '../components/Button';
@@ -269,9 +269,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         lineForCard: Line,
         trainTypeForCard?: TrainType | null
       ) => {
-        const lineName = isJapanese
-          ? lineForCard.nameShort
-          : lineForCard.nameRoman || lineForCard.nameShort;
+        const lineName = getLocalizedLineName(lineForCard, isJapanese);
         if (!trainTypeForCard) {
           return lineName;
         }

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -273,10 +273,10 @@ export const SelectBoundModal: React.FC<Props> = ({
         if (!trainTypeForCard) {
           return lineName;
         }
-        const trainTypeName = isJapanese
-          ? trainTypeForCard.name
-          : trainTypeForCard.nameRoman;
-        return `${lineName} ${!isLoopLine && trainTypeName ? trainTypeName : ''}`;
+        const trainTypeName =
+          !isLoopLine &&
+          (isJapanese ? trainTypeForCard.name : trainTypeForCard.nameRoman);
+        return trainTypeName ? `${lineName} ${trainTypeName}` : lineName;
       };
       const finalStop =
         wantedDestination ??

--- a/src/components/StationSettingsModal.tsx
+++ b/src/components/StationSettingsModal.tsx
@@ -81,7 +81,9 @@ export const StationSettingsModal: React.FC<Props> = ({
     >
       <View style={styles.container}>
         <Typography style={styles.lineText}>
-          {isJapanese ? station?.line?.nameShort : station?.line?.nameRoman}
+          {isJapanese
+            ? station?.line?.nameShort
+            : station?.line?.nameRoman || station?.line?.nameShort}
         </Typography>
         <Heading style={styles.heading}>
           {isJapanese ? station?.name : station?.nameRoman}

--- a/src/components/StationSettingsModal.tsx
+++ b/src/components/StationSettingsModal.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { Station } from '~/@types/graphql';
 import isTablet from '~/utils/isTablet';
-import { isBusLine } from '~/utils/line';
+import { getLocalizedLineName, isBusLine } from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
 import Button from '../components/Button';
 import { Heading } from '../components/Heading';
@@ -81,9 +81,7 @@ export const StationSettingsModal: React.FC<Props> = ({
     >
       <View style={styles.container}>
         <Typography style={styles.lineText}>
-          {isJapanese
-            ? station?.line?.nameShort
-            : station?.line?.nameRoman || station?.line?.nameShort}
+          {getLocalizedLineName(station?.line, isJapanese)}
         </Typography>
         <Heading style={styles.heading}>
           {isJapanese ? station?.name : station?.nameRoman}

--- a/src/hooks/useAppleWatch.ts
+++ b/src/hooks/useAppleWatch.ts
@@ -8,6 +8,7 @@ import {
 } from 'react-native-watch-connectivity';
 import type { Station } from '~/@types/graphql';
 import { isJapanese } from '~/translation';
+import { getLocalizedLineName } from '~/utils/line';
 import { parenthesisRegexp } from '../constants';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
@@ -63,9 +64,10 @@ export const useAppleWatch = (): void => {
           .map((l) => ({
             id: l.id,
             lineColorC: l.color,
-            name: isJapanese
-              ? l.nameShort?.replace(parenthesisRegexp, '')
-              : (l.nameRoman || l.nameShort)?.replace(parenthesisRegexp, ''),
+            name: getLocalizedLineName(l, isJapanese).replace(
+              parenthesisRegexp,
+              ''
+            ),
             lineSymbol: currentNumbering?.lineSymbol ?? '',
           })),
         stationNumber: currentNumbering?.stationNumber,
@@ -80,13 +82,10 @@ export const useAppleWatch = (): void => {
       })),
       selectedLine: {
         id: currentLine.id,
-        name:
-          (isJapanese
-            ? currentLine.nameShort?.replace(parenthesisRegexp, '')
-            : (currentLine.nameRoman || currentLine.nameShort)?.replace(
-                parenthesisRegexp,
-                ''
-              )) ?? '',
+        name: getLocalizedLineName(currentLine, isJapanese).replace(
+          parenthesisRegexp,
+          ''
+        ),
         lineColorC: currentLine.color,
         lineSymbol: currentNumbering?.lineSymbol ?? '',
       },

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { useEffect, useMemo, useState } from 'react';
-import { isBusLine } from '~/utils/line';
+import { getLocalizedLineName, isBusLine } from '~/utils/line';
 import { parenthesisRegexp } from '../constants';
 import { directionToDirectionName } from '../models/Bound';
 import stationState from '../store/atoms/station';
@@ -147,11 +147,8 @@ export const useUpdateLiveActivities = (): void => {
     [currentLine?.color]
   );
   const lineName = useMemo(
-    () =>
-      (isJapanese
-        ? currentLine?.nameShort
-        : currentLine?.nameRoman || currentLine?.nameShort) ?? '',
-    [currentLine?.nameRoman, currentLine?.nameShort]
+    () => getLocalizedLineName(currentLine, isJapanese),
+    [currentLine]
   );
 
   const passingStationName = useMemo(

--- a/src/utils/line.test.ts
+++ b/src/utils/line.test.ts
@@ -5,6 +5,7 @@ import {
   filterBusLinesForNonBusStation,
   filterWithoutCurrentLine,
   getCurrentStationLinesWithoutCurrentLine,
+  getLocalizedLineName,
   getNextStationLinesWithoutCurrentLine,
   isBusLine,
 } from './line';
@@ -226,5 +227,115 @@ describe('getNextStationLinesWithoutCurrentLine', () => {
     ];
     const result = getNextStationLinesWithoutCurrentLine(stations, line1);
     expect(result).toEqual([]);
+  });
+});
+
+describe('getLocalizedLineName', () => {
+  describe('日本語環境（isJapanese: true）', () => {
+    it('nameShortを返す', () => {
+      const line = createLine(1, {
+        nameShort: '池袋線',
+        nameRoman: 'Ikebukuro Line',
+      });
+      expect(getLocalizedLineName(line, true)).toBe('池袋線');
+    });
+
+    it('nameShortがnullの場合、空文字を返す', () => {
+      const line = createLine(1, {
+        nameShort: null,
+        nameRoman: 'Ikebukuro Line',
+      });
+      expect(getLocalizedLineName(line, true)).toBe('');
+    });
+
+    it('nameShortがundefinedの場合、空文字を返す', () => {
+      const line = createLine(1, {
+        nameShort: undefined,
+        nameRoman: 'Ikebukuro Line',
+      });
+      expect(getLocalizedLineName(line, true)).toBe('');
+    });
+  });
+
+  describe('英語環境（isJapanese: false）', () => {
+    it('nameRomanを返す', () => {
+      const line = createLine(1, {
+        nameShort: '池袋線',
+        nameRoman: 'Ikebukuro Line',
+      });
+      expect(getLocalizedLineName(line, false)).toBe('Ikebukuro Line');
+    });
+
+    it('nameRomanが空文字の場合、nameShortにフォールバックする', () => {
+      const line = createLine(1, {
+        nameShort: '池袋線',
+        nameRoman: '',
+      });
+      expect(getLocalizedLineName(line, false)).toBe('池袋線');
+    });
+
+    it('nameRomanがnullの場合、nameShortにフォールバックする', () => {
+      const line = createLine(1, {
+        nameShort: '池袋線',
+        nameRoman: null,
+      });
+      expect(getLocalizedLineName(line, false)).toBe('池袋線');
+    });
+
+    it('nameRomanがundefinedの場合、nameShortにフォールバックする', () => {
+      const line = createLine(1, {
+        nameShort: '池袋線',
+        nameRoman: undefined,
+      });
+      expect(getLocalizedLineName(line, false)).toBe('池袋線');
+    });
+
+    it('nameRomanとnameShort両方が空の場合、空文字を返す', () => {
+      const line = createLine(1, {
+        nameShort: '',
+        nameRoman: '',
+      });
+      expect(getLocalizedLineName(line, false)).toBe('');
+    });
+
+    it('nameRomanとnameShort両方がnullの場合、空文字を返す', () => {
+      const line = createLine(1, {
+        nameShort: null,
+        nameRoman: null,
+      });
+      expect(getLocalizedLineName(line, false)).toBe('');
+    });
+  });
+
+  describe('バス路線のケース（nameRomanが空になりがち）', () => {
+    it('バス路線でnameRomanがない場合、英語環境でもnameShortを返す', () => {
+      const busLine = createLine(1, {
+        nameShort: '池65',
+        nameRoman: '',
+        transportType: TransportType.Bus,
+      });
+      expect(getLocalizedLineName(busLine, false)).toBe('池65');
+    });
+
+    it('バス路線でnameRomanがnullの場合、英語環境でもnameShortを返す', () => {
+      const busLine = createLine(1, {
+        nameShort: '池65',
+        nameRoman: null,
+        transportType: TransportType.Bus,
+      });
+      expect(getLocalizedLineName(busLine, false)).toBe('池65');
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('lineがnullの場合、空文字を返す', () => {
+      expect(getLocalizedLineName(null, true)).toBe('');
+      expect(getLocalizedLineName(null, false)).toBe('');
+    });
+
+    it('lineがundefinedの場合、空文字を返す', () => {
+      expect(getLocalizedLineName(undefined, true)).toBe('');
+      expect(getLocalizedLineName(undefined, false)).toBe('');
+    });
   });
 });

--- a/src/utils/line.ts
+++ b/src/utils/line.ts
@@ -48,3 +48,16 @@ export const filterBusLinesForNonBusStation = <
   if (!lines) return [];
   return lines.filter((l) => isBusLine(currentLine) || !isBusLine(l));
 };
+
+/**
+ * ローカライズされた路線名を取得する
+ * 英語環境でnameRomanが空の場合、nameShortにフォールバックする（バス路線対応）
+ */
+export const getLocalizedLineName = (
+  line: Pick<Line, 'nameShort' | 'nameRoman'> | null | undefined,
+  isJapanese: boolean
+): string => {
+  if (!line) return '';
+  if (isJapanese) return line.nameShort ?? '';
+  return line.nameRoman || line.nameShort || '';
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 路線名の多言語表示をアプリ全体で統一。カード・モーダル・選択画面・Apple Watch表示・ライブアクティビティなどで、日本語／英語の路線名表示と副題の組み立てが一貫して正確になりました。
* **テスト**
  * 路線名表示の多言語・空値・バス路線の振る舞いに関する単体テストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->