### PR TITLE
hermes v1導入

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -11,6 +11,7 @@ export default ({ config }: ConfigContext) => ({
     'expo-web-browser',
     'expo-sqlite',
     'expo-asset',
+    'expo-build-properties',
     [
       'expo-location',
       {
@@ -33,6 +34,13 @@ export default ({ config }: ConfigContext) => ({
       {
         backgroundColor: '#fff',
         image: './assets/splash-icon.png',
+      },
+    ],
+    [
+      'expo-build-properties',
+      {
+        buildReactNativeFromSource: true,
+        useHermesV1: true,
       },
     ],
   ],

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,9 @@ export default ({ config }: ConfigContext) => ({
     'expo-web-browser',
     'expo-sqlite',
     'expo-asset',
-    'expo-build-properties',
+    'expo-asset',
+    [
+      'expo-location',
     [
       'expo-location',
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "expo-audio": "^55.0.8",
         "expo-battery": "~55.0.8",
         "expo-blur": "~55.0.8",
+        "expo-build-properties": "~55.0.9",
         "expo-constants": "~55.0.7",
         "expo-crypto": "~55.0.8",
         "expo-device": "~55.0.9",
@@ -9201,6 +9202,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.9.tgz",
+      "integrity": "sha512-p0rNHW/6ghKsvjlUn2DQfbLYuTB6ba+15SeTPOz5BYbyU1F/0F/YyxBtHdmWitqgDPn6VgXQeKhiNC1fMwYDpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "55.0.7",
       "license": "MIT",
@@ -10368,7 +10383,9 @@
       "license": "0BSD"
     },
     "node_modules/hermes-compiler": {
-      "version": "0.14.1",
+      "version": "250829098.0.4",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.4.tgz",
+      "integrity": "sha512-8PEHLTuGOXUAnv2zByUG7Vud0TbU21fPuVqlMuek8PZgdYwb7KFWjw3+6In9J93Tx/6c/nRf5I30vzbaHBlgAQ==",
       "license": "MIT"
     },
     "node_modules/hermes-estree": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "expo start",
-    "android": "expo run:android",
+    "android": "expo run:android -- --variant devDebug",
     "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "biome check ./src",
@@ -36,6 +36,7 @@
     "expo-audio": "^55.0.8",
     "expo-battery": "~55.0.8",
     "expo-blur": "~55.0.8",
+    "expo-build-properties": "~55.0.9",
     "expo-constants": "~55.0.7",
     "expo-crypto": "~55.0.8",
     "expo-device": "~55.0.9",
@@ -158,7 +159,8 @@
   "overrides": {
     "react-native-skeleton-placeholder": {
       "@react-native-masked-view/masked-view": "0.3.2"
-    }
+    },
+    "hermes-compiler": "250829098.0.4"
   },
   "name": "trainlcd",
   "version": "10.2.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ビルド設定に新しいビルドプロパティを導入し、React Native をソースからビルドできるオプションとHermes V1の利用を有効化しました。

* **Chores**
  * 開発向けAndroidビルドの実行コマンドをデバッグ向けのバリアントに変更しました（devDebug）。
  * Hermes関連のツールバージョン上書きを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->