### PR TITLE
位置情報の許容精度を1kmに引き下げ、EMAスムージングをGPS精度に連動させる

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 5;
 export const LOCATION_TIME_INTERVAL = 3000;
 
-export const MAX_PERMIT_ACCURACY = 4000;
+export const MAX_PERMIT_ACCURACY = 1000;
 
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;


### PR DESCRIPTION
https://claude.ai/code/session_01KcvuGaJxXTfLWKoQw9otY7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **改善**
  * ロケーション精度の許容値を調整し、GPS信号の品質に基づいた動的な位置情報平滑化を実装しました。これにより、様々なGPS精度の条件下でより正確な位置追跡が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->