### PR TITLE
開発者オーバレイのUIと長押しメニュー切り替えを整備

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -205,6 +205,8 @@
   "canaryNotice": "This TrainLCD is a canary release.",
   "setAsTerminus": "Set as terminus",
   "optInTelemetryTitle": "Enable telemetry",
+  "showDevOverlay": "Show developer overlay",
+  "hideDevOverlay": "Hide developer overlay",
   "telemetrySettingWillPersist": "Enabling telemetry will be persisted.",
   "personalize": "Personalize",
   "forDevelopers": "Developers",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -206,6 +206,8 @@
   "canaryNotice": "このTrainLCDはカナリアリリースです。",
   "setAsTerminus": "終着駅に設定する",
   "optInTelemetryTitle": "テレメトリを有効にする",
+  "showDevOverlay": "開発者オーバレイを表示",
+  "hideDevOverlay": "開発者オーバレイを非表示",
   "telemetrySettingWillPersist": "テレメトリ有効化は永続的に保持されます。",
   "personalize": "パーソナライズ",
   "forDevelopers": "開発者向け",

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -2,6 +2,11 @@ import { render } from '@testing-library/react-native';
 import * as Application from 'expo-application';
 import { useAtomValue } from 'jotai';
 import type { Station } from '~/@types/graphql';
