### PR TITLE
オートモードの終着前巻き戻りを防ぐ

### DIFF
--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -918,6 +918,57 @@ describe('useSimulationMode', () => {
       expect(callsBeyondMidpoint.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('同一駅オブジェクトが再登場する場合でも終端まで前進する', () => {
+      const stationA = mockStation(10, 10, 35.0, 139.0);
+      const stationB = mockStation(20, 20, 35.05, 139.05);
+      const stationC = mockStation(30, 30, 35.1, 139.1);
+      const stationD = mockStation(50, 50, 35.25, 139.25);
+      const stations = [
+        stationA,
+        stationB,
+        stationC,
+        stationB, // 同一参照を再利用
+        stationD,
+      ];
+
+      setupAtomMocks(
+        {
+          station: stationC,
+          stations,
+          selectedDirection: 'INBOUND',
+        },
+        { autoModeEnabled: true }
+      );
+
+      jest
+        .spyOn(trainSpeedModule, 'generateTrainSpeedProfile')
+        .mockReturnValue([2000]);
+
+      (store.get as jest.Mock).mockReturnValue(mockLocationObject(35.1, 139.1));
+
+      renderHook(() => useSimulationMode(), {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      });
+
+      // tick 1: C→(2回目の)B
+      // tick 2: dwellPending
+      // tick 3: dwell処理でDセグメントへ移動
+      // tick 4: B→D で緯度が大きく前進する
+      jest.advanceTimersByTime(4000);
+
+      const locationSetCalls = (store.set as jest.Mock).mock.calls
+        .filter((call) => call[0] === locationAtom)
+        .map((call) => call[1]);
+      const steppingCalls = locationSetCalls.filter(
+        (loc) => typeof loc?.coords?.speed === 'number' && loc.coords.speed > 0
+      );
+      const reachedTerminalSide = steppingCalls.some(
+        (loc) => loc.coords.latitude >= 35.2
+      );
+
+      expect(reachedTerminalSide).toBe(true);
+    });
+
     it('重複IDの駅間に通過駅がある場合も正しいウェイポイントが使用される', () => {
       const stations = [
         mockStation(10, 10, 35.0, 139.0),

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -154,26 +154,23 @@ export const useSimulationMode = (): void => {
   useEffect(() => {
     const speedProfiles = maybeRevsersedStations.map(
       (cur, curMapIndex, arr) => {
-        const stationsWithoutPass = arr.filter((s) => !getIsPass(s));
-
-        const curIdx = stationsWithoutPass.indexOf(cur);
-        if (curIdx === -1) {
+        if (getIsPass(cur)) {
           // 通過駅は速度プロファイル生成対象外
           return [];
         }
 
-        const next = stationsWithoutPass[curIdx + 1];
+        const nextStationIndex = arr.findIndex(
+          (station, idx) => idx > curMapIndex && !getIsPass(station)
+        );
+        if (nextStationIndex === -1) {
+          return [];
+        }
+        const next = arr[nextStationIndex];
         if (!next) {
           return [];
         }
 
-        const stationIndex = curMapIndex;
-        const nextStationIndex = arr.indexOf(next);
-
-        const betweenNextStation = arr.slice(
-          stationIndex + 1,
-          nextStationIndex
-        );
+        const betweenNextStation = arr.slice(curMapIndex + 1, nextStationIndex);
 
         if (
           cur.latitude == null ||
@@ -261,26 +258,10 @@ export const useSimulationMode = (): void => {
       }
 
       // segmentIndexRefに基づいて目的地を決定（nextStationフックに依存しない）
-      const stationsWithoutPass = maybeRevsersedStations.filter(
-        (s) => !getIsPass(s)
+      const nextStopStationIndex = maybeRevsersedStations.findIndex(
+        (station, idx) => idx > normalizedSegmentIndex && !getIsPass(station)
       );
-      if (stationsWithoutPass.length === 0) {
-        return;
-      }
-
-      const currentSegmentStation =
-        maybeRevsersedStations[normalizedSegmentIndex];
-      if (!currentSegmentStation) {
-        return;
-      }
-      const currentSegmentStationIndex = normalizedSegmentIndex;
-
-      const currentSegmentStopIndex = stationsWithoutPass.indexOf(
-        currentSegmentStation
-      );
-      const nextStopStation = stationsWithoutPass[currentSegmentStopIndex + 1];
-
-      if (!nextStopStation) {
+      if (nextStopStationIndex === -1) {
         segmentIndexRef.current = 0;
         childIndexRef.current = 0;
         segmentProgressDistanceRef.current = 0;
@@ -302,6 +283,18 @@ export const useSimulationMode = (): void => {
         return;
       }
 
+      const currentSegmentStation =
+        maybeRevsersedStations[normalizedSegmentIndex];
+      if (!currentSegmentStation) {
+        return;
+      }
+      const currentSegmentStationIndex = normalizedSegmentIndex;
+
+      const nextStopStation = maybeRevsersedStations[nextStopStationIndex];
+      if (!nextStopStation) {
+        return;
+      }
+
       if (
         nextStopStation.latitude == null ||
         nextStopStation.longitude == null
@@ -309,8 +302,6 @@ export const useSimulationMode = (): void => {
         return;
       }
 
-      const nextStopStationIndex =
-        maybeRevsersedStations.indexOf(nextStopStation);
       if (
         nextStopStationIndex < 0 ||
         nextStopStationIndex < currentSegmentStationIndex


### PR DESCRIPTION
## 概要
- オートモードで次停車駅を前方インデックス走査で解決するよう修正
- 同一駅IDや同一駅オブジェクトが再登場する長い駅リストでも終着側へ進行を継続
- 同一駅オブジェクト再登場ケースの回帰テストを追加

## リスク
- オートモードの停車駅遷移ロジックに影響するため、長距離路線と重複駅を含む路線で重点確認が必要
- 通過駅を含む区間の速度プロファイル生成に影響するため、既存ケースの回帰確認が必要

## 実行コマンド
- npm test -- src/hooks/useSimulationMode.test.tsx --runInBand
- npm run typecheck
- npm run lint

## チケット
- なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数回登場する駅を含むルートでのシミュレーション動作が改善されました。
  * 特殊な駅配置での速度プロファイル生成がより正確になりました。
  * 終着駅到着判定の精度が向上しました。

* **パフォーマンス改善**
  * シミュレーション実行時の計算処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->