### PR TITLE
lineGroupListStationsで種別プリセットを一括取得しupdateStationsCacheを軽量クエリに切り替え

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -116,6 +116,7 @@ export type Query = {
   __typename: 'Query';
   connectedRoutes: Array<Route>;
   line: Maybe<Line>;
+  lineGroupListStations: Array<Station>;
   lineGroupStations: Array<Station>;
   lineListStations: Array<Station>;
   lineStations: Array<Station>;
@@ -137,6 +138,11 @@ export type QueryConnectedRoutesArgs = {
 
 export type QueryLineArgs = {
   lineId: Scalars['Int']['input'];
+};
+
+export type QueryLineGroupListStationsArgs = {
+  lineGroupIds: Array<Scalars['Int']['input']>;
+  transportType: InputMaybe<TransportType>;
 };
 
 export type QueryLineGroupStationsArgs = {
@@ -1764,6 +1770,399 @@ export type GetStationsNearbyQueryVariables = Exact<{
 
 export type GetStationsNearbyQuery = {
   stationsNearby: Array<{
+    __typename: 'Station';
+    id: number | null | undefined;
+    groupId: number | null | undefined;
+    name: string | null | undefined;
+    nameKatakana: string | null | undefined;
+    nameRoman: string | null | undefined;
+    nameChinese: string | null | undefined;
+    nameKorean: string | null | undefined;
+    threeLetterCode: string | null | undefined;
+    latitude: number | null | undefined;
+    longitude: number | null | undefined;
+    address: string | null | undefined;
+    postalCode: string | null | undefined;
+    prefectureId: number | null | undefined;
+    openedAt: string | null | undefined;
+    closedAt: string | null | undefined;
+    status: OperationStatus | null | undefined;
+    distance: number | null | undefined;
+    hasTrainTypes: boolean | null | undefined;
+    stopCondition: StopCondition | null | undefined;
+    transportType: TransportType | null | undefined;
+    stationNumbers:
+      | Array<{
+          __typename: 'StationNumber';
+          lineSymbol: string | null | undefined;
+          lineSymbolColor: string | null | undefined;
+          lineSymbolShape: string | null | undefined;
+          stationNumber: string | null | undefined;
+        }>
+      | null
+      | undefined;
+    line:
+      | {
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          averageDistance: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameFull: string | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          status: OperationStatus | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                name: string | null | undefined;
+                nameEnglishFull: string | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+                railroadId: number | null | undefined;
+                status: OperationStatus | null | undefined;
+                type: CompanyType | null | undefined;
+                url: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          trainType:
+            | {
+                __typename: 'TrainTypeNested';
+                id: number | null | undefined;
+                typeId: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                color: string | null | undefined;
+                direction: TrainDirection | null | undefined;
+                kind: TrainTypeKind | null | undefined;
+              }
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+    lines:
+      | Array<{
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          averageDistance: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameFull: string | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          status: OperationStatus | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                name: string | null | undefined;
+                nameEnglishFull: string | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+                railroadId: number | null | undefined;
+                status: OperationStatus | null | undefined;
+                type: CompanyType | null | undefined;
+                url: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          trainType:
+            | {
+                __typename: 'TrainTypeNested';
+                id: number | null | undefined;
+                typeId: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                color: string | null | undefined;
+                direction: TrainDirection | null | undefined;
+                kind: TrainTypeKind | null | undefined;
+              }
+            | null
+            | undefined;
+        }>
+      | null
+      | undefined;
+    trainType:
+      | {
+          __typename: 'TrainTypeNested';
+          id: number | null | undefined;
+          typeId: number | null | undefined;
+          groupId: number | null | undefined;
+          name: string | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          color: string | null | undefined;
+          direction: TrainDirection | null | undefined;
+          kind: TrainTypeKind | null | undefined;
+          line:
+            | {
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                averageDistance: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      name: string | null | undefined;
+                      nameEnglishFull: string | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameFull: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                      railroadId: number | null | undefined;
+                      status: OperationStatus | null | undefined;
+                      type: CompanyType | null | undefined;
+                      url: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                    }
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          lines:
+            | Array<{
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                averageDistance: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      name: string | null | undefined;
+                      nameEnglishFull: string | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameFull: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                      railroadId: number | null | undefined;
+                      status: OperationStatus | null | undefined;
+                      type: CompanyType | null | undefined;
+                      url: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                    }
+                  | null
+                  | undefined;
+              }>
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+  }>;
+};
+
+export type GetLineListStationsQueryVariables = Exact<{
+  lineIds: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
+}>;
+
+export type GetLineListStationsQuery = {
+  lineListStations: Array<{
     __typename: 'Station';
     id: number | null | undefined;
     groupId: number | null | undefined;

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -314,6 +314,31 @@ export const GET_STATIONS_NEARBY = gql`
   }
 `;
 
+// Lightweight fragment for station cache (bounds display only)
+export const STATION_LIGHT_FRAGMENT = gql`
+  fragment StationLightFields on Station {
+    id
+    groupId
+    name
+    nameRoman
+    nameChinese
+    nameKorean
+    line {
+      id
+    }
+  }
+`;
+
+// Query for getting stations by multiple line IDs (lightweight, for line card bounds)
+export const GET_LINE_LIST_STATIONS_LIGHT = gql`
+  ${STATION_LIGHT_FRAGMENT}
+  query GetLineListStationsLight($lineIds: [Int!]!) {
+    lineListStations(lineIds: $lineIds) {
+      ...StationLightFields
+    }
+  }
+`;
+
 // Query for getting stations by multiple line IDs in a single request
 export const GET_LINE_LIST_STATIONS = gql`
   ${STATION_FRAGMENT}
@@ -347,6 +372,16 @@ export const GET_STATIONS_BY_NAME = gql`
       limit: $limit
       fromStationGroupId: $fromStationGroupId
     ) {
+      ...StationFields
+    }
+  }
+`;
+
+// Query for getting stations by multiple line group IDs in a single request
+export const GET_LINE_GROUP_LIST_STATIONS = gql`
+  ${STATION_FRAGMENT}
+  query GetLineGroupListStations($lineGroupIds: [Int!]!) {
+    lineGroupListStations(lineGroupIds: $lineGroupIds) {
       ...StationFields
     }
   }


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - 線グループを指定して複数の駅情報を一括取得できるようになりました

* **パフォーマンス改善**
  - 駅データ取得処理を複数の個別リクエストから一括フェッチに最適化しました
  - 軽量な駅情報クエリを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->