### PR TITLE
パフォーマンス改善: 不要な再計算とレンダーを削減

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import type React from 'react';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { Path, Svg } from 'react-native-svg';
@@ -122,47 +122,44 @@ type SubtitleProps = {
   loading?: boolean;
 };
 
-const Subtitle = ({
-  inboundText,
-  outboundText,
-  numberOfLines,
-  loading,
-}: SubtitleProps) => {
-  if (loading) {
+const Subtitle = memo(
+  ({ inboundText, outboundText, numberOfLines, loading }: SubtitleProps) => {
+    if (loading) {
+      return (
+        <View style={styles.subtitleContainer}>
+          <SkeletonPlaceholder borderRadius={1} speed={1500}>
+            <SkeletonPlaceholder.Item opacity={0.9} width={60} height={12} />
+          </SkeletonPlaceholder>
+        </View>
+      );
+    }
+
     return (
       <View style={styles.subtitleContainer}>
-        <SkeletonPlaceholder borderRadius={1} speed={1500}>
-          <SkeletonPlaceholder.Item opacity={0.9} width={60} height={12} />
-        </SkeletonPlaceholder>
+        {inboundText ? (
+          <Typography style={styles.subtitle} numberOfLines={numberOfLines}>
+            {inboundText}
+          </Typography>
+        ) : null}
+        {inboundText && outboundText ? (
+          <Svg width={16} height={16} viewBox="0 0 24 24" style={styles.arrow}>
+            <Path
+              d="M5 12h14M5 12l3-3M5 12l3 3M19 12l-3-3M19 12l-3 3"
+              fill="none"
+              stroke="#fff"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </Svg>
+        ) : null}
+        {outboundText ? (
+          <Typography style={styles.subtitle}>{outboundText}</Typography>
+        ) : null}
       </View>
     );
   }
-
-  return (
-    <View style={styles.subtitleContainer}>
-      {inboundText ? (
-        <Typography style={styles.subtitle} numberOfLines={numberOfLines}>
-          {inboundText}
-        </Typography>
-      ) : null}
-      {inboundText && outboundText ? (
-        <Svg width={16} height={16} viewBox="0 0 24 24" style={styles.arrow}>
-          <Path
-            d="M5 12h14M5 12l3-3M5 12l3 3M19 12l-3-3M19 12l-3 3"
-            fill="none"
-            stroke="#fff"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </Svg>
-      ) : null}
-      {outboundText ? (
-        <Typography style={styles.subtitle}>{outboundText}</Typography>
-      ) : null}
-    </View>
-  );
-};
+);
 
 export const CommonCard: React.FC<Props> = ({
   line,
@@ -215,6 +212,11 @@ export const CommonCard: React.FC<Props> = ({
   const targetStationColor =
     targetStation?.stationNumbers?.[0]?.lineSymbolColor;
   const targetStationThreeLetterCode = targetStation?.threeLetterCode;
+
+  const titleParts = useMemo(
+    () => titleOrLineName.split(/(\([^)]*\))/),
+    [titleOrLineName]
+  );
 
   const additionalRootStyle = useMemo(
     () => ({
@@ -291,10 +293,10 @@ export const CommonCard: React.FC<Props> = ({
       )}
       <View style={styles.texts}>
         <Typography style={styles.title} numberOfLines={1}>
-          {titleOrLineName.split(/(\([^)]*\))/).map((part, index, parts) =>
+          {titleParts.map((part, index) =>
             /^\(.*\)$/.test(part) ? (
               <Typography key={`${index}-${part}`} style={styles.titleParens}>
-                {index > 0 && !/\s$/.test(parts[index - 1] ?? '')
+                {index > 0 && !/\s$/.test(titleParts[index - 1] ?? '')
                   ? ` ${part}`
                   : part}
               </Typography>

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useAtomValue } from 'jotai';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   type LayoutChangeEvent,
   Platform,
@@ -23,6 +23,11 @@ export type ButtonLayout = {
   width: number;
   height: number;
 };
+
+const ICON_COLOR = {
+  active: '#0A84FF',
+  inactive: '#6B7280', // gray-500 相当
+} as const;
 
 const styles = StyleSheet.create({
   container: {
@@ -100,14 +105,6 @@ const FooterTabBar: React.FC<Props> = ({
     [onSettingsButtonLayout]
   );
 
-  const iconColor = useMemo(
-    () => ({
-      active: '#0A84FF',
-      inactive: '#6B7280', // gray-500 相当
-    }),
-    []
-  );
-
   if (!visible) return null;
 
   const safePad = Math.max(insets.bottom, Platform.OS === 'android' ? 8 : 0);
@@ -137,7 +134,7 @@ const FooterTabBar: React.FC<Props> = ({
               name={active === 'search' ? 'git-commit' : 'git-commit-outline'}
               size={26}
               color={
-                active === 'search' ? iconColor.active : iconColor.inactive
+                active === 'search' ? ICON_COLOR.active : ICON_COLOR.inactive
               }
             />
           </Pressable>
@@ -152,7 +149,9 @@ const FooterTabBar: React.FC<Props> = ({
             <Ionicons
               name={active === 'home' ? 'navigate' : 'navigate-outline'}
               size={28}
-              color={active === 'home' ? iconColor.active : iconColor.inactive}
+              color={
+                active === 'home' ? ICON_COLOR.active : ICON_COLOR.inactive
+              }
             />
           </Pressable>
 
@@ -169,7 +168,7 @@ const FooterTabBar: React.FC<Props> = ({
               name={active === 'settings' ? 'settings' : 'settings-outline'}
               size={26}
               color={
-                active === 'settings' ? iconColor.active : iconColor.inactive
+                active === 'settings' ? ICON_COLOR.active : ICON_COLOR.inactive
               }
             />
           </Pressable>

--- a/src/components/PadLineMarks.tsx
+++ b/src/components/PadLineMarks.tsx
@@ -84,6 +84,25 @@ const PadLineMarks: React.FC<Props> = ({
 
   const isDifferentStationName = useIsDifferentStationName();
 
+  const lineLabels = useMemo(
+    () =>
+      transferLines.map((tl) => {
+        const name = isEn
+          ? tl.nameRoman?.replace(parenthesisRegexp, '')
+          : tl.nameShort?.replace(parenthesisRegexp, '');
+        const diff = isDifferentStationName(station, tl);
+        const suffix = diff
+          ? `\n[ ${
+              isEn
+                ? tl.station?.nameRoman?.replace(parenthesisRegexp, '')
+                : tl.station?.name?.replace(parenthesisRegexp, '')
+            } ]`
+          : '';
+        return `${name}${suffix}`;
+      }),
+    [transferLines, isEn, isDifferentStationName, station]
+  );
+
   const { heightScale } = useScale();
 
   if (!isTablet) {
@@ -128,31 +147,7 @@ const PadLineMarks: React.FC<Props> = ({
                   },
                 ]}
               >
-                {`${
-                  isEn
-                    ? transferLines[i]?.nameRoman?.replace(
-                        parenthesisRegexp,
-                        ''
-                      )
-                    : transferLines[i]?.nameShort?.replace(
-                        parenthesisRegexp,
-                        ''
-                      )
-                }${
-                  isDifferentStationName(station, transferLines[i])
-                    ? `\n[ ${
-                        isEn
-                          ? transferLines[i]?.station?.nameRoman?.replace(
-                              parenthesisRegexp,
-                              ''
-                            )
-                          : transferLines[i]?.station?.name?.replace(
-                              parenthesisRegexp,
-                              ''
-                            )
-                      } ]`
-                    : ''
-                }`}
+                {lineLabels[i]}
               </Typography>
             </View>
           </View>

--- a/src/components/PresetCard.tsx
+++ b/src/components/PresetCard.tsx
@@ -184,6 +184,27 @@ const PresetCardBase: React.FC<Props> = ({ title, from, to }) => {
       : (rightLine.nameRoman ?? rightLine.nameShort ?? null);
   })();
 
+  const leftCodeRendered = useMemo(
+    () =>
+      renderTextWithSmallerParens(
+        leftCode,
+        styles.stationCode,
+        styles.stationCodeParen,
+        metaFg
+      ),
+    [leftCode, metaFg]
+  );
+  const rightCodeRendered = useMemo(
+    () =>
+      renderTextWithSmallerParens(
+        rightCode,
+        styles.stationCode,
+        styles.stationCodeParen,
+        metaFg
+      ),
+    [rightCode, metaFg]
+  );
+
   if (!from || !to)
     return (
       <NoPresetsCard
@@ -270,12 +291,7 @@ const PresetCardBase: React.FC<Props> = ({ title, from, to }) => {
             {leftName}
           </Typography>
           <Typography style={[styles.stationCode, { color: metaFg }]}>
-            {renderTextWithSmallerParens(
-              leftCode,
-              styles.stationCode,
-              styles.stationCodeParen,
-              metaFg
-            )}
+            {leftCodeRendered}
           </Typography>
         </View>
         <View style={styles.colCenter}>
@@ -300,12 +316,7 @@ const PresetCardBase: React.FC<Props> = ({ title, from, to }) => {
             {rightName}
           </Typography>
           <Typography style={[styles.stationCode, { color: metaFg }]}>
-            {renderTextWithSmallerParens(
-              rightCode,
-              styles.stationCode,
-              styles.stationCodeParen,
-              metaFg
-            )}
+            {rightCodeRendered}
           </Typography>
         </View>
       </View>

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -103,20 +103,31 @@ export const RouteInfoModal = ({
     ? (trainType?.name ?? '普通/各駅停車')
     : (trainType?.nameRoman ?? 'Local');
 
+  const stationSubtitles = useMemo(
+    () =>
+      new Map(
+        stations.map((item) => {
+          const lines = filterBusLinesForNonBusStation(item.line, item.lines);
+          const subtitle = Array.from(
+            new Set(
+              (lines ?? [])
+                .map((l) => getLocalizedLineName(l, isJapanese))
+                .filter(Boolean)
+            )
+          ).join(isJapanese ? ' ' : ', ');
+          return [item.id, subtitle];
+        })
+      ),
+    [stations]
+  );
+
   const renderItem = useCallback(
     ({ item }: { item: Station }) => {
-      const { line, lines: linesRaw } = item;
-      const lines = filterBusLinesForNonBusStation(line, linesRaw);
+      const { line } = item;
       if (!line) return null;
 
       const title = (isJapanese ? item.name : item.nameRoman) || undefined;
-      const subtitle = Array.from(
-        new Set(
-          (lines ?? [])
-            .map((l) => getLocalizedLineName(l, isJapanese))
-            .filter(Boolean)
-        )
-      ).join(isJapanese ? ' ' : ', ');
+      const subtitle = stationSubtitles.get(item.id) ?? '';
 
       return (
         <CommonCard
@@ -129,7 +140,7 @@ export const RouteInfoModal = ({
         />
       );
     },
-    [onSelect]
+    [onSelect, stationSubtitles]
   );
 
   const keyExtractor = useCallback(

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -233,26 +233,39 @@ export const SelectBoundModal: React.FC<Props> = ({
     [wantedDestination]
   );
 
+  const inboundNames = useMemo(
+    () => inboundStations.map((s) => s.name).join('・'),
+    [inboundStations]
+  );
+  const outboundNames = useMemo(
+    () => outboundStations.map((s) => s.name).join('・'),
+    [outboundStations]
+  );
+  const inboundNamesRoman = useMemo(
+    () => inboundStations.map((s) => s.nameRoman).join(' and '),
+    [inboundStations]
+  );
+  const outboundNamesRoman = useMemo(
+    () => outboundStations.map((s) => s.nameRoman).join(' and '),
+    [outboundStations]
+  );
+
   const loopLineDirectionText = useCallback(
     (direction: LineDirection) => {
       const directionName = directionToDirectionName(line, direction);
 
       if (isJapanese) {
         if (direction === 'INBOUND') {
-          return `${directionName}(${inboundStations
-            .map((s) => s.name)
-            .join('・')}方面)`;
+          return `${directionName}(${inboundNames}方面)`;
         }
-        return `${directionName}(${outboundStations
-          .map((s) => s.name)
-          .join('・')}方面)`;
+        return `${directionName}(${outboundNames}方面)`;
       }
       if (direction === 'INBOUND') {
-        return `for ${inboundStations.map((s) => s.nameRoman).join(' and ')}`;
+        return `for ${inboundNamesRoman}`;
       }
-      return `for ${outboundStations.map((s) => s.nameRoman).join(' and ')}`;
+      return `for ${outboundNamesRoman}`;
     },
-    [inboundStations, outboundStations, line]
+    [inboundNames, outboundNames, inboundNamesRoman, outboundNamesRoman, line]
   );
 
   const renderButton = useCallback(

--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -91,46 +91,44 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
 
   const stationNumbers = useMemo(
     () =>
-      lines
-        ?.map((l) => l)
-        ?.map((l) => {
-          const stationNumberData = l.station?.stationNumbers?.find((sn) =>
-            l.lineSymbols?.some((sym) => sym.symbol === sn.lineSymbol)
-          );
-          const lineSymbol = stationNumberData?.lineSymbol ?? '';
-          const lineSymbolColor = stationNumberData?.lineSymbolColor ?? '';
-          const stationNumber = stationNumberData?.stationNumber ?? '';
-          const lineSymbolShape = stationNumberData?.lineSymbolShape ?? 'NOOP';
+      lines?.map((l) => {
+        const stationNumberData = l.station?.stationNumbers?.find((sn) =>
+          l.lineSymbols?.some((sym) => sym.symbol === sn.lineSymbol)
+        );
+        const lineSymbol = stationNumberData?.lineSymbol ?? '';
+        const lineSymbolColor = stationNumberData?.lineSymbolColor ?? '';
+        const stationNumber = stationNumberData?.stationNumber ?? '';
+        const lineSymbolShape = stationNumberData?.lineSymbolShape ?? 'NOOP';
 
-          if (!lineSymbol.length || !stationNumber.length) {
-            const stationNumberWhenEmptySymbol =
-              l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
-                ?.stationNumber ?? '';
-            const lineSymbolWhenEmptySymbol = l.lineSymbols?.[0]?.symbol ?? '';
-            const lineSymbolColorWhenEmptySymbol =
-              l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
-                ?.lineSymbolColor ?? '#000000';
-            const lineSymbolShapeWhenEmptySymbol =
-              l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
-                ?.lineSymbolShape ?? 'NOOP';
-
-            return {
-              __typename: 'StationNumber' as const,
-              lineSymbol: lineSymbolWhenEmptySymbol,
-              lineSymbolColor: lineSymbolColorWhenEmptySymbol,
-              stationNumber: stationNumberWhenEmptySymbol,
-              lineSymbolShape: lineSymbolShapeWhenEmptySymbol,
-            };
-          }
+        if (!lineSymbol.length || !stationNumber.length) {
+          const stationNumberWhenEmptySymbol =
+            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
+              ?.stationNumber ?? '';
+          const lineSymbolWhenEmptySymbol = l.lineSymbols?.[0]?.symbol ?? '';
+          const lineSymbolColorWhenEmptySymbol =
+            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
+              ?.lineSymbolColor ?? '#000000';
+          const lineSymbolShapeWhenEmptySymbol =
+            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
+              ?.lineSymbolShape ?? 'NOOP';
 
           return {
             __typename: 'StationNumber' as const,
-            lineSymbol,
-            lineSymbolColor,
-            stationNumber,
-            lineSymbolShape,
+            lineSymbol: lineSymbolWhenEmptySymbol,
+            lineSymbolColor: lineSymbolColorWhenEmptySymbol,
+            stationNumber: stationNumberWhenEmptySymbol,
+            lineSymbolShape: lineSymbolShapeWhenEmptySymbol,
           };
-        }),
+        }
+
+        return {
+          __typename: 'StationNumber' as const,
+          lineSymbol,
+          lineSymbolColor,
+          stationNumber,
+          lineSymbolShape,
+        };
+      }),
     [lines]
   );
 


### PR DESCRIPTION
## Summary

### 第1コミット: 不要な再計算とレンダーを削減
- `Transfers.tsx`: 冗長な `.map((l) => l)` チェーンを削除し、1回の `.map()` に統合
- `CommonCard.tsx`: `titleOrLineName.split()` の結果を `useMemo` でメモ化。`Subtitle` を `React.memo` でラップ
- `FooterTabBar.tsx`: 定数 `iconColor` を `useMemo` からコンポーネント外の定数 `ICON_COLOR` に移動

### 第2コミット: 各コンポーネントのレンダー内計算をメモ化
- `PresetCard.tsx`: `renderTextWithSmallerParens` の結果を `useMemo` でメモ化（1レンダーあたり2回の呼び出しを削減）
- `SelectBoundModal.tsx`: `loopLineDirectionText` 内の `.map()` を事前メモ化した文字列に置換
- `PadLineMarks.tsx`: JSX内のテキスト生成ロジックを `useMemo` で事前計算
- `RouteInfoModal.tsx`: `renderItem` 内の `Set` 生成を `stationSubtitles` Map に事前計算

## Regression risk
- 表示ロジックの変更はなく、メモ化とコード整理のみのためリグレッションリスクは低い

## Commands executed
```
npm run lint
npm run typecheck
npm test (136 suites, 1262 tests passed)
```

## Test plan
- [ ] 乗換路線一覧（Transfers）が正しく表示されること
- [ ] CommonCard のタイトル（括弧付き）とサブタイトルが正しく表示されること
- [ ] FooterTabBar のアイコン色が正しく切り替わること
- [ ] PresetCard の駅コード表示が正しいこと
- [ ] SelectBoundModal の方面テキストが正しいこと
- [ ] PadLineMarks の乗換路線名が正しく表示されること
- [ ] RouteInfoModal の路線名サブタイトルが正しく表示されること

https://claude.ai/code/session_01P3RbNTu7mxQvLyfzzerBFB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 各コンポーネントで表示レンダリングを事前計算・メモ化し、UI の応答性とスクロール時の表示性能を改善
  * 表示テキスト（駅名・行名・副題・路線ラベル）を安定化し、表示結果は現状維持しつつ再描画を削減
  * フッタのアイコン色管理を定数化して表示色を安定化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->