### PR TITLE
オートモードで移動が開始しない場合があるバグを修正

### DIFF
--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
 import { renderHook, waitFor } from '@testing-library/react-native';
 import * as Location from 'expo-location';
 import { Provider, useAtomValue } from 'jotai';
@@ -125,6 +124,7 @@ const setupAtomMocks = (
   },
   navigationStateValue: { autoModeEnabled: boolean }
 ) => {
+  // biome-ignore lint/suspicious/noExplicitAny: モック用コールバックの引数型が不明
   (useAtomValue as jest.Mock).mockImplementation((atom: any) => {
     if (atom.toString() === 'stationState') {
       return {
@@ -148,6 +148,7 @@ describe('useSimulationMode', () => {
     jest.spyOn(useCurrentLineModule, 'useCurrentLine').mockReturnValue({
       id: YAMANOTE_LINE_ID,
       lineType: LineType.Normal,
+      // biome-ignore lint/suspicious/noExplicitAny: 部分的なモック戻り値
     } as any);
 
     jest
@@ -760,6 +761,7 @@ describe('useSimulationMode', () => {
 
       jest
         .spyOn(useCurrentLineModule, 'useCurrentLine')
+        // biome-ignore lint/suspicious/noExplicitAny: 部分的なモック戻り値
         .mockReturnValue({ id: 1, lineType: LineType.BulletTrain } as any);
 
       const generateSpy = jest.spyOn(
@@ -794,6 +796,7 @@ describe('useSimulationMode', () => {
         .mockReturnValue({
           id: 1,
           kind: TrainTypeKind.LimitedExpress,
+          // biome-ignore lint/suspicious/noExplicitAny: 部分的なモック戻り値
         } as any);
 
       const generateSpy = jest.spyOn(

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -89,7 +89,7 @@ export const useSimulationMode = (): void => {
     const directIndex = maybeRevsersedStations.findIndex(
       (s) => s.id === currentStation?.id
     );
-    if (directIndex !== -1) {
+    if (directIndex !== -1 && !getIsPass(maybeRevsersedStations[directIndex])) {
       return directIndex;
     }
 

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -260,6 +260,7 @@ export const useSimulationMode = (): void => {
 
       if (!nextStopStation) {
         segmentIndexRef.current = 0;
+        childIndexRef.current = 0;
         segmentProgressDistanceRef.current = 0;
         const firstStation = maybeRevsersedStations[0];
         if (firstStation?.latitude != null && firstStation?.longitude != null) {

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -138,7 +138,6 @@ export const useSimulationMode = (): void => {
     stopLocationUpdates();
   }, [enabled]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: プロファイル生成は初回のみ
   useEffect(() => {
     const speedProfiles = maybeRevsersedStations.map((cur, _, arr) => {
       const stationsWithoutPass = arr.filter((s) => !getIsPass(s));
@@ -214,7 +213,13 @@ export const useSimulationMode = (): void => {
     childIndexRef.current = 0;
     segmentProgressDistanceRef.current = 0;
     dwellPendingRef.current = false;
-  }, []);
+  }, [
+    maybeRevsersedStations,
+    isBus,
+    currentLineType,
+    maxSpeed,
+    resolveStartIndex,
+  ]);
 
   const step = useCallback(
     (speed: number) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テストを共通の状態モックへ移行し、開始位置、経路順序、通過駅／非停車駅、速度プロファイル、間隔更新など多様なシナリオを追加しました。

* **改善**
  * 現在駅ベースの開始位置解決を強化し、路線外や座標未設定時のフォールバックや順序反転に対する動作を安定化しました。

* **破壊的変更**
  * 位置更新の公開インターフェースが変更され、位置更新の呼び出し方法が変わっています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->