### PR TITLE
開発者オーバレイの位置精度表示を整数に揃える

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -188,6 +188,21 @@ describe('DevOverlay', () => {
       );
     });
 
+    it('精度情報の小数点を切り捨てて表示する', () => {
+      setupAtomValues({
+        location: {
+          coords: { speed: 10, accuracy: 15.9 },
+        },
+        accuracyHistory: [10, 15, 20],
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent(
+        '15m'
+      );
+    });
+
     it('速度情報をkm/hで表示する', () => {
       const { getByText, getByTestId } = render(<DevOverlay />);
       expect(getByText('CURRENT SPEED')).toBeTruthy();

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -284,6 +284,8 @@ const DevOverlay: React.FC = () => {
   );
 
   const coordsSpeed = ((speed ?? 0) < 0 ? 0 : speed) ?? 0;
+  const accuracyMeters =
+    accuracy != null ? Math.max(0, Math.floor(accuracy)) : null;
 
   const speedKMH = useMemo(
     () =>
@@ -577,7 +579,7 @@ const DevOverlay: React.FC = () => {
                 <View style={styles.landscapeSubGrid}>
                   <MetricCard
                     label="LOCATION ACCURACY"
-                    value={accuracy != null ? `${accuracy}` : '--'}
+                    value={accuracyMeters != null ? `${accuracyMeters}` : '--'}
                     suffix="m"
                     style={[{ width: leftMetricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-accuracy-value"
@@ -631,7 +633,7 @@ const DevOverlay: React.FC = () => {
                 <View style={[styles.metricsGrid, { gap: metricsGap }]}>
                   <MetricCard
                     label="LOCATION ACCURACY"
-                    value={accuracy != null ? `${accuracy}` : '--'}
+                    value={accuracyMeters != null ? `${accuracyMeters}` : '--'}
                     suffix="m"
                     style={[{ width: metricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-accuracy-value"


### PR DESCRIPTION
## 概要
- 開発者オーバレイの位置精度表示で小数点以下を切り捨てて整数表示に変更
- 位置精度の小数点切り捨てを確認するテストを追加

## 確認
- npm run lint
- npm run typecheck
- npm test -- DevOverlay.test.tsx --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ロケーション精度の表示値が小数点以下で切り捨てられるようになりました。例えば、精度15.9mは「15m」と表示されるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->