### PR TITLE
プリセット機能の不具合修正と関連UI改善

### DIFF
--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -82,6 +82,11 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     elevation: 0,
     shadowOpacity: 0,
+    paddingHorizontal: 12,
+  },
+  expandableToggleStatePanel: {
+    minWidth: 56,
+    maxWidth: 56,
   },
   expandableToggleTextLight: {
     color: '#333',
@@ -185,6 +190,7 @@ export const RouteInfoModal = ({
                     onToggle={() => onToggleNotification(item)}
                     state={isNotifyEnabled}
                     style={styles.expandableToggle}
+                    statePanelStyle={styles.expandableToggleStatePanel}
                     textStyle={
                       isLEDTheme
                         ? styles.expandableToggleTextLED
@@ -199,6 +205,7 @@ export const RouteInfoModal = ({
                   <ToggleButton
                     outline
                     style={styles.expandableToggle}
+                    statePanelStyle={styles.expandableToggleStatePanel}
                     textStyle={
                       isLEDTheme
                         ? styles.expandableToggleTextLED

--- a/src/components/SelectBoundModal.render.test.tsx
+++ b/src/components/SelectBoundModal.render.test.tsx
@@ -130,7 +130,6 @@ jest.mock('../store/atoms/theme', () => ({
 
 describe('SelectBoundModal', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
     (useAtomValue as jest.Mock).mockReturnValue(false);
     (useAtom as jest.Mock).mockImplementation((atom: string) => {
       if (atom === 'stationState') {
@@ -176,6 +175,10 @@ describe('SelectBoundModal', () => {
       }
       return [{}, jest.fn()];
     });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('プリセット名モーダルは親モーダルの外側に描画される', () => {

--- a/src/components/SelectBoundModal.render.test.tsx
+++ b/src/components/SelectBoundModal.render.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, within } from '@testing-library/react-native';
+import { useAtom, useAtomValue } from 'jotai';
+import type React from 'react';
+import { SelectBoundModal } from './SelectBoundModal';
+
+jest.mock('@react-navigation/native', () => ({
+  CommonActions: { navigate: jest.fn() },
+  useNavigation: jest.fn(() => ({ navigate: jest.fn() })),
+}));
+
+jest.mock('jotai', () => ({
+  useAtom: jest.fn(),
+  useAtomValue: jest.fn(),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('~/hooks', () => ({
+  useBounds: jest.fn(() => ({
+    bounds: [[{ id: 1, groupId: 1 }], [{ id: 2, groupId: 2 }]],
+  })),
+  useGetStationsWithTermination: jest.fn(() => jest.fn()),
+  useLoopLine: jest.fn(() => ({ isLoopLine: false })),
+  useSavedRoutes: jest.fn(() => ({
+    isInitialized: true,
+    find: jest.fn(() => null),
+    save: jest.fn(),
+    remove: jest.fn(),
+  })),
+}));
+
+jest.mock('~/translation', () => ({
+  isJapanese: true,
+  translate: jest.fn((key: string) => key),
+}));
+
+jest.mock('~/utils/isTablet', () => false);
+jest.mock('~/utils/line', () => ({
+  getLocalizedLineName: jest.fn(() => 'Yamanote Line'),
+  isBusLine: jest.fn(() => false),
+}));
+jest.mock('~/utils/toast', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('./Button', () => {
+  const { Pressable, Text: NativeText } = require('react-native');
+  return ({
+    children,
+    onPress,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+    disabled?: boolean;
+  }) => (
+    <Pressable accessibilityRole="button" disabled={disabled} onPress={onPress}>
+      <NativeText>{children}</NativeText>
+    </Pressable>
+  );
+});
+
+jest.mock('./CommonCard', () => ({
+  CommonCard: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{title}</Text>;
+  },
+}));
+jest.mock('./Heading', () => ({
+  Heading: ({ children }: { children: React.ReactNode }) => {
+    const { Text } = require('react-native');
+    return <Text>{children}</Text>;
+  },
+}));
+jest.mock('./CustomModal', () => ({
+  CustomModal: ({
+    children,
+    visible,
+  }: {
+    children: React.ReactNode;
+    visible: boolean;
+  }) => {
+    const { View } = require('react-native');
+    return visible ? (
+      <View testID="select-bound-custom-modal">{children}</View>
+    ) : null;
+  },
+}));
+jest.mock('./RouteInfoModal', () => ({
+  RouteInfoModal: () => null,
+}));
+jest.mock('./SelectBoundSettingListModal', () => ({
+  SelectBoundSettingListModal: () => null,
+}));
+jest.mock('./TrainTypeListModal', () => ({
+  TrainTypeListModal: () => null,
+}));
+jest.mock('./SavePresetNameModal', () => ({
+  SavePresetNameModal: ({ visible }: { visible: boolean }) =>
+    visible
+      ? (() => {
+          const { View } = require('react-native');
+          return <View testID="save-preset-modal" />;
+        })()
+      : null,
+}));
+
+jest.mock('../stacks/rootNavigation', () => ({
+  navigationRef: {
+    isReady: jest.fn(() => false),
+    dispatch: jest.fn(),
+  },
+}));
+
+jest.mock('../store/atoms/station', () => 'stationState');
+jest.mock('../store/atoms/navigation', () => 'navigationState');
+jest.mock('../store/atoms/line', () => 'lineState');
+jest.mock('../store/atoms/notify', () => 'notifyState');
+jest.mock('../store/atoms/theme', () => ({
+  isLEDThemeAtom: 'isLEDThemeAtom',
+}));
+
+describe('SelectBoundModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAtomValue as jest.Mock).mockReturnValue(false);
+    (useAtom as jest.Mock).mockImplementation((atom: string) => {
+      if (atom === 'stationState') {
+        return [
+          {
+            pendingStation: { id: 1, groupId: 1, lines: [{ id: 10 }] },
+            pendingStations: [
+              { id: 1, groupId: 1, line: { id: 10 }, lines: [{ id: 10 }] },
+              { id: 2, groupId: 2, line: { id: 10 }, lines: [{ id: 10 }] },
+            ],
+            wantedDestination: null,
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'navigationState') {
+        return [
+          {
+            autoModeEnabled: false,
+            fetchedTrainTypes: [
+              { groupId: 100, name: 'Rapid', nameRoman: 'Rapid' },
+            ],
+            pendingTrainType: null,
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'lineState') {
+        return [
+          {
+            pendingLine: { id: 10, name: '山手線', nameRoman: 'Yamanote Line' },
+            selectedLine: {
+              id: 10,
+              name: '山手線',
+              nameRoman: 'Yamanote Line',
+            },
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'notifyState') {
+        return [{ targetStationIds: [] }, jest.fn()];
+      }
+      return [{}, jest.fn()];
+    });
+  });
+
+  it('プリセット名モーダルは親モーダルの外側に描画される', () => {
+    const screen = render(
+      <SelectBoundModal
+        visible={true}
+        onClose={jest.fn()}
+        loading={false}
+        error={null}
+        onTrainTypeSelect={jest.fn()}
+        onBoundSelect={jest.fn()}
+      />
+    );
+
+    fireEvent.press(screen.getByText('saveCurrentRoute'));
+
+    expect(screen.getByTestId('save-preset-modal')).toBeTruthy();
+    expect(
+      within(screen.getByTestId('select-bound-custom-modal')).queryByTestId(
+        'save-preset-modal'
+      )
+    ).toBeNull();
+  });
+});

--- a/src/components/SelectBoundModal.render.test.tsx
+++ b/src/components/SelectBoundModal.render.test.tsx
@@ -3,6 +3,8 @@ import { useAtom, useAtomValue } from 'jotai';
 import type React from 'react';
 import { SelectBoundModal } from './SelectBoundModal';
 
+const mockRouteInfoModal = jest.fn();
+
 jest.mock('@react-navigation/native', () => ({
   CommonActions: { navigate: jest.fn() },
   useNavigation: jest.fn(() => ({ navigate: jest.fn() })),
@@ -40,6 +42,10 @@ jest.mock('~/utils/line', () => ({
 }));
 jest.mock('~/utils/toast', () => ({
   showToast: jest.fn(),
+}));
+jest.mock('~/utils/isPass', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
 }));
 
 jest.mock('./Button', () => {
@@ -86,7 +92,10 @@ jest.mock('./CustomModal', () => ({
   },
 }));
 jest.mock('./RouteInfoModal', () => ({
-  RouteInfoModal: () => null,
+  RouteInfoModal: (props: unknown) => {
+    mockRouteInfoModal(props);
+    return null;
+  },
 }));
 jest.mock('./SelectBoundSettingListModal', () => ({
   SelectBoundSettingListModal: () => null,
@@ -189,5 +198,64 @@ describe('SelectBoundModal', () => {
         'save-preset-modal'
       )
     ).toBeNull();
+  });
+
+  it('終着駅設定中でも RouteInfoModal には全駅が渡される', () => {
+    (useAtom as jest.Mock).mockImplementation((atom: string) => {
+      if (atom === 'stationState') {
+        return [
+          {
+            pendingStation: { id: 2, groupId: 2, lines: [{ id: 10 }] },
+            pendingStations: [
+              { id: 1, groupId: 1, line: { id: 10 }, lines: [{ id: 10 }] },
+              { id: 2, groupId: 2, line: { id: 10 }, lines: [{ id: 10 }] },
+              { id: 3, groupId: 3, line: { id: 10 }, lines: [{ id: 10 }] },
+            ],
+            wantedDestination: { id: 3, groupId: 3 },
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'navigationState') {
+        return [
+          {
+            autoModeEnabled: false,
+            fetchedTrainTypes: [],
+            pendingTrainType: null,
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'lineState') {
+        return [
+          {
+            pendingLine: { id: 10, name: '山手線', nameRoman: 'Yamanote Line' },
+            selectedLine: null,
+          },
+          jest.fn(),
+        ];
+      }
+      if (atom === 'notifyState') {
+        return [{ targetStationIds: [] }, jest.fn()];
+      }
+      return [{}, jest.fn()];
+    });
+
+    render(
+      <SelectBoundModal
+        visible={true}
+        onClose={jest.fn()}
+        loading={false}
+        error={null}
+        onTrainTypeSelect={jest.fn()}
+        onBoundSelect={jest.fn()}
+      />
+    );
+
+    const lastCall =
+      mockRouteInfoModal.mock.calls[mockRouteInfoModal.mock.calls.length - 1];
+    const props = lastCall?.[0] as { stations: Array<{ groupId: number }> };
+
+    expect(props.stations.map((station) => station.groupId)).toEqual([1, 2, 3]);
   });
 });

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -710,107 +710,111 @@ export const SelectBoundModal: React.FC<Props> = ({
   ]);
 
   return (
-    <CustomModal
-      visible={visible}
-      onClose={onClose}
-      onCloseAnimationEnd={onCloseAnimationEnd}
-      dismissOnBackdropPress={!loading && !isTransitioning}
-      backdropStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-      contentContainerStyle={[
-        styles.contentView,
-        {
-          backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
-          borderRadius: isLEDTheme ? 0 : 8,
-        },
-        isTablet && {
-          width: '80%',
-          maxHeight: '90%',
-          shadowOpacity: 0.25,
-          shadowColor: '#333',
-          borderRadius: isLEDTheme ? 0 : 16,
-        },
-      ]}
-    >
-      <View style={styles.container}>
-        <Heading style={styles.heading}>
-          {translate('selectBoundTitle')}
-        </Heading>
+    <>
+      <CustomModal
+        visible={visible}
+        onClose={onClose}
+        onCloseAnimationEnd={onCloseAnimationEnd}
+        dismissOnBackdropPress={!loading && !isTransitioning}
+        backdropStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+        contentContainerStyle={[
+          styles.contentView,
+          {
+            backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
+            borderRadius: isLEDTheme ? 0 : 8,
+          },
+          isTablet && {
+            width: '80%',
+            maxHeight: '90%',
+            shadowOpacity: 0.25,
+            shadowColor: '#333',
+            borderRadius: isLEDTheme ? 0 : 16,
+          },
+        ]}
+      >
+        <View style={styles.container}>
+          <Heading style={styles.heading}>
+            {translate('selectBoundTitle')}
+          </Heading>
 
-        <View style={styles.buttonsContainer}>
-          <View
-            pointerEvents={isTransitioning ? 'none' : 'auto'}
-            style={[
-              styles.boundCardsContainer,
-              isTransitioning && styles.boundCardsDisabled,
-            ]}
-          >
-            {inboundStations.length
-              ? renderButton({
-                  boundStations: inboundStations,
-                  direction: 'INBOUND',
-                  loading,
-                })
-              : null}
-            {outboundStations.length
-              ? renderButton({
-                  boundStations: outboundStations,
-                  direction: 'OUTBOUND',
-                  loading,
-                })
-              : null}
-          </View>
+          <View style={styles.buttonsContainer}>
+            <View
+              pointerEvents={isTransitioning ? 'none' : 'auto'}
+              style={[
+                styles.boundCardsContainer,
+                isTransitioning && styles.boundCardsDisabled,
+              ]}
+            >
+              {inboundStations.length
+                ? renderButton({
+                    boundStations: inboundStations,
+                    direction: 'INBOUND',
+                    loading,
+                  })
+                : null}
+              {outboundStations.length
+                ? renderButton({
+                    boundStations: outboundStations,
+                    direction: 'OUTBOUND',
+                    loading,
+                  })
+                : null}
+            </View>
 
-          <View style={styles.stopsContainer}>
+            <View style={styles.stopsContainer}>
+              <Button
+                outline
+                onPress={() => setRouteInfoModalVisible(true)}
+                disabled={loading || isTransitioning}
+              >
+                {isBus
+                  ? translate('viewBusStops')
+                  : translate('viewStopStations')}
+              </Button>
+
+              <Button
+                outline
+                onPress={() => setIsTrainTypeModalVisible(true)}
+                disabled={
+                  !fetchedTrainTypes.length || loading || isTransitioning
+                }
+              >
+                {trainTypeText}
+              </Button>
+
+              <Button
+                outline
+                style={savedRoute ? styles.redOutlinedButton : null}
+                textStyle={savedRoute ? styles.redOutlinedButtonText : null}
+                onPress={handleSaveRoutePress}
+                disabled={
+                  !line || !isRoutesDBInitialized || loading || isTransitioning
+                }
+              >
+                {translate(
+                  !savedRoute ? 'saveCurrentRoute' : 'removeFromSavedRoutes'
+                )}
+              </Button>
+              <Button
+                outline
+                onPress={() => setSelectBoundSettingListModalVisible(true)}
+                disabled={isTransitioning}
+              >
+                {translate('settings')}
+              </Button>
+            </View>
+
             <Button
-              outline
-              onPress={() => setRouteInfoModalVisible(true)}
+              style={styles.closeButton}
+              textStyle={styles.closeButtonText}
+              onPress={onClose}
               disabled={loading || isTransitioning}
             >
-              {isBus
-                ? translate('viewBusStops')
-                : translate('viewStopStations')}
-            </Button>
-
-            <Button
-              outline
-              onPress={() => setIsTrainTypeModalVisible(true)}
-              disabled={!fetchedTrainTypes.length || loading || isTransitioning}
-            >
-              {trainTypeText}
-            </Button>
-
-            <Button
-              outline
-              style={savedRoute ? styles.redOutlinedButton : null}
-              textStyle={savedRoute ? styles.redOutlinedButtonText : null}
-              onPress={handleSaveRoutePress}
-              disabled={
-                !line || !isRoutesDBInitialized || loading || isTransitioning
-              }
-            >
-              {translate(
-                !savedRoute ? 'saveCurrentRoute' : 'removeFromSavedRoutes'
-              )}
-            </Button>
-            <Button
-              outline
-              onPress={() => setSelectBoundSettingListModalVisible(true)}
-              disabled={isTransitioning}
-            >
-              {translate('settings')}
+              {translate('close')}
             </Button>
           </View>
-
-          <Button
-            style={styles.closeButton}
-            textStyle={styles.closeButtonText}
-            onPress={onClose}
-            disabled={loading || isTransitioning}
-          >
-            {translate('close')}
-          </Button>
         </View>
-      </View>
+      </CustomModal>
 
       <RouteInfoModal
         visible={routeInfoModalVisible}
@@ -842,6 +846,10 @@ export const SelectBoundModal: React.FC<Props> = ({
           onTrainTypeSelect(trainType);
         }}
       />
+      {/*
+        Keep the preset-name modal outside the parent modal tree to avoid
+        nested modal lifecycle glitches on iOS during route-save updates.
+      */}
       <SavePresetNameModal
         visible={isPresetNameModalVisible}
         onClose={() => setIsPresetNameModalVisible(false)}
@@ -849,6 +857,6 @@ export const SelectBoundModal: React.FC<Props> = ({
         defaultName={presetDefaultName}
         directionOptions={presetDirectionOptions}
       />
-    </CustomModal>
+    </>
   );
 };

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -673,8 +673,8 @@ export const SelectBoundModal: React.FC<Props> = ({
   }, [fetchedTrainTypes, pendingTrainType]);
 
   const stationsWithoutPass = useMemo(
-    () => effectiveStations.filter((s) => !getIsPass(s)),
-    [effectiveStations]
+    () => stations.filter((s) => !getIsPass(s)),
+    [stations]
   );
 
   const isBus = isBusLine(line);

--- a/src/components/ToggleButton.test.tsx
+++ b/src/components/ToggleButton.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { ToggleButton } from './ToggleButton';
 
 // Mock jotai
@@ -116,5 +116,14 @@ describe('ToggleButton', () => {
     const button = getByText('テストボタン').parent?.parent;
     expect(button).toBeTruthy();
     // スタイルのアサーションは実際のスナップショットテストで確認されるべき
+  });
+
+  it('ラベルが横幅を埋めて状態パネルを右端に寄せる', () => {
+    const { getByText } = render(<ToggleButton {...defaultProps} />);
+
+    const label = getByText('テストボタン');
+    const style = StyleSheet.flatten(label.props.style);
+
+    expect(style.flex).toBe(1);
   });
 });

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -21,6 +21,7 @@ type Props = {
   onToggle: (event: GestureResponderEvent) => void;
   outline?: boolean;
   style?: StyleProp<ViewStyle>;
+  statePanelStyle?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
   state?: boolean;
   onText?: string;
@@ -68,6 +69,10 @@ const styles = StyleSheet.create({
     fontSize: RFValue(14),
     color: '#fff',
   },
+  textFill: {
+    flex: 1,
+    marginRight: 12,
+  },
   outlinedButton: {
     borderColor: '#008ffe',
     borderWidth: 1,
@@ -83,7 +88,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 1,
-    flex: 1,
   },
   stateIndicatorText: {
     fontSize: RFValue(14),
@@ -96,11 +100,13 @@ export const StatePanel = ({
   onText = 'ON',
   offText = 'OFF',
   disabled,
+  style,
 }: {
   state: boolean;
   onText?: string;
   offText?: string;
   disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
@@ -123,7 +129,7 @@ export const StatePanel = ({
   );
 
   return (
-    <View style={[styles.stateIndicator, styleIndicatorStyle]}>
+    <View style={[styles.stateIndicator, styleIndicatorStyle, style]}>
       <Typography
         style={[styles.stateIndicatorText, { color: state ? '#fff' : '#888' }]}
       >
@@ -138,6 +144,7 @@ export const ToggleButton: React.FC<Props> = ({
   onToggle,
   outline,
   style,
+  statePanelStyle,
   textStyle,
   state,
   onText = 'ON',
@@ -166,12 +173,22 @@ export const ToggleButton: React.FC<Props> = ({
     >
       <Typography
         numberOfLines={1}
-        style={[styles.text, outline && styles.outlinedButtonText, textStyle]}
+        style={[
+          styles.text,
+          styles.textFill,
+          outline && styles.outlinedButtonText,
+          textStyle,
+        ]}
       >
         {children}
       </Typography>
 
-      <StatePanel state={!!state} onText={onText} offText={offText} />
+      <StatePanel
+        state={!!state}
+        onText={onText}
+        offText={offText}
+        style={statePanelStyle}
+      />
     </TouchableOpacity>
   );
 };


### PR DESCRIPTION
## 目的
プリセット保存まわりのモーダル不具合を修正し、関連する駅設定UIの操作性を改善します。

## 変更概要
- プリセット名モーダルを親モーダルの外に出し、iPhone実機で保存時に白背景だけ消えてバックドロップが残る不具合を修正
- RouteInfoModal のトグル行でラベル表示領域を広げ、文言の欠けを軽減
- 終着駅設定を切り替えても駅一覧モーダル内では全駅表示を維持
- 回帰テストを追加して、モーダル階層と駅一覧受け渡しを固定

## リスクと軽減策
- ToggleButton のレイアウト変更が他画面へ波及する可能性があります

## ローカル実行コマンド
- npm test -- --runInBand src/components/SelectBoundModal.render.test.tsx
- npm test -- --runInBand src/components/ToggleButton.test.tsx
- npx biome check --config-path ./biome.json src/components/SelectBoundModal.tsx src/components/SelectBoundModal.render.test.tsx
- npx biome check --config-path ./biome.json src/components/ToggleButton.tsx src/components/ToggleButton.test.tsx src/components/RouteInfoModal.tsx
- npm run typecheck

## スクリーンショット
- なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * 展開可能なトグルパネルのスタイルを改善し、固定幅とパディングを追加しました
  * UI要素の間隔調整を実施しました

* **Bug Fixes**
  * モーダルレイアウトを再構成し、ライフサイクル管理を最適化しました

* **Tests**
  * UI動作検証のための包括的なテストを追加しました
  * ラベルレイアウト検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->