### PR TITLE
Android用のRefreshControl colors propを削除

### DIFF
--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -289,7 +289,6 @@ const SelectLineScreen = () => {
               onRefresh={handleRefresh}
               progressViewOffset={nowHeaderHeight}
               tintColor={refreshTintColor}
-              colors={isLEDTheme ? ['#fff'] : undefined}
             />
           }
           contentContainerStyle={[


### PR DESCRIPTION
## Summary
- SelectLineScreenのRefreshControlからAndroid用の`colors` propを削除

## Test plan
- [x] iOS: Pull to RefreshのLEDテーマでスピナーが白く表示されること
- [x] Android: Pull to Refreshが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * リフレッシュコントロールの色設定ロジックを簡素化しました。条件付き色配列の処理を削除し、色の管理をより効率化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->