### PR TITLE
経路プリセットをクイックアクションから呼び出せるようにする

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -11,6 +11,7 @@ export default ({ config }: ConfigContext) => ({
     'expo-web-browser',
     'expo-sqlite',
     'expo-asset',
+    'expo-quick-actions',
     [
       'expo-location',
       {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1344,6 +1344,8 @@ PODS:
     - ExpoModulesCore
   - ExpoNotifications (55.0.10):
     - ExpoModulesCore
+  - ExpoQuickActions (6.0.1):
+    - ExpoModulesCore
   - ExpoScreenCapture (55.0.8):
     - ExpoModulesCore
   - ExpoScreenOrientation (55.0.8):
@@ -4858,6 +4860,7 @@ DEPENDENCIES:
   - ExpoModulesJSI (from `../node_modules/expo-modules-core`)
   - ExpoNetwork (from `../node_modules/expo-network/ios`)
   - ExpoNotifications (from `../node_modules/expo-notifications/ios`)
+  - ExpoQuickActions (from `../node_modules/expo-quick-actions/ios`)
   - ExpoScreenCapture (from `../node_modules/expo-screen-capture/ios`)
   - ExpoScreenOrientation (from `../node_modules/expo-screen-orientation/ios`)
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
@@ -5059,6 +5062,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-network/ios"
   ExpoNotifications:
     :path: "../node_modules/expo-notifications/ios"
+  ExpoQuickActions:
+    :path: "../node_modules/expo-quick-actions/ios"
   ExpoScreenCapture:
     :path: "../node_modules/expo-screen-capture/ios"
   ExpoScreenOrientation:
@@ -5299,13 +5304,14 @@ SPEC CHECKSUMS:
   ExpoModulesJSI: bcc87b51e04bdfc9a23102baac1d886630316e49
   ExpoNetwork: 567db7b29039cecd83c7b6fe9ee649f14aa84300
   ExpoNotifications: fa5cf77a46c8ea6bfc93bdbad9805c4f8d8a81fb
+  ExpoQuickActions: 61e27ec458e4e06b854ddc6967c2b57aa6a772d5
   ExpoScreenCapture: eb36e5572368a3862d128c9e09f08435a37b298e
   ExpoScreenOrientation: 51ac87fa33f0af12ace9b8992b41ac344da6cb0b
   ExpoSplashScreen: 6452aefb424acc76347d62482caef9b4e613e59e
   ExpoSQLite: 77506d3d056c57118280d1e2a2d76cc06e4926b3
   ExpoTaskManager: 6038b80fbe63915383dcf57fa0156b23e2615fab
   ExpoWebBrowser: f13a6e46e44049bbb8ce49ff8aaa4d819c87d1fe
-  fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
+  fast_float: 914e00b8b67cb8ba184a778c7bbc2e9fe98d37b3
   FBLazyVector: f1200e6ef6cf24885501668bdbb9eff4cf48843f
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
   FirebaseAnalytics: f20bbad8cb7f65d8a5eaefeb424ae8800a31bdfc
@@ -5320,21 +5326,21 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseSharedSwift: f57ed48f4542b2d7eb4738f4f23ba443f78b3780
   FirebaseStorage: 7c37558dc72731aa5f0a1a2401d8c6de10a513f5
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  fmt: b85d977e8fe789fd71c77123f9f4920d88c4d170
+  glog: 682871fb30f4a65f657bf357581110656ea90b08
   GoogleAppMeasurement: 72c9a682fec6290327ea5e3c4b829b247fcb2c17
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMSessionFetcher: 02d6e866e90bc236f48a703a041dfe43e6221a29
-  hermes-engine: cf793502cf318098c07975b890e2de32bfcdcf3a
+  hermes-engine: daf64caf2c32346fe06a11b1a688f94e0c9731f8
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: fb64616e25cfac1c3d10bfd784d68926325ae67f
   RCTDeprecation: 3b915a7b166f7d04eaeb4ae30aaf24236a016551
   RCTRequired: fcfec6ba532cfe4e53c49e0a4061b5eff87f8c64
   RCTSwiftUI: b2f0c2f2761631b8cd605767536cbb1cbf8d020f

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "expo-location": "~55.1.2",
         "expo-network": "~55.0.8",
         "expo-notifications": "~55.0.10",
+        "expo-quick-actions": "^6.0.1",
         "expo-screen-capture": "~55.0.8",
         "expo-screen-orientation": "~55.0.8",
         "expo-splash-screen": "~55.0.10",
@@ -6582,6 +6583,12 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.23",
       "dev": true,
@@ -6832,6 +6839,51 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/anser": {
@@ -9119,6 +9171,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-quick-actions": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/expo-quick-actions/-/expo-quick-actions-6.0.1.tgz",
+      "integrity": "sha512-BzYvKoF1dJWe+1E2X2gMY0k4d4yp+FPINIH9/kc/25/0QtXsi72Y3VPN7iM3bmpyxXKHQ/78KR0OXHbJ5o+t1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.7",
+        "schema-utils": "^4.3.2",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-screen-capture": {
       "version": "55.0.8",
       "license": "MIT",
@@ -9597,6 +9663,22 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -11897,6 +11979,12 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-to-pretty-yaml": {
@@ -14854,6 +14942,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "devOptional": true,
@@ -15033,6 +15130,25 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "expo-location": "~55.1.2",
     "expo-network": "~55.0.8",
     "expo-notifications": "~55.0.10",
+    "expo-quick-actions": "^6.0.1",
     "expo-screen-capture": "~55.0.8",
     "expo-screen-orientation": "~55.0.8",
     "expo-splash-screen": "~55.0.10",

--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -82,6 +82,7 @@ const createNavigationState = (
   presetsFetched: false,
   presetRoutes: [],
   pendingTrainType: null,
+  pendingQuickActionRouteId: null,
   ...overrides,
 });
 

--- a/src/hooks/useLineSelection.test.tsx
+++ b/src/hooks/useLineSelection.test.tsx
@@ -62,6 +62,7 @@ const createNavigationState = (
   presetsFetched: false,
   presetRoutes: [],
   pendingTrainType: null,
+  pendingQuickActionRouteId: null,
   ...overrides,
 });
 

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -12,7 +12,7 @@ const INITIAL_RETRY_DELAY_MS = 100;
 
 let handledInitial = false;
 
-const navigateToSelectLine = async () => {
+const navigateToSelectLine = async (): Promise<boolean> => {
   const waitForNavReady = (): Promise<boolean> =>
     new Promise((resolve) => {
       let attempt = 0;
@@ -39,7 +39,13 @@ const navigateToSelectLine = async () => {
         params: { screen: 'SelectLine' },
       })
     );
+    return true;
   }
+
+  console.warn(
+    'useQuickActions: ナビゲーションの準備が完了しなかったためクイックアクションをスキップ'
+  );
+  return false;
 };
 
 /**
@@ -71,7 +77,7 @@ export const useQuickActions = () => {
 
   // クイックアクション選択を監視
   useEffect(() => {
-    const handleAction = (action: QuickActions.Action | null) => {
+    const handleAction = async (action: QuickActions.Action | null) => {
       const routeId = action?.params?.routeId;
       if (typeof routeId !== 'string') return;
 
@@ -80,7 +86,13 @@ export const useQuickActions = () => {
         pendingQuickActionRouteId: routeId,
       }));
 
-      navigateToSelectLine();
+      const navigated = await navigateToSelectLine();
+      if (!navigated) {
+        setNavigationState((prev) => ({
+          ...prev,
+          pendingQuickActionRouteId: null,
+        }));
+      }
     };
 
     // コールドスタート時（リマウントでの重複処理を防止）

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -53,13 +53,19 @@ export const useQuickActions = () => {
 
   // プリセットが変わるたびにOSのクイックアクションを同期
   useEffect(() => {
-    QuickActions.setItems(
-      presetRoutes.slice(0, MAX_QUICK_ACTIONS).map((route) => ({
-        id: route.id,
-        title: route.name,
-        icon: Platform.OS === 'ios' ? 'symbol:tram.fill' : undefined,
-        params: { routeId: route.id },
-      }))
+    const syncItems = async () => {
+      if (!(await QuickActions.isSupported())) return;
+      await QuickActions.setItems(
+        presetRoutes.slice(0, MAX_QUICK_ACTIONS).map((route) => ({
+          id: route.id,
+          title: route.name,
+          icon: Platform.OS === 'ios' ? 'symbol:tram.fill' : undefined,
+          params: { routeId: route.id },
+        }))
+      );
+    };
+    syncItems().catch((err) =>
+      console.warn('useQuickActions: クイックアクション同期に失敗', err)
     );
   }, [presetRoutes]);
 

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -7,6 +7,40 @@ import { navigationRef } from '~/stacks/rootNavigation';
 import navigationState from '~/store/atoms/navigation';
 
 const MAX_QUICK_ACTIONS = 4;
+const MAX_NAV_RETRIES = 5;
+const INITIAL_RETRY_DELAY_MS = 100;
+
+let handledInitial = false;
+
+const navigateToSelectLine = async () => {
+  const waitForNavReady = (): Promise<boolean> =>
+    new Promise((resolve) => {
+      let attempt = 0;
+      const check = () => {
+        if (navigationRef.isReady()) {
+          resolve(true);
+          return;
+        }
+        attempt++;
+        if (attempt >= MAX_NAV_RETRIES) {
+          resolve(false);
+          return;
+        }
+        setTimeout(check, INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1));
+      };
+      check();
+    });
+
+  const ready = navigationRef.isReady() || (await waitForNavReady());
+  if (ready) {
+    navigationRef.dispatch(
+      CommonActions.navigate({
+        name: 'MainStack',
+        params: { screen: 'SelectLine' },
+      })
+    );
+  }
+};
 
 /**
  * アプリルートで使用するフック。
@@ -40,19 +74,12 @@ export const useQuickActions = () => {
         pendingQuickActionRouteId: routeId,
       }));
 
-      // どの画面にいても SelectLine に遷移させる
-      if (navigationRef.isReady()) {
-        navigationRef.dispatch(
-          CommonActions.navigate({
-            name: 'MainStack',
-            params: { screen: 'SelectLine' },
-          })
-        );
-      }
+      navigateToSelectLine();
     };
 
-    // コールドスタート時
-    if (QuickActions.initial) {
+    // コールドスタート時（リマウントでの重複処理を防止）
+    if (QuickActions.initial && !handledInitial) {
+      handledInitial = true;
       handleAction(QuickActions.initial);
     }
 

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -7,45 +7,24 @@ import { navigationRef } from '~/stacks/rootNavigation';
 import navigationState from '~/store/atoms/navigation';
 
 const MAX_QUICK_ACTIONS = 4;
-const MAX_NAV_RETRIES = 5;
-const INITIAL_RETRY_DELAY_MS = 100;
 
 let handledInitial = false;
 
-const navigateToSelectLine = async (): Promise<boolean> => {
-  const waitForNavReady = (): Promise<boolean> =>
-    new Promise((resolve) => {
-      let attempt = 0;
-      const check = () => {
-        if (navigationRef.isReady()) {
-          resolve(true);
-          return;
-        }
-        attempt++;
-        if (attempt >= MAX_NAV_RETRIES) {
-          resolve(false);
-          return;
-        }
-        setTimeout(check, INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1));
-      };
-      check();
-    });
-
-  const ready = navigationRef.isReady() || (await waitForNavReady());
-  if (ready) {
-    navigationRef.dispatch(
-      CommonActions.navigate({
-        name: 'MainStack',
-        params: { screen: 'SelectLine' },
-      })
+const navigateToSelectLine = () => {
+  if (!navigationRef.isReady()) {
+    console.warn(
+      'useQuickActions: ナビゲーションが未準備のためクイックアクションをスキップ'
     );
-    return true;
+    return false;
   }
 
-  console.warn(
-    'useQuickActions: ナビゲーションの準備が完了しなかったためクイックアクションをスキップ'
+  navigationRef.dispatch(
+    CommonActions.navigate({
+      name: 'MainStack',
+      params: { screen: 'SelectLine' },
+    })
   );
-  return false;
+  return true;
 };
 
 /**
@@ -77,7 +56,7 @@ export const useQuickActions = () => {
 
   // クイックアクション選択を監視
   useEffect(() => {
-    const handleAction = async (action: QuickActions.Action | null) => {
+    const handleAction = (action: QuickActions.Action | null) => {
       const routeId = action?.params?.routeId;
       if (typeof routeId !== 'string') return;
 
@@ -86,8 +65,7 @@ export const useQuickActions = () => {
         pendingQuickActionRouteId: routeId,
       }));
 
-      const navigated = await navigateToSelectLine();
-      if (!navigated) {
+      if (!navigateToSelectLine()) {
         setNavigationState((prev) => ({
           ...prev,
           pendingQuickActionRouteId: null,

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -1,0 +1,47 @@
+import * as QuickActions from 'expo-quick-actions';
+import { useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+import type { SavedRoute } from '~/models/SavedRoute';
+import navigationState from '~/store/atoms/navigation';
+
+const MAX_QUICK_ACTIONS = 4;
+
+const buildQuickActionItems = (routes: SavedRoute[]): QuickActions.Action[] => {
+  return routes.slice(0, MAX_QUICK_ACTIONS).map((route) => ({
+    id: route.id,
+    title: route.name,
+    icon: Platform.OS === 'ios' ? 'symbol:tram.fill' : undefined,
+    params: { routeId: route.id },
+  }));
+};
+
+export const useQuickActions = (routes: SavedRoute[]) => {
+  const setNavigationState = useSetAtom(navigationState);
+
+  // プリセットが変わるたびにOSのクイックアクションを同期
+  useEffect(() => {
+    QuickActions.setItems(buildQuickActionItems(routes));
+  }, [routes]);
+
+  // クイックアクション選択を監視
+  useEffect(() => {
+    const handleAction = (action: QuickActions.Action | null) => {
+      const routeId = action?.params?.routeId;
+      if (typeof routeId !== 'string') return;
+      setNavigationState((prev) => ({
+        ...prev,
+        pendingQuickActionRouteId: routeId,
+      }));
+    };
+
+    // コールドスタート時
+    if (QuickActions.initial) {
+      handleAction(QuickActions.initial);
+    }
+
+    // ウォームスタート時
+    const subscription = QuickActions.addListener(handleAction);
+    return () => subscription.remove();
+  }, [setNavigationState]);
+};

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -1,38 +1,54 @@
+import { CommonActions } from '@react-navigation/native';
 import * as QuickActions from 'expo-quick-actions';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-import type { SavedRoute } from '~/models/SavedRoute';
+import { navigationRef } from '~/stacks/rootNavigation';
 import navigationState from '~/store/atoms/navigation';
 
 const MAX_QUICK_ACTIONS = 4;
 
-const buildQuickActionItems = (routes: SavedRoute[]): QuickActions.Action[] => {
-  return routes.slice(0, MAX_QUICK_ACTIONS).map((route) => ({
-    id: route.id,
-    title: route.name,
-    icon: Platform.OS === 'ios' ? 'symbol:tram.fill' : undefined,
-    params: { routeId: route.id },
-  }));
-};
-
-export const useQuickActions = (routes: SavedRoute[]) => {
+/**
+ * アプリルートで使用するフック。
+ * - presetRoutes をOSのクイックアクションに同期
+ * - クイックアクション選択時に pendingQuickActionRouteId を設定し、SelectLine に遷移
+ */
+export const useQuickActions = () => {
+  const { presetRoutes } = useAtomValue(navigationState);
   const setNavigationState = useSetAtom(navigationState);
 
   // プリセットが変わるたびにOSのクイックアクションを同期
   useEffect(() => {
-    QuickActions.setItems(buildQuickActionItems(routes));
-  }, [routes]);
+    QuickActions.setItems(
+      presetRoutes.slice(0, MAX_QUICK_ACTIONS).map((route) => ({
+        id: route.id,
+        title: route.name,
+        icon: Platform.OS === 'ios' ? 'symbol:tram.fill' : undefined,
+        params: { routeId: route.id },
+      }))
+    );
+  }, [presetRoutes]);
 
   // クイックアクション選択を監視
   useEffect(() => {
     const handleAction = (action: QuickActions.Action | null) => {
       const routeId = action?.params?.routeId;
       if (typeof routeId !== 'string') return;
+
       setNavigationState((prev) => ({
         ...prev,
         pendingQuickActionRouteId: routeId,
       }));
+
+      // どの画面にいても SelectLine に遷移させる
+      if (navigationRef.isReady()) {
+        navigationRef.dispatch(
+          CommonActions.navigate({
+            name: 'MainStack',
+            params: { screen: 'SelectLine' },
+          })
+        );
+      }
     };
 
     // コールドスタート時

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -73,6 +73,61 @@ const convertRowToSavedRoute = (row: SavedRouteRow): SavedRoute | null => {
   };
 };
 
+// モジュールスコープで初期化 Promise を保持し、並行実行を防ぐ
+let initPromise: Promise<void> | null = null;
+
+const initDb = async (): Promise<void> => {
+  await db.execAsync(
+    `CREATE TABLE IF NOT EXISTS saved_routes (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    lineId INTEGER NOT NULL,
+    trainTypeId INTEGER,
+    wantedDestinationId INTEGER,
+    direction TEXT,
+    notifyStationIds TEXT,
+    hasTrainType INTEGER NOT NULL CHECK (hasTrainType IN (0,1)),
+    createdAt TEXT NOT NULL,
+    CHECK ((hasTrainType = 1 AND trainTypeId IS NOT NULL) OR (hasTrainType = 0 AND trainTypeId IS NULL))
+  );`
+  );
+  // よく使う検索条件に合わせて索引を付与
+  await db.execAsync(
+    'CREATE INDEX IF NOT EXISTS idx_saved_routes_createdAt ON saved_routes(createdAt DESC);'
+  );
+  await db.execAsync(
+    'CREATE INDEX IF NOT EXISTS idx_saved_routes_line_dest_has ON saved_routes(lineId, hasTrainType, createdAt DESC);'
+  );
+  await db.execAsync(
+    'CREATE INDEX IF NOT EXISTS idx_saved_routes_ttype_dest_has ON saved_routes(trainTypeId, hasTrainType, createdAt DESC);'
+  );
+  // 既存テーブルにカラムを追加（存在しない場合のみ）
+  const columns = (await db.getAllAsync(
+    "PRAGMA table_info('saved_routes')"
+  )) as { name: string }[];
+  const columnNames = new Set(columns.map((c) => c.name));
+  if (!columnNames.has('wantedDestinationId')) {
+    await db.execAsync(
+      'ALTER TABLE saved_routes ADD COLUMN wantedDestinationId INTEGER;'
+    );
+  }
+  if (!columnNames.has('direction')) {
+    await db.execAsync('ALTER TABLE saved_routes ADD COLUMN direction TEXT;');
+  }
+  if (!columnNames.has('notifyStationIds')) {
+    await db.execAsync(
+      'ALTER TABLE saved_routes ADD COLUMN notifyStationIds TEXT;'
+    );
+  }
+};
+
+const ensureDbInitialized = (): Promise<void> => {
+  if (!initPromise) {
+    initPromise = initDb();
+  }
+  return initPromise;
+};
+
 export const useSavedRoutes = () => {
   const [
     { presetRoutes: routes, presetsFetched: isInitialized },
@@ -80,54 +135,9 @@ export const useSavedRoutes = () => {
   ] = useAtom(navigationState);
 
   useEffect(() => {
-    const initDb = async () => {
-      await db.execAsync(
-        `CREATE TABLE IF NOT EXISTS saved_routes (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        lineId INTEGER NOT NULL,
-        trainTypeId INTEGER,
-        wantedDestinationId INTEGER,
-        direction TEXT,
-        notifyStationIds TEXT,
-        hasTrainType INTEGER NOT NULL CHECK (hasTrainType IN (0,1)),
-        createdAt TEXT NOT NULL,
-        CHECK ((hasTrainType = 1 AND trainTypeId IS NOT NULL) OR (hasTrainType = 0 AND trainTypeId IS NULL))
-      );`
-      );
-      // よく使う検索条件に合わせて索引を付与
-      await db.execAsync(
-        'CREATE INDEX IF NOT EXISTS idx_saved_routes_createdAt ON saved_routes(createdAt DESC);'
-      );
-      await db.execAsync(
-        'CREATE INDEX IF NOT EXISTS idx_saved_routes_line_dest_has ON saved_routes(lineId, hasTrainType, createdAt DESC);'
-      );
-      await db.execAsync(
-        'CREATE INDEX IF NOT EXISTS idx_saved_routes_ttype_dest_has ON saved_routes(trainTypeId, hasTrainType, createdAt DESC);'
-      );
-      // 既存テーブルにカラムを追加（存在しない場合のみ）
-      const columns = (await db.getAllAsync(
-        "PRAGMA table_info('saved_routes')"
-      )) as { name: string }[];
-      const columnNames = new Set(columns.map((c) => c.name));
-      if (!columnNames.has('wantedDestinationId')) {
-        await db.execAsync(
-          'ALTER TABLE saved_routes ADD COLUMN wantedDestinationId INTEGER;'
-        );
-      }
-      if (!columnNames.has('direction')) {
-        await db.execAsync(
-          'ALTER TABLE saved_routes ADD COLUMN direction TEXT;'
-        );
-      }
-      if (!columnNames.has('notifyStationIds')) {
-        await db.execAsync(
-          'ALTER TABLE saved_routes ADD COLUMN notifyStationIds TEXT;'
-        );
-      }
+    ensureDbInitialized().then(() => {
       setNavigationAtom((prev) => ({ ...prev, presetsFetched: true }));
-    };
-    initDb();
+    });
   }, [setNavigationAtom]);
 
   const updateRoutes = useCallback(async (): Promise<void> => {

--- a/src/hooks/useSavedRoutes.ts
+++ b/src/hooks/useSavedRoutes.ts
@@ -123,7 +123,10 @@ const initDb = async (): Promise<void> => {
 
 const ensureDbInitialized = (): Promise<void> => {
   if (!initPromise) {
-    initPromise = initDb();
+    initPromise = initDb().catch((err) => {
+      initPromise = null;
+      throw err;
+    });
   }
   return initPromise;
 };
@@ -135,9 +138,14 @@ export const useSavedRoutes = () => {
   ] = useAtom(navigationState);
 
   useEffect(() => {
-    ensureDbInitialized().then(() => {
-      setNavigationAtom((prev) => ({ ...prev, presetsFetched: true }));
-    });
+    ensureDbInitialized()
+      .then(() => {
+        setNavigationAtom((prev) => ({ ...prev, presetsFetched: true }));
+      })
+      .catch((err) => {
+        console.error('useSavedRoutes: DB初期化に失敗しました', err);
+        setNavigationAtom((prev) => ({ ...prev, presetsFetched: true }));
+      });
   }, [setNavigationAtom]);
 
   const updateRoutes = useCallback(async (): Promise<void> => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import { GlobalToast } from './components/GlobalToast';
 import TuningSettings from './components/TuningSettings';
 import { gqlClient } from './lib/gql';
 import DeepLinkProvider from './providers/DeepLinkProvider';
+import QuickActionsProvider from './providers/QuickActionsProvider';
 import PrivacyScreen from './screens/Privacy';
 import MainStack from './stacks/MainStack';
 import { navigationRef } from './stacks/rootNavigation';
@@ -85,29 +86,31 @@ const App: React.FC = () => {
               <Provider store={store}>
                 <NavigationContainer ref={navigationRef}>
                   <DeepLinkProvider>
-                    <PortalProvider>
-                      <Stack.Navigator screenOptions={screenOptions}>
-                        {!permStatus?.granted ? (
+                    <QuickActionsProvider>
+                      <PortalProvider>
+                        <Stack.Navigator screenOptions={screenOptions}>
+                          {!permStatus?.granted ? (
+                            <Stack.Screen
+                              options={options}
+                              name="Privacy"
+                              component={PrivacyScreen}
+                            />
+                          ) : null}
+
                           <Stack.Screen
                             options={options}
-                            name="Privacy"
-                            component={PrivacyScreen}
+                            name="MainStack"
+                            component={MainStack}
                           />
-                        ) : null}
 
-                        <Stack.Screen
-                          options={options}
-                          name="MainStack"
-                          component={MainStack}
-                        />
-
-                        <Stack.Screen
-                          options={options}
-                          name="TuningSettings"
-                          component={TuningSettings}
-                        />
-                      </Stack.Navigator>
-                    </PortalProvider>
+                          <Stack.Screen
+                            options={options}
+                            name="TuningSettings"
+                            component={TuningSettings}
+                          />
+                        </Stack.Navigator>
+                      </PortalProvider>
+                    </QuickActionsProvider>
                     <GlobalToast />
                   </DeepLinkProvider>
                 </NavigationContainer>

--- a/src/providers/QuickActionsProvider.tsx
+++ b/src/providers/QuickActionsProvider.tsx
@@ -1,0 +1,13 @@
+import { memo, type ReactNode } from 'react';
+import { useQuickActions } from '~/hooks/useQuickActions';
+
+type Props = {
+  children: ReactNode;
+};
+
+const QuickActionsProvider = ({ children }: Props) => {
+  useQuickActions();
+  return children;
+};
+
+export default memo(QuickActionsProvider);

--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react-native';
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import type React from 'react';
 import type { Line, Station } from '~/@types/graphql';
 import { TransportType } from '~/@types/graphql';
@@ -70,7 +70,6 @@ jest.mock('~/hooks/usePresetCarouselData');
 jest.mock('~/hooks/useLineSelection');
 jest.mock('~/hooks/useSelectLineWalkthrough');
 jest.mock('~/hooks/useDeviceOrientation');
-jest.mock('~/hooks/useQuickActions');
 
 // 子コンポーネント
 jest.mock('~/components/CommonCard', () => ({
@@ -492,6 +491,78 @@ describe('SelectLineScreen', () => {
       const { getByTestId } = render(<SelectLineScreen />);
 
       expect(getByTestId('presets-count').props.children).toBe(2);
+    });
+  });
+
+  describe('クイックアクション', () => {
+    it('pendingQuickActionRouteId がセットされるとプリセットが自動選択される', () => {
+      const localHandlePresetPress = jest.fn();
+      const mockSetNavigationState = jest.fn();
+      const routeId = '00000000-0000-0000-0000-000000000001';
+
+      setupDefaults();
+
+      // handlePresetPress を差し替え
+      (useLineSelection as jest.Mock).mockReturnValue({
+        ...defaultLineSelection(),
+        handlePresetPress: localHandlePresetPress,
+      });
+
+      // routes に該当するプリセットを用意
+      (usePresetCarouselData as jest.Mock).mockReturnValue({
+        carouselData: [],
+        routes: [
+          {
+            id: routeId,
+            name: 'テスト路線',
+            lineId: 1,
+            trainTypeId: null,
+            hasTrainType: false,
+            wantedDestinationId: null,
+            direction: null,
+            notifyStationIds: [],
+            createdAt: new Date(),
+          },
+        ],
+        isRoutesDBInitialized: true,
+      });
+
+      (useAtom as jest.Mock).mockReturnValue([
+        { pendingQuickActionRouteId: routeId },
+        mockSetNavigationState,
+      ]);
+
+      render(<SelectLineScreen />);
+
+      expect(localHandlePresetPress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: routeId })
+      );
+      expect(mockSetNavigationState).toHaveBeenCalledWith(expect.any(Function));
+      // setter が pendingQuickActionRouteId を null にリセットすることを検証
+      const setterFn = mockSetNavigationState.mock.calls[0][0];
+      const result = setterFn({ pendingQuickActionRouteId: routeId });
+      expect(result.pendingQuickActionRouteId).toBeNull();
+    });
+
+    it('pendingQuickActionRouteId に該当するルートがない場合は handlePresetPress を呼ばない', () => {
+      const mockSetNavigationState = jest.fn();
+
+      setupDefaults();
+
+      (usePresetCarouselData as jest.Mock).mockReturnValue({
+        carouselData: [],
+        routes: [],
+        isRoutesDBInitialized: true,
+      });
+
+      (useAtom as jest.Mock).mockReturnValue([
+        { pendingQuickActionRouteId: 'non-existent-id' },
+        mockSetNavigationState,
+      ]);
+
+      render(<SelectLineScreen />);
+
+      expect(mockHandlePresetPress).not.toHaveBeenCalled();
     });
   });
 

--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -16,6 +16,7 @@ import SelectLineScreen from './SelectLineScreen';
 
 jest.mock('jotai', () => ({
   useAtomValue: jest.fn(),
+  useAtom: jest.fn(() => [{ pendingQuickActionRouteId: null }, jest.fn()]),
   atom: jest.fn(),
 }));
 
@@ -69,6 +70,7 @@ jest.mock('~/hooks/usePresetCarouselData');
 jest.mock('~/hooks/useLineSelection');
 jest.mock('~/hooks/useSelectLineWalkthrough');
 jest.mock('~/hooks/useDeviceOrientation');
+jest.mock('~/hooks/useQuickActions');
 
 // 子コンポーネント
 jest.mock('~/components/CommonCard', () => ({

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -1,6 +1,6 @@
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { Orientation } from 'expo-screen-orientation';
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import React, {
   useCallback,
   useEffect,
@@ -32,12 +32,14 @@ import { useDeviceOrientation } from '~/hooks/useDeviceOrientation';
 import { useInitialNearbyStation } from '~/hooks/useInitialNearbyStation';
 import { useLineSelection } from '~/hooks/useLineSelection';
 import { usePresetCarouselData } from '~/hooks/usePresetCarouselData';
+import { useQuickActions } from '~/hooks/useQuickActions';
 import { useSelectLineWalkthrough } from '~/hooks/useSelectLineWalkthrough';
 import { useStationsCache } from '~/hooks/useStationsCache';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
 import FooterTabBar, { FOOTER_BASE_HEIGHT } from '../components/FooterTabBar';
 import { Heading } from '../components/Heading';
+import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import { isJapanese, translate } from '../translation';
@@ -83,7 +85,9 @@ const SelectLineScreen = () => {
   // --- カスタムフック ---
   const { station, nearbyStationLoading, refetch } = useInitialNearbyStation();
   useStationsCache(station);
-  const { carouselData, isRoutesDBInitialized } = usePresetCarouselData();
+  const { carouselData, routes, isRoutesDBInitialized } =
+    usePresetCarouselData();
+  useQuickActions(routes);
   const {
     handleLineSelected,
     handleTrainTypeSelect,
@@ -116,9 +120,29 @@ const SelectLineScreen = () => {
 
   // --- atom 読み取り ---
   const { stationsCache } = useAtomValue(stationState);
+  const [{ pendingQuickActionRouteId }, setNavigationState] =
+    useAtom(navigationState);
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const insets = useSafeAreaInsets();
   const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  // --- クイックアクションからのプリセット選択 ---
+  useEffect(() => {
+    if (!pendingQuickActionRouteId || !routes.length) return;
+    const route = routes.find((r) => r.id === pendingQuickActionRouteId);
+    if (route) {
+      handlePresetPress(route);
+    }
+    setNavigationState((prev) => ({
+      ...prev,
+      pendingQuickActionRouteId: null,
+    }));
+  }, [
+    pendingQuickActionRouteId,
+    routes,
+    handlePresetPress,
+    setNavigationState,
+  ]);
 
   // --- 画面回転ロック解除 ---
   useEffect(() => {

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -32,7 +32,6 @@ import { useDeviceOrientation } from '~/hooks/useDeviceOrientation';
 import { useInitialNearbyStation } from '~/hooks/useInitialNearbyStation';
 import { useLineSelection } from '~/hooks/useLineSelection';
 import { usePresetCarouselData } from '~/hooks/usePresetCarouselData';
-import { useQuickActions } from '~/hooks/useQuickActions';
 import { useSelectLineWalkthrough } from '~/hooks/useSelectLineWalkthrough';
 import { useStationsCache } from '~/hooks/useStationsCache';
 import isTablet from '~/utils/isTablet';
@@ -87,7 +86,6 @@ const SelectLineScreen = () => {
   useStationsCache(station);
   const { carouselData, routes, isRoutesDBInitialized } =
     usePresetCarouselData();
-  useQuickActions(routes);
   const {
     handleLineSelected,
     handleTrainTypeSelect,

--- a/src/store/atoms/navigation.ts
+++ b/src/store/atoms/navigation.ts
@@ -29,6 +29,7 @@ export interface NavigationState {
   firstStop: boolean;
   presetsFetched: boolean;
   presetRoutes: SavedRoute[];
+  pendingQuickActionRouteId: string | null;
 }
 
 export const initialNavigationState: NavigationState = {
@@ -45,6 +46,7 @@ export const initialNavigationState: NavigationState = {
   firstStop: true,
   presetsFetched: false,
   presetRoutes: [],
+  pendingQuickActionRouteId: null,
 };
 
 const navigationState = atom<NavigationState>(initialNavigationState);


### PR DESCRIPTION
## Summary
close #4490
- `expo-quick-actions` を導入し、SQLiteに保存された経路プリセット（最大4件）をiOS/Androidのクイックアクション（ホーム画面長押しショートカット）として表示
- クイックアクション選択時、対応するプリセットの SelectBoundModal を自動で開く
- iOSでは `tram.fill` SFSymbol アイコンを表示

## 主な変更
- `src/hooks/useQuickActions.ts`: プリセット同期・アクション選択ハンドリングフック（新規）
- `src/store/atoms/navigation.ts`: `pendingQuickActionRouteId` ステート追加
- `src/screens/SelectLineScreen.tsx`: クイックアクション統合（同期 + 自動発火）
- `app.config.ts`: `expo-quick-actions` プラグイン追加

## 動作フロー
1. プリセット保存 → OSクイックアクションに自動反映
2. ホーム画面でアイコン長押し → プリセット一覧表示
3. タップ → アプリ起動 → SelectBoundModal 自動オープン

## Test plan
- [x] iOSでホーム画面長押し → プリセットがクイックアクションに表示される
- [ ] Androidでホーム画面長押し → プリセットがクイックアクションに表示される
- [x] クイックアクションタップ → SelectBoundModal が開く（コールドスタート）
- [x] クイックアクションタップ → SelectBoundModal が開く（ウォームスタート）
- [x] プリセット追加/削除でクイックアクションが更新される
- [x] `npm run typecheck` パス
- [x] `npm test` 全1261テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * クイックアクションを導入し、保存したルートへ素早く移動できるようになりました。起動時の保留アクションにも対応します。
* **改善**
  * DB初期化を一度だけ確実に行うよう安定化し、トップレベルにクイックアクション用プロバイダーを追加しました。
* **Behavior**
  * 保留中のクイックアクションが該当プリセットを自動選択し、処理後に保留状態をクリアします。
* **Tests**
  * クイックアクション連携のテストを追加・拡充しました。
* **Chores**
  * クイックアクション用の依存パッケージを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->