### PR TITLE
プリセットが２件しかない場合のレイアウトを修正

### DIFF
--- a/src/screens/SelectLineScreen.test.tsx
+++ b/src/screens/SelectLineScreen.test.tsx
@@ -439,7 +439,7 @@ describe('SelectLineScreenPresets', () => {
       expect(presetCards.length).toBe(1);
     });
 
-    it('複数のプリセットがある場合、全てがループデータとして3倍表示される', () => {
+    it('プリセットが2件の場合は重複せず2件だけ表示される', () => {
       const stations1 = [
         createMockStation(1, '新宿', 'Shinjuku'),
         createMockStation(2, '渋谷', 'Shibuya'),
@@ -461,9 +461,9 @@ describe('SelectLineScreenPresets', () => {
         />
       );
 
-      // 2プリセット × 3倍 = 6
+      // 2プリセットの場合はループしないので2件のみ表示
       const presetCards = getAllByTestId('preset-card');
-      expect(presetCards.length).toBe(6);
+      expect(presetCards.length).toBe(2);
     });
 
     it('プリセットのタイトルが正しく表示される', () => {

--- a/src/screens/SelectLineScreenPresets.tsx
+++ b/src/screens/SelectLineScreenPresets.tsx
@@ -64,8 +64,8 @@ export const SelectLineScreenPresets = ({
       numCardsVisible
     : screenWidth;
 
-  // プリセットが2件以上の場合のみループ用に3倍にする
-  const shouldLoop = carouselData.length >= 2;
+  // プリセットが3件以上の場合のみループ用に3倍にする
+  const shouldLoop = carouselData.length >= 3;
   const loopData = useMemo(
     () =>
       carouselData.length
@@ -205,7 +205,7 @@ export const SelectLineScreenPresets = ({
         contentContainerStyle={[
           styles.contentContainer,
           isTablet && { paddingHorizontal: HORIZONTAL_PADDING },
-          carouselData.length <= 1 && { flexGrow: 1, justifyContent: 'center' },
+          !shouldLoop && { flexGrow: 1, justifyContent: 'center' },
         ]}
       />
     </View>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プリセットの表示ロジックを調整。2個のプリセットの場合、ループ・重複なしで2つのアイテムのみ表示するように修正。3個以上のプリセットでのみ重複表示が発生するように改善。
  * プリセット数が3未満の場合、コンテンツの中央揃え表示を適切に適用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->