### PR TITLE
開発環境でSentryの初期化はしない

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,24 +6,26 @@ import App from './src';
 import { LOCATION_TASK_NAME, MAX_PERMIT_ACCURACY } from './src/constants';
 import { setLocation } from './src/store/atoms/location';
 
-Sentry.init({
-  dsn: SENTRY_DSN,
-  enableAutoSessionTracking: true,
-  tracesSampleRate: 1.0,
-  profilesSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [
-    Sentry.mobileReplayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
-      privacyOptions: {
-        maskAllInputs: true,
-        blockClass: ['sensitive-screen', 'payment-view'],
-      },
-    }),
-  ],
-});
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    enableAutoSessionTracking: true,
+    tracesSampleRate: 1.0,
+    profilesSampleRate: 1.0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    integrations: [
+      Sentry.mobileReplayIntegration({
+        maskAllText: true,
+        blockAllMedia: true,
+        privacyOptions: {
+          maskAllInputs: true,
+          blockClass: ['sensitive-screen', 'payment-view'],
+        },
+      }),
+    ],
+  });
+}
 
 if (!TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {
   TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正**
  * エラートラッキングサービスの初期化が本番環境に限定されるようになりました。これまでは全ての環境で有効でしたが、本番環境でのみ機能するように改善されました。プライバシー設定とリプレイ機能の動作は変更されていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->