### PR TITLE
phonemeタグにxml:lang属性を追加してTTSの日本語発音を改善

### DIFF
--- a/src/utils/ssml.ts
+++ b/src/utils/ssml.ts
@@ -21,7 +21,7 @@ export const wrapIpa = (
   if (!nameIpa) {
     return nameRoman;
   }
-  return `<phoneme alphabet="ipa" ph="${escapeXml(nameIpa)}">${escapeXml(nameRoman)}</phoneme>`;
+  return `<phoneme alphabet="ipa" ph="${escapeXml(nameIpa)}" xml:lang="ja-JP">${escapeXml(nameRoman)}</phoneme>`;
 };
 
 export class SSMLBuilder {


### PR DESCRIPTION
## Summary
- `wrapIpa` が生成する `<phoneme>` タグに `xml:lang="ja-JP"` 属性を追加
- en-USボイスで英語表記の駅名（例: Kasai Rinkai Park）を読み上げる際、IPAが日本語の音素体系として解釈されるようにヒントを付与
- ローマ字表記と日本語表記が異なる駅名（葛西臨海公園 / Kasai Rinkai Park 等）で正しい日本語発音が得られることを期待

## Test plan
- [ ] `npm test` パス確認済み
- [ ] 実機でTTS再生し、日本語駅名の発音が改善されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 音声合成における言語タグの指定精度を改善しました。日本語コンテンツの処理がより正確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->