### PR TITLE
Android 16(API 36)以上でバックグラウンド自動音声トグルを無効化

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -156,6 +156,7 @@
   "selectFirstStationTitle": "Please select the first station",
   "longPressNotice": "Press and hold the screen to open the menu.",
   "autoAnnounceBackgroundTitle": "Enable background voice announcement",
+  "bgTtsUnavailableOnAndroid16": "Background playback is not available on Android 16 or later due to OS restrictions.",
   "loadingLocation": "Getting location information...",
   "loadingAPI": "Communicating with server...",
   "routeSearchTitle": "Find a route",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -157,6 +157,7 @@
   "selectFirstStationTitle": "始発駅を選択してください",
   "longPressNotice": "画面を長押しするとメニューが開けます",
   "autoAnnounceBackgroundTitle": "バックグラウンド再生",
+  "bgTtsUnavailableOnAndroid16": "Android 16以降ではOSの制限によりバックグラウンド再生を利用できません。",
   "loadingLocation": "位置情報を取得中です",
   "loadingAPI": "サーバーと通信中です",
   "routeSearchTitle": "経路を検索",

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -303,11 +303,18 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           enabled: speechEnabledStr === 'true',
         }));
       }
+      const isAndroid16OrHigher =
+        Platform.OS === 'android' && Number(Platform.Version) >= 36;
       if (bgTTSEnabledStr) {
+        const bgEnabled = bgTTSEnabledStr === 'true' && !isAndroid16OrHigher;
         setSpeech((prev) => ({
           ...prev,
-          backgroundEnabled: bgTTSEnabledStr === 'true',
+          backgroundEnabled: bgEnabled,
         }));
+        // Android 16以上で保存値がtrueの場合、永続化もfalseに上書き
+        if (isAndroid16OrHigher && bgTTSEnabledStr === 'true') {
+          AsyncStorage.setItem(ASYNC_STORAGE_KEYS.BG_TTS_ENABLED, 'false');
+        }
       }
       if (legacyAutoModeEnabledStr) {
         setNavigation((prev) => ({

--- a/src/screens/TTSSettings.tsx
+++ b/src/screens/TTSSettings.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState } from 'react';
 import {
   Alert,
   type GestureResponderEvent,
+  Platform,
   Pressable,
   StyleSheet,
   View,
@@ -95,6 +96,10 @@ const TTSSettingsScreen: React.FC = () => {
     useAtom(speechState);
 
   const navigation = useNavigation();
+
+  // Android 16 (API 36) ではバックグラウンド音声再生が制限されるため無効化
+  const isAndroid16OrHigher =
+    Platform.OS === 'android' && Number(Platform.Version) >= 36;
 
   const SETTING_ITEMS: SettingItem[] = [
     {
@@ -247,7 +252,10 @@ const TTSSettingsScreen: React.FC = () => {
           isLast={index === SETTING_ITEMS.length - 1}
           onToggle={onToggle}
           state={state}
-          disabled={speechEnabled === false && item.id === 'enable_bg_tts'}
+          disabled={
+            item.id === 'enable_bg_tts' &&
+            (!speechEnabled || isAndroid16OrHigher)
+          }
         />
       );
     },
@@ -256,6 +264,7 @@ const TTSSettingsScreen: React.FC = () => {
       handleToggleBgTTS,
       speechEnabled,
       backgroundEnabled,
+      isAndroid16OrHigher,
       SETTING_ITEMS.length,
     ]
   );

--- a/src/screens/TTSSettings.tsx
+++ b/src/screens/TTSSettings.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
 import { useAtom, useAtomValue } from 'jotai';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
   type GestureResponderEvent,
@@ -100,6 +100,14 @@ const TTSSettingsScreen: React.FC = () => {
   // Android 16 (API 36) ではバックグラウンド音声再生が制限されるため無効化
   const isAndroid16OrHigher =
     Platform.OS === 'android' && Number(Platform.Version) >= 36;
+
+  // Android 16以上ではバックグラウンド再生を強制的にfalseにする
+  useEffect(() => {
+    if (isAndroid16OrHigher && backgroundEnabled) {
+      setSpeechState((prev) => ({ ...prev, backgroundEnabled: false }));
+      AsyncStorage.setItem(ASYNC_STORAGE_KEYS.BG_TTS_ENABLED, 'false');
+    }
+  }, [isAndroid16OrHigher, backgroundEnabled, setSpeechState]);
 
   const SETTING_ITEMS: SettingItem[] = [
     {

--- a/src/screens/TTSSettings.tsx
+++ b/src/screens/TTSSettings.tsx
@@ -289,13 +289,26 @@ const TTSSettingsScreen: React.FC = () => {
           renderItem={renderItem}
           onScroll={handleScroll}
           ListFooterComponent={() => (
-            <Button
-              style={{ width: 128, alignSelf: 'center', marginTop: 32 }}
-              textStyle={{ fontWeight: 'bold' }}
-              onPress={() => navigation.goBack()}
-            >
-              OK
-            </Button>
+            <>
+              {isAndroid16OrHigher ? (
+                <Typography
+                  style={{
+                    marginTop: 12,
+                    fontSize: 14,
+                    color: isLEDTheme ? '#ccc' : '#666',
+                  }}
+                >
+                  {translate('bgTtsUnavailableOnAndroid16')}
+                </Typography>
+              ) : null}
+              <Button
+                style={{ width: 128, alignSelf: 'center', marginTop: 32 }}
+                textStyle={{ fontWeight: 'bold' }}
+                onPress={() => navigation.goBack()}
+              >
+                OK
+              </Button>
+            </>
           )}
         />
       </View>


### PR DESCRIPTION
https://claude.ai/code/session_01P7dZtkqNhgVWf9cSSX4eX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Android 16以降でバックグラウンド再生が利用できない旨の案内メッセージを英語・日本語で追加しました。

* **改善**
  * Android 16以上では設定画面でバックグラウンドTTSを自動的に無効化し、該当する説明文を表示するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->