### PR TITLE
MAX_PERMIT_ACCURACYを4kmに戻した

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 5;
 export const LOCATION_TIME_INTERVAL = 3000;
 
-export const MAX_PERMIT_ACCURACY = 1000;
+export const MAX_PERMIT_ACCURACY = 4000;
 
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;


### PR DESCRIPTION
地下鉄で全く使えなくなったので、多少不安定でも動くように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 位置情報の精度許容値を拡張しました。より広い精度レベルでの位置情報処理が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->