### PR TITLE
LineBoardLEDの全Text要素にnumberOfLines制約を追加

### DIFF
--- a/src/components/LineBoardLED.tsx
+++ b/src/components/LineBoardLED.tsx
@@ -34,13 +34,19 @@ const styles = StyleSheet.create({
 });
 
 const GreenText = ({ children }: { children: React.ReactNode }) => (
-  <Text style={[styles.text, styles.green]}>{children}</Text>
+  <Text numberOfLines={1} style={[styles.text, styles.green]}>
+    {children}
+  </Text>
 );
 const OrangeText = ({ children }: { children: React.ReactNode }) => (
-  <Text style={[styles.text, styles.orange]}>{children}</Text>
+  <Text numberOfLines={1} style={[styles.text, styles.orange]}>
+    {children}
+  </Text>
 );
 const CrimsonText = ({ children }: { children: React.ReactNode }) => (
-  <Text style={[styles.text, styles.crimson]}>{children}</Text>
+  <Text numberOfLines={1} style={[styles.text, styles.crimson]}>
+    {children}
+  </Text>
 );
 
 // Helper component for arriving state content
@@ -87,7 +93,7 @@ const ArrivingContent = ({
     ) : null}
 
     <GreenText>The next stop is</GreenText>
-    <Text>
+    <Text numberOfLines={1}>
       <OrangeText>
         {nextStation?.nameRoman}
         {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
@@ -98,7 +104,7 @@ const ArrivingContent = ({
     {afterNextStation ? (
       <>
         <GreenText>The stop after</GreenText>
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {nextStation?.nameRoman}
             {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
@@ -108,7 +114,7 @@ const ArrivingContent = ({
 
         <GreenText>will be</GreenText>
 
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {afterNextStation?.nameRoman}
             {afterNextStation?.stationNumbers?.[0]
@@ -123,7 +129,7 @@ const ArrivingContent = ({
       <>
         <GreenText>Please change here for</GreenText>
 
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {transferLines
               .map((l) => l.nameRoman)
@@ -167,7 +173,7 @@ const CurrentContent = ({
     </GreenText>
     <OrangeText>{trainTypeTexts[1]}</OrangeText>
     <GreenText>train for</GreenText>
-    <Text>
+    <Text numberOfLines={1}>
       <OrangeText>{boundTexts[1]}</OrangeText>
       <GreenText>.</GreenText>
     </Text>
@@ -216,7 +222,7 @@ const NextStopContent = ({
       </>
     ) : null}
     <GreenText>The next stop is</GreenText>
-    <Text>
+    <Text numberOfLines={1}>
       <OrangeText>
         {nextStation?.nameRoman}
         {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
@@ -226,7 +232,7 @@ const NextStopContent = ({
     {afterNextStation ? (
       <>
         <GreenText>The stop after</GreenText>
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {nextStation?.nameRoman}
             {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
@@ -235,7 +241,7 @@ const NextStopContent = ({
         </Text>
 
         <GreenText>will be</GreenText>
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {afterNextStation?.nameRoman}
             {afterNextStation?.stationNumbers?.[0]
@@ -249,7 +255,7 @@ const NextStopContent = ({
     {transferLines.length > 0 ? (
       <>
         <GreenText>Please change here for</GreenText>
-        <Text>
+        <Text numberOfLines={1}>
           <OrangeText>
             {transferLines
               .map((l) => l.nameRoman)


### PR DESCRIPTION
## Summary
- LineBoardLEDの GreenText / OrangeText / CrimsonText コンポーネントおよび素の `<Text>` ラッパー全9箇所に `numberOfLines={1}` を追加
- #5458 で `flex: 1` を削除したが、`<Text>` 要素内部でのテキスト折り返しが依然として発生していたため、明示的に1行制約を追加
- horizontal ScrollView 内では `numberOfLines={1}` はテキストを truncate せず、1行レイアウトを維持しつつ Marquee が正しくスクロールする

## Test plan
- [ ] LEDテーマで行き先が長い路線（例: 六本木・大門方面）を選択し、Marqueeが1行で横スクロールすることを確認
- [ ] 短いテキストの場合にスクロールせず正常に表示されることを確認
- [ ] ARRIVING / CURRENT / NEXT の各状態でテキストが1行表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* テキスト表示の改善：駅名や関連情報が複数行に折り返されないよう修正しました。到着予定・現在地・次停車駅の情報表示がより整理されて見やすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->