### PR TITLE
CommonCardアコーディオンのラインバー表示を修正

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -311,7 +311,7 @@ export const CommonCard: React.FC<Props> = ({
           : undefined
       }
     >
-      {hasAccordion && expanded && (
+      {hasAccordion && (
         <View
           style={[
             styles.fullHeightColorBar,


### PR DESCRIPTION
## Summary
- CommonCardのアコーディオンを閉じる際、左端のカラーバーが即座に消えてしまう不自然な挙動を修正
- `expanded` 条件を削除し、アコーディオンがある場合は常にバーを表示するように変更
- 外側コンテナの `overflow: 'hidden'` により、アコーディオンの高さアニメーションに連動してバーも自然に畳まれる

## Test plan
- [ ] アコーディオンを開閉し、左端のカラーバーがアニメーションに追従して自然に表示・非表示されることを確認
- [ ] アコーディオンが閉じた状態でカラーバーがカードヘッダーに影響を与えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* カードコンポーネントの色バー表示ロジックを改善しました。アコーディオン機能を搭載しているアイテムについて、従来は展開状態にある場合のみ色バーが表示されていました。この変更により、アコーディオンが存在する場合、その展開状態に関わらず常に色バーが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->