### PR TITLE
メインウォークスルーに経路検索ステップを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -251,6 +251,8 @@
   "walkthroughDescription4": "You can change the display style to your preference, such as Tokyu Toyoko Line style or Saikyo Line style, by setting the theme.",
   "walkthroughTitle5": "Presets",
   "walkthroughDescription5": "Save your frequently used routes as presets. Saved routes appear here and can be quickly selected with a single tap.",
+  "walkthroughTitle6": "Route Search",
+  "walkthroughDescription6": "Tap here to go to the route search screen. Enter a destination station name to find the best route.",
   "walkthroughNext": "Next",
   "walkthroughStart": "Get Started",
   "walkthroughSkip": "Skip",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -252,6 +252,8 @@
   "walkthroughDescription4": "テーマ設定で東急東横線風や埼京線風など、お好みの表示スタイルに変更できます。",
   "walkthroughTitle5": "プリセット",
   "walkthroughDescription5": "よく使う路線をプリセットとして保存できます。保存した路線はここに表示され、タップするだけで素早く選択できます。",
+  "walkthroughTitle6": "経路検索",
+  "walkthroughDescription6": "ここから経路検索画面に移動できます。目的地の駅名を入力して、最適な経路を見つけましょう。",
   "walkthroughNext": "次へ",
   "walkthroughStart": "はじめる",
   "walkthroughSkip": "スキップ",

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -62,18 +62,32 @@ const styles = StyleSheet.create({
 type Props = {
   active?: FooterTab;
   visible?: boolean;
+  onSearchButtonLayout?: (layout: ButtonLayout) => void;
   onSettingsButtonLayout?: (layout: ButtonLayout) => void;
 };
 
 const FooterTabBar: React.FC<Props> = ({
   active = 'home',
   visible = true,
+  onSearchButtonLayout,
   onSettingsButtonLayout,
 }) => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const searchButtonRef = useRef<View>(null);
   const settingsButtonRef = useRef<View>(null);
+
+  const handleSearchButtonLayout = useCallback(
+    (_event: LayoutChangeEvent) => {
+      if (onSearchButtonLayout && searchButtonRef.current) {
+        searchButtonRef.current.measureInWindow((x, y, width, height) => {
+          onSearchButtonLayout({ x, y, width, height });
+        });
+      }
+    },
+    [onSearchButtonLayout]
+  );
 
   const handleSettingsButtonLayout = useCallback(
     (_event: LayoutChangeEvent) => {
@@ -111,11 +125,13 @@ const FooterTabBar: React.FC<Props> = ({
       >
         <View style={styles.content}>
           <Pressable
+            ref={searchButtonRef}
             style={styles.button}
             accessibilityRole="button"
             onPress={() => {
               navigation.navigate('RouteSearch' as never);
             }}
+            onLayout={handleSearchButtonLayout}
           >
             <Ionicons
               name={active === 'search' ? 'git-commit' : 'git-commit-outline'}

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -27,6 +27,7 @@ export type WalkthroughStepId =
   | 'changeLocation'
   | 'savedRoutes'
   | 'selectLine'
+  | 'routeSearch'
   | 'customize'
   | 'routeSearchIntro'
   | 'routeSearchBar'

--- a/src/hooks/useSelectLineWalkthrough.test.tsx
+++ b/src/hooks/useSelectLineWalkthrough.test.tsx
@@ -22,7 +22,7 @@ const createMockWalkthrough = (
     descriptionKey: 'walkthroughDescription1',
     tooltipPosition: 'bottom',
   },
-  totalSteps: 5,
+  totalSteps: 6,
   nextStep: mockNextStep,
   goToStep: mockGoToStep,
   skipWalkthrough: mockSkipWalkthrough,
@@ -42,7 +42,7 @@ describe('useSelectLineWalkthrough', () => {
     const { result } = renderHook(() => useSelectLineWalkthrough());
 
     expect(result.current.isWalkthroughActive).toBe(true);
-    expect(result.current.totalSteps).toBe(5);
+    expect(result.current.totalSteps).toBe(6);
     expect(result.current.currentStepIndex).toBe(0);
   });
 

--- a/src/hooks/useSelectLineWalkthrough.ts
+++ b/src/hooks/useSelectLineWalkthrough.ts
@@ -24,6 +24,8 @@ export const useSelectLineWalkthrough = () => {
     setSpotlightArea,
   } = useWalkthroughCompleted();
 
+  const [searchButtonLayout, setSearchButtonLayout] =
+    useState<ButtonLayout | null>(null);
   const [settingsButtonLayout, setSettingsButtonLayout] =
     useState<ButtonLayout | null>(null);
   const [nowHeaderLayout, setNowHeaderLayout] = useState<HeaderLayout | null>(
@@ -73,6 +75,19 @@ export const useSelectLineWalkthrough = () => {
     }
   }, [currentStepId, presetsLayout, setSpotlightArea]);
 
+  // 経路検索ボタンをハイライト
+  useEffect(() => {
+    if (currentStepId === 'routeSearch' && searchButtonLayout) {
+      setSpotlightArea({
+        x: searchButtonLayout.x,
+        y: searchButtonLayout.y,
+        width: searchButtonLayout.width,
+        height: searchButtonLayout.height,
+        borderRadius: 24,
+      });
+    }
+  }, [currentStepId, searchButtonLayout, setSpotlightArea]);
+
   // 設定ボタンをハイライト
   useEffect(() => {
     if (currentStepId === 'customize' && settingsButtonLayout) {
@@ -114,6 +129,7 @@ export const useSelectLineWalkthrough = () => {
     nextStep,
     goToStep,
     skipWalkthrough,
+    setSearchButtonLayout,
     setSettingsButtonLayout,
     setNowHeaderLayout,
     lineListRef,

--- a/src/hooks/useWalkthroughCompleted.test.tsx
+++ b/src/hooks/useWalkthroughCompleted.test.tsx
@@ -102,6 +102,13 @@ describe('useWalkthroughCompleted', () => {
       });
 
       expect(result.current.currentStepIndex).toBe(4);
+      expect(result.current.currentStepId).toBe('routeSearch');
+
+      act(() => {
+        result.current.nextStep();
+      });
+
+      expect(result.current.currentStepIndex).toBe(5);
       expect(result.current.currentStepId).toBe('customize');
     });
 
@@ -117,7 +124,7 @@ describe('useWalkthroughCompleted', () => {
 
       // 最後のステップまで進む
       act(() => {
-        result.current.goToStep(4);
+        result.current.goToStep(5);
       });
 
       expect(result.current.currentStepId).toBe('customize');
@@ -295,7 +302,14 @@ describe('useWalkthroughCompleted', () => {
       expect(result.current.currentStep?.id).toBe('savedRoutes');
       expect(result.current.currentStep?.titleKey).toBe('walkthroughTitle5');
 
-      // Step 4: customize
+      // Step 4: routeSearch
+      act(() => {
+        result.current.nextStep();
+      });
+      expect(result.current.currentStep?.id).toBe('routeSearch');
+      expect(result.current.currentStep?.titleKey).toBe('walkthroughTitle6');
+
+      // Step 5: customize
       act(() => {
         result.current.nextStep();
       });
@@ -312,7 +326,7 @@ describe('useWalkthroughCompleted', () => {
         expect(result.current.isWalkthroughActive).toBe(true);
       });
 
-      expect(result.current.totalSteps).toBe(5);
+      expect(result.current.totalSteps).toBe(6);
     });
   });
 
@@ -332,7 +346,7 @@ describe('useWalkthroughCompleted', () => {
 
       // 最後のステップに移動してnextStepを呼ぶ
       act(() => {
-        result.current.goToStep(4);
+        result.current.goToStep(5);
       });
 
       await act(async () => {

--- a/src/hooks/useWalkthroughCompleted.ts
+++ b/src/hooks/useWalkthroughCompleted.ts
@@ -32,6 +32,12 @@ const WALKTHROUGH_STEPS: WalkthroughStep[] = [
     tooltipPosition: 'bottom',
   },
   {
+    id: 'routeSearch',
+    titleKey: 'walkthroughTitle6',
+    descriptionKey: 'walkthroughDescription6',
+    tooltipPosition: 'top',
+  },
+  {
     id: 'customize',
     titleKey: 'walkthroughTitle4',
     descriptionKey: 'walkthroughDescription4',

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -105,6 +105,7 @@ const SelectLineScreen = () => {
     nextStep,
     goToStep,
     skipWalkthrough,
+    setSearchButtonLayout,
     setSettingsButtonLayout,
     setNowHeaderLayout,
     lineListRef,
@@ -381,6 +382,7 @@ const SelectLineScreen = () => {
       {/* フッター */}
       <FooterTabBar
         active="home"
+        onSearchButtonLayout={setSearchButtonLayout}
         onSettingsButtonLayout={setSettingsButtonLayout}
       />
       {/* モーダル */}


### PR DESCRIPTION
## Summary
- メインウォークスルー（SelectLineScreen）のプリセットとカスタマイズの間に「経路検索」ステップを追加
- FooterTabBarの経路検索ボタンをスポットライトでハイライトし、経路検索画面への導線を案内
- ステップ順: welcome → changeLocation → selectLine → savedRoutes → **routeSearch** → customize（計6ステップ）

## 変更内容
- `WalkthroughStepId` に `routeSearch` を追加
- `WALKTHROUGH_STEPS` に新ステップを挿入
- `FooterTabBar` に `onSearchButtonLayout` prop を追加し、検索ボタンの位置計測に対応
- `useSelectLineWalkthrough` で `routeSearch` ステップのスポットライト処理を追加
- 翻訳キー `walkthroughTitle6` / `walkthroughDescription6` を日英両方に追加
- テストを更新（ステップ数 5→6、新ステップの検証追加）

## Test plan
- [ ] `npm run typecheck` パス済み
- [ ] `npm test -- --testPathPattern="useWalkthroughCompleted|useSelectLineWalkthrough"` パス済み（18テスト全通過）
- [ ] SelectLineScreen でウォークスルーを実行し、プリセット→経路検索→カスタマイズの順で表示されることを確認
- [ ] 経路検索ステップでFooterBarの検索ボタンがスポットライトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプリケーションのウォークスルー（チュートリアル）に「経路検索」に関する新しいステップを追加。ユーザーが経路検索機能の使用方法を学習できるようになりました。目的地の駅名を入力して最適な経路を検索する手順が案内されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->