### PR TITLE
布施駅、稲毛駅、稲毛海岸駅、喜連瓜破駅、八尾駅のIPA定義追加

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -89,6 +89,25 @@ export const tts = onCall({ region: 'asia-northeast1' }, async (req) => {
       /Fukiage/gi,
       '<phoneme alphabet="ipa" ph="ɸɯkʲiaɡe">ふきあげ</phoneme>'
     )
+    // 布施
+    .replace(/\bFuse\b/gi, '<phoneme alphabet="ipa" ph="ɸɯse">ふせ</phoneme>')
+    // 稲毛海岸
+    .replace(
+      /\bInagekaigan\b/gi,
+      '<phoneme alphabet="ipa" ph="inaɡekaiɡaɴ">いなげかいがん</phoneme>'
+    )
+    // 稲毛
+    .replace(
+      /\bInage\b/gi,
+      '<phoneme alphabet="ipa" ph="inaɡe">いなげ</phoneme>'
+    )
+    // 喜連瓜破
+    .replace(
+      /\bKire-Uriwari\b/gi,
+      '<phoneme alphabet="ipa" ph="kiɾeɯɾiwaɾi">きれうりわり</phoneme>'
+    )
+    // 八尾
+    .replace(/\bYao\b/gi, '<phoneme alphabet="ipa" ph="jao">やお</phoneme>')
     // 新橋
     .replace(
       /Shimbashi/gi,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能追加**
  * テキスト読み上げ機能で対応する日本の地名の発音を拡張しました。複数の地名が正確に読み上げられるようになり、ユーザーエクスペリエンスが向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->