### PR TITLE
英語TTS音量ブースト値の調整と配列フォーマットの整形

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -23,7 +23,7 @@ const googleTtsApiKey = defineSecret('GOOGLE_TTS_API_KEY');
 const GEMINI_TTS_MODEL = 'gemini-2.5-flash-tts';
 const VERTEX_AI_LOCATION = 'us-central1';
 const GOOGLE_TTS_API_VERSION = 'v1';
-const EN_GEMINI_VOLUME_BOOST_DB = 6;
+const EN_GEMINI_VOLUME_BOOST_DB = 4;
 
 interface SynthesizedAudio {
   audioContent: string;
@@ -82,13 +82,38 @@ const ensureMp3 = async (
 /** 0〜99 の整数を英単語に変換する */
 const numberToEnglishWord = (n: number): string => {
   const ones = [
-    'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
-    'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
-    'sixteen', 'seventeen', 'eighteen', 'nineteen',
+    'zero',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine',
+    'ten',
+    'eleven',
+    'twelve',
+    'thirteen',
+    'fourteen',
+    'fifteen',
+    'sixteen',
+    'seventeen',
+    'eighteen',
+    'nineteen',
   ];
   const tens = [
-    '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy',
-    'eighty', 'ninety',
+    '',
+    '',
+    'twenty',
+    'thirty',
+    'forty',
+    'fifty',
+    'sixty',
+    'seventy',
+    'eighty',
+    'ninety',
   ];
   if (n < 20) return ones[n] ?? String(n);
   if (n < 100) {


### PR DESCRIPTION
## Summary
- 英語TTSの音量ブースト値を6dBから4dBに調整
- `numberToEnglishWord` 関数内の配列フォーマットを整形

## Test plan
- [ ] 英語TTS音声の音量が適切であることを確認
- [ ] 既存のTTS機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Gemini英語版のデフォルト音声出力のボリュームブーストを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->