### PR TITLE
TTS日本語・英語プロンプトをチューニング設定から編集可能にする

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -143,6 +143,8 @@
   "tuningItemTTSVoice": "TTS Voice",
   "tuningItemTTSJaVoiceName": "Japanese voice name",
   "tuningItemTTSEnVoiceName": "English voice name",
+  "tuningItemTTSJaPrompt": "Japanese prompt",
+  "tuningItemTTSEnPrompt": "English prompt",
   "tuningItemLocationAccuracy": "location accuracy",
   "headerDelayTooShortErrorText": "Header animation delay must be greater than the Header animation duration.",
   "nanErrorText": "The value must be entered numerically.",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -144,6 +144,8 @@
   "tuningItemTTSVoice": "TTS ボイス",
   "tuningItemTTSJaVoiceName": "日本語ボイス名",
   "tuningItemTTSEnVoiceName": "英語ボイス名",
+  "tuningItemTTSJaPrompt": "日本語プロンプト",
+  "tuningItemTTSEnPrompt": "英語プロンプト",
   "tuningItemLocationAccuracy": "位置情報の精度",
   "headerDelayTooShortErrorText": "ヘッダーアニメーション遅延はヘッダーアニメーション時間より大きい値である必要があります。",
   "nanErrorText": "値は数値で入力してください。",

--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -245,11 +245,43 @@ export const tts = onCall(
       defaultEnVoice;
 
     const jaPrompt =
-      (typeof req.data.jaPrompt === 'string' && req.data.jaPrompt) ||
+      (typeof req.data.jaPrompt === 'string' && req.data.jaPrompt.trim()) ||
       JA_TTS_PROMPT;
     const enPrompt =
-      (typeof req.data.enPrompt === 'string' && req.data.enPrompt) ||
+      (typeof req.data.enPrompt === 'string' && req.data.enPrompt.trim()) ||
       EN_TTS_PROMPT;
+
+    const PROMPT_BYTE_LIMIT = 4000;
+    const COMBINED_BYTE_LIMIT = 8000;
+    const jaTextBytes = Buffer.byteLength(stripSsml(ssmlJa), 'utf8');
+    const enTextBytes = Buffer.byteLength(stripSsml(ssmlEn), 'utf8');
+    const jaPromptBytes = Buffer.byteLength(jaPrompt, 'utf8');
+    const enPromptBytes = Buffer.byteLength(enPrompt, 'utf8');
+
+    if (jaPromptBytes > PROMPT_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `jaPrompt exceeds ${PROMPT_BYTE_LIMIT} byte limit (${jaPromptBytes} bytes)`
+      );
+    }
+    if (enPromptBytes > PROMPT_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `enPrompt exceeds ${PROMPT_BYTE_LIMIT} byte limit (${enPromptBytes} bytes)`
+      );
+    }
+    if (jaTextBytes + jaPromptBytes > COMBINED_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `Japanese text + prompt exceeds ${COMBINED_BYTE_LIMIT} byte limit`
+      );
+    }
+    if (enTextBytes + enPromptBytes > COMBINED_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `English text + prompt exceeds ${COMBINED_BYTE_LIMIT} byte limit`
+      );
+    }
 
     const voicesCollection = firestore
       .collection('caches')

--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -34,10 +34,17 @@ const getTtsConfig = async (): Promise<
   if (ttsConfigCache && Date.now() - ttsConfigCache.fetchedAt < TTS_CONFIG_CACHE_TTL_MS) {
     return ttsConfigCache.data;
   }
