### PR TITLE
Prod版のInfo.plistにITSAppUsesNonExemptEncryptionを追加してApple輸出コンプラチェックをスキップ

### DIFF
--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -43,6 +43,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CURRENT_SCHEME_NAME</key>
 	<string>ProdTrainLCD</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
https://claude.ai/code/session_017pquDycSTE92qREsDHtjVu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プロダクション環境の基本設定を更新して、アプリケーションの安定性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->