### PR TITLE
ThemeSettings画面のoffTextに専用の翻訳キーを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -177,6 +177,7 @@
   "routeListTitle": "Directions to %{stationName} Station",
   "legacyAutoModeTitle": "Enable legacy auto mode",
   "inUse": "In use",
+  "select": "Select",
   "updateRequiredForReport": "Please update the app to send a feedback.",
   "updateApp": "Update app",
   "jrKyushuLike": "JR Kyushu",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -178,6 +178,7 @@
   "routeListTitle": "%{stationName}駅までの経路",
   "legacyAutoModeTitle": "従来のオートモードを有効にする",
   "inUse": "使用中",
+  "select": "設定",
   "updateRequiredForReport": "フィードバックを送信するにはアプリをアップデートしてください。",
   "updateApp": "アプリをアップデート",
   "jrKyushuLike": "JR九州風",

--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -113,7 +113,7 @@ const SettingsItem = ({
       <StatePanel
         state={state}
         onText={translate('inUse')}
-        offText={translate('settings')}
+        offText={translate('select')}
       />
     </Pressable>
   );


### PR DESCRIPTION
## Summary
- ThemeSettings画面の`StatePanel`で使用する`offText`に、既存の`settings`キーではなく専用の`select`翻訳キーを追加
- `en.json`に`"select": "Select"`、`ja.json`に`"select": "設定"`を追加
- `ThemeSettings.tsx`の`offText`を`translate('select')`に変更

## Test plan
- [ ] ThemeSettings画面で未選択のテーマに「設定」(日本語) / 「Select」(英語) と表示されることを確認
- [ ] 選択中のテーマには「使用中」/ 「In use」が引き続き表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ローカライゼーション**
  * テーマ設定画面に「Select」ラベルを新たに追加し、英語および日本語の多言語対応を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->