### PR TITLE
テレメトリーログの機密情報サニタイズとconsole.warn/errorの保持

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,7 @@ module.exports = function (api) {
     ],
     env: {
       production: {
-        plugins: ["transform-remove-console"],
+        plugins: [["transform-remove-console", { exclude: ["warn", "error"] }]],
       },
     },
   };

--- a/src/hooks/useConsoleTelemetry.enabled.test.tsx
+++ b/src/hooks/useConsoleTelemetry.enabled.test.tsx
@@ -179,6 +179,28 @@ describe('useConsoleTelemetry (enabled)', () => {
     unmount();
   });
 
+  test('should redact sensitive token-like values before sending', async () => {
+    const { unmount } = renderHook(() =>
+      useConsoleTelemetry('https://example.com', 'test-token')
+    );
+
+    console.error('Authorization: Bearer my-super-secret-token');
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const logCalls = mockFetch.mock.calls.filter(
+      (call: any[]) => call[0] === 'https://example.com/api/log'
+    );
+    expect(logCalls.length).toBeGreaterThanOrEqual(1);
+    const body = JSON.parse(logCalls[0][1].body);
+    expect(body.log.message).toContain('[REDACTED]');
+    expect(body.log.message).not.toContain('my-super-secret-token');
+
+    unmount();
+  });
+
   test('should include Authorization header', async () => {
     const { unmount } = renderHook(() =>
       useConsoleTelemetry('https://example.com', 'my-secret-token')

--- a/src/hooks/useConsoleTelemetry.ts
+++ b/src/hooks/useConsoleTelemetry.ts
@@ -6,6 +6,7 @@ import {
 } from 'react-native-dotenv';
 import { z } from 'zod';
 import { TELEMETRY_MAX_QUEUE_SIZE } from '~/constants/telemetry';
+import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import { useTelemetryEnabled } from './useTelemetryEnabled';
 
 const LogRequest = z.object({
@@ -63,7 +64,7 @@ export const useConsoleTelemetry = (
       if (isFlushingRef.current) {
         return;
       }
-      const message = formatArgs(args);
+      const message = sanitizeTelemetryMessage(formatArgs(args));
       if (!message) {
         return;
       }

--- a/src/hooks/useTelemetrySender.enabled.test.tsx
+++ b/src/hooks/useTelemetrySender.enabled.test.tsx
@@ -182,6 +182,33 @@ describe('useTelemetrySender', () => {
     );
   });
 
+  test('should redact sensitive token-like values in telemetry payload', async () => {
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendLog('token=abc123-secret-value', 'error');
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        expect(mockFetch).toHaveBeenCalled();
+        const calls = mockFetch.mock.calls;
+        const logCall = calls.find((call: any[]) => {
+          return call[0] === 'https://example.com/api/log';
+        });
+        expect(logCall).toBeDefined();
+        const body = JSON.parse(logCall[1].body);
+        expect(body.log.message).toContain('token=[REDACTED]');
+        expect(body.log.message).not.toContain('abc123-secret-value');
+      },
+      { timeout: 2000 }
+    );
+  });
+
   test('should not send log if telemetry is disabled', async () => {
     (useTelemetryEnabled as jest.Mock).mockReturnValue(false);
 

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -9,11 +9,11 @@ import {
 import { z } from 'zod';
 import { TELEMETRY_THROTTLE_MS } from '~/constants/telemetry';
 import { locationAtom } from '~/store/atoms/location';
-import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import {
   type GnssState,
   subscribeGnss,
 } from '~/utils/native/android/gnssModule';
+import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import stationState from '../store/atoms/station';
 import { useCurrentLine } from './useCurrentLine';
 import { useCurrentStation } from './useCurrentStation';

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -9,6 +9,7 @@ import {
 import { z } from 'zod';
 import { TELEMETRY_THROTTLE_MS } from '~/constants/telemetry';
 import { locationAtom } from '~/store/atoms/location';
+import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import {
   type GnssState,
   subscribeGnss,
@@ -113,7 +114,7 @@ export const useTelemetrySender = (
         log: {
           type: 'app',
           level,
-          message,
+          message: sanitizeTelemetryMessage(message),
         },
       });
 

--- a/src/utils/sanitizeTelemetryMessage.ts
+++ b/src/utils/sanitizeTelemetryMessage.ts
@@ -1,10 +1,7 @@
 const MAX_TELEMETRY_MESSAGE_LENGTH = 2000;
 
 const TELEMETRY_REDACTIONS: Array<[RegExp, string]> = [
-  [
-    /\b(Authorization["']?\s*[:=]\s*["']?Bearer\s+)[^\s"']+/gi,
-    '$1[REDACTED]',
-  ],
+  [/\b(Authorization["']?\s*[:=]\s*["']?Bearer\s+)[^\s"']+/gi, '$1[REDACTED]'],
   [/\b(Bearer\s+)[A-Za-z0-9\-._~+/]+=*/g, '$1[REDACTED]'],
   [
     /(\b(?:idToken|accessToken|refreshToken|token|apiKey|secret|password|authorization)\b["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi,
@@ -43,4 +40,3 @@ export const sanitizeTelemetryMessage = (value: unknown): string => {
 
   return `${redacted.slice(0, MAX_TELEMETRY_MESSAGE_LENGTH)}...<truncated>`;
 };
-

--- a/src/utils/sanitizeTelemetryMessage.ts
+++ b/src/utils/sanitizeTelemetryMessage.ts
@@ -1,0 +1,46 @@
+const MAX_TELEMETRY_MESSAGE_LENGTH = 2000;
+
+const TELEMETRY_REDACTIONS: Array<[RegExp, string]> = [
+  [
+    /\b(Authorization["']?\s*[:=]\s*["']?Bearer\s+)[^\s"']+/gi,
+    '$1[REDACTED]',
+  ],
+  [/\b(Bearer\s+)[A-Za-z0-9\-._~+/]+=*/g, '$1[REDACTED]'],
+  [
+    /(\b(?:idToken|accessToken|refreshToken|token|apiKey|secret|password|authorization)\b["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi,
+    '$1[REDACTED]',
+  ],
+  [
+    /([?&](?:token|access_token|refresh_token|api_key|code|signature)=)[^&\s]+/gi,
+    '$1[REDACTED]',
+  ],
+];
+
+const stringify = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const sanitizeTelemetryMessage = (value: unknown): string => {
+  const raw = stringify(value);
+  const redacted = TELEMETRY_REDACTIONS.reduce(
+    (acc, [pattern, replacement]) => acc.replace(pattern, replacement),
+    raw
+  );
+
+  if (redacted.length <= MAX_TELEMETRY_MESSAGE_LENGTH) {
+    return redacted;
+  }
+
+  return `${redacted.slice(0, MAX_TELEMETRY_MESSAGE_LENGTH)}...<truncated>`;
+};
+

--- a/src/utils/sanitizeTelemetryMessage.ts
+++ b/src/utils/sanitizeTelemetryMessage.ts
@@ -21,7 +21,8 @@ const stringify = (value: unknown): string => {
     return `${value.name}: ${value.message}`;
   }
   try {
-    return JSON.stringify(value);
+    const json = JSON.stringify(value);
+    return json ?? String(value);
   } catch {
     return String(value);
   }
@@ -38,5 +39,6 @@ export const sanitizeTelemetryMessage = (value: unknown): string => {
     return redacted;
   }
 
-  return `${redacted.slice(0, MAX_TELEMETRY_MESSAGE_LENGTH)}...<truncated>`;
+  const suffix = '...<truncated>';
+  return `${redacted.slice(0, MAX_TELEMETRY_MESSAGE_LENGTH - suffix.length)}${suffix}`;
 };


### PR DESCRIPTION
## Summary
- リリースビルドで `console.warn` / `console.error` を除去せず保持するよう `babel.config.js` を変更
- テレメトリー送信前にトークン・パスワード・APIキー等の機密情報を `[REDACTED]` に置換する `sanitizeTelemetryMessage` ユーティリティを追加
- `useConsoleTelemetry` / `useTelemetrySender` の両フックでサニタイズを適用
- 長すぎるメッセージの自動切り詰め（2000文字上限）

## Test plan
- [x] `useConsoleTelemetry` の機密情報リダクションテストを追加
- [x] `useTelemetrySender` の機密情報リダクションテストを追加
- [x] `npm run lint` / `npm test` / `npm run typecheck` の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * テレメトリーログ内の認可トークンやAPIキー等の機密情報が自動的にマスクされるようになりました（送信前に文字列をサニタイズ）。

* **新機能**
  * 長さ制限と切り詰めを含むログメッセージのサニタイズ処理を導入しました。

* **テスト**
  * 機密値がマスクされることを検証するテストを追加しました。

* **変更**
  * 本番環境でのコンソール処理を調整し、警告とエラーは保持されその他は除去されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->