### PR TITLE
再訪駅でTTS再生が抑制される不具合を修正

### DIFF
--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -143,8 +143,10 @@ export const useTTS = (): void => {
         return;
       }
 
-      firstSpeechRef.current = false;
-      suppressPostFirstSpeechRef.current = true;
+      if (firstSpeechRef.current) {
+        firstSpeechRef.current = false;
+        suppressPostFirstSpeechRef.current = true;
+      }
 
       cleanupAllPlayers();
 


### PR DESCRIPTION
speakFromPathが毎回suppressPostFirstSpeechRefをtrueに設定していたため、
Reactのステート更新バッチ処理によりstoppingStateが変化しないまま
テキストが更新されるケースでTTS再生が誤って抑制されていた。
suppressPostFirstSpeechRefの設定をfirstSpeechRefがtrueの場合のみに限定し、
初回放送後のテキスト変化抑制のみに正しく機能するよう修正。

https://claude.ai/code/session_01SPLM9x5YFrttZaJ61jktxA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * テキスト音声読み上げ機能の内部ロジックを最適化し、不要な再処理を削減しました。ユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->