### PR TITLE
プリセットの種別カッコはフォントサイズを下げる

### DIFF
--- a/src/components/PresetCard.tsx
+++ b/src/components/PresetCard.tsx
@@ -86,6 +86,11 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlignVertical: 'auto',
   },
+  stationCodeParen: {
+    fontSize: RFValue(8),
+    fontWeight: 'bold',
+    textAlignVertical: 'auto',
+  },
   lineDot: {
     width: 16,
     height: 16,
@@ -93,6 +98,26 @@ const styles = StyleSheet.create({
     marginRight: 4,
   },
 });
+
+const renderTextWithSmallerParens = (
+  text: string,
+  _baseStyle: typeof styles.stationCode,
+  parenStyle: typeof styles.stationCodeParen,
+  color: string
+) => {
+  const parts = text.split(/([(\uFF08][^)\uFF09]*[)\uFF09])/);
+  if (parts.length === 1) return text;
+  return parts.map((part, i) => {
+    const key = `${i}-${part}`;
+    return /^[(\uFF08]/.test(part) ? (
+      <Typography key={key} style={[parenStyle, { color }]}>
+        {part}
+      </Typography>
+    ) : (
+      <React.Fragment key={key}>{part}</React.Fragment>
+    );
+  });
+};
 
 const BrokenIcon = () => (
   <Svg width="34" height="34" viewBox="0 0 24 24">
@@ -243,7 +268,12 @@ const PresetCardBase: React.FC<Props> = ({ title, from, to }) => {
             {leftName}
           </Typography>
           <Typography style={[styles.stationCode, { color: metaFg }]}>
-            {leftCode}
+            {renderTextWithSmallerParens(
+              leftCode,
+              styles.stationCode,
+              styles.stationCodeParen,
+              metaFg
+            )}
           </Typography>
         </View>
         <View style={styles.colCenter}>
@@ -268,7 +298,12 @@ const PresetCardBase: React.FC<Props> = ({ title, from, to }) => {
             {rightName}
           </Typography>
           <Typography style={[styles.stationCode, { color: metaFg }]}>
-            {rightCode}
+            {renderTextWithSmallerParens(
+              rightCode,
+              styles.stationCode,
+              styles.stationCodeParen,
+              metaFg
+            )}
           </Typography>
         </View>
       </View>

--- a/src/components/PresetCard.tsx
+++ b/src/components/PresetCard.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 
 const renderTextWithSmallerParens = (
   text: string,
-  _baseStyle: typeof styles.stationCode,
+  baseStyle: typeof styles.stationCode,
   parenStyle: typeof styles.stationCodeParen,
   color: string
 ) => {
@@ -114,7 +114,9 @@ const renderTextWithSmallerParens = (
         {part}
       </Typography>
     ) : (
-      <React.Fragment key={key}>{part}</React.Fragment>
+      <Typography key={key} style={[baseStyle, { color }]}>
+        {part}
+      </Typography>
     );
   });
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * 駅コード表示の視覚的改善：括弧内のテキストをより小さなサイズと異なる色で表示するようにしました。駅情報の可読性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->