### PR TITLE
バージョンバンプスクリプトのiOS設定検出を修正

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -39,7 +39,6 @@ export default ({ config }: ConfigContext) => ({
       'expo-build-properties',
       {
         ios: {
-    buildNumber: '2509',
           buildReactNativeFromSource: true,
         },
       },
@@ -74,4 +73,3 @@ export default ({ config }: ConfigContext) => ({
   },
   owner: 'trainlcd',
 });
-

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -113,7 +113,7 @@ const updateAppConfig = (filePath, version, versionCode, iosBuildNumber) => {
     let iosStartIndex = -1;
     let iosEndIndex = -1;
     for (let i = 0; i < lines.length; i += 1) {
-      if (lines[i].includes('ios: {')) {
+      if (/^  ios:\s*\{/.test(lines[i])) {
         iosStartIndex = i;
         break;
       }


### PR DESCRIPTION
## Summary
- `scripts/bump-version.js` の iOS 設定ブロック検出を `includes('ios: {')` から正規表現 `/^  ios:\s*\{/` に変更し、`expo-build-properties` プラグイン内の `ios:` と誤マッチしないようにした
- `app.config.ts` から `expo-build-properties` の `ios` ブロック内に誤挿入されていた `buildNumber` を削除

## Test plan
- [x] `npm run typecheck` が通ること
- [x] canary リリースでバージョンバンプが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルド設定を最適化し、iOS ビルドナンバー設定の重複を削除しました。
  * バージョンバンプスクリプトの iOS セクション検出ロジックをより堅牢に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->