### PR TITLE
CustomModalにonShowコールバックを追加しiOSフォーカス遅延のマジックナンバーを除去

### DIFF
--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -19,6 +19,8 @@ type Props = {
   onClose?: () => void;
   /** 閉じるアニメーションが完了した後に呼ばれるコールバック */
   onCloseAnimationEnd?: () => void;
+  /** 開くアニメーションが完了した後に呼ばれるコールバック */
+  onShow?: () => void;
   dismissOnBackdropPress?: boolean;
   backdropStyle?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
@@ -39,6 +41,7 @@ export const CustomModal: React.FC<Props> = ({
   children,
   onClose,
   onCloseAnimationEnd,
+  onShow,
   dismissOnBackdropPress = true,
   backdropStyle,
   containerStyle,
@@ -72,7 +75,11 @@ export const CustomModal: React.FC<Props> = ({
         toValue: 1,
         duration: animationDuration,
         useNativeDriver: true,
-      }).start();
+      }).start(({ finished }) => {
+        if (finished) {
+          onShow?.();
+        }
+      });
       return;
     }
 
@@ -86,7 +93,7 @@ export const CustomModal: React.FC<Props> = ({
         onCloseAnimationEnd?.();
       }
     });
-  }, [animationDuration, opacity, visible, onCloseAnimationEnd]);
+  }, [animationDuration, opacity, visible, onCloseAnimationEnd, onShow]);
 
   const handleBackdropPress = () => {
     Keyboard.dismiss();

--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -52,6 +52,8 @@ export const CustomModal: React.FC<Props> = ({
 }) => {
   const [isMounted, setIsMounted] = useState(visible);
   const opacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  const onShowRef = useRef(onShow);
+  const onCloseAnimationEndRef = useRef(onCloseAnimationEnd);
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const animatedBackdropStyle = {
     opacity,
@@ -69,6 +71,14 @@ export const CustomModal: React.FC<Props> = ({
   };
 
   useEffect(() => {
+    onShowRef.current = onShow;
+  }, [onShow]);
+
+  useEffect(() => {
+    onCloseAnimationEndRef.current = onCloseAnimationEnd;
+  }, [onCloseAnimationEnd]);
+
+  useEffect(() => {
     if (visible) {
       setIsMounted(true);
       Animated.timing(opacity, {
@@ -77,7 +87,7 @@ export const CustomModal: React.FC<Props> = ({
         useNativeDriver: true,
       }).start(({ finished }) => {
         if (finished) {
-          onShow?.();
+          onShowRef.current?.();
         }
       });
       return;
@@ -90,10 +100,10 @@ export const CustomModal: React.FC<Props> = ({
     }).start(({ finished }) => {
       if (finished && !visible) {
         setIsMounted(false);
-        onCloseAnimationEnd?.();
+        onCloseAnimationEndRef.current?.();
       }
     });
-  }, [animationDuration, opacity, visible, onCloseAnimationEnd, onShow]);
+  }, [animationDuration, opacity, visible]);
 
   const handleBackdropPress = () => {
     Keyboard.dismiss();

--- a/src/components/SavePresetNameModal.tsx
+++ b/src/components/SavePresetNameModal.tsx
@@ -110,11 +110,11 @@ export const SavePresetNameModal: React.FC<Props> = ({
       inboundOpacity.setValue(1);
       outboundOpacity.setValue(1);
 
-      // モーダルアニメーション(180ms)とKeyboardAvoidingViewのレイアウト確定を待ってからフォーカスする
+      // モーダルアニメーション(180ms)の完了を待ってからフォーカスする
       if (Platform.OS === 'ios') {
         const timer = setTimeout(() => {
           textInputRef.current?.focus();
-        }, 300);
+        }, 180);
         return () => clearTimeout(timer);
       }
     }

--- a/src/components/SavePresetNameModal.tsx
+++ b/src/components/SavePresetNameModal.tsx
@@ -109,14 +109,6 @@ export const SavePresetNameModal: React.FC<Props> = ({
       );
       inboundOpacity.setValue(1);
       outboundOpacity.setValue(1);
-
-      // モーダルアニメーション(180ms)の完了を待ってからフォーカスする
-      if (Platform.OS === 'ios') {
-        const timer = setTimeout(() => {
-          textInputRef.current?.focus();
-        }, 180);
-        return () => clearTimeout(timer);
-      }
     }
   }, [visible, defaultName, directionOptions, inboundOpacity, outboundOpacity]);
 
@@ -163,6 +155,12 @@ export const SavePresetNameModal: React.FC<Props> = ({
     onSubmit(name, selectedDirection);
   }, [onSubmit, selectedDirection, hasDirectionOptions]);
 
+  const handleShow = useCallback(() => {
+    if (Platform.OS === 'ios') {
+      textInputRef.current?.focus();
+    }
+  }, []);
+
   const canSubmit =
     !isEmpty && (!hasDirectionOptions || selectedDirection !== null);
   const textColor = isLEDTheme ? '#fff' : '#000';
@@ -171,6 +169,7 @@ export const SavePresetNameModal: React.FC<Props> = ({
     <CustomModal
       visible={visible}
       onClose={onClose}
+      onShow={handleShow}
       backdropStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
       contentContainerStyle={[
         styles.contentView,


### PR DESCRIPTION
## Summary
- `CustomModal` に `onShow` コールバック prop を追加（開くアニメーション完了時に発火）
- `SavePresetNameModal` の `setTimeout(() => focus(), 180)` を削除し、`onShow` 経由でフォーカスするよう変更
- `onShow` / `onCloseAnimationEnd` を ref パターンに変更し、親の再レンダーによる不要なエフェクト再実行を防止

## Test plan
- [ ] iPhone（またはiOSシミュレータ）でプリセット保存モーダルを開き、アニメーション完了後にフォーカスが当たることを確認
- [ ] モーダル表示直後にキーボードが表示され、コンテンツが画面内に収まることを確認
- [ ] Android でも `autoFocus` による従来のフォーカス動作が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)