### PR TITLE
shortCriticalTextに状態プレフィックスを追加して次は・まもなく・通過中を表示

### DIFF
--- a/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
@@ -186,9 +186,10 @@ class LiveUpdateModule(reactContext: ReactApplicationContext) :
             )
 
         val shortCriticalText = when {
-            passingStationName.isNotEmpty() -> passingStationName
+            passingStationName.isNotEmpty() -> reactApplicationContext.getString(R.string.live_update_passing, passingStationName)
             stopped -> stationName
-            else -> nextStationName
+            approaching -> reactApplicationContext.getString(R.string.live_update_approaching, nextStationName)
+            else -> reactApplicationContext.getString(R.string.live_update_next, nextStationName)
         }
 
         val builder = Notification.Builder(reactApplicationContext, CHANNEL_ID)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 列車運行情報通知のメッセージが端末の言語設定に対応するようになりました。通過駅、接近駅、次駅に関する通知の表示が適切にローカライズされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->