### PR TITLE
英語TTS乗換案内の改善とTTSボイス名変更

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -19,8 +19,8 @@ const googleAuth = new GoogleAuth({
 });
 
 const GOOGLE_TTS_API_VERSION = 'v1';
-const DEFAULT_JA_VOICE_NAME = 'ja-JP-Neural2-B';
-const DEFAULT_EN_VOICE_NAME = 'en-US-Neural2-F';
+const DEFAULT_JA_VOICE_NAME = 'ja-JP-Standard-B';
+const DEFAULT_EN_VOICE_NAME = 'en-US-Standard-G';
 
 const TTS_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000; // 5分
 let ttsConfigCache: {
@@ -31,7 +31,10 @@ let ttsConfigCache: {
 const getTtsConfig = async (): Promise<
   FirebaseFirestore.DocumentData | undefined
 > => {
-  if (ttsConfigCache && Date.now() - ttsConfigCache.fetchedAt < TTS_CONFIG_CACHE_TTL_MS) {
+  if (
+    ttsConfigCache &&
+    Date.now() - ttsConfigCache.fetchedAt < TTS_CONFIG_CACHE_TTL_MS
+  ) {
     return ttsConfigCache.data;
   }
   try {
@@ -335,8 +338,20 @@ export const tts = onCall(
     try {
       const accessToken = await getAccessToken();
       const [jaAudio, enAudio] = await Promise.all([
-        synthesizeWithNeural2(projectId, accessToken, ssmlJa, 'ja-JP', jaVoiceName),
-        synthesizeWithNeural2(projectId, accessToken, ssmlEn, 'en-US', enVoiceName),
+        synthesizeWithNeural2(
+          projectId,
+          accessToken,
+          ssmlJa,
+          'ja-JP',
+          jaVoiceName
+        ),
+        synthesizeWithNeural2(
+          projectId,
+          accessToken,
+          ssmlEn,
+          'en-US',
+          enVoiceName
+        ),
       ]);
       const jaAudioContent = jaAudio.audioContent;
       const jaAudioMimeType = jaAudio.mimeType || 'audio/mpeg';

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_JA_TTS_VOICE_NAME = 'ja-JP-Neural2-B';
-export const DEFAULT_EN_TTS_VOICE_NAME = 'en-US-Neural2-F';
+export const DEFAULT_JA_TTS_VOICE_NAME = 'ja-JP-Standard-B';
+export const DEFAULT_EN_TTS_VOICE_NAME = 'en-US-Standard-F';

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -129,7 +129,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -141,7 +141,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -156,7 +156,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -168,7 +168,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
       ]);
     });
   });
@@ -183,7 +183,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -195,7 +195,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -210,7 +210,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -222,7 +222,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、次は、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
+        'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
       ]);
     });
   });
@@ -237,7 +237,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -249,7 +249,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -264,7 +264,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。 <sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。この電車は、各駅停車、<sub alias="もとやわた">本八幡</sub>ゆきです。',
-        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -276,7 +276,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -291,7 +291,7 @@ describe('Without trainType & With numbering', () => {
       );
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.',
+        'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -311,7 +311,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 日本語: 期待される英語SSML出力を検証
       expect(en).toBe(
-        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line, and the Tokyo Metro Fukutoshin Line.'
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.'
       );
 
       // 日本語: 英語SSMLに日本語文字（ひらがな・カタカナ・漢字）が含まれていないことを厳密に検証

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -800,21 +800,17 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
           }${
             firstSpeech
               ? ` This train is the ${
-                  yamanoteTrainTypeEn ??
-                  (currentTrainType
-                    ? ph(
-                        currentTrainType.nameTtsSegments,
-                        currentTrainType.nameRoman
-                      )
-                    : 'Local')
-                } Service on the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)} bound for ${boundForEn}. ${
+                  yamanoteTrainTypeEn
+                    ? `${yamanoteTrainTypeEn} train`
+                    : `${currentTrainType ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman) : 'Local'} Service on the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)}`
+                } bound for ${boundForEn}. ${
                   currentTrainType && afterNextStation
                     ? `The next stop after ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${`, is ${ph(afterNextStation?.nameTtsSegments, afterNextStation?.nameRoman)}${isAfterNextStopTerminus ? ' terminal' : ''}`}.`
                     : ''
@@ -833,7 +829,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -862,7 +858,9 @@ export const useTTSText = (
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
                       : `the ${ph(l.nameTtsSegments, l.nameRoman)}`
                   )
-                  .join(', ')}, Please transfer at this station.`
+                  .join(
+                    ',<break time="200ms"/> '
+                  )}, Please transfer at this station.`
               : ''
           }`,
           ARRIVING: `We will soon make a brief stop at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
@@ -875,7 +873,9 @@ export const useTTSText = (
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
                       : `the ${ph(l.nameTtsSegments, l.nameRoman)}`
                   )
-                  .join(', ')}, Please transfer at this station.`
+                  .join(
+                    ',<break time="200ms"/> '
+                  )}, Please transfer at this station.`
               : ''
           }${
             currentTrainType && afterNextStation
@@ -898,7 +898,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -911,7 +911,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -937,7 +937,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -950,7 +950,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -1002,7 +1002,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -1017,7 +1017,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -1038,7 +1038,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -1049,7 +1049,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
                   )
                   .join(' ')}`
               : ''
@@ -1074,7 +1074,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(
                     ' '
@@ -1087,7 +1087,7 @@ export const useTTSText = (
                   .map((l, i, a) =>
                     a.length > 1 && a.length - 1 === i
                       ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ','}`
+                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
                   )
                   .join(
                     ' '


### PR DESCRIPTION
## Summary
- 英語TTS乗換案内で路線名の間に`<break time="200ms"/>`を追加し、自然な間を確保
- 山手線使用時のTOKYO_METROテーマ英語テンプレで「Yamanote Line Service on the Yamanote Line」の路線名重複を解消（`Yamanote Line train bound for...`に修正）
- TTS音声をNeural2からStandardに変更（`functions/src/funcs/tts.ts`、`src/constants/tts.ts`）
- テストのexpected値を`<break>`タグ追加に合わせて更新

## Test plan
- [x] `npm test -- --testPathPattern=useTTSText` 28テスト全パス確認済み
- [ ] 山手線固有パス（やまのて線内回り/外回り、英語Yamanote Line重複解消）のテスト追加（後続対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * テキスト読み上げの既定音声を変更し、より自然な発音を提供します
  * 英語のアナウンスに適切な間隔を追加し、リスニング体験を向上させます
  * 列車タイプと転乗案内の表現を改善し、より明確な案内を実現します

<!-- end of auto-generated comment: release notes by coderabbit.ai -->