### PR TITLE
startLocationUpdatesAsyncに指数バックオフ付きリトライ処理を追加

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -7,6 +7,9 @@ export const LOCATION_TIME_INTERVAL = 2000;
 
 export const MAX_PERMIT_ACCURACY = 4000;
 
+export const LOCATION_START_MAX_RETRIES = 3;
+export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;
+
 export const LOCATION_TASK_OPTIONS: Location.LocationTaskOptions = {
   accuracy: LOCATION_ACCURACY,
   distanceInterval: LOCATION_DISTANCE_INTERVAL,

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -167,7 +167,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       mockUseLocationPermissionsGranted.mockReturnValue(true);
 
       // startLocationUpdatesAsyncが解決する前にunmountされるケースをシミュレート
-      let resolveStart: () => void;
+      let resolveStart: () => void = () => {};
       mockStartLocationUpdatesAsync.mockImplementation(
         () =>
           new Promise<void>((resolve) => {
@@ -181,7 +181,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       unmount();
 
       // startが完了
-      resolveStart?.();
+      resolveStart();
       await new Promise(process.nextTick);
 
       // クリーンアップのstop + cancelled検知後のstopで2回呼ばれる
@@ -198,7 +198,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       mockAutoModeEnabled = false;
       mockUseLocationPermissionsGranted.mockReturnValue(true);
 
-      let resolveStart: () => void;
+      let resolveStart: () => void = () => {};
       mockStartLocationUpdatesAsync.mockImplementation(
         () =>
           new Promise<void>((resolve) => {
@@ -213,7 +213,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       unmount();
 
       // startが完了 → cancelled=trueなのでstopを試みるが失敗する
-      resolveStart?.();
+      resolveStart();
       await new Promise(process.nextTick);
 
       // startは1回だけ（stop失敗でリトライされない）

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -181,7 +181,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       unmount();
 
       // startが完了
-      resolveStart!();
+      resolveStart?.();
       await new Promise(process.nextTick);
 
       // クリーンアップのstop + cancelled検知後のstopで2回呼ばれる
@@ -205,9 +205,7 @@ describe('useStartBackgroundLocationUpdates', () => {
             resolveStart = resolve;
           })
       );
-      mockStopLocationUpdatesAsync.mockRejectedValue(
-        new Error('Stop failed')
-      );
+      mockStopLocationUpdatesAsync.mockRejectedValue(new Error('Stop failed'));
 
       const { unmount } = renderHook(() => useStartBackgroundLocationUpdates());
 
@@ -215,7 +213,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       unmount();
 
       // startが完了 → cancelled=trueなのでstopを試みるが失敗する
-      resolveStart!();
+      resolveStart?.();
       await new Promise(process.nextTick);
 
       // startは1回だけ（stop失敗でリトライされない）

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -52,7 +52,14 @@ export const useStartBackgroundLocationUpdates = () => {
           // クリーンアップがstartの完了前に実行された場合、
           // stopが先に走り開始済みの更新が残るため、ここで再度停止する
           if (cancelled) {
-            await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+            try {
+              await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+            } catch (stopError) {
+              console.warn(
+                'バックグラウンド位置情報の更新停止に失敗しました:',
+                stopError
+              );
+            }
           }
           return;
         } catch (error) {

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -49,6 +49,11 @@ export const useStartBackgroundLocationUpdates = () => {
               killServiceOnDestroy: false,
             },
           });
+          // クリーンアップがstartの完了前に実行された場合、
+          // stopが先に走り開始済みの更新が残るため、ここで再度停止する
+          if (cancelled) {
+            await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+          }
           return;
         } catch (error) {
           if (attempt < LOCATION_START_MAX_RETRIES) {

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -3,9 +3,19 @@ import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
 import { setLocation } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
-import { LOCATION_TASK_NAME, LOCATION_TASK_OPTIONS } from '../constants';
+import {
+  LOCATION_START_MAX_RETRIES,
+  LOCATION_START_RETRY_BASE_DELAY_MS,
+  LOCATION_TASK_NAME,
+  LOCATION_TASK_OPTIONS,
+} from '../constants';
 import { translate } from '../translation';
 import { useLocationPermissionsGranted } from './useLocationPermissionsGranted';
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 export const useStartBackgroundLocationUpdates = () => {
   const bgPermGranted = useLocationPermissionsGranted();
@@ -16,31 +26,50 @@ export const useStartBackgroundLocationUpdates = () => {
       return;
     }
 
+    let cancelled = false;
+
     (async () => {
-      try {
-        // Android/iOS共通でexpo-locationのフォアグラウンドサービスを使用
-        // Android 16以降ではJobSchedulerにランタイムクォータが適用されるため、
-        // expo-locationのフォアグラウンドサービス内で直接位置更新を実行する必要がある
-        await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-          ...LOCATION_TASK_OPTIONS,
-          // NOTE: マップマッチが勝手に行われると電車での経路と大きく異なることがあるはずなので
-          // OtherNavigationは必須
-          activityType: Location.ActivityType.OtherNavigation,
-          foregroundService: {
-            notificationTitle: translate('bgAlertTitle'),
-            notificationBody: translate('bgAlertContent'),
-            killServiceOnDestroy: false,
-          },
-        });
-      } catch (error) {
-        console.warn(
-          'バックグラウンド位置情報の更新開始に失敗しました:',
-          error
-        );
+      for (let attempt = 0; attempt <= LOCATION_START_MAX_RETRIES; attempt++) {
+        if (cancelled) {
+          return;
+        }
+
+        try {
+          // Android/iOS共通でexpo-locationのフォアグラウンドサービスを使用
+          // Android 16以降ではJobSchedulerにランタイムクォータが適用されるため、
+          // expo-locationのフォアグラウンドサービス内で直接位置更新を実行する必要がある
+          await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+            ...LOCATION_TASK_OPTIONS,
+            // NOTE: マップマッチが勝手に行われると電車での経路と大きく異なることがあるはずなので
+            // OtherNavigationは必須
+            activityType: Location.ActivityType.OtherNavigation,
+            foregroundService: {
+              notificationTitle: translate('bgAlertTitle'),
+              notificationBody: translate('bgAlertContent'),
+              killServiceOnDestroy: false,
+            },
+          });
+          return;
+        } catch (error) {
+          if (attempt < LOCATION_START_MAX_RETRIES) {
+            const delay = LOCATION_START_RETRY_BASE_DELAY_MS * 2 ** attempt;
+            console.warn(
+              `バックグラウンド位置情報の更新開始に失敗しました（リトライ ${attempt + 1}/${LOCATION_START_MAX_RETRIES}）:`,
+              error
+            );
+            await wait(delay);
+          } else {
+            console.warn(
+              'バックグラウンド位置情報の更新開始に失敗しました（リトライ上限到達）:',
+              error
+            );
+          }
+        }
       }
     })();
 
     return () => {
+      cancelled = true;
       Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME).catch((error) => {
         console.warn(
           'バックグラウンド位置情報の更新停止に失敗しました:',


### PR DESCRIPTION
https://claude.ai/code/session_011UAtpQJK1XnENVkcaQRmMi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * バックグラウンド位置情報更新の開始処理で失敗時に最大3回まで自動リトライを行うようにし、再試行間に基準遅延を用いたバックオフを適用します。アンマウント／クリーンアップ時は再試行を中止し、起動処理中の不要な更新を停止、失敗時には警告ログを出力します。

* **テスト**
  * リトライ成功・上限到達・クリーンアップ中の停止・停止失敗など、さまざまな再試行シナリオを検証するテストを追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->