### PR TITLE
normalizeRomanTextでSSMLタグが破壊される問題を修正

### DIFF
--- a/functions/src/utils/normalize.test.ts
+++ b/functions/src/utils/normalize.test.ts
@@ -13,4 +13,24 @@ describe('utils/normalize.ts', () => {
   it.each(['Tokyo', 'tOkyo'])('text: %s', (text) => {
     expect(normalizeRomanText(text)).toBe('Tokyo');
   });
+
+  it('should not modify SSML/XML tags', () => {
+    expect(
+      normalizeRomanText(
+        '<phoneme alphabet="ipa" ph="çɯɯga" xml:lang="ja-JP">HYUGA</phoneme>'
+      )
+    ).toBe(
+      '<phoneme alphabet="ipa" ph="çɯɯga" xml:lang="ja-JP">Hyuga</phoneme>'
+    );
+  });
+
+  it('should handle mixed text and SSML tags', () => {
+    expect(
+      normalizeRomanText(
+        'The next stop is <phoneme alphabet="ipa" ph="naɾɯtoː" xml:lang="ja-JP">NARUTO</phoneme>.'
+      )
+    ).toBe(
+      'The next stop is <phoneme alphabet="ipa" ph="naɾɯtoː" xml:lang="ja-JP">Naruto</phoneme>.'
+    );
+  });
 });

--- a/functions/src/utils/normalize.ts
+++ b/functions/src/utils/normalize.ts
@@ -1,16 +1,25 @@
 import { removeMacron } from './removeMacron';
 
+const capitalizeSegment = (seg: string): string =>
+  /[A-Z]/.test(seg)
+    ? seg.charAt(0).toUpperCase() + seg.slice(1).toLowerCase()
+    : seg;
+
 export const normalizeRomanText = (str: string | undefined): string => {
   if (!str) return '';
 
+  // XMLタグを保護しつつテキスト部分のみ正規化する
   const replaced = str
-    .split(' ')
-    .map((seg) =>
-      /[A-Z]/.test(seg)
-        ? seg.charAt(0).toUpperCase() + seg.slice(1).toLowerCase()
-        : seg
+    .split(/(<[^>]+>)/g)
+    .map((part) =>
+      part.startsWith('<')
+        ? part
+        : part
+            .split(' ')
+            .map((seg) => capitalizeSegment(seg))
+            .join(' ')
     )
-    .join(' ');
+    .join('');
 
   return removeMacron(replaced.replace('Jr', 'J-R'));
 };


### PR DESCRIPTION
## Summary
- `normalizeRomanText`がSSML文字列全体をスペース区切りで正規化していたため、`xml:lang`が`Xml:lang`に変換され、`<phoneme>`タグ内の駅名が小文字化される問題を修正
- XMLタグ部分とテキスト部分を分離し、テキスト部分のみに大文字小文字の正規化を適用するように変更
- SSMLタグ保護のテストケースを追加

## Test plan
- [x] `npx jest src/utils/normalize.test.ts` 全5件パス
- [ ] canaryビルドでTTS音声の発音が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * テキスト正規化機能を改善し、XML/SSMLタグを含むテキスト処理時にタグを保持しながらテキスト内容を適切に正規化するようになりました。

* **テスト**
  * XML/SSMLタグを含むテキスト処理の検証テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->