### PR TITLE
SelectBoundModalで読み込み中は設定ボタン以外は無効化

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -546,7 +546,11 @@ export const SelectBoundModal: React.FC<Props> = ({
             : null}
 
           <View style={styles.stopsContainer}>
-            <Button outline onPress={() => setRouteInfoModalVisible(true)}>
+            <Button
+              outline
+              onPress={() => setRouteInfoModalVisible(true)}
+              disabled={loading}
+            >
               {isBus
                 ? translate('viewBusStops')
                 : translate('viewStopStations')}
@@ -555,7 +559,7 @@ export const SelectBoundModal: React.FC<Props> = ({
             <Button
               outline
               onPress={() => setIsTrainTypeModalVisible(true)}
-              disabled={!fetchedTrainTypes.length}
+              disabled={!fetchedTrainTypes.length || loading}
             >
               {trainTypeText}
             </Button>
@@ -565,7 +569,7 @@ export const SelectBoundModal: React.FC<Props> = ({
               style={savedRoute ? styles.redOutlinedButton : null}
               textStyle={savedRoute ? styles.redOutlinedButtonText : null}
               onPress={handleSaveRoutePress}
-              disabled={!line || !isRoutesDBInitialized}
+              disabled={!line || !isRoutesDBInitialized || loading}
             >
               {translate(
                 !savedRoute ? 'saveCurrentRoute' : 'removeFromSavedRoutes'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ローディング状態中、ルート情報、列車タイプ、ルート保存操作に関連するボタンが無効化されるようになりました。ユーザーインターフェースの応答性が向上し、データ読み込み中のユーザー操作がより適切に処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->