### PR TITLE
phonemeタグの内側テキストをひらがなに変更

### DIFF
--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -169,7 +169,7 @@ export const useTTSText = (
       isLoopLine
         ? (loopLineBoundEn?.boundFor?.replaceAll('&', ' and ') ?? '')
         : (directionalStops
-            ?.map((s) => ph(s?.nameRoman, s?.nameRomanIpa))
+            ?.map((s) => ph(s?.nameRoman, s?.nameRomanIpa, s?.nameKatakana))
             .join(' and ') ?? ''),
 
     [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
@@ -784,15 +784,15 @@ export const useTTSText = (
 
       const map = {
         [APP_THEME.TOKYO_METRO]: {
-          NEXT: `The next stop is ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}${
+          NEXT: `The next stop is ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}${
             nextStationNumberText.length ? ` ${nextStationNumberText}` : '.'
           }${
             transferLines.length
               ? ` Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '.' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -811,7 +811,7 @@ export const useTTSText = (
                   currentLine.nameRomanIpa
                 )} bound for ${boundForEn}. ${
                   currentTrainType && afterNextStation
-                    ? `The next stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}${`, is ${ph(
+                    ? `The next stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}${`, is ${ph(
                         afterNextStation?.nameRoman,
                         afterNextStation?.nameRomanIpa
                       )}${isAfterNextStopTerminus ? ' terminal' : ''}`}.`
@@ -833,14 +833,14 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(' ')}`
               : ''
           }. ${
             isNextStopTerminus
-              ? `Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa)}.`
+              ? `Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa, currentLine?.nameKatakana)}.`
               : ''
           }`,
         },
@@ -850,9 +850,9 @@ export const useTTSText = (
               ? `Thank you for using the ${ph(
                   currentLine.nameRoman,
                   currentLine.nameRomanIpa
-                )}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa) || 'Local')} train ${
+                )}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train ${
                   connectedLines[0]?.nameRoman
-                    ? `on the ${ph(connectedLines[0]?.nameRoman, connectedLines[0]?.nameRomanIpa)}`
+                    ? `on the ${ph(connectedLines[0]?.nameRoman, connectedLines[0]?.nameRomanIpa, connectedLines[0]?.nameKatakana)}`
                     : ''
                 } to ${boundForEn}. `
               : ''
@@ -866,8 +866,8 @@ export const useTTSText = (
               ? `Passengers changing to ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
                   )
                   .join(', ')}, Please transfer at this station.`
               : ''
@@ -882,28 +882,28 @@ export const useTTSText = (
               ? ` Passengers changing to ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
                   )
                   .join(', ')}, Please transfer at this station.`
               : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}, will be ${ph(
+              ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}, will be ${ph(
                   afterNextStation.nameRoman,
                   afterNextStation.nameRomanIpa
                 )}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${
             isNextStopTerminus
-              ? ` Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa)}.`
+              ? ` Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa, currentLine?.nameKatakana)}.`
               : ''
           }`,
         },
         [APP_THEME.YAMANOTE]: {
           NEXT: `${
             firstSpeech
-              ? `This is the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa)} train bound for ${boundForEn}. `
+              ? `This is the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa, currentLine.nameKatakana)} train bound for ${boundForEn}. `
               : ''
           }The next station is ${ph(
             nextStation?.nameRoman,
@@ -913,8 +913,8 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -929,8 +929,8 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -948,7 +948,7 @@ export const useTTSText = (
         [APP_THEME.SAIKYO]: {
           NEXT: `${
             firstSpeech
-              ? `This is the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa)} train bound for ${boundForEn}. `
+              ? `This is the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa, currentLine.nameKatakana)} train bound for ${boundForEn}. `
               : ''
           }The next station is ${ph(
             nextStation?.nameRoman,
@@ -958,8 +958,8 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -974,8 +974,8 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -988,16 +988,16 @@ export const useTTSText = (
         [APP_THEME.JR_WEST]: {
           NEXT: `${
             firstSpeech
-              ? `Thank you for using ${currentLine?.company?.nameEnglishShort}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa) || 'Local')} Service bound for ${boundForEn} ${
+              ? `Thank you for using ${currentLine?.company?.nameEnglishShort}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} Service bound for ${boundForEn} ${
                   viaStation
-                    ? `via ${ph(viaStation.nameRoman, viaStation.nameRomanIpa)}`
+                    ? `via ${ph(viaStation.nameRoman, viaStation.nameRomanIpa, viaStation.nameKatakana)}`
                     : ''
                 }. We will be stopping at ${allStops
                   .slice(0, 5)
                   .map((s) =>
                     s.id === selectedBound?.id && !isLoopLine
-                      ? `${ph(s.nameRoman, s.nameRomanIpa)} terminal`
-                      : `${ph(s.nameRoman, s.nameRomanIpa)}`
+                      ? `${ph(s.nameRoman, s.nameRomanIpa, s.nameKatakana)} terminal`
+                      : `${ph(s.nameRoman, s.nameRomanIpa, s.nameKatakana)}`
                   )
                   .join(', ')}. ${
                   allStops
@@ -1017,7 +1017,7 @@ export const useTTSText = (
                       )} will be announced later. `
                 }`
               : ''
-          }The next stop is ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}${
+          }The next stop is ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}${
             nextStationNumber?.lineSymbol?.length
               ? ` station number ${nextStationNumberText.replace(/\.$/, '')}.`
               : '.'
@@ -1026,8 +1026,8 @@ export const useTTSText = (
               ? `Transfer here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '.' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -1044,8 +1044,8 @@ export const useTTSText = (
               ? `Transfer here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '.' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -1054,16 +1054,16 @@ export const useTTSText = (
               ? `After leaving ${ph(
                   nextStation?.nameRoman,
                   nextStation?.nameRomanIpa
-                )}, We will be stopping at ${ph(afterNextStation.nameRoman, afterNextStation.nameRomanIpa)}.`
+                )}, We will be stopping at ${ph(afterNextStation.nameRoman, afterNextStation.nameRomanIpa, afterNextStation.nameKatakana)}.`
               : ''
           }`,
         },
         [APP_THEME.TOEI]: {
           NEXT: `${
             firstSpeech
-              ? `Thank you for using the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa)}. `
+              ? `Thank you for using the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa, currentLine.nameKatakana)}. `
               : ''
-          }This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa) || 'Local')} train bound for ${boundForEn}. The next station is ${ph(
+          }This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train bound for ${boundForEn}. The next station is ${ph(
             nextStation?.nameRoman,
             nextStation?.nameRomanIpa
           )} ${nextStationNumberText} ${
@@ -1071,8 +1071,8 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '.' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
               : ''
@@ -1085,21 +1085,21 @@ export const useTTSText = (
               ? `Please change here for ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '.' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '.' : ','}`
                   )
                   .join(' ')}`
               : ''
           }${
             currentTrainType && afterNextStation
-              ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}, will be ${ph(
+              ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}, will be ${ph(
                   afterNextStation.nameRoman,
                   afterNextStation.nameRomanIpa
                 )}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${
             isNextStopTerminus
-              ? ` Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa)}.`
+              ? ` Thank you for using the ${ph(currentLine?.nameRoman, currentLine?.nameRomanIpa, currentLine?.nameKatakana)}.`
               : ''
           }`,
         },
