### PR TITLE
路線を選び直した際に列車種別モーダルが古いselectedLineを参照して0件になるバグを修正

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -509,6 +509,11 @@ export const SelectBoundModal: React.FC<Props> = ({
       !!targetLine &&
       stationLines.some((stationLine) => stationLine.id === targetLine.id);
 
+    // pendingLine（選択中の路線）をselectedLine（前回確定した路線）より優先する
+    // 路線選択画面から別の路線を選び直した場合にselectedLineが古い値のまま残るため
+    if (hasStationLine(line)) {
+      return line;
+    }
     if (hasStationLine(selectedLine)) {
       return selectedLine;
     }
@@ -518,11 +523,8 @@ export const SelectBoundModal: React.FC<Props> = ({
     if (hasStationLine(pendingTrainType?.line)) {
       return pendingTrainType?.line ?? null;
     }
-    if (hasStationLine(line)) {
-      return line;
-    }
 
-    return station?.line ?? stationLines[0] ?? selectedLine ?? line ?? null;
+    return station?.line ?? stationLines[0] ?? line ?? selectedLine ?? null;
   }, [
     line,
     pendingTrainType?.line,

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -107,6 +107,7 @@ export const useLineSelection = (): UseLineSelectionResult => {
       }));
       setLineState((prev) => ({
         ...prev,
+        selectedLine: null,
         pendingLine: line ?? null,
       }));
       setNavigationState((prev) => ({


### PR DESCRIPTION
https://claude.ai/code/session_01Wvjh2EijjdmLCxfdpGaVn4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 駅の線選択時に、現在選択されている線の優先度処理を改善しました。
  * 線選択時の状態管理を修正し、不要な状態の重複を解消しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->