### PR TITLE
駅検索で同じグループでも名前が異なる場合は別の駅として扱うように修正

### DIFF
--- a/src/components/StationSearchModal.tsx
+++ b/src/components/StationSearchModal.tsx
@@ -45,7 +45,7 @@ type GetStationsByNameVariables = {
 
 const getStationUniqueKey = (station: Station) => {
   if (station.groupId) {
-    return String(station.groupId);
+    return `${station.groupId}|${station.name}`;
   }
   if (station.id) {
     return String(station.id);


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ステーション検索モーダルにおける駅の重複排除処理を改善しました。同一グループに属する複数の駅がより正確に処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->