-  const doc = await firestore.collection('configs').doc('tts').get();
-  const data = doc.data();
-  ttsConfigCache = { data, fetchedAt: Date.now() };
-  return data;
+  try {
+    const doc = await firestore.collection('configs').doc('tts').get();
+    const data = doc.data();
+    ttsConfigCache = { data, fetchedAt: Date.now() };
+    return data;
+  } catch (e) {
+    if (ttsConfigCache) {
+      return ttsConfigCache.data;
+    }
+    throw e;
+  }
 };
 
 const JA_TTS_PROMPT = [
@@ -238,10 +245,12 @@ export const tts = onCall(
     const defaultEnVoice = ttsConfig?.enVoiceName || DEFAULT_TTS_VOICE_NAME;
 
     const jaVoiceName =
-      (typeof req.data.jaVoiceName === 'string' && req.data.jaVoiceName) ||
+      (typeof req.data.jaVoiceName === 'string' &&
+        req.data.jaVoiceName.trim()) ||
       defaultJaVoice;
     const enVoiceName =
-      (typeof req.data.enVoiceName === 'string' && req.data.enVoiceName) ||
+      (typeof req.data.enVoiceName === 'string' &&
+        req.data.enVoiceName.trim()) ||
       defaultEnVoice;
 
     const jaPrompt =

--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -20,6 +20,49 @@ const googleAuth = new GoogleAuth({
 
 const GEMINI_TTS_MODEL = 'gemini-2.5-flash-tts';
 const GOOGLE_TTS_API_VERSION = 'v1';
+const DEFAULT_TTS_VOICE_NAME = 'Aoede';
+
+const TTS_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000; // 5分
+let ttsConfigCache: {
+  data: FirebaseFirestore.DocumentData | undefined;
+  fetchedAt: number;
+} | null = null;
+
+const getTtsConfig = async (): Promise<
+  FirebaseFirestore.DocumentData | undefined
+> => {
+  if (ttsConfigCache && Date.now() - ttsConfigCache.fetchedAt < TTS_CONFIG_CACHE_TTL_MS) {
+    return ttsConfigCache.data;
+  }
+  const doc = await firestore.collection('configs').doc('tts').get();
+  const data = doc.data();
+  ttsConfigCache = { data, fetchedAt: Date.now() };
+  return data;
+};
+
+const JA_TTS_PROMPT = [
+  '以下の日本語を、現代的な鉄道自動放送のように読み上げてください。',
+  '全体的に平板なイントネーションを維持し、感情を込めず淡々と読んでください。',
+  '文のイントネーションは文末に向かって自然に下降させてください。',
+  '助詞（は、の、で、を等）で不自然にピッチを上げないでください。',
+  '駅名や路線名は平板アクセントで読んでください（一般会話のアクセントとは異なります）。',
+  '無駄な間を入れず、一定のテンポで読み進めてください。',
+  '漢字の読みは一文字も省略せず正確に読んでください。',
+  '特に路線名は正式な読みに従ってください（例：副都心線→ふくとしんせん、東海道線→とうかいどうせん、山手線→やまのてせん）。',
+  '鉄道会社の略称も正確に読んでください（例：名鉄→めいてつ、京急→けいきゅう、京王→けいおう、阪急→はんきゅう、阪神→はんしん、南海→なんかい、近鉄→きんてつ、西鉄→にしてつ、東急→とうきゅう、小田急→おだきゅう、京成→けいせい、相鉄→そうてつ）。',
+].join('');
+
+const EN_TTS_PROMPT = [
+  'Read the following in a calm, clear, and composed tone like a modern train announcement.',
+  ' Speak quickly and crisply with a swift, efficient delivery.',
+  ' Do not linger on words or pause unnecessarily.',
+  ' Maintain a steady, relaxed intonation despite the fast pace.',
+  ' The text contains Japanese railway station names and line names in romanized form.',
+  ' Pronounce them using Japanese vowel rules, NOT English rules: a=ah, i=ee, u=oo, e=eh, o=oh.',
+  ' Every vowel is always pronounced the same way regardless of surrounding letters',
+  ' (e.g. "Inage" = ee-nah-geh, NOT "inn-idge"; "Meguro" = meh-goo-roh; "Ebisu" = eh-bee-soo; "Ome" = oh-meh, NOT "ohm").',
+  ' Never apply English spelling conventions like silent e, soft g, or vowel shifts to these names.',
+].join('');
 
 interface SynthesizedAudio {
   audioContent: string;
@@ -80,9 +123,20 @@ const stripSsml = (text: string): string =>
     .replace(/\s{2,}/g, ' ')
     .trim();
 
+const getAccessToken = async (): Promise<string> => {
+  const client = await googleAuth.getClient();
+  const accessTokenResponse = await client.getAccessToken();
+  const token = accessTokenResponse.token;
+  if (!token) {
+    throw new Error('Failed to acquire Google access token for Gemini TTS');
+  }
+  return token;
+};
+
 /** Cloud Text-to-Speech の Gemini-TTS を使用してテキストを音声に変換する。 */
 const synthesizeWithGemini = async (
   projectId: string,
+  accessToken: string,
   text: string,
   languageCode: string,
   voiceName: string,
@@ -91,13 +145,6 @@ const synthesizeWithGemini = async (
     volumeGainDb?: number;
   }
 ): Promise<SynthesizedAudio> => {
-  const client = await googleAuth.getClient();
-  const accessTokenResponse = await client.getAccessToken();
-  const accessToken = accessTokenResponse.token;
-  if (!accessToken) {
-    throw new Error('Failed to acquire Google access token for Gemini TTS');
-  }
-
   const ttsUrl = `https://texttospeech.googleapis.com/${GOOGLE_TTS_API_VERSION}/text:synthesize`;
   const res = await fetch(ttsUrl, {
     headers: {
@@ -180,19 +227,15 @@ export const tts = onCall(
 
     let ttsConfig: FirebaseFirestore.DocumentData | undefined;
     try {
-      const ttsConfigDoc = await firestore
-        .collection('configs')
-        .doc('tts')
-        .get();
-      ttsConfig = ttsConfigDoc.data();
+      ttsConfig = await getTtsConfig();
     } catch (e) {
       console.warn(
         'Failed to read TTS config from Firestore, using defaults:',
         e
       );
     }
-    const defaultJaVoice = ttsConfig?.jaVoiceName || 'Aoede';
-    const defaultEnVoice = ttsConfig?.enVoiceName || 'Aoede';
+    const defaultJaVoice = ttsConfig?.jaVoiceName || DEFAULT_TTS_VOICE_NAME;
+    const defaultEnVoice = ttsConfig?.enVoiceName || DEFAULT_TTS_VOICE_NAME;
 
     const jaVoiceName =
       (typeof req.data.jaVoiceName === 'string' && req.data.jaVoiceName) ||
@@ -201,16 +244,25 @@ export const tts = onCall(
       (typeof req.data.enVoiceName === 'string' && req.data.enVoiceName) ||
       defaultEnVoice;
 
+    const jaPrompt =
+      (typeof req.data.jaPrompt === 'string' && req.data.jaPrompt) ||
+      JA_TTS_PROMPT;
+    const enPrompt =
+      (typeof req.data.enPrompt === 'string' && req.data.enPrompt) ||
+      EN_TTS_PROMPT;
+
     const voicesCollection = firestore
       .collection('caches')
       .doc('tts')
       .collection('voices');
 
     const hashAlgorithm = 'sha256';
-    const version = 9;
+    const version = 10;
     const hashPayloadObj = {
       enModel: GEMINI_TTS_MODEL,
+      enPrompt,
       enVoiceName,
+      jaPrompt,
       jaVoiceName,
       ssmlEn,
       ssmlJa,
@@ -276,21 +328,10 @@ export const tts = onCall(
     }
 
     try {
+      const accessToken = await getAccessToken();
       const [jaAudio, enAudio] = await Promise.all([
-        synthesizeWithGemini(
-          projectId,
-          ssmlJa,
-          'ja-JP',
-          jaVoiceName,
-          '以下の日本語を、現代的な鉄道自動放送のように読み上げてください。全体的に平板なイントネーションを維持し、感情を込めず淡々と読んでください。文のイントネーションは文末に向かって自然に下降させてください。助詞（は、の、で、を等）で不自然にピッチを上げないでください。駅名や路線名は平板アクセントで読んでください（一般会話のアクセントとは異なります）。無駄な間を入れず、一定のテンポで読み進めてください。漢字の読みは一文字も省略せず正確に読んでください。特に路線名は正式な読みに従ってください（例：副都心線→ふくとしんせん、東海道線→とうかいどうせん、山手線→やまのてせん）。鉄道会社の略称も正確に読んでください（例：名鉄→めいてつ、京急→けいきゅう、京王→けいおう、阪急→はんきゅう、阪神→はんしん、南海→なんかい、近鉄→きんてつ、西鉄→にしてつ、東急→とうきゅう、小田急→おだきゅう、京成→けいせい、相鉄→そうてつ）。'
-        ),
-        synthesizeWithGemini(
-          projectId,
-          ssmlEn,
-          'en-US',
-          enVoiceName,
-          'Read the following in a calm, clear, and composed tone like a modern train announcement. Speak quickly and crisply with a swift, efficient delivery. Do not linger on words or pause unnecessarily. Maintain a steady, relaxed intonation despite the fast pace. The text contains Japanese railway station names and line names in romanized form. Pronounce them using Japanese vowel rules, NOT English rules: a=ah, i=ee, u=oo, e=eh, o=oh. Every vowel is always pronounced the same way regardless of surrounding letters (e.g. "Inage" = ee-nah-geh, NOT "inn-idge"; "Meguro" = meh-goo-roh; "Ebisu" = eh-bee-soo; "Ome" = oh-meh, NOT "ohm"). Never apply English spelling conventions like silent e, soft g, or vowel shifts to these names.'
-        ),
+        synthesizeWithGemini(projectId, accessToken, ssmlJa, 'ja-JP', jaVoiceName, jaPrompt),
+        synthesizeWithGemini(projectId, accessToken, ssmlEn, 'en-US', enVoiceName, enPrompt),
       ]);
       const jaAudioContent = jaAudio.audioContent;
       const jaAudioMimeType = jaAudio.mimeType || 'audio/mpeg';

--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -258,6 +258,18 @@ export const tts = onCall(
     const jaPromptBytes = Buffer.byteLength(jaPrompt, 'utf8');
     const enPromptBytes = Buffer.byteLength(enPrompt, 'utf8');
 
+    if (jaTextBytes > PROMPT_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `ssmlJa text exceeds ${PROMPT_BYTE_LIMIT} byte limit (${jaTextBytes} bytes)`
+      );
+    }
+    if (enTextBytes > PROMPT_BYTE_LIMIT) {
+      throw new HttpsError(
+        'invalid-argument',
+        `ssmlEn text exceeds ${PROMPT_BYTE_LIMIT} byte limit (${enTextBytes} bytes)`
+      );
+    }
     if (jaPromptBytes > PROMPT_BYTE_LIMIT) {
       throw new HttpsError(
         'invalid-argument',

--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -251,10 +251,26 @@ export const tts = onCall(
       (typeof req.data.enPrompt === 'string' && req.data.enPrompt.trim()) ||
       EN_TTS_PROMPT;
 
+    const strippedJa = stripSsml(ssmlJa);
+    const strippedEn = stripSsml(ssmlEn);
+
+    if (strippedJa.trim().length === 0) {
+      throw new HttpsError(
+        'invalid-argument',
+        'ssmlJa contains no visible text after stripping SSML tags'
+      );
+    }
+    if (strippedEn.trim().length === 0) {
+      throw new HttpsError(
+        'invalid-argument',
+        'ssmlEn contains no visible text after stripping SSML tags'
+      );
+    }
+
     const PROMPT_BYTE_LIMIT = 4000;
     const COMBINED_BYTE_LIMIT = 8000;
-    const jaTextBytes = Buffer.byteLength(stripSsml(ssmlJa), 'utf8');
-    const enTextBytes = Buffer.byteLength(stripSsml(ssmlEn), 'utf8');
+    const jaTextBytes = Buffer.byteLength(strippedJa, 'utf8');
+    const enTextBytes = Buffer.byteLength(strippedEn, 'utf8');
     const jaPromptBytes = Buffer.byteLength(jaPrompt, 'utf8');
     const enPromptBytes = Buffer.byteLength(enPrompt, 'utf8');
 

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -17,7 +17,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ASYNC_STORAGE_KEYS, FONTS } from '~/constants';
+import { ASYNC_STORAGE_KEYS, DEFAULT_TTS_VOICE_NAME, FONTS } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
@@ -72,7 +72,41 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     width: '50%',
   },
+  promptInput: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#aaa',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    maxHeight: 120,
+    textAlignVertical: 'top',
+    fontSize: RFValue(11),
+  },
 });
+
+const DEFAULT_JA_PROMPT = [
+  '以下の日本語を、現代的な鉄道自動放送のように読み上げてください。',
+  '全体的に平板なイントネーションを維持し、感情を込めず淡々と読んでください。',
+  '文のイントネーションは文末に向かって自然に下降させてください。',
+  '助詞（は、の、で、を等）で不自然にピッチを上げないでください。',
+  '駅名や路線名は平板アクセントで読んでください（一般会話のアクセントとは異なります）。',
+  '無駄な間を入れず、一定のテンポで読み進めてください。',
+  '漢字の読みは一文字も省略せず正確に読んでください。',
+  '特に路線名は正式な読みに従ってください（例：副都心線→ふくとしんせん、東海道線→とうかいどうせん、山手線→やまのてせん）。',
+  '鉄道会社の略称も正確に読んでください（例：名鉄→めいてつ、京急→けいきゅう、京王→けいおう、阪急→はんきゅう、阪神→はんしん、南海→なんかい、近鉄→きんてつ、西鉄→にしてつ、東急→とうきゅう、小田急→おだきゅう、京成→けいせい、相鉄→そうてつ）。',
+].join('');
+
+const DEFAULT_EN_PROMPT = [
+  'Read the following in a calm, clear, and composed tone like a modern train announcement.',
+  ' Speak quickly and crisply with a swift, efficient delivery.',
+  ' Do not linger on words or pause unnecessarily.',
+  ' Maintain a steady, relaxed intonation despite the fast pace.',
+  ' The text contains Japanese railway station names and line names in romanized form.',
+  ' Pronounce them using Japanese vowel rules, NOT English rules: a=ah, i=ee, u=oo, e=eh, o=oh.',
+  ' Every vowel is always pronounced the same way regardless of surrounding letters',
+  ' (e.g. "Inage" = ee-nah-geh, NOT "inn-idge"; "Meguro" = meh-goo-roh; "Ebisu" = eh-bee-soo; "Ome" = oh-meh, NOT "ohm").',
+  ' Never apply English spelling conventions like silent e, soft g, or vowel shifts to these names.',
+].join('');
 
 const TTS_VOICE_NAMES = [
   'Achernar',
@@ -100,14 +134,18 @@ const TuningSettings: React.FC = () => {
 
   useEffect(() => {
     (async () => {
-      const [enVoice, jaVoice] = await Promise.all([
+      const [enVoice, jaVoice, jaPrompt, enPrompt] = await Promise.all([
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_EN_VOICE_NAME),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_JA_VOICE_NAME),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_JA_PROMPT),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_EN_PROMPT),
       ]);
       setSettings((prev) => ({
         ...prev,
-        ttsEnVoiceName: enVoice ?? '',
-        ttsJaVoiceName: jaVoice ?? '',
+        ttsEnVoiceName: enVoice || DEFAULT_TTS_VOICE_NAME,
+        ttsJaVoiceName: jaVoice || DEFAULT_TTS_VOICE_NAME,
+        ttsJaPrompt: jaPrompt ?? '',
+        ttsEnPrompt: enPrompt ?? '',
       }));
     })();
   }, [setSettings]);
@@ -208,6 +246,16 @@ const TuningSettings: React.FC = () => {
   const handleEnVoiceNameChange = (voice: string) => {
     setSettings((prev) => ({ ...prev, ttsEnVoiceName: voice }));
     AsyncStorage.setItem(ASYNC_STORAGE_KEYS.TTS_EN_VOICE_NAME, voice);
+  };
+
+  const handleJaPromptChange = (text: string) => {
+    setSettings((prev) => ({ ...prev, ttsJaPrompt: text }));
+    AsyncStorage.setItem(ASYNC_STORAGE_KEYS.TTS_JA_PROMPT, text);
+  };
+
+  const handleEnPromptChange = (text: string) => {
+    setSettings((prev) => ({ ...prev, ttsEnPrompt: text }));
+    AsyncStorage.setItem(ASYNC_STORAGE_KEYS.TTS_EN_PROMPT, text);
   };
 
   const handleJaVoiceNameChange = (voice: string) => {
@@ -345,15 +393,11 @@ const TuningSettings: React.FC = () => {
         >
           <Typography
             style={{
-              color: settings.ttsJaVoiceName
-                ? isLEDTheme
-                  ? '#fff'
-                  : 'black'
-                : '#999',
+              color: isLEDTheme ? '#fff' : 'black',
               fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
             }}
           >
-            {settings.ttsJaVoiceName || translate('notSpecified')}
+            {settings.ttsJaVoiceName}
           </Typography>
         </Pressable>
 
@@ -368,17 +412,51 @@ const TuningSettings: React.FC = () => {
         >
           <Typography
             style={{
-              color: settings.ttsEnVoiceName
-                ? isLEDTheme
-                  ? '#fff'
-                  : 'black'
-                : '#999',
+              color: isLEDTheme ? '#fff' : 'black',
               fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
             }}
           >
-            {settings.ttsEnVoiceName || translate('notSpecified')}
+            {settings.ttsEnVoiceName}
           </Typography>
         </Pressable>
+
+        <Typography style={styles.settingItemTitle}>
+          {translate('tuningItemTTSJaPrompt')}
+        </Typography>
+        <TextInput
+          style={[
+            styles.promptInput,
+            {
+              color: isLEDTheme ? '#fff' : 'black',
+              fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
+              borderColor: isLEDTheme ? '#666' : '#aaa',
+            },
+          ]}
+          onChangeText={handleJaPromptChange}
+          value={settings.ttsJaPrompt || DEFAULT_JA_PROMPT}
+          placeholder={DEFAULT_JA_PROMPT}
+          placeholderTextColor="#999"
+          multiline
+        />
+
+        <Typography style={styles.settingItemTitle}>
+          {translate('tuningItemTTSEnPrompt')}
+        </Typography>
+        <TextInput
+          style={[
+            styles.promptInput,
+            {
+              color: isLEDTheme ? '#fff' : 'black',
+              fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
+              borderColor: isLEDTheme ? '#666' : '#aaa',
+            },
+          ]}
+          onChangeText={handleEnPromptChange}
+          value={settings.ttsEnPrompt || DEFAULT_EN_PROMPT}
+          placeholder={DEFAULT_EN_PROMPT}
+          placeholderTextColor="#999"
+          multiline
+        />
 
         <View style={styles.switchSettingItem}>
           {isLEDTheme ? (

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -20,6 +20,8 @@ export const ASYNC_STORAGE_KEYS = {
   DEV_OVERLAY_ENABLED: '@TrainLCD:devOverlayEnabled',
   TTS_JA_VOICE_NAME: '@TrainLCD:ttsJaVoiceName',
   TTS_EN_VOICE_NAME: '@TrainLCD:ttsEnVoiceName',
+  TTS_JA_PROMPT: '@TrainLCD:ttsJaPrompt',
+  TTS_EN_PROMPT: '@TrainLCD:ttsEnPrompt',
   HEADER_TRANSITION_INTERVAL: '@TrainLCD:headerTransitionInterval',
   HEADER_TRANSITION_DELAY: '@TrainLCD:headerTransitionDelay',
   BOTTOM_TRANSITION_INTERVAL: '@TrainLCD:bottomTransitionInterval',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,4 +18,5 @@ export * from './station';
 export * from './storage';
 export * from './theme';
 export * from './threshold';
+export * from './tts';
 export * from './url';

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TTS_VOICE_NAME = 'Aoede';

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -38,7 +38,8 @@ export const useTTS = (): void => {
   const { enabled, backgroundEnabled, ttsEnabledLanguages } =
     useAtomValue(speechState);
   const { arrived, selectedBound } = useAtomValue(stationState);
-  const { ttsJaVoiceName, ttsEnVoiceName } = useAtomValue(tuningState);
+  const { ttsJaVoiceName, ttsEnVoiceName, ttsJaPrompt, ttsEnPrompt } =
+    useAtomValue(tuningState);
   const setTuning = useSetAtom(tuningState);
   const currentLine = useCurrentLine();
   const stoppingState = useStoppingState();
@@ -89,14 +90,18 @@ export const useTTS = (): void => {
 
   useEffect(() => {
     (async () => {
-      const [jaVoice, enVoice] = await Promise.all([
+      const [jaVoice, enVoice, jaPrompt, enPrompt] = await Promise.all([
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_JA_VOICE_NAME),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_EN_VOICE_NAME),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_JA_PROMPT),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.TTS_EN_PROMPT),
       ]);
       setTuning((prev) => ({
         ...prev,
-        ttsJaVoiceName: jaVoice ?? '',
-        ttsEnVoiceName: enVoice ?? '',
+        ttsJaVoiceName: jaVoice || prev.ttsJaVoiceName,
+        ttsEnVoiceName: enVoice || prev.ttsEnVoiceName,
+        ttsJaPrompt: jaPrompt ?? '',
+        ttsEnPrompt: enPrompt ?? '',
       }));
     })();
   }, [setTuning]);
@@ -259,8 +264,10 @@ export const useTTS = (): void => {
           textEn: en,
           apiUrl: ttsApiUrl,
           idToken,
-          jaVoiceName: ttsJaVoiceName || undefined,
-          enVoiceName: ttsEnVoiceName || undefined,
+          jaVoiceName: ttsJaVoiceName,
+          enVoiceName: ttsEnVoiceName,
+          jaPrompt: ttsJaPrompt || undefined,
+          enPrompt: ttsEnPrompt || undefined,
         });
 
         if (!fetched) {
@@ -279,7 +286,9 @@ export const useTTS = (): void => {
       finishPlaying,
       speakFromPath,
       ttsApiUrl,
+      ttsEnPrompt,
       ttsEnVoiceName,
+      ttsJaPrompt,
       ttsJaVoiceName,
       user,
     ]
@@ -307,8 +316,10 @@ export const useTTS = (): void => {
           textEn: prefetchEn,
           apiUrl: ttsApiUrl,
           idToken,
-          jaVoiceName: ttsJaVoiceName || undefined,
-          enVoiceName: ttsEnVoiceName || undefined,
+          jaVoiceName: ttsJaVoiceName,
+          enVoiceName: ttsEnVoiceName,
+          jaPrompt: ttsJaPrompt || undefined,
+          enPrompt: ttsEnPrompt || undefined,
         });
       } catch (e) {
         console.warn('[useTTS] Prefetch failed:', e);
@@ -323,7 +334,9 @@ export const useTTS = (): void => {
     textJa,
     textEn,
     ttsApiUrl,
+    ttsEnPrompt,
     ttsEnVoiceName,
+    ttsJaPrompt,
     ttsJaVoiceName,
     user,
   ]);

--- a/src/store/atoms/tuning.ts
+++ b/src/store/atoms/tuning.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_BOTTOM_TRANSITION_INTERVAL,
   DEFAULT_HEADER_TRANSITION_DELAY,
   DEFAULT_HEADER_TRANSITION_INTERVAL,
+  DEFAULT_TTS_VOICE_NAME,
 } from '../../constants';
 
 export type TuningState = {
@@ -14,6 +15,8 @@ export type TuningState = {
   telemetryEnabled: boolean;
   ttsJaVoiceName: string;
   ttsEnVoiceName: string;
+  ttsJaPrompt: string;
+  ttsEnPrompt: string;
 };
 
 const tuningState = atom<TuningState>({
@@ -23,8 +26,10 @@ const tuningState = atom<TuningState>({
   devOverlayEnabled: true,
   untouchableModeEnabled: false,
   telemetryEnabled: false,
-  ttsJaVoiceName: '',
-  ttsEnVoiceName: '',
+  ttsJaVoiceName: DEFAULT_TTS_VOICE_NAME,
+  ttsEnVoiceName: DEFAULT_TTS_VOICE_NAME,
+  ttsJaPrompt: '',
+  ttsEnPrompt: '',
 });
 
 export default tuningState;

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -9,6 +9,8 @@ export interface FetchSpeechOptions {
   idToken: string;
   jaVoiceName?: string;
   enVoiceName?: string;
+  jaPrompt?: string;
+  enPrompt?: string;
 }
 
 const getSampleRateFromMimeType = (mimeType: string): number => {
@@ -96,7 +98,7 @@ const fetchCache = new Map<
 >();
 
 const buildCacheKey = (opts: FetchSpeechOptions): string =>
-  `${opts.textJa}\0${opts.textEn}\0${opts.jaVoiceName ?? ''}\0${opts.enVoiceName ?? ''}`;
+  `${opts.textJa}\0${opts.textEn}\0${opts.jaVoiceName ?? ''}\0${opts.enVoiceName ?? ''}\0${opts.jaPrompt ?? ''}\0${opts.enPrompt ?? ''}`;
 
 export const clearFetchCache = (): void => {
   fetchCache.clear();
@@ -105,7 +107,16 @@ export const clearFetchCache = (): void => {
 export const fetchSpeechAudio = async (
   options: FetchSpeechOptions
 ): Promise<{ id: string; pathJa: string; pathEn: string } | null> => {
-  const { textJa, textEn, apiUrl, idToken, jaVoiceName, enVoiceName } = options;
+  const {
+    textJa,
+    textEn,
+    apiUrl,
+    idToken,
+    jaVoiceName,
+    enVoiceName,
+    jaPrompt,
+    enPrompt,
+  } = options;
 
   if (!textJa.length || !textEn.length) {
     return null;
@@ -123,6 +134,8 @@ export const fetchSpeechAudio = async (
       ssmlEn: `<speak>${textEn.trim()}</speak>`,
       ...(jaVoiceName ? { jaVoiceName } : {}),
       ...(enVoiceName ? { enVoiceName } : {}),
+      ...(jaPrompt ? { jaPrompt } : {}),
+      ...(enPrompt ? { enPrompt } : {}),
     },
   };
 

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -133,22 +133,19 @@ export const fetchSpeechAudio = async (
     return cached;
   }
 
+  const normalizedJaVoiceName = normalizeOptional(jaVoiceName);
+  const normalizedEnVoiceName = normalizeOptional(enVoiceName);
+  const normalizedJaPrompt = normalizeOptional(jaPrompt);
+  const normalizedEnPrompt = normalizeOptional(enPrompt);
+
   const reqBody = {
     data: {
       ssmlJa: `<speak>${textJa.trim()}</speak>`,
       ssmlEn: `<speak>${textEn.trim()}</speak>`,
-      ...(normalizeOptional(jaVoiceName)
-        ? { jaVoiceName: normalizeOptional(jaVoiceName) }
-        : {}),
-      ...(normalizeOptional(enVoiceName)
-        ? { enVoiceName: normalizeOptional(enVoiceName) }
-        : {}),
-      ...(normalizeOptional(jaPrompt)
-        ? { jaPrompt: normalizeOptional(jaPrompt) }
-        : {}),
-      ...(normalizeOptional(enPrompt)
-        ? { enPrompt: normalizeOptional(enPrompt) }
-        : {}),
+      ...(normalizedJaVoiceName ? { jaVoiceName: normalizedJaVoiceName } : {}),
+      ...(normalizedEnVoiceName ? { enVoiceName: normalizedEnVoiceName } : {}),
+      ...(normalizedJaPrompt ? { jaPrompt: normalizedJaPrompt } : {}),
+      ...(normalizedEnPrompt ? { enPrompt: normalizedEnPrompt } : {}),
     },
   };
 

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -97,8 +97,13 @@ const fetchCache = new Map<
   { id: string; pathJa: string; pathEn: string }
 >();
 
+const normalizeOptional = (val: string | undefined): string => {
+  const trimmed = (val ?? '').trim();
+  return trimmed.length > 0 ? trimmed : '';
+};
+
 const buildCacheKey = (opts: FetchSpeechOptions): string =>
-  `${opts.textJa}\0${opts.textEn}\0${opts.jaVoiceName ?? ''}\0${opts.enVoiceName ?? ''}\0${opts.jaPrompt ?? ''}\0${opts.enPrompt ?? ''}`;
+  `${opts.textJa}\0${opts.textEn}\0${normalizeOptional(opts.jaVoiceName)}\0${normalizeOptional(opts.enVoiceName)}\0${normalizeOptional(opts.jaPrompt)}\0${normalizeOptional(opts.enPrompt)}`;
 
 export const clearFetchCache = (): void => {
   fetchCache.clear();
@@ -132,10 +137,18 @@ export const fetchSpeechAudio = async (
     data: {
       ssmlJa: `<speak>${textJa.trim()}</speak>`,
       ssmlEn: `<speak>${textEn.trim()}</speak>`,
-      ...(jaVoiceName ? { jaVoiceName } : {}),
-      ...(enVoiceName ? { enVoiceName } : {}),
-      ...(jaPrompt ? { jaPrompt } : {}),
-      ...(enPrompt ? { enPrompt } : {}),
+      ...(normalizeOptional(jaVoiceName)
+        ? { jaVoiceName: normalizeOptional(jaVoiceName) }
+        : {}),
+      ...(normalizeOptional(enVoiceName)
+        ? { enVoiceName: normalizeOptional(enVoiceName) }
+        : {}),
+      ...(normalizeOptional(jaPrompt)
+        ? { jaPrompt: normalizeOptional(jaPrompt) }
+        : {}),
+      ...(normalizeOptional(enPrompt)
+        ? { enPrompt: normalizeOptional(enPrompt) }
+        : {}),
     },
   };
 


### PR DESCRIPTION
## Summary
- チューニング設定画面にTTS日本語プロンプト・英語プロンプトの編集用TextInputを追加
- デフォルト値はCloud Function側の既存プロンプト文言と同一で、ユーザーが自由に書き換え可能
- 入力されたカスタムプロンプトはAsyncStorageに永続化され、TTS API呼び出し時にサーバーへ送信
- Cloud Function側でカスタムプロンプトを受け取り、既存のデフォルトプロンプトを置き換えて合成に使用
- ボイス名のデフォルト値 `Aoede` を `DEFAULT_TTS_VOICE_NAME` 定数に集約
- キャッシュバージョンを9→10に更新（プロンプトをハッシュペイロードに含めるため）

## Test plan
- [ ] チューニング設定画面で日本語・英語プロンプトがデフォルト値で表示されることを確認
- [ ] プロンプトを編集してTTS再生し、変更が反映されることを確認
- [ ] プロンプトを空にした場合、サーバー側のデフォルトプロンプトが使用されることを確認
- [ ] ボイス名がデフォルトでAoedeと表示されることを確認
- [ ] アプリ再起動後もプロンプト・ボイス名の設定が永続化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 日本語／英語それぞれのTTSプロンプト入力欄を追加し、プロンプトを保存・編集可能になりました。
  * 翻訳ファイルに両言語の新しいラベルを追加しました。

* **Improvements**
  * デフォルトTTS音声名を導入し初期設定が改善されました。
  * 合成処理でキャッシュ利用とアクセストークン取得を導入し、安定性と速度が向上しました。

* **Validation**
  * 空入力チェックとフィールド／合算の長さ制限を追加し生成エラーを低減します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->