### PR TITLE
EXTRA_REQUEST_PROMOTED_ONGOINGがEASビルド環境のSDKに未定義のため文字列リテラルに置換

### DIFF
--- a/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
@@ -201,7 +201,7 @@ class LiveUpdateModule(reactContext: ReactApplicationContext) :
             .setOnlyAlertOnce(true)
             .setShortCriticalText(shortCriticalText)
             .addExtras(Bundle().apply {
-                putBoolean(Notification.EXTRA_REQUEST_PROMOTED_ONGOING, true)
+                putBoolean("android.requestPromotedOngoing", true)
             })
 
         createContentIntent()?.let { builder.setContentIntent(it) }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* Android通知の継続中ステータスのリクエスト処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->