@@ -1108,7 +1108,7 @@ export const useTTSText = (
           ARRIVING: '',
         },
         [APP_THEME.JR_KYUSHU]: {
-          NEXT: `${firstSpeech ? `This is a ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa) || 'Local')} train bound for ${boundForEn}.` : ''} The next station is ${ph(
+          NEXT: `${firstSpeech ? `This is a ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train bound for ${boundForEn}.` : ''} The next station is ${ph(
             nextStation?.nameRoman,
             nextStation?.nameRomanIpa
           )} ${nextStationNumberText}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}. ${
@@ -1116,12 +1116,12 @@ export const useTTSText = (
               ? `You can transfer to ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(
                     ' '
-                  )} at ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}.`
+                  )} at ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}.`
               : ''
           }`,
           ARRIVING: `We will soon be arriving at ${ph(
@@ -1132,12 +1132,12 @@ export const useTTSText = (
               ? `You can transfer to ${transferLines
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa)}.`
-                      : `the ${ph(l.nameRoman, l.nameRomanIpa)}${a.length === 1 ? '' : ','}`
+                      ? `and the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}.`
+                      : `the ${ph(l.nameRoman, l.nameRomanIpa, l.nameKatakana)}${a.length === 1 ? '' : ','}`
                   )
                   .join(
                     ' '
-                  )} at ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa)}. ${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? `Thank you for using the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa)}.` : ''}`
+                  )} at ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}. ${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? `Thank you for using the ${ph(currentLine.nameRoman, currentLine.nameRomanIpa, currentLine.nameKatakana)}.` : ''}`
               : ''
           }`,
         },
