### PR TITLE
TTS設定画面からAndroid 16判定ロジックを撤廃

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -156,7 +156,6 @@
   "selectFirstStationTitle": "Please select the first station",
   "longPressNotice": "Press and hold the screen to open the menu.",
   "autoAnnounceBackgroundTitle": "Enable background voice announcement",
-  "bgTtsUnavailableOnAndroid16": "Background playback is not available on Android 16 or later due to OS restrictions.",
   "loadingLocation": "Getting location information...",
   "loadingAPI": "Communicating with server...",
   "routeSearchTitle": "Find a route",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -157,7 +157,6 @@
   "selectFirstStationTitle": "始発駅を選択してください",
   "longPressNotice": "画面を長押しするとメニューが開けます",
   "autoAnnounceBackgroundTitle": "バックグラウンド再生",
-  "bgTtsUnavailableOnAndroid16": "Android 16以降ではOSの制限によりバックグラウンド再生を利用できません。",
   "loadingLocation": "位置情報を取得中です",
   "loadingAPI": "サーバーと通信中です",
   "routeSearchTitle": "経路を検索",

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -303,18 +303,11 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           enabled: speechEnabledStr === 'true',
         }));
       }
-      const isAndroid16OrHigher =
-        Platform.OS === 'android' && Number(Platform.Version) >= 36;
       if (bgTTSEnabledStr) {
-        const bgEnabled = bgTTSEnabledStr === 'true' && !isAndroid16OrHigher;
         setSpeech((prev) => ({
           ...prev,
-          backgroundEnabled: bgEnabled,
+          backgroundEnabled: bgTTSEnabledStr === 'true',
         }));
-        // Android 16以上で保存値がtrueの場合、永続化もfalseに上書き
-        if (isAndroid16OrHigher && bgTTSEnabledStr === 'true') {
-          AsyncStorage.setItem(ASYNC_STORAGE_KEYS.BG_TTS_ENABLED, 'false');
-        }
       }
       if (ttsEnabledLanguagesStr) {
         try {


### PR DESCRIPTION
https://claude.ai/code/session_01QJxW4UaH8moFYJvMQiL6rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Android 16以上でのバックグラウンド音声再生の制限を削除しました。
  * テキスト読み上げ機能の設定ロジックを簡素化しました。

* **その他の変更**
  * 不要な翻訳エントリを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->