### PR TITLE
bump hermes-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10483,9 +10483,9 @@
       "license": "0BSD"
     },
     "node_modules/hermes-compiler": {
-      "version": "250829098.0.1",
-      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.1.tgz",
-      "integrity": "sha512-Nsg8kzc0CbVJXxXCeafNZmzBYFJyAMFWt/UJjz2BTlFCFTKLLc0Y/4eNA+vop7HP/lbBcjg+SVHSTqjC9lAByA==",
+      "version": "250829098.0.4",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.4.tgz",
+      "integrity": "sha512-8PEHLTuGOXUAnv2zByUG7Vud0TbU21fPuVqlMuek8PZgdYwb7KFWjw3+6In9J93Tx/6c/nRf5I30vzbaHBlgAQ==",
       "license": "MIT"
     },
     "node_modules/hermes-estree": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "react-native-skeleton-placeholder": {
       "@react-native-masked-view/masked-view": "0.3.2"
     },
-    "hermes-compiler": "250829098.0.1"
+    "hermes-compiler": "250829098.0.4"
   },
   "name": "trainlcd",
   "version": "10.2.1"


### PR DESCRIPTION
Error: `useHermesV1` requires setting the hermes-compiler version to 250829098.0.4 through resolutions. Found version "250829098.0.1" instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Hermes コンパイラーの依存関係をアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->