### PR TITLE
LineBoardLEDのMarqueeが2行に折り返される問題を修正

### DIFF
--- a/src/components/LineBoardLED.tsx
+++ b/src/components/LineBoardLED.tsx
@@ -21,7 +21,6 @@ import Marquee from './Marquee';
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    flex: 1,
     gap: 16,
   },
   text: {


### PR DESCRIPTION
## Summary
- LineBoardLEDのコンテナスタイルから `flex: 1` を削除し、Marquee内のテキストが2行に折り返される問題を修正
- `flex: 1` によりコンテナ幅が画面幅に制約され、長いテキスト（行き先の英語表記等）が折り返されていた
- 削除により、コンテナがコンテンツの自然な幅を取るようになり、Marqueeが正しく横スクロールする

## Test plan
- [x] LEDテーマで行き先が長い路線（例: 複数駅表示）を選択し、Marqueeが1行で横スクロールすることを確認
- [x] 短いテキストの場合にスクロールせず正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * LineBoardLED コンポーネントの表示レイアウトを調整しました。コンテナが利用可能なスペースを埋めるように拡張されなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->