### PR TITLE
中黒消しすぎた

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -193,7 +193,7 @@ export const CommonCard: React.FC<Props> = ({
         .slice(0, 2)
         .map((s) => s.name)
         .filter(Boolean)
-        .join(' ');
+        .join('・');
       const en = arr
         .slice(0, 2)
         .map((s) => s.nameRoman || s.name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 日本語での駅名表示フォーマットを改善しました。往路・復路の駅名が中点「・」で区切られるようになり、より適切な日本語表記になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->