### PR TITLE
環状路線でオートモードを使うと逆向きに進むバグを修正

### DIFF
--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -46,6 +46,12 @@ jest.mock('~/store/atoms/location', () => ({
   locationAtom: { toString: () => 'locationAtom' },
 }));
 
+jest.mock('~/hooks/useLoopLine', () => ({
+  useLoopLine: jest.fn(() => ({
+    isLoopLine: false,
+  })),
+}));
+
 jest.mock('expo-location', () => ({
   hasStartedLocationUpdatesAsync: jest.fn(),
   stopLocationUpdatesAsync: jest.fn(),

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -25,6 +25,7 @@ import getIsPass from '../utils/isPass';
 import { isBusLine } from '../utils/line';
 import { useCurrentLine } from './useCurrentLine';
 import { useCurrentTrainType } from './useCurrentTrainType';
+import { useLoopLine } from './useLoopLine';
 
 export const useSimulationMode = (): void => {
   const {
@@ -39,6 +40,7 @@ export const useSimulationMode = (): void => {
 
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
+  const { isLoopLine } = useLoopLine();
 
   const segmentIndexRef = useRef(0);
   const childIndexRef = useRef(0);
@@ -80,8 +82,11 @@ export const useSimulationMode = (): void => {
 
   const maybeRevsersedStations = useMemo(
     () =>
-      selectedDirection === 'INBOUND' ? stations : stations.slice().reverse(),
-    [stations, selectedDirection]
+      // ループ線では INBOUND/OUTBOUND の進行方向が非ループ線と逆になる
+      (isLoopLine ? selectedDirection !== 'INBOUND' : selectedDirection === 'INBOUND')
+        ? stations
+        : stations.slice().reverse(),
+    [stations, selectedDirection, isLoopLine]
   );
 
   const enabled = useMemo(() => {

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -83,7 +83,11 @@ export const useSimulationMode = (): void => {
   const maybeRevsersedStations = useMemo(
     () =>
       // ループ線では INBOUND/OUTBOUND の進行方向が非ループ線と逆になる
-      (isLoopLine ? selectedDirection !== 'INBOUND' : selectedDirection === 'INBOUND')
+      (
+        isLoopLine
+          ? selectedDirection !== 'INBOUND'
+          : selectedDirection === 'INBOUND'
+      )
         ? stations
         : stations.slice().reverse(),
     [stations, selectedDirection, isLoopLine]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ループ線における乗車方向の処理を改善しました。駅情報がより正確な順序で表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->