### PR TITLE
HeaderTokyoMetroの行き先表示改行デグレを修正

### DIFF
--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -205,7 +205,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
           <TrainTypeBox trainType={trainType} />
           {selectedBound && !firstStop ? (
             <View style={styles.boundWrapper}>
-              <RNAnimated.View
+              <RNAnimated.Text
                 style={[styles.boundTextContainer, { opacity: currentOpacity }]}
               >
                 <Text
@@ -218,8 +218,8 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                     : null}
                 </Text>
                 <Text style={styles.boundText}>{boundText}</Text>
-              </RNAnimated.View>
-              <RNAnimated.View
+              </RNAnimated.Text>
+              <RNAnimated.Text
                 style={[
                   styles.boundTextContainer,
                   { opacity: previousOpacity },
@@ -235,7 +235,7 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
                     : null}
                 </Text>
                 <Text style={styles.boundText}>{previousTexts.boundText}</Text>
-              </RNAnimated.View>
+              </RNAnimated.Text>
             </View>
           ) : null}
         </View>

--- a/src/components/HeaderTokyoMetro.tsx
+++ b/src/components/HeaderTokyoMetro.tsx
@@ -278,7 +278,10 @@ const HeaderTokyoMetro: React.FC<CommonHeaderProps> = (props) => {
               style={[styles.firstTextWrapper, { width: dim.width * 0.14 }]}
             >
               <RNAnimated.Text
-                style={[animation.stateTopAnimatedStylesRight, styles.firstText]}
+                style={[
+                  animation.stateTopAnimatedStylesRight,
+                  styles.firstText,
+                ]}
               >
                 {stateTextRight}
               </RNAnimated.Text>


### PR DESCRIPTION
## 概要
- HeaderTokyoMetroの行き先表示で、connectionTextとboundTextが2行に分かれるデグレを修正
- 行き先表示のアニメーションラッパーをRNAnimated.ViewからRNAnimated.Textへ戻し、masterと同等の1行表示に統一

## 影響範囲
- src/components/HeaderTokyoMetro.tsx

## 動作確認
- npm test -- --runInBand src/components/HeaderTokyoMetro.test.tsx
  - 13 tests passed