### PR TITLE
iPadアーチ表示で直通運転時に路線カラーを区間ごとに色分け

### DIFF
--- a/src/components/LineBoardYamanotePad.test.tsx
+++ b/src/components/LineBoardYamanotePad.test.tsx
@@ -12,6 +12,7 @@ jest.mock('jotai', () => ({
 
 jest.mock('~/hooks', () => ({
   useCurrentLine: jest.fn(),
+  useCurrentTrainType: jest.fn(() => null),
   useGetLineMark: jest.fn(() => jest.fn(() => null)),
   useNextStation: jest.fn(() => null),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),

--- a/src/components/LineBoardYamanotePad.tsx
+++ b/src/components/LineBoardYamanotePad.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import type { Station } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useCurrentTrainType,
   useGetLineMark,
   useNextStation,
   useStationNumberIndexFunc,
@@ -24,6 +25,7 @@ const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
   const isEn = useAtomValue(isEnAtom);
 
   const currentLine = useCurrentLine();
+  const trainType = useCurrentTrainType();
   const getLineMarkFunc = useGetLineMark();
   const nextStation = useNextStation();
   const transferLines = useTransferLines();
@@ -114,6 +116,7 @@ const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
       station={switchedStation}
       numberingInfo={numberingInfo}
       lineMarks={lineMarks}
+      trainTypeLines={trainType?.lines ?? []}
       isEn={isEn}
     />
   );


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 電車種別に基づく色分割表示を導入し、駅表示で複数色のセグメントが反映されるようになりました。視認性と路線色の表現が向上します。
* **テスト**
  * 電車種別取得のテスト用モックを追加し、表示ロジックの安定性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->