### PR TITLE
一部テーマで行き先を１行で表示するように修正

### DIFF
--- a/src/hooks/useHeaderStateText.ts
+++ b/src/hooks/useHeaderStateText.ts
@@ -1,5 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
+import { APP_THEME } from '~/models/Theme';
+import { themeAtom } from '~/store/atoms/theme';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
@@ -23,6 +25,7 @@ export const useHeaderStateText = ({
 }: UseHeaderStateTextOptions): UseHeaderStateTextResult => {
   const { headerState } = useAtomValue(navigationState);
   const { selectedBound } = useAtomValue(stationState);
+  const currentTheme = useAtomValue(themeAtom);
 
   const stateText = useMemo<string>(() => {
     if (firstStop && selectedBound) {
@@ -88,6 +91,17 @@ export const useHeaderStateText = ({
     }
     return '';
   }, [firstStop, selectedBound, headerLangState]);
+
+  if (
+    currentTheme === APP_THEME.YAMANOTE ||
+    currentTheme === APP_THEME.JL ||
+    currentTheme === APP_THEME.JO
+  ) {
+    return {
+      stateText: stateText.replaceAll('\n', ' '),
+      stateTextRight: stateTextRight,
+    };
+  }
 
   return { stateText, stateTextRight };
 };

--- a/src/hooks/useHeaderStateText.ts
+++ b/src/hooks/useHeaderStateText.ts
@@ -99,7 +99,7 @@ export const useHeaderStateText = ({
   ) {
     return {
       stateText: stateText.replaceAll('\n', ' '),
-      stateTextRight: stateTextRight,
+      stateTextRight,
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 一部テーマ（YAMANOTE、JL、JO）でヘッダーの状態テキスト内の改行がスペースに置換され、表示が崩れないようにしました。右側のテキスト表示はそのまま維持されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->