@@ -1165,6 +1165,7 @@ export const useTTSText = (
       transferLines,
       viaStation,
       yamanoteTrainTypeEn,
+      nextStation?.nameKatakana,
     ]);
 
   const resolved = resolveTemplateTheme(theme);

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -813,7 +813,8 @@ export const useTTSText = (
                   currentTrainType && afterNextStation
                     ? `The next stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}${`, is ${ph(
                         afterNextStation?.nameRoman,
-                        afterNextStation?.nameRomanIpa
+                        afterNextStation?.nameRomanIpa,
+                        afterNextStation?.nameKatakana
                       )}${isAfterNextStopTerminus ? ' terminal' : ''}`}.`
                     : ''
                 }${
@@ -891,7 +892,8 @@ export const useTTSText = (
             currentTrainType && afterNextStation
               ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}, will be ${ph(
                   afterNextStation.nameRoman,
-                  afterNextStation.nameRomanIpa
+                  afterNextStation.nameRomanIpa,
+                  afterNextStation.nameKatakana
                 )}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${
@@ -1094,7 +1096,8 @@ export const useTTSText = (
             currentTrainType && afterNextStation
               ? ` The stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}, will be ${ph(
                   afterNextStation.nameRoman,
-                  afterNextStation.nameRomanIpa
+                  afterNextStation.nameRomanIpa,
+                  afterNextStation.nameKatakana
                 )}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
               : ''
           }${

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -106,9 +106,11 @@ export const useTTSText = (
       name: string | undefined | null,
       nameKatakana: string | undefined | null
     ) =>
-      !name || !nameKatakana
+      !name && !nameKatakana
         ? `<sub alias="かくえきていしゃ">各駅停車</sub>`
-        : `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`,
+        : !nameKatakana
+          ? (name ?? '')
+          : `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`,
     []
   );
 
@@ -803,12 +805,14 @@ export const useTTSText = (
                   (currentTrainType
                     ? ph(
                         currentTrainType.nameRoman,
-                        currentTrainType.nameRomanIpa
+                        currentTrainType.nameRomanIpa,
+                        currentTrainType.nameKatakana
                       )
                     : 'Local')
                 } Service on the ${ph(
                   currentLine.nameRoman,
-                  currentLine.nameRomanIpa
+                  currentLine.nameRomanIpa,
+                  currentLine.nameKatakana
                 )} bound for ${boundForEn}. ${
                   currentTrainType && afterNextStation
                     ? `The next stop after ${ph(nextStation?.nameRoman, nextStation?.nameRomanIpa, nextStation?.nameKatakana)}${`, is ${ph(
@@ -826,7 +830,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `Arriving at ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop.' : ''
           } ${
@@ -850,7 +855,8 @@ export const useTTSText = (
             firstSpeech
               ? `Thank you for using the ${ph(
                   currentLine.nameRoman,
-                  currentLine.nameRomanIpa
+                  currentLine.nameRomanIpa,
+                  currentLine.nameKatakana
                 )}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train ${
                   connectedLines[0]?.nameRoman
                     ? `on the ${ph(connectedLines[0]?.nameRoman, connectedLines[0]?.nameRomanIpa, connectedLines[0]?.nameKatakana)}`
@@ -859,7 +865,8 @@ export const useTTSText = (
               : ''
           }The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           } ${
@@ -875,7 +882,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `We will soon make a brief stop at ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${
             isNextStopTerminus ? ', the last stop' : ''
           }${
@@ -909,7 +917,8 @@ export const useTTSText = (
               : ''
           }The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
@@ -923,7 +932,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${
             isNextStopTerminus ? ', terminal.' : ''
           } ${
@@ -954,7 +964,8 @@ export const useTTSText = (
               : ''
           }The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${isNextStopTerminus ? ', terminal' : ''} ${
             transferLines.length
               ? `Please change here for ${transferLines
@@ -968,7 +979,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${
             isNextStopTerminus ? ', terminal.' : ''
           } ${
@@ -1015,7 +1027,11 @@ export const useTTSText = (
                         allStops
                           .slice(0, 5)
                           .filter((s) => s)
-                          .reverse()[0]?.nameRomanIpa
+                          .reverse()[0]?.nameRomanIpa,
+                        allStops
+                          .slice(0, 5)
+                          .filter((s) => s)
+                          .reverse()[0]?.nameKatakana
                       )} will be announced later. `
                 }`
               : ''
@@ -1036,7 +1052,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `We will soon be making a brief stop at ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )}${
             nextStationNumber?.lineSymbol?.length
               ? ` station number ${nextStationNumberText.replace(/\.$/, '')}.`
@@ -1055,7 +1072,8 @@ export const useTTSText = (
             afterNextStation
               ? `After leaving ${ph(
                   nextStation?.nameRoman,
-                  nextStation?.nameRomanIpa
+                  nextStation?.nameRomanIpa,
+                  nextStation?.nameKatakana
                 )}, We will be stopping at ${ph(afterNextStation.nameRoman, afterNextStation.nameRomanIpa, afterNextStation.nameKatakana)}.`
               : ''
           }`,
@@ -1067,7 +1085,8 @@ export const useTTSText = (
               : ''
           }This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train bound for ${boundForEn}. The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
@@ -1081,7 +1100,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `We will soon be arriving at ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText} ${
             transferLines.length
               ? `Please change here for ${transferLines
@@ -1113,7 +1133,8 @@ export const useTTSText = (
         [APP_THEME.JR_KYUSHU]: {
           NEXT: `${firstSpeech ? `This is a ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameRoman, currentTrainType?.nameRomanIpa, currentTrainType?.nameKatakana) || 'Local')} train bound for ${boundForEn}.` : ''} The next station is ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )} ${nextStationNumberText}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}. ${
             transferLines.length
               ? `You can transfer to ${transferLines
@@ -1129,7 +1150,8 @@ export const useTTSText = (
           }`,
           ARRIVING: `We will soon be arriving at ${ph(
             nextStation?.nameRoman,
-            nextStation?.nameRomanIpa
+            nextStation?.nameRomanIpa,
+            nextStation?.nameKatakana
           )}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''} ${nextStationNumberText}. ${
             transferLines.length
               ? `You can transfer to ${transferLines

--- a/src/utils/phoneme.ts
+++ b/src/utils/phoneme.ts
@@ -1,3 +1,5 @@
+import katakanaToHiragana from './kanaToHiragana';
+
 const escapeXml = (s: string): string =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
@@ -7,9 +9,11 @@ const escapeXmlAttr = (s: string): string =>
 /** nameRomanIpa が定義されていれば SSML phoneme タグで囲み、なければ nameRoman をそのまま返す */
 export const wrapPhoneme = (
   nameRoman: string | null | undefined,
-  nameRomanIpa?: string | null | undefined
+  nameRomanIpa?: string | null | undefined,
+  nameKatakana?: string | null | undefined
 ): string => {
   if (!nameRoman) return '';
   if (!nameRomanIpa) return escapeXml(nameRoman);
-  return `<phoneme alphabet="ipa" ph="${escapeXmlAttr(nameRomanIpa)}">${escapeXml(nameRoman)}</phoneme>`;
+  const innerText = nameKatakana ? katakanaToHiragana(nameKatakana) : nameRoman;
+  return `<phoneme alphabet="ipa" ph="${escapeXmlAttr(nameRomanIpa)}">${escapeXml(innerText)}</phoneme>`;
 };


### PR DESCRIPTION
## Summary
- `wrapPhoneme` に第3引数 `nameKatakana` を追加し、IPA phonemeタグ使用時の内側テキストをカタカナ→ひらがな変換した文字列に変更
- 変更前: `<phoneme alphabet="ipa" ph="ɯbe">Ube</phoneme>`
- 変更後: `<phoneme alphabet="ipa" ph="ɯbe">うべ</phoneme>`
- `useTTSText.ts` の英語テンプレート内の全 `ph()` 呼び出しに対応する `nameKatakana` を追加

## Test plan
- [x] typecheckパス確認済み (`npx tsc --noEmit`)
- [x] biome check適用済み
- [ ] TTS再生時にphonemeタグの発音が正しくIPA通りになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 駅名・路線名のカタカナ表記が案内文や放送で利用可能になりました。

* **改善**
  * 日本語・英語の案内テンプレート（次駅、到着、接続／経由、終点など）でカタカナ表記が反映され、発話や表示がより自然になりました。
  * 放送文や終わりの案内で公共名のカタカナ版が適切に参照されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->