### PR TITLE
Android Live UpdateのshortTextで「まもなく」を廃止し「次は」に統合

### DIFF
--- a/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/LiveUpdateModule.kt
@@ -188,7 +188,6 @@ class LiveUpdateModule(reactContext: ReactApplicationContext) :
         val shortCriticalText = when {
             passingStationName.isNotEmpty() -> reactApplicationContext.getString(R.string.live_update_passing, passingStationName)
             stopped -> stationName
-            approaching -> reactApplicationContext.getString(R.string.live_update_approaching, nextStationName)
             else -> reactApplicationContext.getString(R.string.live_update_next, nextStationName)
         }
 


### PR DESCRIPTION
https://claude.ai/code/session_01KBPf4rJnxLCCkDr1QvPGdx
文言が長すぎて表示しきれないので

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 駅接近時のテキスト表示ロジックを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->