+import {
+  accuracyHistoryAtom,
+  backgroundLocationTrackingAtom,
+  locationAtom,
+} from '~/store/atoms/location';
 import DevOverlay from './DevOverlay';
 
 jest.mock('jotai', () => {
@@ -62,20 +67,36 @@ const mockUseNextStation = useNextStation as jest.MockedFunction<
 >;
 
 describe('DevOverlay', () => {
-  beforeEach(() => {
-    // Default mock implementations for useAtomValue
-    // locationAtom, accuracyHistoryAtom, backgroundLocationTrackingAtomの順で呼ばれる
-    // (useTelemetryEnabledは別途モック済み)
-    mockUseAtomValue
-      .mockReturnValueOnce({
-        coords: {
-          speed: 10,
-          accuracy: 15,
-        },
-      }) // locationAtom
-      .mockReturnValueOnce([10, 15, 20]) // accuracyHistoryAtom
-      .mockReturnValue(false); // backgroundLocationTrackingAtom
+  const setupAtomValues = ({
+    location = {
+      coords: {
+        speed: 10,
+        accuracy: 15,
+      },
+    },
+    accuracyHistory = [10, 15, 20],
+    backgroundLocationTracking = false,
+  }: {
+    location?: unknown;
+    accuracyHistory?: unknown;
+    backgroundLocationTracking?: boolean;
+  } = {}) => {
+    mockUseAtomValue.mockImplementation((atom) => {
+      if (atom === locationAtom) {
+        return location as never;
+      }
+      if (atom === accuracyHistoryAtom) {
+        return accuracyHistory as never;
+      }
+      if (atom === backgroundLocationTrackingAtom) {
+        return backgroundLocationTracking as never;
+      }
+      return undefined as never;
+    });
+  };
 
+  beforeEach(() => {
+    setupAtomValues();
     mockUseDistanceToNextStation.mockReturnValue('500');
     mockUseNextStation.mockReturnValue({
       id: 1,
@@ -106,59 +127,72 @@ describe('DevOverlay', () => {
 
     it('テレメトリー状態を表示する', () => {
       const { getByText } = render(<DevOverlay />);
-      expect(getByText('Telemetry: ON')).toBeTruthy();
+      expect(getByText('TELEMETRY')).toBeTruthy();
+      expect(getByText('ON')).toBeTruthy();
     });
 
     it('バックグラウンド位置情報のOFF状態を表示する', () => {
       const { getByText } = render(<DevOverlay />);
-      expect(getByText('BG Loc: OFF')).toBeTruthy();
+      expect(getByText('BG LOC')).toBeTruthy();
+      expect(getByText('OFF')).toBeTruthy();
     });
 
     it('バックグラウンド位置情報のON状態を表示する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: 10, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValueOnce([10, 15, 20]) // accuracyHistoryAtom
-        .mockReturnValue(true); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [10, 15, 20],
+        backgroundLocationTracking: true,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('BG Loc: ON')).toBeTruthy();
+      const { getByText, getAllByText } = render(<DevOverlay />);
+      expect(getByText('BG LOC')).toBeTruthy();
+      expect(getAllByText('ON')).toHaveLength(2);
     });
   });
 
   describe('位置情報の表示', () => {
     it('精度情報を表示する', () => {
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Accuracy: 15m')).toBeTruthy();
+      const { getByText, getByTestId } = render(<DevOverlay />);
+      expect(getByText('LOCATION ACCURACY')).toBeTruthy();
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent(
+        '15m'
+      );
     });
 
     it('速度情報をkm/hで表示する', () => {
-      const { getByText } = render(<DevOverlay />);
-      // speed: 10 m/s = 36 km/h
-      expect(getByText('Speed: 36km/h')).toBeTruthy();
+      const { getByText, getByTestId } = render(<DevOverlay />);
+      expect(getByText('CURRENT SPEED')).toBeTruthy();
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+        '36km/h'
+      );
     });
 
     it('次の駅までの距離を表示する', () => {
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText(/Next: 500m テスト駅/)).toBeTruthy();
+      const { getByText, getByTestId } = render(<DevOverlay />);
+      expect(getByText('NEXT TARGET')).toBeTruthy();
+      expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('500m');
+      expect(getByTestId('dev-overlay-next-meta')).toHaveTextContent(
+        'テスト駅'
+      );
     });
 
     it('精度チャートを表示する', () => {
-      const { getByText } = render(<DevOverlay />);
-      // accuracyHistory: [10, 15, 20] -> '▇▇▇'
-      expect(getByText('▇▇▇')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
+        '▇▇▇'
+      );
     });
   });
 
   describe('エッジケース', () => {
     it('位置情報がnullの場合にクラッシュしない', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce(null) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+      setupAtomValues({
+        location: null,
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
       expect(() => {
         render(<DevOverlay />);
@@ -166,52 +200,52 @@ describe('DevOverlay', () => {
     });
 
     it('速度がnullの場合に0km/hを表示する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: null, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Speed: 0km/h')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent('0km/h');
     });
 
     it('速度が負の値の場合に0km/hを表示する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: -5, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Speed: 0km/h')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent('0km/h');
     });
 
     it('精度がnullの場合に空文字を表示する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: 10, accuracy: null },
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Accuracy: m')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent('--');
     });
 
     it('accuracyHistoryが空配列の場合にクラッシュしない', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: 10, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
       expect(() => {
         render(<DevOverlay />);
@@ -219,12 +253,13 @@ describe('DevOverlay', () => {
     });
 
     it('accuracyHistoryがnullの場合にクラッシュしない', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: 10, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValue(null); // accuracyHistoryAtom
+        },
+        accuracyHistory: null,
+        backgroundLocationTracking: false,
+      });
 
       expect(() => {
         render(<DevOverlay />);
@@ -234,51 +269,54 @@ describe('DevOverlay', () => {
     it('次の駅までの距離が0の場合に適切に表示する', () => {
       mockUseDistanceToNextStation.mockReturnValue(0);
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Next:')).toBeTruthy();
+      const { getByText, getByTestId } = render(<DevOverlay />);
+      expect(getByText('NEXT TARGET')).toBeTruthy();
+      expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('--');
     });
 
     it('次の駅情報がundefinedの場合に距離のみ表示する', () => {
       mockUseNextStation.mockReturnValue(undefined);
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText(/Next: 500m$/)).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('500m');
     });
 
     it('次の駅情報と距離の両方がundefined/0の場合', () => {
       mockUseDistanceToNextStation.mockReturnValue(0);
       mockUseNextStation.mockReturnValue(undefined);
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Next:')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('--');
     });
   });
 
   describe('速度計算のロジック', () => {
     it('速度が0の場合に0km/hを表示する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
+      setupAtomValues({
+        location: {
           coords: { speed: 0, accuracy: 15 },
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Speed: 0km/h')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent('0km/h');
     });
 
     it('速度が正の小数値の場合に正しく変換する', () => {
-      mockUseAtomValue.mockReset();
-      mockUseAtomValue
-        .mockReturnValueOnce({
-          coords: { speed: 13.89, accuracy: 15 }, // 約50 km/h
-        }) // locationAtom
-        .mockReturnValueOnce([]) // accuracyHistoryAtom
-        .mockReturnValue(false); // backgroundLocationTrackingAtom
+      setupAtomValues({
+        location: {
+          coords: { speed: 13.89, accuracy: 15 },
+        },
+        accuracyHistory: [],
+        backgroundLocationTracking: false,
+      });
 
-      const { getByText } = render(<DevOverlay />);
-      expect(getByText('Speed: 50km/h')).toBeTruthy();
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+        '50km/h'
+      );
     });
   });
 });

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -7,6 +7,7 @@ import {
   backgroundLocationTrackingAtom,
   locationAtom,
 } from '~/store/atoms/location';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
 import DevOverlay from './DevOverlay';
 
 jest.mock('jotai', () => {
@@ -91,7 +92,10 @@ describe('DevOverlay', () => {
       if (atom === backgroundLocationTrackingAtom) {
         return backgroundLocationTracking as never;
       }
-      return undefined as never;
+      if (atom === isLEDThemeAtom) {
+        return false as never;
+      }
+      throw new Error(`Unexpected atom mock: ${String(atom)}`);
     });
   };
 

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react-native';
 import * as Application from 'expo-application';
 import { useAtomValue } from 'jotai';
+import { Dimensions } from 'react-native';
 import type { Station } from '~/@types/graphql';
 import {
   accuracyHistoryAtom,
@@ -68,6 +69,8 @@ const mockUseNextStation = useNextStation as jest.MockedFunction<
 >;
 
 describe('DevOverlay', () => {
+  const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
+
   const setupAtomValues = ({
     location = {
       coords: {
@@ -100,6 +103,12 @@ describe('DevOverlay', () => {
   };
 
   beforeEach(() => {
+    mockDimensionsGet.mockReturnValue({
+      width: 393,
+      height: 852,
+      scale: 3,
+      fontScale: 1,
+    } as ReturnType<typeof Dimensions.get>);
     setupAtomValues();
     mockUseDistanceToNextStation.mockReturnValue('500');
     mockUseNextStation.mockReturnValue({
@@ -112,6 +121,7 @@ describe('DevOverlay', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    mockDimensionsGet.mockReset();
   });
 
   describe('基本的なレンダリング', () => {
@@ -154,6 +164,18 @@ describe('DevOverlay', () => {
       const { getByText, getAllByText } = render(<DevOverlay />);
       expect(getByText('BG LOC')).toBeTruthy();
       expect(getAllByText('ON')).toHaveLength(2);
+    });
+
+    it('横画面レイアウトを表示する', () => {
+      mockDimensionsGet.mockReturnValue({
+        width: 852,
+        height: 393,
+        scale: 3,
+        fontScale: 1,
+      } as ReturnType<typeof Dimensions.get>);
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-landscape')).toBeTruthy();
     });
   });
 

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -102,6 +102,7 @@ describe('DevOverlay', () => {
       id: 1,
       name: 'テスト駅',
       nameRoman: 'Test Station',
+      stationNumbers: [{ stationNumber: 'JK-01' }],
     } as Station);
   });
 
@@ -174,7 +175,7 @@ describe('DevOverlay', () => {
       expect(getByText('NEXT TARGET')).toBeTruthy();
       expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('500m');
       expect(getByTestId('dev-overlay-next-meta')).toHaveTextContent(
-        'テスト駅'
+        'テスト駅 / JK-01'
       );
     });
 

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -520,9 +520,7 @@ const DevOverlay: React.FC = () => {
                     <Typography style={styles.chartLabel}>
                       ACCURACY HISTORY
                     </Typography>
-                    <Typography style={[styles.chartValue, chartValueStyle]}>
-                      {accuracyChartBlocks.length === 0 ? '---' : null}
-                    </Typography>
+                    <Typography style={[styles.chartValue, chartValueStyle]} />
                     <Typography
                       style={[styles.chartValue, chartValueStyle]}
                       testID="dev-overlay-accuracy-history"
@@ -592,9 +590,7 @@ const DevOverlay: React.FC = () => {
                 <Typography style={styles.chartLabel}>
                   ACCURACY HISTORY
                 </Typography>
-                <Typography style={[styles.chartValue, chartValueStyle]}>
-                  {accuracyChartBlocks.length === 0 ? '---' : null}
-                </Typography>
+                <Typography style={[styles.chartValue, chartValueStyle]} />
                 <Typography
                   style={[styles.chartValue, chartValueStyle]}
                   testID="dev-overlay-accuracy-history"

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -1,7 +1,18 @@
 import * as Application from 'expo-application';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useAtomValue } from 'jotai';
-import React, { useMemo } from 'react';
-import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  PanResponder,
+  type StyleProp,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import { useDistanceToNextStation, useNextStation } from '~/hooks';
 import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import {
@@ -12,24 +23,242 @@ import {
 import { generateAccuracyChart } from '~/utils/accuracyChart';
 import Typography from './Typography';
 
+const PANEL_BORDER = 'rgba(255,255,255,0.18)';
+const PANEL_BG = 'rgba(7, 11, 24, 0.78)';
+const LABEL_COLOR = 'rgba(199, 210, 254, 0.72)';
+const VALUE_COLOR = '#f8fafc';
+const AURORA_COLORS = [
+  'rgba(56, 189, 248, 0.28)',
+  'rgba(217, 70, 239, 0.2)',
+] as const;
+
 const styles = StyleSheet.create({
   root: {
     position: 'absolute',
-    right: 0,
-    backgroundColor: 'rgba(0,0,0,0.5)',
+    left: 0,
+    top: 0,
     zIndex: 9999,
-    padding: 4,
+    borderRadius: 24,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: PANEL_BORDER,
+    backgroundColor: PANEL_BG,
+    shadowColor: '#020617',
+    shadowOpacity: 0.35,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 12 },
+    elevation: 20,
   },
-  text: {
-    color: 'white',
+  chrome: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  headerCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  eyebrow: {
+    fontSize: 10,
+    letterSpacing: 2.2,
+    color: 'rgba(191, 219, 254, 0.78)',
+  },
+  title: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  version: {
+    color: 'rgba(226, 232, 240, 0.72)',
     fontSize: 11,
   },
-  textHeading: {
-    color: 'white',
-    fontWeight: 'bold',
+  statusRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexShrink: 0,
+    alignItems: 'center',
+  },
+  statusPill: {
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderWidth: 1,
+    minWidth: 72,
+  },
+  statusLabel: {
+    color: 'rgba(226, 232, 240, 0.78)',
+    fontSize: 8,
+    letterSpacing: 1.2,
+    marginBottom: 2,
+  },
+  statusValue: {
+    color: '#fff',
     fontSize: 11,
+    fontWeight: '700',
+  },
+  chartShell: {
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(125, 211, 252, 0.16)',
+    backgroundColor: 'rgba(15, 23, 42, 0.8)',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    gap: 4,
+  },
+  chartLabel: {
+    color: LABEL_COLOR,
+    fontSize: 9,
+    letterSpacing: 1.6,
+  },
+  chartValue: {
+    color: '#fff',
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  metricsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  metricCard: {
+    minHeight: 82,
+    borderRadius: 18,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: PANEL_BORDER,
+    backgroundColor: 'rgba(9, 14, 28, 0.7)',
+    justifyContent: 'space-between',
+  },
+  metricLabel: {
+    color: LABEL_COLOR,
+    fontSize: 9,
+    letterSpacing: 1.4,
+    marginBottom: 6,
+  },
+  metricValue: {
+    color: VALUE_COLOR,
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 22,
+  },
+  metricSuffix: {
+    color: 'rgba(191, 219, 254, 0.78)',
+    fontSize: 11,
+    fontWeight: '500',
+  },
+  metricMeta: {
+    color: 'rgba(226, 232, 240, 0.72)',
+    fontSize: 11,
+    lineHeight: 14,
+  },
+  footerText: {
+    color: 'rgba(148, 163, 184, 0.92)',
+    fontSize: 10,
+    letterSpacing: 1.2,
+  },
+  bodyRow: {
+    gap: 10,
+  },
+  landscapeBodyRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+  },
+  chartColumn: {
+    gap: 10,
+  },
+  landscapeTopRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  landscapeSubGrid: {
+    flexDirection: 'row',
+    gap: 8,
   },
 });
+
+type StatusPillProps = {
+  label: string;
+  value: 'ON' | 'OFF';
+  style?: StyleProp<ViewStyle>;
+};
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  suffix?: string;
+  meta?: string;
+  valueTestID?: string;
+  metaTestID?: string;
+  style?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+  valueStyle?: StyleProp<TextStyle>;
+  metaStyle?: StyleProp<TextStyle>;
+};
+
+const StatusPill: React.FC<StatusPillProps> = ({ label, value, style }) => {
+  const isOn = value === 'ON';
+  const colors = isOn
+    ? (['rgba(34,197,94,0.32)', 'rgba(14,165,233,0.2)'] as const)
+    : (['rgba(71,85,105,0.34)', 'rgba(30,41,59,0.34)'] as const);
+
+  return (
+    <LinearGradient
+      colors={colors}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={[
+        styles.statusPill,
+        style,
+        {
+          borderColor: isOn ? 'rgba(74, 222, 128, 0.38)' : PANEL_BORDER,
+        },
+      ]}
+    >
+      <Typography style={styles.statusLabel}>{label}</Typography>
+      <Typography style={styles.statusValue}>{value}</Typography>
+    </LinearGradient>
+  );
+};
+
+const MetricCard: React.FC<MetricCardProps> = ({
+  label,
+  value,
+  suffix,
+  meta,
+  valueTestID,
+  metaTestID,
+  style,
+  labelStyle,
+  valueStyle,
+  metaStyle,
+}) => (
+  <View style={[styles.metricCard, style]}>
+    <View>
+      <Typography style={[styles.metricLabel, labelStyle]}>{label}</Typography>
+      <Typography style={[styles.metricValue, valueStyle]} testID={valueTestID}>
+        {value}
+        {suffix && value !== '--' ? (
+          <Typography style={styles.metricSuffix}>{suffix}</Typography>
+        ) : null}
+      </Typography>
+    </View>
+    {meta ? (
+      <Typography style={[styles.metricMeta, metaStyle]} testID={metaTestID}>
+        {meta}
+      </Typography>
+    ) : null}
+  </View>
+);
 
 const DevOverlay: React.FC = () => {
   const location = useAtomValue(locationAtom);
@@ -59,46 +288,368 @@ const DevOverlay: React.FC = () => {
     [accuracyHistory]
   );
 
+  const versionLabel = `TrainLCD DO ${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`;
+  const telemetryValue = isTelemetryEnabled ? 'ON' : 'OFF';
+  const backgroundValue = isBackgroundLocationTracking ? 'ON' : 'OFF';
+  const nextStationMeta = nextStation?.name ?? undefined;
+
   const dim = useWindowDimensions();
+  const [panelHeight, setPanelHeight] = useState(0);
+  const [basePosition, setBasePosition] = useState({ x: 0, y: 0 });
+  const isLandscape = dim.width > dim.height;
+  const panelWidth = isLandscape
+    ? Math.min(Math.max(dim.width * 0.29, 360), 520)
+    : Math.min(Math.max(dim.width * 0.34, 280), 430);
+  const compactSpacing = isLandscape ? 10 : 12;
+  const compactPaddingX = isLandscape ? 12 : 16;
+  const compactPaddingY = isLandscape ? 12 : 14;
+  const compactRadius = isLandscape ? 20 : 24;
+  const headerTitleStyle = isLandscape
+    ? { fontSize: 13, lineHeight: 17 }
+    : null;
+  const versionStyle = isLandscape ? { fontSize: 10 } : null;
+  const chartShellStyle = isLandscape
+    ? {
+        paddingHorizontal: 10,
+        paddingVertical: 8,
+        borderRadius: 16,
+        minHeight: 76,
+      }
+    : null;
+  const chartValueStyle = isLandscape ? { fontSize: 12, lineHeight: 15 } : null;
+  const metricCardStyle = isLandscape
+    ? {
+        minHeight: 68,
+        borderRadius: 16,
+        paddingHorizontal: 10,
+        paddingVertical: 8,
+      }
+    : null;
+  const metricLabelStyle = isLandscape
+    ? { fontSize: 8, marginBottom: 4, letterSpacing: 1.2 }
+    : null;
+  const metricValueStyle = isLandscape
+    ? { fontSize: 15, lineHeight: 18 }
+    : null;
+  const metricMetaStyle = isLandscape ? { fontSize: 10, lineHeight: 12 } : null;
+  const statusRowStyle = isLandscape ? { gap: 6 } : null;
+  const statusPillStyle = isLandscape
+    ? { minWidth: 60, paddingHorizontal: 8, paddingVertical: 5 }
+    : null;
+  const footerTextStyle = isLandscape ? { fontSize: 9 } : null;
+  const bodyRowStyle = isLandscape ? styles.landscapeBodyRow : null;
+  const contentWidth = panelWidth - compactPaddingX * 2;
+  const chartColumnWidth = isLandscape ? panelWidth * 0.4 : panelWidth;
+  const metricsGap = isLandscape ? 8 : 10;
+  const metricsColumnWidth = isLandscape
+    ? contentWidth - chartColumnWidth - metricsGap
+    : contentWidth;
+  const metricWidth = (metricsColumnWidth - metricsGap) / 2;
+  const nextCardWidth = metricsColumnWidth;
+  const leftMetricWidth = metricWidth;
+  const nextTargetCardStyle: ViewStyle = {
+    justifyContent: 'flex-start',
+    gap: 6,
+  };
+  const dragTranslation = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
+  const basePositionRef = useRef(basePosition);
+  const hasDraggedRef = useRef(false);
+
+  useEffect(() => {
+    basePositionRef.current = basePosition;
+  }, [basePosition]);
+
+  const clampPosition = useMemo(
+    () => (x: number, y: number, width: number, height: number) => {
+      const margin = isLandscape ? 8 : 12;
+      const maxX = Math.max(margin, dim.width - width - margin);
+      const maxY = Math.max(margin, dim.height - height - margin);
+
+      return {
+        x: Math.min(Math.max(x, margin), maxX),
+        y: Math.min(Math.max(y, margin), maxY),
+      };
+    },
+    [dim.height, dim.width, isLandscape]
+  );
+
+  useEffect(() => {
+    const margin = isLandscape ? 8 : 12;
+    const initialPosition = {
+      x: Math.max(margin, dim.width - panelWidth - margin),
+      y: margin,
+    };
+    const nextPosition = hasDraggedRef.current
+      ? clampPosition(
+          basePositionRef.current.x,
+          basePositionRef.current.y,
+          panelWidth,
+          panelHeight || 0
+        )
+      : initialPosition;
+
+    setBasePosition(nextPosition);
+    dragTranslation.setValue({ x: 0, y: 0 });
+  }, [
+    clampPosition,
+    dim.width,
+    isLandscape,
+    panelHeight,
+    panelWidth,
+    dragTranslation,
+  ]);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_event, gestureState) =>
+          Math.abs(gestureState.dx) > 4 || Math.abs(gestureState.dy) > 4,
+        onPanResponderGrant: () => {
+          dragTranslation.stopAnimation();
+          dragTranslation.setValue({ x: 0, y: 0 });
+        },
+        onPanResponderMove: Animated.event(
+          [null, { dx: dragTranslation.x, dy: dragTranslation.y }],
+          { useNativeDriver: false }
+        ),
+        onPanResponderRelease: () => {
+          dragTranslation.stopAnimation((value) => {
+            const clampedPosition = clampPosition(
+              basePositionRef.current.x + value.x,
+              basePositionRef.current.y + value.y,
+              panelWidth,
+              panelHeight || 0
+            );
+            hasDraggedRef.current = true;
+            setBasePosition(clampedPosition);
+            dragTranslation.setValue({ x: 0, y: 0 });
+          });
+        },
+        onPanResponderTerminate: () => {
+          dragTranslation.stopAnimation((value) => {
+            const clampedPosition = clampPosition(
+              basePositionRef.current.x + value.x,
+              basePositionRef.current.y + value.y,
+              panelWidth,
+              panelHeight || 0
+            );
+            setBasePosition(clampedPosition);
+            dragTranslation.setValue({ x: 0, y: 0 });
+          });
+        },
+      }),
+    [clampPosition, dragTranslation, panelHeight, panelWidth]
+  );
 
   return (
-    <View style={[styles.root, { width: dim.width / 4 }]}>
-      <Typography style={styles.textHeading}>
-        TrainLCD DO
-        {` ${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`}
-      </Typography>
-      <Typography style={styles.text}>
-        {accuracyChartBlocks.map((block, index) => (
-          <Text
-            key={`${index}-${block.char}-${block.color}`}
-            style={{ color: block.color }}
-          >
-            {block.char}
-          </Text>
-        ))}
-      </Typography>
-      <Typography style={styles.text}>{`Accuracy: ${
-        accuracy ?? ''
-      }m`}</Typography>
-      {distanceToNextStation ? (
-        <Typography style={styles.text}>
-          Next: {distanceToNextStation}m
-          {nextStation?.name && ` ${nextStation.name}`}
-        </Typography>
-      ) : (
-        <Typography style={styles.text}>Next:</Typography>
-      )}
-      <Typography style={styles.text}>
-        Speed: {speedKMH}
-        km/h
-      </Typography>
-      <Typography style={styles.text}>
-        Telemetry: {isTelemetryEnabled ? 'ON' : 'OFF'}
-      </Typography>
-      <Typography style={styles.text}>
-        BG Loc: {isBackgroundLocationTracking ? 'ON' : 'OFF'}
-      </Typography>
-    </View>
+    <Animated.View
+      {...panResponder.panHandlers}
+      onLayout={(event) => {
+        setPanelHeight(event.nativeEvent.layout.height);
+      }}
+      style={[
+        styles.root,
+        {
+          width: panelWidth,
+          borderRadius: compactRadius,
+          left: basePosition.x,
+          top: basePosition.y,
+        },
+        { transform: dragTranslation.getTranslateTransform() },
+      ]}
+    >
+      <LinearGradient
+        colors={AURORA_COLORS}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.chrome}
+      />
+      <View
+        style={[
+          styles.content,
+          {
+            paddingHorizontal: compactPaddingX,
+            paddingVertical: compactPaddingY,
+            gap: compactSpacing,
+          },
+        ]}
+      >
+        <View style={styles.headerRow}>
+          <View style={styles.headerCopy}>
+            <Typography style={styles.eyebrow}>DEV OVERLAY</Typography>
+            <Typography style={[styles.title, headerTitleStyle]}>
+              TrainLCD Diagnostics
+            </Typography>
+            <Typography style={[styles.version, versionStyle]}>
+              {versionLabel}
+            </Typography>
+          </View>
+          <View style={[styles.statusRow, statusRowStyle]}>
+            <StatusPill
+              label="TELEMETRY"
+              value={telemetryValue}
+              style={statusPillStyle}
+            />
+            <StatusPill
+              label="BG LOC"
+              value={backgroundValue}
+              style={statusPillStyle}
+            />
+          </View>
+        </View>
+
+        <View style={[styles.bodyRow, bodyRowStyle]}>
+          {isLandscape ? (
+            <View style={styles.chartColumn}>
+              <View style={styles.landscapeTopRow}>
+                <View style={{ width: chartColumnWidth }}>
+                  <View style={[styles.chartShell, chartShellStyle]}>
+                    <Typography style={styles.chartLabel}>
+                      ACCURACY HISTORY
+                    </Typography>
+                    <Typography style={[styles.chartValue, chartValueStyle]}>
+                      {accuracyChartBlocks.length === 0 ? '---' : null}
+                    </Typography>
+                    <Typography
+                      style={[styles.chartValue, chartValueStyle]}
+                      testID="dev-overlay-accuracy-history"
+                    >
+                      {accuracyChartBlocks.length === 0
+                        ? '---'
+                        : accuracyChartBlocks.map((block, index) => (
+                            <Text
+                              key={`${index}-${block.char}-${block.color}`}
+                              style={{ color: block.color }}
+                            >
+                              {block.char}
+                            </Text>
+                          ))}
+                    </Typography>
+                  </View>
+                </View>
+                <MetricCard
+                  label="NEXT TARGET"
+                  value={
+                    distanceToNextStation ? `${distanceToNextStation}m` : '--'
+                  }
+                  meta={nextStationMeta}
+                  style={[
+                    { width: nextCardWidth },
+                    metricCardStyle,
+                    nextTargetCardStyle,
+                  ]}
+                  valueTestID="dev-overlay-next-value"
+                  metaTestID="dev-overlay-next-meta"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+              </View>
+
+              <View style={styles.landscapeSubGrid}>
+                <MetricCard
+                  label="LOCATION ACCURACY"
+                  value={accuracy != null ? `${accuracy}` : '--'}
+                  suffix="m"
+                  style={[{ width: leftMetricWidth }, metricCardStyle]}
+                  valueTestID="dev-overlay-accuracy-value"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+                <MetricCard
+                  label="CURRENT SPEED"
+                  value={speedKMH}
+                  suffix="km/h"
+                  style={[{ width: leftMetricWidth }, metricCardStyle]}
+                  valueTestID="dev-overlay-speed-value"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+              </View>
+
+              <Typography style={[styles.footerText, footerTextStyle]}>
+                LIVE SENSOR TRACE / INTERNAL BUILD
+              </Typography>
+            </View>
+          ) : (
+            <View style={styles.chartColumn}>
+              <View style={[styles.chartShell, chartShellStyle]}>
+                <Typography style={styles.chartLabel}>
+                  ACCURACY HISTORY
+                </Typography>
+                <Typography style={[styles.chartValue, chartValueStyle]}>
+                  {accuracyChartBlocks.length === 0 ? '---' : null}
+                </Typography>
+                <Typography
+                  style={[styles.chartValue, chartValueStyle]}
+                  testID="dev-overlay-accuracy-history"
+                >
+                  {accuracyChartBlocks.length === 0
+                    ? '---'
+                    : accuracyChartBlocks.map((block, index) => (
+                        <Text
+                          key={`${index}-${block.char}-${block.color}`}
+                          style={{ color: block.color }}
+                        >
+                          {block.char}
+                        </Text>
+                      ))}
+                </Typography>
+              </View>
+
+              <View style={[styles.metricsGrid, { gap: metricsGap }]}>
+                <MetricCard
+                  label="LOCATION ACCURACY"
+                  value={accuracy != null ? `${accuracy}` : '--'}
+                  suffix="m"
+                  style={[{ width: metricWidth }, metricCardStyle]}
+                  valueTestID="dev-overlay-accuracy-value"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+                <MetricCard
+                  label="CURRENT SPEED"
+                  value={speedKMH}
+                  suffix="km/h"
+                  style={[{ width: metricWidth }, metricCardStyle]}
+                  valueTestID="dev-overlay-speed-value"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+                <MetricCard
+                  label="NEXT TARGET"
+                  value={
+                    distanceToNextStation ? `${distanceToNextStation}m` : '--'
+                  }
+                  meta={nextStationMeta}
+                  style={[
+                    { width: nextCardWidth },
+                    metricCardStyle,
+                    nextTargetCardStyle,
+                  ]}
+                  valueTestID="dev-overlay-next-value"
+                  metaTestID="dev-overlay-next-meta"
+                  labelStyle={metricLabelStyle}
+                  valueStyle={metricValueStyle}
+                  metaStyle={metricMetaStyle}
+                />
+              </View>
+            </View>
+          )}
+        </View>
+
+        {!isLandscape ? (
+          <Typography style={[styles.footerText, footerTextStyle]}>
+            LIVE SENSOR TRACE / INTERNAL BUILD
+          </Typography>
+        ) : null}
+      </View>
+    </Animated.View>
   );
 };
 

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -291,7 +291,12 @@ const DevOverlay: React.FC = () => {
   const versionLabel = `TrainLCD DO ${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`;
   const telemetryValue = isTelemetryEnabled ? 'ON' : 'OFF';
   const backgroundValue = isBackgroundLocationTracking ? 'ON' : 'OFF';
-  const nextStationMeta = nextStation?.name ?? undefined;
+  const nextStationNumber =
+    nextStation?.stationNumbers?.find((item) => !!item?.stationNumber)
+      ?.stationNumber ?? undefined;
+  const nextStationMeta = [nextStation?.name, nextStationNumber]
+    .filter(Boolean)
+    .join(' / ');
 
   const dim = useWindowDimensions();
   const [panelHeight, setPanelHeight] = useState(0);

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -38,16 +38,18 @@ const styles = StyleSheet.create({
     left: 0,
     top: 0,
     zIndex: 9999,
-    borderRadius: 24,
-    overflow: 'hidden',
-    borderWidth: 1,
-    borderColor: PANEL_BORDER,
-    backgroundColor: PANEL_BG,
     shadowColor: '#020617',
     shadowOpacity: 0.35,
     shadowRadius: 20,
     shadowOffset: { width: 0, height: 12 },
     elevation: 20,
+  },
+  panelFrame: {
+    borderRadius: 24,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: PANEL_BORDER,
+    backgroundColor: PANEL_BG,
   },
   chrome: {
     ...StyleSheet.absoluteFillObject,
@@ -113,6 +115,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     gap: 4,
+  },
+  chartShellContent: {
+    flex: 1,
+    justifyContent: 'space-between',
   },
   chartLabel: {
     color: LABEL_COLOR,
@@ -446,6 +452,7 @@ const DevOverlay: React.FC = () => {
               panelWidth,
               panelHeight || 0
             );
+            hasDraggedRef.current = true;
             setBasePosition(clampedPosition);
             dragTranslation.setValue({ x: 0, y: 0 });
           });
@@ -464,66 +471,148 @@ const DevOverlay: React.FC = () => {
         styles.root,
         {
           width: panelWidth,
-          borderRadius: compactRadius,
           left: basePosition.x,
           top: basePosition.y,
         },
         { transform: dragTranslation.getTranslateTransform() },
       ]}
     >
-      <LinearGradient
-        colors={AURORA_COLORS}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={styles.chrome}
-      />
       <View
         style={[
-          styles.content,
+          styles.panelFrame,
           {
-            paddingHorizontal: compactPaddingX,
-            paddingVertical: compactPaddingY,
-            gap: compactSpacing,
+            borderRadius: compactRadius,
           },
         ]}
       >
-        <View style={styles.headerRow}>
-          <View style={styles.headerCopy}>
-            <Typography style={styles.eyebrow}>DEV OVERLAY</Typography>
-            <Typography style={[styles.title, headerTitleStyle]}>
-              TrainLCD Diagnostics
-            </Typography>
-            <Typography style={[styles.version, versionStyle]}>
-              {versionLabel}
-            </Typography>
+        <LinearGradient
+          colors={AURORA_COLORS}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.chrome}
+        />
+        <View
+          style={[
+            styles.content,
+            {
+              paddingHorizontal: compactPaddingX,
+              paddingVertical: compactPaddingY,
+              gap: compactSpacing,
+            },
+          ]}
+        >
+          <View style={styles.headerRow}>
+            <View style={styles.headerCopy}>
+              <Typography style={styles.eyebrow}>DEV OVERLAY</Typography>
+              <Typography style={[styles.title, headerTitleStyle]}>
+                TrainLCD Diagnostics
+              </Typography>
+              <Typography style={[styles.version, versionStyle]}>
+                {versionLabel}
+              </Typography>
+            </View>
+            <View style={[styles.statusRow, statusRowStyle]}>
+              <StatusPill
+                label="TELEMETRY"
+                value={telemetryValue}
+                style={statusPillStyle}
+              />
+              <StatusPill
+                label="BG LOC"
+                value={backgroundValue}
+                style={statusPillStyle}
+              />
+            </View>
           </View>
-          <View style={[styles.statusRow, statusRowStyle]}>
-            <StatusPill
-              label="TELEMETRY"
-              value={telemetryValue}
-              style={statusPillStyle}
-            />
-            <StatusPill
-              label="BG LOC"
-              value={backgroundValue}
-              style={statusPillStyle}
-            />
-          </View>
-        </View>
 
-        <View style={[styles.bodyRow, bodyRowStyle]}>
-          {isLandscape ? (
-            <View style={styles.chartColumn}>
-              <View style={styles.landscapeTopRow}>
-                <View style={{ width: chartColumnWidth }}>
-                  <View style={[styles.chartShell, chartShellStyle]}>
+          <View style={[styles.bodyRow, bodyRowStyle]}>
+            {isLandscape ? (
+              <View style={styles.chartColumn} testID="dev-overlay-landscape">
+                <View style={styles.landscapeTopRow}>
+                  <View style={{ width: chartColumnWidth }}>
+                    <View style={[styles.chartShell, chartShellStyle]}>
+                      <View style={styles.chartShellContent}>
+                        <Typography style={styles.chartLabel}>
+                          ACCURACY HISTORY
+                        </Typography>
+                        <Typography
+                          style={[styles.chartValue, chartValueStyle]}
+                          testID="dev-overlay-accuracy-history"
+                          numberOfLines={1}
+                          ellipsizeMode="clip"
+                        >
+                          {accuracyChartBlocks.length === 0
+                            ? '---'
+                            : accuracyChartBlocks.map((block, index) => (
+                                <Text
+                                  key={`${index}-${block.char}-${block.color}`}
+                                  style={{ color: block.color }}
+                                >
+                                  {block.char}
+                                </Text>
+                              ))}
+                        </Typography>
+                      </View>
+                    </View>
+                  </View>
+                  <MetricCard
+                    label="NEXT TARGET"
+                    value={
+                      distanceToNextStation ? `${distanceToNextStation}m` : '--'
+                    }
+                    meta={nextStationMeta}
+                    style={[
+                      { width: nextCardWidth },
+                      metricCardStyle,
+                      nextTargetCardStyle,
+                    ]}
+                    valueTestID="dev-overlay-next-value"
+                    metaTestID="dev-overlay-next-meta"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                </View>
+
+                <View style={styles.landscapeSubGrid}>
+                  <MetricCard
+                    label="LOCATION ACCURACY"
+                    value={accuracy != null ? `${accuracy}` : '--'}
+                    suffix="m"
+                    style={[{ width: leftMetricWidth }, metricCardStyle]}
+                    valueTestID="dev-overlay-accuracy-value"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                  <MetricCard
+                    label="CURRENT SPEED"
+                    value={speedKMH}
+                    suffix="km/h"
+                    style={[{ width: leftMetricWidth }, metricCardStyle]}
+                    valueTestID="dev-overlay-speed-value"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                </View>
+
+                <Typography style={[styles.footerText, footerTextStyle]}>
+                  LIVE SENSOR TRACE / INTERNAL BUILD
+                </Typography>
+              </View>
+            ) : (
+              <View style={styles.chartColumn}>
+                <View style={[styles.chartShell, chartShellStyle]}>
+                  <View style={styles.chartShellContent}>
                     <Typography style={styles.chartLabel}>
                       ACCURACY HISTORY
                     </Typography>
-                    <Typography style={[styles.chartValue, chartValueStyle]} />
                     <Typography
                       style={[styles.chartValue, chartValueStyle]}
                       testID="dev-overlay-accuracy-history"
+                      numberOfLines={1}
+                      ellipsizeMode="clip"
                     >
                       {accuracyChartBlocks.length === 0
                         ? '---'
@@ -538,124 +627,56 @@ const DevOverlay: React.FC = () => {
                     </Typography>
                   </View>
                 </View>
-                <MetricCard
-                  label="NEXT TARGET"
-                  value={
-                    distanceToNextStation ? `${distanceToNextStation}m` : '--'
-                  }
-                  meta={nextStationMeta}
-                  style={[
-                    { width: nextCardWidth },
-                    metricCardStyle,
-                    nextTargetCardStyle,
-                  ]}
-                  valueTestID="dev-overlay-next-value"
-                  metaTestID="dev-overlay-next-meta"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
-              </View>
 
-              <View style={styles.landscapeSubGrid}>
-                <MetricCard
-                  label="LOCATION ACCURACY"
-                  value={accuracy != null ? `${accuracy}` : '--'}
-                  suffix="m"
-                  style={[{ width: leftMetricWidth }, metricCardStyle]}
-                  valueTestID="dev-overlay-accuracy-value"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
-                <MetricCard
-                  label="CURRENT SPEED"
-                  value={speedKMH}
-                  suffix="km/h"
-                  style={[{ width: leftMetricWidth }, metricCardStyle]}
-                  valueTestID="dev-overlay-speed-value"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
+                <View style={[styles.metricsGrid, { gap: metricsGap }]}>
+                  <MetricCard
+                    label="LOCATION ACCURACY"
+                    value={accuracy != null ? `${accuracy}` : '--'}
+                    suffix="m"
+                    style={[{ width: metricWidth }, metricCardStyle]}
+                    valueTestID="dev-overlay-accuracy-value"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                  <MetricCard
+                    label="CURRENT SPEED"
+                    value={speedKMH}
+                    suffix="km/h"
+                    style={[{ width: metricWidth }, metricCardStyle]}
+                    valueTestID="dev-overlay-speed-value"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                  <MetricCard
+                    label="NEXT TARGET"
+                    value={
+                      distanceToNextStation ? `${distanceToNextStation}m` : '--'
+                    }
+                    meta={nextStationMeta}
+                    style={[
+                      { width: nextCardWidth },
+                      metricCardStyle,
+                      nextTargetCardStyle,
+                    ]}
+                    valueTestID="dev-overlay-next-value"
+                    metaTestID="dev-overlay-next-meta"
+                    labelStyle={metricLabelStyle}
+                    valueStyle={metricValueStyle}
+                    metaStyle={metricMetaStyle}
+                  />
+                </View>
               </View>
+            )}
+          </View>
 
-              <Typography style={[styles.footerText, footerTextStyle]}>
-                LIVE SENSOR TRACE / INTERNAL BUILD
-              </Typography>
-            </View>
-          ) : (
-            <View style={styles.chartColumn}>
-              <View style={[styles.chartShell, chartShellStyle]}>
-                <Typography style={styles.chartLabel}>
-                  ACCURACY HISTORY
-                </Typography>
-                <Typography style={[styles.chartValue, chartValueStyle]} />
-                <Typography
-                  style={[styles.chartValue, chartValueStyle]}
-                  testID="dev-overlay-accuracy-history"
-                >
-                  {accuracyChartBlocks.length === 0
-                    ? '---'
-                    : accuracyChartBlocks.map((block, index) => (
-                        <Text
-                          key={`${index}-${block.char}-${block.color}`}
-                          style={{ color: block.color }}
-                        >
-                          {block.char}
-                        </Text>
-                      ))}
-                </Typography>
-              </View>
-
-              <View style={[styles.metricsGrid, { gap: metricsGap }]}>
-                <MetricCard
-                  label="LOCATION ACCURACY"
-                  value={accuracy != null ? `${accuracy}` : '--'}
-                  suffix="m"
-                  style={[{ width: metricWidth }, metricCardStyle]}
-                  valueTestID="dev-overlay-accuracy-value"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
-                <MetricCard
-                  label="CURRENT SPEED"
-                  value={speedKMH}
-                  suffix="km/h"
-                  style={[{ width: metricWidth }, metricCardStyle]}
-                  valueTestID="dev-overlay-speed-value"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
-                <MetricCard
-                  label="NEXT TARGET"
-                  value={
-                    distanceToNextStation ? `${distanceToNextStation}m` : '--'
-                  }
-                  meta={nextStationMeta}
-                  style={[
-                    { width: nextCardWidth },
-                    metricCardStyle,
-                    nextTargetCardStyle,
-                  ]}
-                  valueTestID="dev-overlay-next-value"
-                  metaTestID="dev-overlay-next-meta"
-                  labelStyle={metricLabelStyle}
-                  valueStyle={metricValueStyle}
-                  metaStyle={metricMetaStyle}
-                />
-              </View>
-            </View>
-          )}
+          {!isLandscape ? (
+            <Typography style={[styles.footerText, footerTextStyle]}>
+              LIVE SENSOR TRACE / INTERNAL BUILD
+            </Typography>
+          ) : null}
         </View>
-
-        {!isLandscape ? (
-          <Typography style={[styles.footerText, footerTextStyle]}>
-            LIVE SENSOR TRACE / INTERNAL BUILD
-          </Typography>
-        ) : null}
       </View>
     </Animated.View>
   );

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -133,11 +133,13 @@ const styles = StyleSheet.create({
     minHeight: 82,
     borderRadius: 18,
     paddingHorizontal: 12,
-    paddingVertical: 10,
+    paddingTop: 8,
+    paddingBottom: 8,
     borderWidth: 1,
     borderColor: PANEL_BORDER,
     backgroundColor: 'rgba(9, 14, 28, 0.7)',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
+    gap: 6,
   },
   metricLabel: {
     color: LABEL_COLOR,
@@ -160,6 +162,9 @@ const styles = StyleSheet.create({
     color: 'rgba(226, 232, 240, 0.72)',
     fontSize: 11,
     lineHeight: 14,
+  },
+  metricHeader: {
+    gap: 2,
   },
   footerText: {
     color: 'rgba(148, 163, 184, 0.92)',
@@ -243,7 +248,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
   metaStyle,
 }) => (
   <View style={[styles.metricCard, style]}>
-    <View>
+    <View style={styles.metricHeader}>
       <Typography style={[styles.metricLabel, labelStyle]}>{label}</Typography>
       <Typography style={[styles.metricValue, valueStyle]} testID={valueTestID}>
         {value}
@@ -316,18 +321,20 @@ const DevOverlay: React.FC = () => {
   const chartShellStyle = isLandscape
     ? {
         paddingHorizontal: 10,
-        paddingVertical: 8,
+        paddingTop: 8,
+        paddingBottom: 6,
         borderRadius: 16,
-        minHeight: 76,
+        minHeight: 64,
       }
     : null;
   const chartValueStyle = isLandscape ? { fontSize: 12, lineHeight: 15 } : null;
   const metricCardStyle = isLandscape
     ? {
-        minHeight: 68,
+        minHeight: 56,
         borderRadius: 16,
         paddingHorizontal: 10,
-        paddingVertical: 8,
+        paddingTop: 6,
+        paddingBottom: 4,
       }
     : null;
   const metricLabelStyle = isLandscape

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -239,15 +239,28 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
             devOverlayEnabled ? 'hideDevOverlay' : 'showDevOverlay'
           ),
           handler: async () => {
+            const prevValue = devOverlayEnabled;
             const nextValue = !devOverlayEnabled;
             setTuning((prev) => ({
               ...prev,
               devOverlayEnabled: nextValue,
             }));
-            await AsyncStorage.setItem(
-              ASYNC_STORAGE_KEYS.DEV_OVERLAY_ENABLED,
-              String(nextValue)
-            );
+            try {
+              await AsyncStorage.setItem(
+                ASYNC_STORAGE_KEYS.DEV_OVERLAY_ENABLED,
+                String(nextValue)
+              );
+            } catch (error) {
+              console.error(error);
+              setTuning((prev) => ({
+                ...prev,
+                devOverlayEnabled: prevValue,
+              }));
+              Alert.alert(
+                translate('errorTitle'),
+                translate('failedToSavePreference')
+              );
+            }
           },
         });
       }

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -13,6 +13,7 @@ import Share from 'react-native-share';
 import ViewShot from 'react-native-view-shot';
 import reportModalVisibleAtom from '~/store/atoms/reportModal';
 import tuningState from '~/store/atoms/tuning';
+import { isDevApp } from '~/utils/isDevApp';
 import {
   ALL_AVAILABLE_LANGUAGES,
   APP_STORE_URL,
@@ -45,7 +46,8 @@ type Props = {
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { selectedBound } = useAtomValue(stationState);
-  const { untouchableModeEnabled } = useAtomValue(tuningState);
+  const { untouchableModeEnabled, devOverlayEnabled } =
+    useAtomValue(tuningState);
   const setNavigation = useSetAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
   const setTuning = useSetAtom(tuningState);
@@ -197,20 +199,63 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         return;
       }
 
-      const options =
+      const actions =
         Platform.select({
           ios: [
-            translate('back'),
-            translate('share'),
-            translate('report'),
-            translate('cancel'),
+            {
+              label: translate('back'),
+              handler: () => {
+                navigation.dispatch(
+                  StackActions.replace('MainStack', {
+                    screen: 'SelectLine',
+                  })
+                );
+              },
+            },
+            {
+              label: translate('share'),
+              handler: handleShare,
+            },
+            {
+              label: translate('report'),
+              handler: handleReport,
+            },
           ],
           android: [
-            translate('share'),
-            translate('report'),
-            translate('cancel'),
+            {
+              label: translate('share'),
+              handler: handleShare,
+            },
+            {
+              label: translate('report'),
+              handler: handleReport,
+            },
           ],
         }) ?? [];
+
+      if (isDevApp) {
+        actions.push({
+          label: translate(
+            devOverlayEnabled ? 'hideDevOverlay' : 'showDevOverlay'
+          ),
+          handler: async () => {
+            const nextValue = !devOverlayEnabled;
+            setTuning((prev) => ({
+              ...prev,
+              devOverlayEnabled: nextValue,
+            }));
+            await AsyncStorage.setItem(
+              ASYNC_STORAGE_KEYS.DEV_OVERLAY_ENABLED,
+              String(nextValue)
+            );
+          },
+        });
+      }
+
+      const options = [
+        ...actions.map((action) => action.label),
+        translate('cancel'),
+      ];
 
       showActionSheetWithOptions(
         {
@@ -219,53 +264,22 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           cancelButtonIndex: options.length - 1,
         },
         (buttonIndex) => {
-          switch (buttonIndex) {
-            // iOS: back, Android: share
-            case 0:
-              if (Platform.OS === 'ios') {
-                navigation.dispatch(
-                  StackActions.replace('MainStack', {
-                    screen: 'SelectLine',
-                  })
-                );
-                break;
-              }
-              handleShare();
-              break;
-            // iOS: share, Android: feedback
-            case 1:
-              if (Platform.OS === 'ios') {
-                handleShare();
-                break;
-              }
-              handleReport();
-              break;
-            // iOS: feedback, Android: cancel
-            case 2: {
-              if (Platform.OS === 'ios') {
-                handleReport();
-                break;
-              }
-              break;
-            }
-            // iOS: cancel, Android: will be not passed here
-            case 3: {
-              break;
-            }
-            // iOS, Android: will be not passed here
-            default:
-              break;
+          if (buttonIndex == null || buttonIndex >= actions.length) {
+            return;
           }
+          void actions[buttonIndex]?.handler();
         }
       );
     },
     [
+      devOverlayEnabled,
       handleReport,
       handleShare,
+      navigation,
       selectedBound,
+      setTuning,
       showActionSheetWithOptions,
       untouchableModeEnabled,
-      navigation.dispatch,
     ]
   );
 
@@ -278,6 +292,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         bgTTSEnabledStr,
         ttsEnabledLanguagesStr,
         telemetryEnabledStr,
+        devOverlayEnabledStr,
       ] = await Promise.all([
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PREVIOUS_THEME),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.ENABLED_LANGUAGES),
@@ -285,6 +300,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.BG_TTS_ENABLED),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_ENABLED_LANGUAGES),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TELEMETRY_ENABLED),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.DEV_OVERLAY_ENABLED),
       ]);
 
       if (prevThemeKey) {
@@ -334,6 +350,12 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         setTuning((prev) => ({
           ...prev,
           telemetryEnabled: telemetryEnabledStr === 'true',
+        }));
+      }
+      if (devOverlayEnabledStr) {
+        setTuning((prev) => ({
+          ...prev,
+          devOverlayEnabled: devOverlayEnabledStr === 'true',
         }));
       }
     };

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -17,6 +17,7 @@ export const ASYNC_STORAGE_KEYS = {
   WEEKDAY_ALERT_DISMISSED: '@TrainLCD:weekdayAlertDismissed',
   PARTIALLY_PASS_ALERT_DISMISSED: '@TrainLCD:partiallyPassAlertDismissed',
   TELEMETRY_ENABLED: '@TrainLCD:telemetryEnabled',
+  DEV_OVERLAY_ENABLED: '@TrainLCD:devOverlayEnabled',
   TTS_JA_VOICE_NAME: '@TrainLCD:ttsJaVoiceName',
   TTS_EN_VOICE_NAME: '@TrainLCD:ttsEnVoiceName',
   WALKTHROUGH_COMPLETED: '@TrainLCD:walkthroughCompleted',


### PR DESCRIPTION
## 目的
開発者オーバレイの使い勝手と見た目を改善し、長押しメニューから表示/非表示を切り替えられるようにします。

## 主な変更
- 開発者オーバレイのデザインを再構成し、横画面レイアウトを最適化
- オーバレイをドラッグ移動できるように変更
- 長押しメニューに開発者オーバレイの表示/非表示トグルを追加
- オーバレイ表示状態の永続化と文言追加
- DevOverlay のテストを表示実装に合わせて更新

## リスク
- 開発者向けオーバレイ周辺の UI と入力挙動に影響します
- 長押しメニューの項目追加により dev app のみ選択肢が増えます

## 確認コマンド
- npm run lint
- npm run typecheck
- npm test -- DevOverlay.test.tsx --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 開発者オーバーレイをドラッグ可能なインタラクティブパネルに刷新。ランドスケープ対応や新しいメトリック表示、状態バッジを追加。
  * 長押しメニューからオーバーレイの表示/非表示を切替え、設定を永続化。
* **多言語対応**
  * 英語・日本語の表示文言を追加（オーバーレイ表示切替）。
* **テスト**
  * 新UI構造と境界ケースに合わせて表示テストを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->