### PR TITLE
E235系風ヘッダーの行き先表示２行化

### DIFF
--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -26,7 +26,6 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
     width: '100%',
-    justifyContent: 'center',
   },
   boundGrayText: {
     color: '#aaa',

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -20,13 +20,13 @@ const styles = StyleSheet.create({
   },
   boundContainer: {
     width: '100%',
-    height: '50%',
     justifyContent: 'flex-end',
   },
   bound: {
     color: '#fff',
     fontWeight: 'bold',
     width: '100%',
+    justifyContent: 'center',
   },
   boundGrayText: {
     color: '#aaa',
@@ -177,7 +177,9 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
               },
             ]}
             adjustsFontSizeToFit
-            numberOfLines={1}
+            numberOfLines={2}
+            lineBreakStrategyIOS="push-out"
+            textBreakStrategy="balanced"
           >
             {boundText}
           </Typography>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ヘッダーのテキストが2行まで表示され、折り返しが改善されました（iOSでの行区切り挙動を調整）。
  * 固定高さの制約を解除し、テキスト表示領域が柔軟になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->