### PR TITLE
東京メトロヘッダーの行き先表示を1行に修正

### DIFF
--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -129,13 +129,15 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
   } = props;
 
   const progress = useRef(new RNAnimated.Value(1)).current;
+  const connectedLinesRef = useRef(connectedLines);
+  connectedLinesRef.current = connectedLines;
   const [previousTexts, setPreviousTexts] = useState(() => ({
     stationText,
     stateText,
     stateTextRight,
     boundText,
     connectionText,
-    connectedLines,
+    hasConnectedLines: !!connectedLines?.length,
     isJapaneseState,
   }));
 
@@ -168,13 +170,12 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
         stateTextRight,
         boundText,
         connectionText,
-        connectedLines,
+        hasConnectedLines: !!connectedLinesRef.current?.length,
         isJapaneseState,
       });
     });
   }, [
     boundText,
-    connectedLines,
     connectionText,
     headerTransitionDelay,
     isJapaneseState,
@@ -235,7 +236,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                   numberOfLines={1}
                   style={styles.boundText}
                 >
-                  {previousTexts.connectedLines?.length &&
+                  {previousTexts.hasConnectedLines &&
                   previousTexts.isJapaneseState ? (
                     <Text style={styles.connectedLines}>
                       {`${previousTexts.connectionText}直通 `}

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -235,7 +235,8 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                   numberOfLines={1}
                   style={styles.boundText}
                 >
-                  {previousTexts.connectedLines?.length && previousTexts.isJapaneseState ? (
+                  {previousTexts.connectedLines?.length &&
+                  previousTexts.isJapaneseState ? (
                     <Text style={styles.connectedLines}>
                       {`${previousTexts.connectionText}直通 `}
                     </Text>

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -135,6 +135,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
     stateTextRight,
     boundText,
     connectionText,
+    connectedLines,
     isJapaneseState,
   }));
 
@@ -167,11 +168,13 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
         stateTextRight,
         boundText,
         connectionText,
+        connectedLines,
         isJapaneseState,
       });
     });
   }, [
     boundText,
+    connectedLines,
     connectionText,
     headerTransitionDelay,
     isJapaneseState,
@@ -232,7 +235,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                   numberOfLines={1}
                   style={styles.boundText}
                 >
-                  {connectedLines?.length && previousTexts.isJapaneseState ? (
+                  {previousTexts.connectedLines?.length && previousTexts.isJapaneseState ? (
                     <Text style={styles.connectedLines}>
                       {`${previousTexts.connectionText}直通 `}
                     </Text>

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -211,13 +211,15 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                 <Text
                   adjustsFontSizeToFit
                   numberOfLines={1}
-                  style={styles.connectedLines}
+                  style={styles.boundText}
                 >
-                  {connectedLines?.length && isJapaneseState
-                    ? `${connectionText}直通 `
-                    : null}
+                  {connectedLines?.length && isJapaneseState ? (
+                    <Text style={styles.connectedLines}>
+                      {`${connectionText}直通 `}
+                    </Text>
+                  ) : null}
+                  {boundText}
                 </Text>
-                <Text style={styles.boundText}>{boundText}</Text>
               </RNAnimated.View>
               <RNAnimated.View
                 style={[
@@ -228,13 +230,15 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                 <Text
                   adjustsFontSizeToFit
                   numberOfLines={1}
-                  style={styles.connectedLines}
+                  style={styles.boundText}
                 >
-                  {connectedLines?.length && previousTexts.isJapaneseState
-                    ? `${previousTexts.connectionText}直通 `
-                    : null}
+                  {connectedLines?.length && previousTexts.isJapaneseState ? (
+                    <Text style={styles.connectedLines}>
+                      {`${previousTexts.connectionText}直通 `}
+                    </Text>
+                  ) : null}
+                  {previousTexts.boundText}
                 </Text>
-                <Text style={styles.boundText}>{previousTexts.boundText}</Text>
               </RNAnimated.View>
             </View>
           ) : null}


### PR DESCRIPTION
## Summary
- 東京メトロヘッダーで直通先テキスト（例:「川越線直通」）と行き先テキスト（例:「川越ゆき」）が2行に分かれて表示されていた問題を修正
- 2つの別々の`<Text>`コンポーネントを1つの親`<Text>`にネストすることでインライン表示（1行）に変更
- current / previous 両方のアニメーションテキストに同じ修正を適用

## Test plan
- [ ] 東京メトロ路線で直通運転ありの行き先を選択し、「○○線直通 ○○ゆき」が1行で表示されることを確認
- [ ] 直通なしの行き先で行き先テキストが正常に表示されることを確認
- [ ] 行き先切り替え時のフェードアニメーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ヘッダーに接続路線ラベルを表示するようになり、日本語表示時は専用スタイルで整列されます。
* **リファクタリング**
  * 表示とアニメーションの遷移処理を改善し、現在表示中と前回表示のテキストが一貫して正しくスタイル適用されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->