### PR TITLE
MarqueeコンポーネントにnumberOfLines制約を追加

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -85,6 +85,7 @@ const Marquee = ({ children }: Props) => {
       style: childStyle,
       onLayout: handleLayout,
       ref: wrapperViewRef,
+      numberOfLines: 1,
     };
 
     return cloneElement(children, mergedProps);


### PR DESCRIPTION
## Summary
- Marqueeコンポーネントの子要素に `numberOfLines: 1` を付与し、テキストが複数行に折り返されないよう強制

## Test plan
- [ ] Marquee表示箇所で長いテキストが1行のままスクロールすることを確認
- [ ] 短いテキスト（画面幅内に収まる場合）が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Marqueeコンポーネントが単一行でコンテンツを表示するよう改善し、テキストの折り返しを防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->