### PR TITLE
駅到着直後に次の駅へ一瞬進んでしまうデグレを修正

### DIFF
--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -49,10 +49,11 @@ export const useNearestStation = (): Station | undefined => {
         sta.longitude === nearestCoordinates.longitude
     );
 
+    // currentStationを優先して返すことで、到着直後にnextStationへ誤って進むのを防ぐ
     return (
-      nearestStations.find(
-        (s) => s.id === currentStation?.id || s.id === nextStation?.id
-      ) ?? nearestStations[0]
+      nearestStations.find((s) => s.id === currentStation?.id) ??
+      nearestStations.find((s) => s.id === nextStation?.id) ??
+      nearestStations[0]
     );
   }, [latitude, longitude, validStations, currentStation, nextStation]);
 


### PR DESCRIPTION
グレース期間中にnearestStationが変わった場合でもisArrivedがtrueを返していたため、
到着直後にGPSのぶれで次の駅に誤って進む問題が発生していた。
グレース期間の適用を到着を引き起こした駅に限定し、useNearestStationで
currentStationをnextStationより優先するように変更。

https://claude.ai/code/session_0125DF6zeKaFmYsCqKciDTog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数の駅が同じ位置に存在する場合の駅選択の順序を改善しました。
  * 到着時のグレースピリオド処理をより正確に適用するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->