### PR TITLE
Gradle Configuration Cache互換のためbuild.gradleの.execute()をproviders.exec{}に置換

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,14 +10,26 @@ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
  * By default you don't need to apply any configuration, just uncomment the lines you need.
  */
 react {
-    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-    reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
-    codegenDir = new File(["node", "--print", "require.resolve('@react-native/codegen/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
+    entryFile = file(providers.exec {
+        commandLine("node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute")
+        workingDir(rootDir)
+    }.standardOutput.asText.get().trim())
+    reactNativeDir = new File(providers.exec {
+        commandLine("node", "--print", "require.resolve('react-native/package.json')")
+        workingDir(rootDir)
+    }.standardOutput.asText.get().trim()).getParentFile().getAbsoluteFile()
+    codegenDir = new File(providers.exec {
+        commandLine("node", "--print", "require.resolve('@react-native/codegen/package.json', { paths: [require.resolve('react-native/package.json')] })")
+        workingDir(rootDir)
+    }.standardOutput.asText.get().trim()).getParentFile().getAbsoluteFile()
 
     enableBundleCompression = (findProperty('android.enableBundleCompression') ?: false).toBoolean()
     // Use Expo CLI to bundle the app, this ensures the Metro config
     // works correctly with Expo projects.
-    cliFile = new File(["node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim())
+    cliFile = new File(providers.exec {
+        commandLine("node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })")
+        workingDir(rootDir)
+    }.standardOutput.asText.get().trim())
     bundleCommand = "export:embed"
 
     /* Folders */


### PR DESCRIPTION
https://claude.ai/code/session_018ZQRVpFTxVmDWFS3dFZgVs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * Androidビルド構成の内部メカニズムを改善しました。ビルドプロセスの効率性と信頼性を強化しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->