### PR TITLE
警告パネルの表示を安全化してクラッシュを回避

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -343,17 +343,18 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     return remove;
   }, [clearWarningInfo, selectedBound]);
 
-  const NullableWarningPanel: React.FC = useCallback(
-    () =>
-      warningInfo ? (
-        <WarningPanel
-          onPress={clearWarningInfo}
-          text={warningInfo.text}
-          warningLevel={warningInfo.level}
-        />
-      ) : null,
-    [clearWarningInfo, warningInfo]
-  );
+  const NullableWarningPanel: React.FC = useCallback(() => {
+    if (!warningInfo?.text || !warningInfo?.level) {
+      return null;
+    }
+    return (
+      <WarningPanel
+        onPress={clearWarningInfo}
+        text={warningInfo.text}
+        warningLevel={warningInfo.level}
+      />
+    );
+  }, [clearWarningInfo, warningInfo?.level, warningInfo?.text]);
 
   const handleNewReportModalClose = useCallback(() => {
     setScreenShotBase64('');

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -343,19 +343,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     return remove;
   }, [clearWarningInfo, selectedBound]);
 
-  const NullableWarningPanel: React.FC = useCallback(() => {
-    if (!warningInfo?.text || !warningInfo?.level) {
-      return null;
-    }
-    return (
-      <WarningPanel
-        onPress={clearWarningInfo}
-        text={warningInfo.text}
-        warningLevel={warningInfo.level}
-      />
-    );
-  }, [clearWarningInfo, warningInfo?.level, warningInfo?.text]);
-
   const handleNewReportModalClose = useCallback(() => {
     setScreenShotBase64('');
     setReportModalShow(false);
@@ -428,7 +415,13 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       >
         <View style={styles.container}>
           {children}
-          <NullableWarningPanel />
+          {warningInfo?.text && warningInfo?.level && (
+            <WarningPanel
+              onPress={clearWarningInfo}
+              text={warningInfo.text}
+              warningLevel={warningInfo.level}
+            />
+          )}
         </View>
       </LongPressGestureHandler>
       {/* NOTE: このViewを外すとフィードバックモーダルのレイアウトが崩御する */}

--- a/src/components/WarningPanel.tsx
+++ b/src/components/WarningPanel.tsx
@@ -64,29 +64,34 @@ const WarningPanel: React.FC<Props> = ({
   const dim = useWindowDimensions();
   const orientation = useDeviceOrientation();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const safeText = typeof text === 'string' ? text : String(text ?? '');
+  const tapToClose = String(translate('tapToClose') ?? '');
+  const isLandscape =
+    orientation === Orientation.LANDSCAPE_LEFT ||
+    orientation === Orientation.LANDSCAPE_RIGHT;
+  const windowWidth = Number.isFinite(dim.width) ? dim.width : 0;
+  const panelWidth =
+    windowWidth > 0
+      ? isLandscape
+        ? windowWidth / 2
+        : windowWidth - 48
+      : undefined;
 
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`${text}. ${translate('tapToClose')}`}
+      accessibilityLabel={`${safeText}. ${tapToClose}`}
       style={[
         styles.root,
         {
-          width:
-            orientation &&
-            (orientation === Orientation.LANDSCAPE_LEFT ||
-              orientation === Orientation.LANDSCAPE_RIGHT)
-              ? dim.width / 2
-              : dim.width - 48,
+          width: panelWidth,
           borderRadius: isLEDTheme ? 0 : 4,
         },
       ]}
     >
-      <Typography style={styles.message}>{text}</Typography>
-      <Typography style={styles.dismissMessage}>
-        {translate('tapToClose')}
-      </Typography>
+      <Typography style={styles.message}>{safeText}</Typography>
+      <Typography style={styles.dismissMessage}>{tapToClose}</Typography>
     </Pressable>
   );
 };


### PR DESCRIPTION
## 目的
- 稀に発生する警告パネル周辺のクラッシュを防止するため、表示条件と値の取り扱いを安全化する

## 変更内容
- WarningPanelで表示文字列とレイアウト幅を安全に扱うように修正
- warningInfo が不完全な場合は警告パネルを表示しないようガード追加
- WarningPanel の条件描画をインライン化し、useCallback コンポーネント生成を回避

## 影響/リスク
- 低。表示条件の防御と文字列/レイアウトの安全化のみ

## テスト
- pnpm test
- pnpm lint
- pnpm typecheck

## 関連
- #4494

## スクリーンショット
- UI変更なしのため不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 警告表示の条件判定を整理し、表示トリガーをより明確に制御
  * 警告UIをインラインで扱うことで描画ロジックを簡潔化
  * 横向き時のレスポンシブ幅調整を追加
  * 表示テキストの正規化と翻訳フォールバックを強化
  * アクセシビリティ向上（ラベルや操作説明の改善）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->