### PR TITLE
SelectLineScreenにPull to Refreshを実装

### DIFF
--- a/src/hooks/useInitialNearbyStation.ts
+++ b/src/hooks/useInitialNearbyStation.ts
@@ -156,13 +156,20 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
     if (fetchInFlightRef.current) return;
     fetchInFlightRef.current = true;
     try {
-      await fetchNearbyAndUpdate();
+      // refetch は常に新鮮な位置情報を取得する
+      const currentLocation = await fetchCurrentLocation();
+      if (!currentLocation) return;
+      setLocation(currentLocation);
+      await fetchNearbyAndUpdate({
+        latitude: currentLocation.coords.latitude,
+        longitude: currentLocation.coords.longitude,
+      });
     } catch (error) {
       console.error(error);
     } finally {
       fetchInFlightRef.current = false;
     }
-  }, [fetchNearbyAndUpdate]);
+  }, [fetchCurrentLocation, fetchNearbyAndUpdate]);
 
   return { station, nearbyStationLoading, refetch };
 };

--- a/src/hooks/useInitialNearbyStation.ts
+++ b/src/hooks/useInitialNearbyStation.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Location from 'expo-location';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Alert } from 'react-native';
 import type { Station } from '~/@types/graphql';
 import { ASYNC_STORAGE_KEYS, LOCATION_TASK_NAME } from '../constants';
@@ -17,6 +17,7 @@ const INITIAL_LOCATION_FALLBACK_DELAY_MS = 800;
 export type UseInitialNearbyStationResult = {
   station: Station | null;
   nearbyStationLoading: boolean;
+  refetch: () => Promise<void>;
 };
 
 export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
@@ -27,7 +28,7 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
   const longitude = location?.coords.longitude;
 
   const { station: stationFromAtom } = stationAtomState;
-  const initialNearbyFetchInFlightRef = useRef(false);
+  const fetchInFlightRef = useRef(false);
 
   const {
     stations: nearbyStations,
@@ -41,6 +42,39 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
   const station = useMemo(
     () => stationFromAtom ?? nearbyStations[0] ?? null,
     [stationFromAtom, nearbyStations]
+  );
+
+  // 位置情報から最寄り駅を取得し atom を更新する共通処理
+  const fetchNearbyAndUpdate = useCallback(
+    async (coords?: { latitude: number; longitude: number }) => {
+      let requestCoords = coords;
+      if (!requestCoords) {
+        const currentLocation = await fetchCurrentLocation(true);
+        if (!currentLocation) return;
+        setLocation(currentLocation);
+        requestCoords = {
+          latitude: currentLocation.coords.latitude,
+          longitude: currentLocation.coords.longitude,
+        };
+      }
+
+      const data = await fetchByCoords({
+        latitude: requestCoords.latitude,
+        longitude: requestCoords.longitude,
+        limit: 1,
+      });
+
+      const stationFromAPI = data.data?.stationsNearby[0] ?? null;
+      setStationState((prev) => ({
+        ...prev,
+        station: stationFromAPI,
+      }));
+      setNavigationState((prev) => ({
+        ...prev,
+        stationForHeader: stationFromAPI,
+      }));
+    },
+    [fetchByCoords, fetchCurrentLocation, setNavigationState, setStationState]
   );
 
   // バックグラウンド位置更新を停止
@@ -61,40 +95,15 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
       latitude: number;
       longitude: number;
     }) => {
-      if (station || initialNearbyFetchInFlightRef.current) return;
-      initialNearbyFetchInFlightRef.current = true;
+      if (station || fetchInFlightRef.current) return;
+      fetchInFlightRef.current = true;
 
       try {
-        let requestCoords = coords;
-        if (!requestCoords) {
-          const currentLocation = await fetchCurrentLocation(true);
-          if (!currentLocation) return;
-          setLocation(currentLocation);
-          requestCoords = {
-            latitude: currentLocation.coords.latitude,
-            longitude: currentLocation.coords.longitude,
-          };
-        }
-
-        const data = await fetchByCoords({
-          latitude: requestCoords.latitude,
-          longitude: requestCoords.longitude,
-          limit: 1,
-        });
-
-        const stationFromAPI = data.data?.stationsNearby[0] ?? null;
-        setStationState((prev) => ({
-          ...prev,
-          station: stationFromAPI,
-        }));
-        setNavigationState((prev) => ({
-          ...prev,
-          stationForHeader: stationFromAPI,
-        }));
+        await fetchNearbyAndUpdate(coords);
       } catch (error) {
         console.error(error);
       } finally {
-        initialNearbyFetchInFlightRef.current = false;
+        fetchInFlightRef.current = false;
       }
     };
 
@@ -110,15 +119,7 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
     return () => {
       clearTimeout(fallbackTimerId);
     };
