### PR TITLE
Android 16でのバックグラウンド位置更新停止問題を修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,5 +36,9 @@
       </intent-filter>
     </activity>
     <service android:name="app.notifee.core.ForegroundService" android:foregroundServiceType="location|mediaPlayback" />
+    <service
+      android:name="expo.modules.location.services.LocationTaskService"
+      android:exported="false"
+      android:foregroundServiceType="location" />
   </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <data android:scheme="@string/app_scheme"/>
       </intent-filter>
     </activity>
-    <service android:name="app.notifee.core.ForegroundService" android:foregroundServiceType="location|mediaPlayback" />
+    <service android:name="app.notifee.core.ForegroundService" android:foregroundServiceType="mediaPlayback" />
     <service
       android:name="expo.modules.location.services.LocationTaskService"
       android:exported="false"

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,6 +11,13 @@ export default ({ config }: ConfigContext) => ({
     'expo-sqlite',
     'expo-asset',
     [
+      'expo-location',
+      {
+        isAndroidBackgroundLocationEnabled: true,
+        isAndroidForegroundServiceEnabled: true,
+      },
+    ],
+    [
       '@sentry/react-native',
       {
         url: 'https://sentry.io/',

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -1,8 +1,13 @@
 import * as Location from 'expo-location';
 import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { setLocation } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
+import {
+  startForegroundService,
+  stopForegroundService,
+} from '~/utils/native/android/foregroundServiceModule';
 import { LOCATION_TASK_NAME, LOCATION_TASK_OPTIONS } from '../constants';
 import { translate } from '../translation';
 import { useLocationPermissionsGranted } from './useLocationPermissionsGranted';
@@ -18,6 +23,11 @@ export const useStartBackgroundLocationUpdates = () => {
 
     (async () => {
       try {
+        // AndroidではNotifeeのフォアグラウンドサービスも起動（バックグラウンドTTS用）
+        if (Platform.OS === 'android') {
+          await startForegroundService();
+        }
+
         // Android/iOS共通でexpo-locationのフォアグラウンドサービスを使用
         // Android 16以降ではJobSchedulerにランタイムクォータが適用されるため、
         // expo-locationのフォアグラウンドサービス内で直接位置更新を実行する必要がある
@@ -41,6 +51,11 @@ export const useStartBackgroundLocationUpdates = () => {
     })();
 
     return () => {
+      // AndroidではNotifeeのフォアグラウンドサービスも停止
+      if (Platform.OS === 'android') {
+        stopForegroundService();
+      }
+
       Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME).catch((error) => {
         console.warn(
           'バックグラウンド位置情報の更新停止に失敗しました:',

--- a/src/utils/native/android/foregroundServiceModule.ts
+++ b/src/utils/native/android/foregroundServiceModule.ts
@@ -3,11 +3,25 @@ import notifee, {
   AndroidImportance,
   EventType,
 } from '@notifee/react-native';
+import * as Location from 'expo-location';
 import { Platform } from 'react-native';
 import { translate } from '~/translation';
 
 const CHANNEL_ID = 'trainlcd-foreground-service';
 const NOTIFICATION_ID = 'trainlcd-foreground-notification';
+
+/**
+ * フォアグラウンドサービスを起動する条件を満たしているかチェック
+ * - 位置情報が常に許可されている
+ */
+const shouldStartForegroundService = async (): Promise<boolean> => {
+  try {
+    const locationPermission = await Location.getBackgroundPermissionsAsync();
+    return locationPermission.granted;
+  } catch {
+    return false;
+  }
+};
 
 /**
  * 通知チャンネルを作成
@@ -35,6 +49,12 @@ export const createNotificationChannel = async (): Promise<void> => {
  */
 export const startForegroundService = async (): Promise<void> => {
   if (Platform.OS !== 'android') {
+    return;
+  }
+
+  // 位置情報が常に許可されている場合のみ起動
+  const shouldStart = await shouldStartForegroundService();
+  if (!shouldStart) {
     return;
   }
 

--- a/src/utils/native/android/foregroundServiceModule.ts
+++ b/src/utils/native/android/foregroundServiceModule.ts
@@ -3,25 +3,11 @@ import notifee, {
   AndroidImportance,
   EventType,
 } from '@notifee/react-native';
-import * as Location from 'expo-location';
 import { Platform } from 'react-native';
 import { translate } from '~/translation';
 
 const CHANNEL_ID = 'trainlcd-foreground-service';
 const NOTIFICATION_ID = 'trainlcd-foreground-notification';
-
-/**
- * フォアグラウンドサービスを起動する条件を満たしているかチェック
- * - 位置情報が常に許可されている
- */
-const shouldStartForegroundService = async (): Promise<boolean> => {
-  try {
-    const locationPermission = await Location.getBackgroundPermissionsAsync();
-    return locationPermission.granted;
-  } catch {
-    return false;
-  }
-};
 
 /**
  * 通知チャンネルを作成
@@ -44,17 +30,11 @@ export const createNotificationChannel = async (): Promise<void> => {
 
 /**
  * Androidフォアグラウンドサービスを開始
- * これによりDozeモードでも位置情報の更新が継続される
- * 位置情報が常に許可されている場合のみ起動
+ * バックグラウンドでのメディア再生（TTS）を継続するために使用
+ * 位置情報の更新はexpo-locationのforegroundServiceで処理する
  */
 export const startForegroundService = async (): Promise<void> => {
   if (Platform.OS !== 'android') {
-    return;
-  }
-
-  // 位置情報が常に許可されている場合のみ起動
-  const shouldStart = await shouldStartForegroundService();
-  if (!shouldStart) {
     return;
   }
 
@@ -69,7 +49,6 @@ export const startForegroundService = async (): Promise<void> => {
         channelId: CHANNEL_ID,
         asForegroundService: true,
         foregroundServiceTypes: [
-          AndroidForegroundServiceType.FOREGROUND_SERVICE_TYPE_LOCATION,
           AndroidForegroundServiceType.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
         ],
         importance: AndroidImportance.LOW,


### PR DESCRIPTION
- expo-locationのforegroundServiceオプションをAndroidでも有効化
- app.config.tsにexpo-location pluginを追加（isAndroidForegroundServiceEnabled: true）
- AndroidManifest.xmlにLocationTaskServiceを追加
- NotifeeのフォアグラウンドサービスではなくJobSchedulerクォータの影響を受けないexpo-locationのフォアグラウンドサービスを使用

#5133

https://claude.ai/code/session_01CPtNGqpk2Jd7LVRwJt4FoN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * iOS/Androidでのバックグラウンド位置情報更新が統一され、一貫性が向上しました
  * 位置情報処理とメディア再生のフォアグラウンドサービスを明確に分離しました（位置は専用サービス、メディア再生は別扱い）
  * フォアグラウンドサービスの起動は、バックグラウンドTTS設定に基づいて制御されるようになりました
  * Android向けの位置情報統合設定が追加され、バックグラウンド位置取得の有効化が簡素化されました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->