### PR TITLE
路線のセパレータを日本語の時は中黒を半角スペースに変更

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -193,7 +193,7 @@ export const CommonCard: React.FC<Props> = ({
         .slice(0, 2)
         .map((s) => s.name)
         .filter(Boolean)
-        .join('・');
+        .join(' ');
       const en = arr
         .slice(0, 2)
         .map((s) => s.nameRoman || s.name)

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -116,7 +116,7 @@ export const RouteInfoModal = ({
             .map((l) => getLocalizedLineName(l, isJapanese))
             .filter(Boolean)
         )
-      ).join(isJapanese ? '・' : ', ');
+      ).join(isJapanese ? ' ' : ', ');
 
       return (
         <CommonCard

--- a/src/components/StationSearchModal.tsx
+++ b/src/components/StationSearchModal.tsx
@@ -162,7 +162,7 @@ export const StationSearchModal = ({ visible, onClose, onSelect }: Props) => {
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;
       const subtitle = isJapanese
-        ? Array.from(new Set((lines ?? []).map((l) => l.nameShort))).join('・')
+        ? Array.from(new Set((lines ?? []).map((l) => l.nameShort))).join(' ')
         : Array.from(new Set((lines ?? []).map((l) => l.nameRoman))).join(', ');
 
       return (

--- a/src/components/TrainTypeListModal.tsx
+++ b/src/components/TrainTypeListModal.tsx
@@ -99,7 +99,7 @@ const getViaLines = (
 // 全路線が同一会社の場合はまとめずに個別表示する
 const formatLineNames = (lines: Line[], ja: boolean): string => {
   const names = (l: Line) => (ja ? l.nameShort : l.nameRoman);
-  const sep = ja ? '・' : ', ';
+  const sep = ja ? ' ' : ', ';
 
   // 全路線が同一会社ならグルーピングせず個別表示
   const allSameCompany =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
* 日本語の駅名・路線名表示における区切り文字の形式を統一しました。アプリケーション全体で複数の駅名・路線名を表示する際の一貫性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->