-  }, [
-    fetchByCoords,
-    fetchCurrentLocation,
-    latitude,
-    longitude,
-    setNavigationState,
-    setStationState,
-    station,
-  ]);
+  }, [fetchNearbyAndUpdate, latitude, longitude, station]);
 
   // 初回起動アラート
   useEffect(() => {
@@ -151,5 +152,17 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
     }
   }, [nearbyStationFetchError]);
 
-  return { station, nearbyStationLoading };
+  const refetch = useCallback(async () => {
+    if (fetchInFlightRef.current) return;
+    fetchInFlightRef.current = true;
+    try {
+      await fetchNearbyAndUpdate();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      fetchInFlightRef.current = false;
+    }
+  }, [fetchNearbyAndUpdate]);
+
+  return { station, nearbyStationLoading, refetch };
 };

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -57,6 +57,10 @@ const styles = StyleSheet.create({
   },
 });
 
+// RN 0.81 + New Architecture で tintColor がマウント時に無視されるバグの回避用遅延(ms)
+// https://github.com/facebook/react-native/issues/53987
+const REFRESH_TINT_DELAY_MS = 500;
+
 const NearbyStationLoader = () => (
   <SkeletonPlaceholder borderRadius={4} speed={1500}>
     <SkeletonPlaceholder.Item width="100%" height={72} />
@@ -112,15 +116,13 @@ const SelectLineScreen = () => {
   }, []);
 
   // --- RefreshControl tintColor ワークアラウンド ---
-  // RN 0.81 + New Architecture で tintColor がマウント時に無視されるバグの回避策
-  // https://github.com/facebook/react-native/issues/53987
   const [refreshTintColor, setRefreshTintColor] = useState<
     string | undefined
   >();
   useEffect(() => {
     const timer = setTimeout(() => {
       setRefreshTintColor(isLEDTheme ? '#fff' : undefined);
-    }, 500);
+    }, REFRESH_TINT_DELAY_MS);
     return () => clearTimeout(timer);
   }, [isLEDTheme]);
 

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -2,16 +2,10 @@ import * as ScreenOrientation from 'expo-screen-orientation';
 import { Orientation } from 'expo-screen-orientation';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  RefreshControl,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { RefreshControl, StyleSheet, View } from 'react-native';
 import Animated, {
   LinearTransition,
+  useAnimatedScrollHandler,
   useSharedValue,
 } from 'react-native-reanimated';
 import {
@@ -188,12 +182,11 @@ const SelectLineScreen = () => {
   );
 
   // --- スクロールハンドラ ---
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.value = e.nativeEvent.contentOffset.y;
+  const handleScroll = useAnimatedScrollHandler({
+    onScroll: (e) => {
+      scrollY.value = e.contentOffset.y;
     },
-    [scrollY]
-  );
+  });
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -284,7 +277,7 @@ const SelectLineScreen = () => {
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <ScrollView
+        <Animated.ScrollView
           style={StyleSheet.absoluteFill}
           onScroll={handleScroll}
           scrollEventThrottle={16}
@@ -363,7 +356,7 @@ const SelectLineScreen = () => {
             </>
           )}
           <EmptyLineSeparator />
-        </ScrollView>
+        </Animated.ScrollView>
       </SafeAreaView>
 
       {/* 固定ヘッダー */}


### PR DESCRIPTION
## Summary
- `SelectLineScreen` の `Animated.ScrollView` に `RefreshControl` を追加し、Pull to Refresh で最寄り駅データを再取得できるようにした
- `useInitialNearbyStation` フックにフェッチ共通処理 (`fetchNearbyAndUpdate`) を抽出し、初回取得と `refetch` のコード重複を解消
- 連打防止ガード (`fetchInFlightRef`)、リフレッシュ中のスケルトン抑制、LED テーマでの `tintColor` 対応を含む

## Test plan
- [x] Pull to Refresh で最寄り駅が再取得されることを確認
- [x] リフレッシュ中に既存の路線リストが表示されたままであることを確認（スケルトンに切り替わらない）
- [x] 素早く連続で引っ張っても重複リクエストが発生しないことを確認
- [x] LED テーマでスピナーが視認できることを確認
- [x] 初回起動時（駅未取得状態）の既存動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 路線選択画面にプルで更新するRefreshControlを追加し、手動で近隣駅情報を再取得可能にしました。
  * フックの公開APIに refetch を追加し、画面側から明示的に再取得を呼べます。

* **改善・修正**
  * 再取得の同時実行を防ぐ制御を導入し、競合や重複更新を抑制しました。
  * リフレッシュ表示の色反映を安定化（LEDテーマ対応の遅延初期化）し、読み込み表示の切り替えを改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->