### PR TITLE
SelectLineScreenの路線情報取得をlineListStationsで一括化しパフォーマンスを改善

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -117,6 +117,7 @@ export type Query = {
   connectedRoutes: Array<Route>;
   line: Maybe<Line>;
   lineGroupStations: Array<Station>;
+  lineListStations: Array<Station>;
   lineStations: Array<Station>;
   linesByName: Array<Line>;
   routeTypes: RouteTypePage;
@@ -139,7 +140,13 @@ export type QueryLineArgs = {
 };
 
 export type QueryLineGroupStationsArgs = {
+  directionId: InputMaybe<Scalars['Int']['input']>;
   lineGroupId: Scalars['Int']['input'];
+  transportType: InputMaybe<TransportType>;
+};
+
+export type QueryLineListStationsArgs = {
+  lineIds: Array<Scalars['Int']['input']>;
   transportType: InputMaybe<TransportType>;
 };
 
@@ -1752,6 +1759,7 @@ export type GetStationsNearbyQueryVariables = Exact<{
   latitude: Scalars['Float']['input'];
   longitude: Scalars['Float']['input'];
   limit: InputMaybe<Scalars['Int']['input']>;
+  transportType: InputMaybe<TransportType>;
 }>;
 
 export type GetStationsNearbyQuery = {

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -1,5 +1,4 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { BatchHttpLink } from '@apollo/client/link/batch-http';
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 import DeviceInfo from 'react-native-device-info';
 import {
   DEV_API_URL,
@@ -30,12 +29,7 @@ const uri = (() => {
 })();
 
 export const gqlClient = new ApolloClient({
-  link: new BatchHttpLink({
-    uri,
-    batchMax: 20,
-    batchInterval: 20,
-    includeExtensions: false,
-  }),
+  link: new HttpLink({ uri }),
   cache: new InMemoryCache({
     typePolicies: {
       LineNested: { keyFields: false },

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -33,13 +33,8 @@ export const gqlClient = new ApolloClient({
   link: new BatchHttpLink({
     uri,
     batchMax: 20,
-    batchInterval: 5,
+    batchInterval: 20,
     includeExtensions: false,
-    batchKey: (operation) => {
-      const context = operation.getContext();
-      const batchGroup = context.batchGroup ?? 'default';
-      return `${uri}:${batchGroup}`;
-    },
   }),
   cache: new InMemoryCache({
     typePolicies: {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -314,6 +314,16 @@ export const GET_STATIONS_NEARBY = gql`
   }
 `;
 
+// Query for getting stations by multiple line IDs in a single request
+export const GET_LINE_LIST_STATIONS = gql`
+  ${STATION_FRAGMENT}
+  query GetLineListStations($lineIds: [Int!]!) {
+    lineListStations(lineIds: $lineIds) {
+      ...StationFields
+    }
+  }
+`;
+
 // Query for getting stations by line ID
 export const GET_LINE_STATIONS = gql`
   ${STATION_FRAGMENT}

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -253,7 +253,6 @@ const SelectLineScreen = () => {
       .map((r) => `${r.id}:${r.lineId}:${r.trainTypeId}:${r.hasTrainType}`)
       .join(',');
     if (routesKey === prevRoutesKeyRef.current) return;
-    prevRoutesKeyRef.current = routesKey;
 
     const fetchAsync = async () => {
       try {
@@ -312,6 +311,7 @@ const SelectLineScreen = () => {
               : (lineStationsMap.get(r.lineId) ?? []),
           }))
         );
+        prevRoutesKeyRef.current = routesKey;
       } catch (err) {
         console.error(err);
       }

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -35,6 +35,7 @@ import { useWalkthroughCompleted } from '~/hooks/useWalkthroughCompleted';
 import { gqlClient } from '~/lib/gql';
 import {
   GET_LINE_GROUP_STATIONS,
+  GET_LINE_LIST_STATIONS,
   GET_LINE_STATIONS,
   GET_STATION_TRAIN_TYPES,
 } from '~/lib/graphql/queries';
@@ -146,6 +147,7 @@ const SelectLineScreen = () => {
   } | null>(null);
   const lineListRef = useRef<View>(null);
   const presetsRef = useRef<View>(null);
+  const prevRoutesKeyRef = useRef('');
 
   const {
     isWalkthroughActive,
@@ -247,52 +249,64 @@ const SelectLineScreen = () => {
   }, [isRoutesDBInitialized, updateRoutes]);
 
   useEffect(() => {
+    const routesKey = routes.map((r) => r.id).join(',');
+    if (routesKey === prevRoutesKeyRef.current) return;
+    prevRoutesKeyRef.current = routesKey;
+
     const fetchAsync = async () => {
       try {
-        const jobs = routes.map((route) => {
-          if (route.hasTrainType) {
-            return gqlClient.query<{ lineGroupStations: Station[] }>({
-              query: GET_LINE_GROUP_STATIONS,
-              variables: {
-                lineGroupId: route.trainTypeId,
-              },
-              context: { batchGroup: 'presets-init' },
-            });
-          }
+        const lineRoutes = routes.filter((r) => !r.hasTrainType);
+        const trainTypeRoutes = routes.filter((r) => r.hasTrainType);
 
-          return gqlClient.query<{ lineStations: Station[] }>({
-            query: GET_LINE_STATIONS,
-            variables: {
-              lineId: route.lineId,
-            },
-            context: { batchGroup: 'presets-init' },
+        // !hasTrainType のルートを lineListStations で一括取得
+        const lineStationsMap = new Map<number, Station[]>();
+        if (lineRoutes.length > 0) {
+          const lineIds = lineRoutes.map((r) => r.lineId);
+          const result = await gqlClient.query<{
+            lineListStations: Station[];
+          }>({
+            query: GET_LINE_LIST_STATIONS,
+            variables: { lineIds },
           });
-        });
+          for (const s of result.data?.lineListStations ?? []) {
+            const lid = s.line?.id;
+            if (lid == null) continue;
+            const arr = lineStationsMap.get(lid);
+            if (arr) {
+              arr.push(s);
+            } else {
+              lineStationsMap.set(lid, [s]);
+            }
+          }
+        }
 
-        const results = await Promise.allSettled(jobs);
-        const routeStations: Array<SavedRoute & { stations: Station[] }> =
-          results.map((r, index) =>
+        // hasTrainType のルートは個別に lineGroupStations で取得
+        const trainTypeResults = await Promise.allSettled(
+          trainTypeRoutes.map((route) =>
+            gqlClient.query<{ lineGroupStations: Station[] }>({
+              query: GET_LINE_GROUP_STATIONS,
+              variables: { lineGroupId: route.trainTypeId },
+            })
+          )
+        );
+        const trainTypeStationsMap = new Map<number, Station[]>();
+        trainTypeRoutes.forEach((route, i) => {
+          const r = trainTypeResults[i];
+          trainTypeStationsMap.set(
+            route.trainTypeId,
             r.status === 'fulfilled'
-              ? {
-                  ...routes[index],
-                  stations:
-                    (r.value.data as { lineGroupStations: Station[] })
-                      .lineGroupStations ??
-                    (r.value.data as { lineStations: Station[] })
-                      .lineStations ??
-                    [],
-                }
-              : ({ ...routes[index], stations: [] } as SavedRoute & {
-                  stations: Station[];
-                })
+              ? (r.value.data?.lineGroupStations ?? [])
+              : []
           );
+        });
 
         setCarouselData(
           routes.map((r) => ({
             ...r,
-            __k: '', // loop用のキー（実際にはloopDataで付与されるのでここでは空文字でよい）
-            stations:
-              routeStations.find((rs) => rs.id === r.id)?.stations ?? [],
+            __k: '',
+            stations: r.hasTrainType
+              ? (trainTypeStationsMap.get(r.trainTypeId) ?? [])
+              : (lineStationsMap.get(r.lineId) ?? []),
           }))
         );
       } catch (err) {
@@ -319,22 +333,31 @@ const SelectLineScreen = () => {
         (line): line is LineNested => line?.id != null
       );
 
-      const jobs = fetchedLines.map((line) =>
-        gqlClient.query<{ lineStations: Station[] }>({
-          query: GET_LINE_STATIONS,
-          variables: {
-            lineId: line.id as number,
-          },
-          context: { batchGroup: 'lines-init' },
-        })
-      );
+      const lineIds = fetchedLines.map((line) => line.id as number);
+      if (lineIds.length === 0) return;
 
-      const results = await Promise.allSettled(jobs);
+      const result = await gqlClient.query<{
+        lineListStations: Station[];
+      }>({
+        query: GET_LINE_LIST_STATIONS,
+        variables: { lineIds },
+      });
 
-      const stationsCache: Station[][] = results.map((r) =>
-        r.status === 'fulfilled'
-          ? (r.value.data?.lineStations ?? [])
-          : ([] as Station[])
+      const allStations = result.data?.lineListStations ?? [];
+      const stationsByLineId = new Map<number, Station[]>();
+      for (const s of allStations) {
+        const lid = s.line?.id;
+        if (lid == null) continue;
+        const arr = stationsByLineId.get(lid);
+        if (arr) {
+          arr.push(s);
+        } else {
+          stationsByLineId.set(lid, [s]);
+        }
+      }
+
+      const stationsCache: Station[][] = fetchedLines.map(
+        (line) => stationsByLineId.get(line.id as number) ?? []
       );
 
       setStationState((prev) => ({
@@ -367,10 +390,6 @@ const SelectLineScreen = () => {
         ...prev,
         stationForHeader: stationFromAPI,
       }));
-
-      if (stationFromAPI) {
-        await updateStationsCache(stationFromAPI);
-      }
     };
     fetchInitialNearbyStationAsync();
   }, [
@@ -379,7 +398,6 @@ const SelectLineScreen = () => {
     setNavigationState,
     setStationState,
     station,
-    updateStationsCache,
   ]);
 
   useEffect(() => {

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -260,8 +260,9 @@ const SelectLineScreen = () => {
 
         // !hasTrainType のルートを lineListStations で一括取得
         const lineStationsMap = new Map<number, Station[]>();
-        if (lineRoutes.length > 0) {
-          const lineIds = lineRoutes.map((r) => r.lineId);
+        const validLineRoutes = lineRoutes.filter((r) => r.lineId !== null);
+        if (validLineRoutes.length > 0) {
+          const lineIds = validLineRoutes.map((r) => r.lineId);
           const result = await gqlClient.query<{
             lineListStations: Station[];
           }>({
@@ -336,14 +337,19 @@ const SelectLineScreen = () => {
       const lineIds = fetchedLines.map((line) => line.id as number);
       if (lineIds.length === 0) return;
 
-      const result = await gqlClient.query<{
-        lineListStations: Station[];
-      }>({
-        query: GET_LINE_LIST_STATIONS,
-        variables: { lineIds },
-      });
-
-      const allStations = result.data?.lineListStations ?? [];
+      let allStations: Station[];
+      try {
+        const result = await gqlClient.query<{
+          lineListStations: Station[];
+        }>({
+          query: GET_LINE_LIST_STATIONS,
+          variables: { lineIds },
+        });
+        allStations = result.data?.lineListStations ?? [];
+      } catch (err) {
+        console.error(err);
+        return;
+      }
       const stationsByLineId = new Map<number, Station[]>();
       for (const s of allStations) {
         const lid = s.line?.id;

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -301,9 +301,9 @@ const SelectLineScreen = () => {
         });
 
         setCarouselData(
-          routes.map((r) => ({
+          routes.map((r, i) => ({
             ...r,
-            __k: '',
+            __k: `${r.id}-${i}`,
             stations: r.hasTrainType
               ? (trainTypeStationsMap.get(r.trainTypeId) ?? [])
               : (lineStationsMap.get(r.lineId) ?? []),

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -291,8 +291,23 @@ const SelectLineScreen = () => {
             })
           )
         );
+        const rejected = trainTypeResults.filter(
+          (r): r is PromiseRejectedResult => r.status === 'rejected'
+        );
+        if (rejected.length > 0) {
+          for (const [i, r] of trainTypeResults.entries()) {
+            if (r.status === 'rejected') {
+              console.error(
+                `trainTypeId=${trainTypeRoutes[i].trainTypeId}`,
+                r.reason
+              );
+            }
+          }
+          return;
+        }
+
         const trainTypeStationsMap = new Map<number, Station[]>();
-        trainTypeRoutes.forEach((route, i) => {
+        for (const [i, route] of trainTypeRoutes.entries()) {
           const r = trainTypeResults[i];
           trainTypeStationsMap.set(
             route.trainTypeId,
@@ -300,7 +315,7 @@ const SelectLineScreen = () => {
               ? (r.value.data?.lineGroupStations ?? [])
               : []
           );
-        });
+        }
 
         setCarouselData(
           routes.map((r, i) => ({

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -249,7 +249,9 @@ const SelectLineScreen = () => {
   }, [isRoutesDBInitialized, updateRoutes]);
 
   useEffect(() => {
-    const routesKey = routes.map((r) => r.id).join(',');
+    const routesKey = routes
+      .map((r) => `${r.id}:${r.lineId}:${r.trainTypeId}:${r.hasTrainType}`)
+      .join(',');
     if (routesKey === prevRoutesKeyRef.current) return;
     prevRoutesKeyRef.current = routesKey;
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数路線IDを指定して一括で駅一覧を取得する「路線単位の駅リスト取得」を追加しました。
  * 駅検索・近隣駅取得で輸送種別（transportType）を任意指定できるようになりました。

* **パフォーマンス改善**
  * 駅・路線データの一括取得を導入し、初期表示や切替時の不要な再取得を削減するため、ルート変更検出による再フェッチ抑制を実装しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->