### PR TITLE
LineBoardToeiの駅番号をposition: absoluteに変更してAndroid16のレイアウト崩れを修正

### DIFF
--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -47,6 +47,9 @@ const localStyles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
   },
+  nameCommon: {
+    marginBottom: isTablet ? undefined : 84,
+  },
   stationNumber: {
     position: isTablet ? 'relative' : 'absolute',
     width: isTablet ? 60 : 45,

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -48,10 +48,12 @@ const localStyles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   stationNumber: {
+    position: isTablet ? 'relative' : 'absolute',
     width: isTablet ? 60 : 45,
     fontSize: RFValue(12),
     fontWeight: 'bold',
-    marginLeft: -5,
+    left: isTablet ? undefined : -5,
+    marginLeft: isTablet ? -5 : undefined,
     bottom: isTablet ? 0 : 64,
     textAlign: 'center',
   },


### PR DESCRIPTION
https://claude.ai/code/session_0131Fm2ri5NYe6XYpedwsATr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Style**
  * タブレット／非タブレットで駅番号の配置を改善し、画面幅に応じた表示品質を向上。
  * 表示間隔（下余白）をデバイスごとに調整し、タブレットとそれ以外で見た目の一貫性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->