### PR TITLE
Adjust station color boundary ratio from 0.65 to 0.8

### DIFF
--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -103,8 +103,8 @@ const computeColorSegments = (
   for (let i = 1; i <= stationColors.length; i++) {
     if (i === stationColors.length || stationColors[i] !== currentColor) {
       // アニメーションSVGはARC_SVG_Y_OFFSETだけ下にずれているため境界もずらす
-      // 境界位置: 前の駅ドットと次の駅ドットの間を 0.65 の比率で按分（やや次の駅寄り）
-      const BOUNDARY_RATIO = 0.65;
+      // 境界位置: 前の駅ドットと次の駅ドットの間を 0.8 の比率で按分（やや次の駅寄り）
+      const BOUNDARY_RATIO = 0.8;
       const yStart =
         segStartIdx === 0
           ? -height


### PR DESCRIPTION
## Summary
Adjusted the boundary position ratio between consecutive station dots in the color segment computation to better align the color transitions in the animated SVG visualization.

## Changes
- Updated `BOUNDARY_RATIO` constant from `0.65` to `0.8` in the `computeColorSegments` function
- This shifts the color boundary position to be closer to the next station dot (from 65% to 80% of the distance between consecutive stations)
- Updated the corresponding Japanese comment to reflect the new ratio value

## Details
The boundary ratio determines where the color transition occurs between two consecutive stations in the pad architecture visualization. By increasing the ratio from 0.65 to 0.8, the color boundary now sits closer to the next station, which provides better visual alignment with the station dots in the animated SVG that is offset by `ARC_SVG_Y_OFFSET`.

https://claude.ai/code/session_01K6MMSXUhUdzXd5ne9UdeQh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * カラーセグメント間の境界位置を調整しました。セグメントの視覚的配置がより精密になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->