### PR TITLE
路線選択時に前回の列車種別データが残るバグを修正

### DIFF
--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -562,18 +562,10 @@ const SelectLineScreen = () => {
 
       setIsSelectBoundModalOpen(true);
 
-      const result = await fetchStationsByLineId({
-        variables: { lineId, stationId: lineStationId },
-      });
-      const fetchedStations = result.data?.lineStations ?? [];
-
-      const pendingStation =
-        fetchedStations.find((s) => s.id === lineStationId) ?? null;
-
       setStationState((prev) => ({
         ...prev,
-        pendingStation,
-        pendingStations: fetchedStations,
+        pendingStation: null,
+        pendingStations: [],
         selectedDirection: null,
         wantedDestination: null,
         selectedBound: null,
@@ -587,6 +579,20 @@ const SelectLineScreen = () => {
         fetchedTrainTypes: [],
         trainType: null,
         pendingTrainType: null,
+      }));
+
+      const result = await fetchStationsByLineId({
+        variables: { lineId, stationId: lineStationId },
+      });
+      const fetchedStations = result.data?.lineStations ?? [];
+
+      const pendingStation =
+        fetchedStations.find((s) => s.id === lineStationId) ?? null;
+
+      setStationState((prev) => ({
+        ...prev,
+        pendingStation,
+        pendingStations: fetchedStations,
       }));
 
       if (line.station?.hasTrainTypes) {


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ラインおよびステーション選択時の状態更新プロセスを改善し、データ取得がより確実に反映されるよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->