### PR TITLE
watchPositionAsyncの直接コールバックを併用してAndroid 16のJobSchedulerクォータによるバックグラウンド位置更新のスロットルを回避

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -10,10 +10,14 @@ export const MAX_PERMIT_ACCURACY = 4000;
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;
 
-export const LOCATION_TASK_OPTIONS: Location.LocationTaskOptions = {
+export const LOCATION_WATCH_OPTIONS: Location.LocationOptions = {
   accuracy: LOCATION_ACCURACY,
   distanceInterval: LOCATION_DISTANCE_INTERVAL,
   timeInterval: LOCATION_TIME_INTERVAL,
+} as const;
+
+export const LOCATION_TASK_OPTIONS: Location.LocationTaskOptions = {
+  ...LOCATION_WATCH_OPTIONS,
   // expo-task-managerはバックグラウンドでJobScheduler経由でJS側にデータを配信する。
   // deferredUpdatesを両方0にするとFLPの更新ごとにジョブがスケジュールされ、
   // Android 16でクォータ超過によりバックグラウンド更新が停止する。

--- a/src/constants/native.ts
+++ b/src/constants/native.ts
@@ -5,3 +5,7 @@ export const IS_LIVE_ACTIVITIES_ELIGIBLE_PLATFORM =
 
 export const IS_LIVE_UPDATE_ELIGIBLE_PLATFORM =
   Platform.OS === 'android' && (Platform.Version as number) >= 36;
+
+// Android 16(API 36)以降ではフォアグラウンドサービス併走のJobにもクォータが適用される
+export const NEEDS_JOBSCHEDULER_BYPASS =
+  Platform.OS === 'android' && (Platform.Version as number) >= 36;

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -4,6 +4,7 @@ import {
   LOCATION_START_MAX_RETRIES,
   LOCATION_TASK_NAME,
   LOCATION_TASK_OPTIONS,
+  LOCATION_WATCH_OPTIONS,
 } from '../constants';
 import { useLocationPermissionsGranted } from './useLocationPermissionsGranted';
 import { useStartBackgroundLocationUpdates } from './useStartBackgroundLocationUpdates';
@@ -361,7 +362,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       await new Promise(process.nextTick);
 
       expect(mockWatchPositionAsync).toHaveBeenCalledWith(
-        LOCATION_TASK_OPTIONS,
+        LOCATION_WATCH_OPTIONS,
         expect.any(Function)
       );
     });
@@ -437,7 +438,7 @@ describe('useStartBackgroundLocationUpdates', () => {
       await new Promise(process.nextTick);
 
       expect(mockWatchPositionAsync).toHaveBeenCalledWith(
-        LOCATION_TASK_OPTIONS,
+        LOCATION_WATCH_OPTIONS,
         expect.any(Function)
       );
     });

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -50,11 +50,15 @@ jest.mock('jotai', () => ({
 describe('useStartBackgroundLocationUpdates', () => {
   const mockRemove = jest.fn();
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   beforeEach(() => {
     // React Testing Libraryのauto-cleanupはafterEachでフックをunmountし、
     // effectクリーンアップ（stopLocationUpdatesAsync等）を発火する。
     // このクリーンアップは登録順の関係でafterEachよりも後に実行されるため、
-    // beforeEachでclearAllMocksを行い、前テストの残留呼び出しを確実にリセットする。
+    // beforeEachでもclearAllMocksを行い、前テストの残留呼び出しを確実にリセットする。
     jest.clearAllMocks();
     mockAutoModeEnabled = false;
     mockNeedsJobSchedulerBypass = false;

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -12,6 +12,7 @@ import {
   LOCATION_START_RETRY_BASE_DELAY_MS,
   LOCATION_TASK_NAME,
   LOCATION_TASK_OPTIONS,
+  LOCATION_WATCH_OPTIONS,
 } from '../constants';
 import { NEEDS_JOBSCHEDULER_BYPASS } from '../constants/native';
 import { translate } from '../translation';
@@ -97,7 +98,7 @@ export const useStartBackgroundLocationUpdates = () => {
             if (NEEDS_JOBSCHEDULER_BYPASS) {
               try {
                 const sub = await Location.watchPositionAsync(
-                  LOCATION_TASK_OPTIONS,
+                  LOCATION_WATCH_OPTIONS,
                   setLocation
                 );
                 if (cancelled) {
@@ -156,7 +157,7 @@ export const useStartBackgroundLocationUpdates = () => {
     (async () => {
       try {
         const sub = await Location.watchPositionAsync(
-          LOCATION_TASK_OPTIONS,
+          LOCATION_WATCH_OPTIONS,
           setLocation
         );
         if (cancelled) {


### PR DESCRIPTION
https://claude.ai/code/session_01RMxd9GFPAFTnDB531mMTrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * バックグラウンド位置更新のテストを拡張し、バイパス条件、直接コールバック、クリーンアップ、失敗時の挙動を確認するケースを追加しました

* **改善**
  * Androidの新しい制約に対応するバイパス経路を導入し、Foreground時のリアルタイム位置更新とクリーンな解除処理を強化しました

* **ログ**
  * 直接コールバック失敗時に警告ログを出す挙動を明確化しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->