### PR TITLE
英語TTSのプロンプト・CPU設定を調整し駅ナンバリングの発音を修正

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -23,7 +23,7 @@ const googleTtsApiKey = defineSecret('GOOGLE_TTS_API_KEY');
 const GEMINI_TTS_MODEL = 'gemini-2.5-flash-tts';
 const VERTEX_AI_LOCATION = 'us-central1';
 const GOOGLE_TTS_API_VERSION = 'v1';
-const EN_GEMINI_VOLUME_BOOST_DB = 8;
+const EN_GEMINI_VOLUME_BOOST_DB = 6;
 
 interface SynthesizedAudio {
   audioContent: string;
@@ -79,6 +79,26 @@ const ensureMp3 = async (
   return encodePcmToMp3(audioBuffer, undefined, volumeDb);
 };
 
+/** 0〜99 の整数を英単語に変換する */
+const numberToEnglishWord = (n: number): string => {
+  const ones = [
+    'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
+    'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
+    'sixteen', 'seventeen', 'eighteen', 'nineteen',
+  ];
+  const tens = [
+    '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy',
+    'eighty', 'ninety',
+  ];
+  if (n < 20) return ones[n] ?? String(n);
+  if (n < 100) {
+    const t = Math.floor(n / 10);
+    const o = n % 10;
+    return (tens[t] ?? '') + (o ? `-${ones[o]}` : '');
+  }
+  return String(n);
+};
+
 /** SSMLタグを除去してプレーンテキストに変換する（<sub alias="X">Y</sub> → Y（X）） */
 const stripSsml = (text: string): string =>
   text
@@ -86,6 +106,10 @@ const stripSsml = (text: string): string =>
       /<sub\s+alias="([^"]*)">([^<]*)<\/sub>/gi,
       (_match, alias, original) =>
         original === alias ? alias : `${original}（${alias}）`
+    )
+    .replace(
+      /<say-as\s+interpret-as="cardinal">(\d+)<\/say-as>/gi,
+      (_match, num) => numberToEnglishWord(Number(num))
     )
     .replace(/<break\s*[^/]*\/>/gi, ' ')
     .replace(/<speak>|<\/speak>/gi, '')
@@ -200,7 +224,7 @@ const synthesizeWithGoogleTts = async (
 };
 
 export const tts = onCall(
-  { region: 'asia-northeast1', secrets: [googleTtsApiKey] },
+  { region: 'asia-northeast1', cpu: 2, secrets: [googleTtsApiKey] },
   async (req) => {
     if (!req.auth) {
       throw new HttpsError(
@@ -345,7 +369,7 @@ export const tts = onCall(
           projectId,
           ssmlEn,
           enVoiceName,
-          'Read the following at a brisk, quick pace like a train announcement. The text contains Japanese railway station names and line names in romanized form. Pronounce them accurately:'
+          'Read the following in a calm, clear, and composed tone like a modern train announcement. Speak quickly and crisply with a swift, efficient delivery — do not linger on words or pause unnecessarily. Maintain a steady, relaxed intonation despite the fast pace. The text contains Japanese railway station names and line names in romanized form. Pronounce them accurately:'
         ),
       ]);
 

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -129,7 +129,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -141,7 +141,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -156,7 +156,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -168,7 +168,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at Shinjuku-sanchome S 2. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
   });
@@ -183,7 +183,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -195,7 +195,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -210,7 +210,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -222,7 +222,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、次は、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon be making a brief stop at Shinjuku-sanchome station number S 2. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
+        'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
       ]);
     });
   });
@@ -237,7 +237,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -249,7 +249,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -264,7 +264,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。 <sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。この電車は、各駅停車、<sub alias="もとやわた">本八幡</sub>ゆきです。',
-        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -276,7 +276,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'We will soon be arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -291,7 +291,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -311,7 +311,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 日本語: 期待される英語SSML出力を検証
       expect(en).toBe(
-        'Arriving at Shinjuku-sanchome S 2. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.'
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.'
       );
 
       // 日本語: 英語SSMLに日本語文字（ひらがな・カタカナ・漢字）が含まれていないことを厳密に検証
@@ -322,7 +322,7 @@ describe('Without trainType & With numbering', () => {
       expect(en).toHaveLength(en.length);
 
       // 日本語: 英語SSMLに駅番号（例: S 2 や station number S 2 など）が含まれていることを検証
-      const stationNumberRegex = /(S \d{1,2}|station number S ?\d{1,2})/;
+      const stationNumberRegex = /(S <say-as interpret-as="cardinal">\d{1,2}<\/say-as>|station number S ?<say-as interpret-as="cardinal">\d{1,2}<\/say-as>)/;
       expect(en).toMatch(stationNumberRegex);
     });
   });

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -322,7 +322,8 @@ describe('Without trainType & With numbering', () => {
       expect(en).toHaveLength(en.length);
 
       // 日本語: 英語SSMLに駅番号（例: S 2 や station number S 2 など）が含まれていることを検証
-      const stationNumberRegex = /(S <say-as interpret-as="cardinal">\d{1,2}<\/say-as>|station number S ?<say-as interpret-as="cardinal">\d{1,2}<\/say-as>)/;
+      const stationNumberRegex =
+        /(S <say-as interpret-as="cardinal">\d{1,2}<\/say-as>|station number S ?<say-as interpret-as="cardinal">\d{1,2}<\/say-as>)/;
       expect(en).toMatch(stationNumberRegex);
     });
   });

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -188,15 +188,15 @@ export const useTTSText = (
       return '';
     }
     if (split.length === 1) {
-      return `${theme === APP_THEME.JR_WEST ? '' : 'Station Number '}${Number(
+      return `${theme === APP_THEME.JR_WEST ? '' : 'Station Number '}<say-as interpret-as="cardinal">${Number(
         nextStationNumber.stationNumber
-      )}`;
+      )}</say-as>`;
     }
 
     const symbol = split[0]?.split('').join(' ');
     const num = split[2]
-      ? `${Number(split[1])}-${Number(split[2])}`
-      : Number(split[1]).toString();
+      ? `<say-as interpret-as="cardinal">${Number(split[1])}</say-as>-<say-as interpret-as="cardinal">${Number(split[2])}</say-as>`
+      : `<say-as interpret-as="cardinal">${Number(split[1])}</say-as>`;
 
     return `${
       nextStationNumber.lineSymbol?.length || theme === APP_THEME.JR_WEST


### PR DESCRIPTION
## Summary
- 英語TTSのプロンプトを落ち着いた口調かつ早口めに更新
- tts関数のCPUを2コアに設定
- `EN_GEMINI_VOLUME_BOOST_DB` を8dBから6dBに戻す
- 駅ナンバリングの数字を `<say-as interpret-as="cardinal">` SSMLタグで囲み、1文字ずつではなく数値として発音されるように修正
- Gemini TTS用の `stripSsml` に `<say-as>` タグのハンドリングを追加（数字を英単語に変換）

## Test plan
- [ ] 英語TTSの発音が落ち着いた口調かつ早口めになっていることを確認
- [ ] 駅ナンバリング（例: JY-12）の数字が "twelve" と発音されることを確認
- [ ] 各テーマでの英語TTS再生が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正・改善**
  * 英語の数字が音声でより自然な語として発音されるようになりました（SSMLによる明示的な読み上げ対応）。
  * 音声の出力音量を調整し、より適切な出力品質を実現しました。
  * 落ち着きのある、クリアで現代的なアナウンス調に改善。より速く、キレのある発話で不要な間を削減しました。

* **パフォーマンス最適化**
  * 音声生成の処理リソース配分を見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->