### PR TITLE
路線切り替え時の前回データクリアに関するテストを追加

### DIFF
--- a/src/screens/SelectLineScreen.test.tsx
+++ b/src/screens/SelectLineScreen.test.tsx
@@ -724,13 +724,14 @@ describe('SelectLineScreen - 路線切り替え時の前回データクリア', 
       stationsCache: [],
     };
 
-    (useAtom as jest.Mock).mockReturnValue([
-      resetState,
-      mockSetStationState,
-    ]);
+    (useAtom as jest.Mock).mockReturnValue([resetState, mockSetStationState]);
 
     // fetch 完了後に行われる状態更新をシミュレート
-    const newPendingStation = { id: 5, name: '大門', line: { id: 200, name: '都営浅草線' } };
+    const newPendingStation = {
+      id: 5,
+      name: '大門',
+      line: { id: 200, name: '都営浅草線' },
+    };
     const newPendingStations = [
       { id: 5, name: '大門' },
       { id: 6, name: '新橋' },


### PR DESCRIPTION
#5352 の対応漏れ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 路線選択時の前回データクリア動作に関するテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->