### PR TITLE
ウォームスタートのクイックアクション遷移時の不具合を修正

### DIFF
--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -22,9 +22,9 @@ const navigateToSelectLine = () => {
   ScreenOrientation.unlockAsync().catch(console.error);
 
   navigationRef.dispatch(
-    CommonActions.navigate({
-      name: 'MainStack',
-      params: { screen: 'SelectLine' },
+    CommonActions.reset({
+      index: 0,
+      routes: [{ name: 'MainStack', params: { screen: 'SelectLine' } }],
     })
   );
   return true;

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -1,5 +1,6 @@
 import { CommonActions } from '@react-navigation/native';
 import * as QuickActions from 'expo-quick-actions';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
@@ -17,6 +18,8 @@ const navigateToSelectLine = () => {
     );
     return false;
   }
+
+  ScreenOrientation.unlockAsync().catch(console.error);
 
   navigationRef.dispatch(
     CommonActions.navigate({


### PR DESCRIPTION
## Summary
- ウォームスタートでクイックアクションからSelectLine画面に遷移する際、Main画面で適用されたランドスケープロックが残ったままになる問題を修正
- `navigateToSelectLine` 内でナビゲーション前に `ScreenOrientation.unlockAsync()` を呼び出すことで画面回転ロックを解除

## Test plan
- [ ] Main画面（ランドスケープ）表示中にクイックアクションでSelectLineに遷移し、画面が縦向きに戻ることを確認
- [ ] コールドスタートからのクイックアクション起動が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * クイックアクション実行時に画面の向きが自動でロック解除されるようになりました。
  * クイックアクションから遷移する際、前の画面履歴をクリアして選択画面に戻る（スタックをリセットする）動作に変更され、戻る操作の挙動が一貫化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->