### PR TITLE
TTS合成関数のNeural2命名を実態に合わせてリネーム

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -119,8 +119,8 @@ const getAccessToken = async (): Promise<string> => {
   return token;
 };
 
-/** Cloud Text-to-Speech の Neural2 を使用してテキストを音声に変換する。 */
-const synthesizeWithNeural2 = async (
+/** Cloud Text-to-Speech を使用してテキストを音声に変換する。 */
+const synthesizeSpeech = async (
   projectId: string,
   accessToken: string,
   text: string,
@@ -162,7 +162,7 @@ const synthesizeWithNeural2 = async (
   };
   if (!res.ok || !json.audioContent) {
     throw new Error(
-      `Neural2 TTS API returned ${res.status}: ${JSON.stringify(json.error ?? json)}`
+      `TTS API returned ${res.status}: ${JSON.stringify(json.error ?? json)}`
     );
   }
 
@@ -338,14 +338,14 @@ export const tts = onCall(
     try {
       const accessToken = await getAccessToken();
       const [jaAudio, enAudio] = await Promise.all([
-        synthesizeWithNeural2(
+        synthesizeSpeech(
           projectId,
           accessToken,
           ssmlJa,
           'ja-JP',
           jaVoiceName
         ),
-        synthesizeWithNeural2(
+        synthesizeSpeech(
           projectId,
           accessToken,
           ssmlEn,


### PR DESCRIPTION
## Summary
- `synthesizeWithNeural2` → `synthesizeSpeech` にリネーム（実際にはStandard音声を使用しているため）
- JSDocコメントおよびエラーメッセージから「Neural2」の記述を削除

## Test plan
- [x] `npm run typecheck` でコンパイルエラーがないことを確認
- [ ] TTS機能の動作確認（音声合成リクエストが正常に処理されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 内部的なテキスト音声変換（TTS）処理を改善しました。エラーメッセージも更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->