### PR TITLE
NumberingIconSquareのTLC黒枠表示を修正

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -285,6 +285,17 @@ export const CommonCard: React.FC<Props> = ({
     targetStation?.stationNumbers?.[0]?.lineSymbolColor;
   const targetStationThreeLetterCode = targetStation?.threeLetterCode;
 
+  const markScaleStyle = useMemo(() => {
+    const needsScale = !mark?.signPath || targetStationNumber;
+    if (!needsScale) {
+      return null;
+    }
+    if (targetStationThreeLetterCode) {
+      return null;
+    }
+    return { transform: [{ scale: 0.5 }] } as const;
+  }, [mark?.signPath, targetStationNumber, targetStationThreeLetterCode]);
+
   const titleParts = useMemo(
     () => titleOrLineName.split(/(\([^)]*\))/),
     [titleOrLineName]
@@ -361,16 +372,7 @@ export const CommonCard: React.FC<Props> = ({
         ]}
       >
         {mark ? (
-          <View
-            style={[
-              styles.mark,
-              !mark.signPath || targetStationNumber
-                ? targetStationThreeLetterCode
-                  ? null
-                  : { transform: [{ scale: 0.5 }] }
-                : null,
-            ]}
-          >
+          <View style={[styles.mark, markScaleStyle]}>
             <TransferLineMark
               line={line}
               mark={mark}

--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -63,6 +63,7 @@ const styles = StyleSheet.create({
     width: isTablet ? 52.5 : 35,
     height: isTablet ? 52.5 : 35,
     marginRight: 12,
+    overflow: 'visible',
   },
   withoutMark: {
     width: isTablet ? 52.5 : 35,
@@ -364,9 +365,9 @@ export const CommonCard: React.FC<Props> = ({
             style={[
               styles.mark,
               !mark.signPath || targetStationNumber
-                ? {
-                    transform: [{ scale: 0.5 }],
-                  }
+                ? targetStationThreeLetterCode
+                  ? null
+                  : { transform: [{ scale: 0.5 }] }
                 : null,
             ]}
           >

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -176,6 +176,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             shape={numberingObj.lineSymbolShape}
             lineColor={numberingColor}
             stationNumber={numberingObj.stationNumber}
+            threeLetterCode={stationInLoop.threeLetterCode}
             allowScaling={false}
           />
         ) : null}

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -39,12 +39,14 @@ type Props = {
 const localStyles = StyleSheet.create({
   numberingIconContainer: {
     position: 'absolute',
-    width: isTablet ? 48 : 32,
-    height: isTablet ? 36 : 24,
-    bottom: isTablet ? 8 : 72,
+    width: isTablet ? 96 : 64,
+    height: isTablet ? 96 : 64,
+    bottom: isTablet ? -22 : 52,
+    left: isTablet ? -24 : -16,
     transform: [{ scale: 0.5 }],
     justifyContent: 'center',
     alignItems: 'center',
+    overflow: 'visible',
   },
 });
 

--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -39,6 +39,7 @@ const styles = StyleSheet.create({
   // TLC デフォルト: ヘッダー等の大きなスペース用 (0.7x)
   tlcRoot: {
     justifyContent: 'center',
+    alignSelf: 'flex-start',
   },
   tlcContainer: {
     backgroundColor: '#231e1f',

--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -18,6 +18,8 @@ type Props = {
   withOutline?: boolean;
 };
 
+const TLC_SCALE = 0.7;
+
 const styles = StyleSheet.create({
   optionalBorder: {
     borderRadius: 8,
@@ -34,27 +36,120 @@ const styles = StyleSheet.create({
     borderWidth: isTablet ? 7 * 1.5 : 7,
     backgroundColor: 'white',
   },
+  // TLC デフォルト: ヘッダー等の大きなスペース用 (0.7x)
   tlcRoot: {
-    transform: [{ scale: 0.7 }],
-    maxWidth: isTablet ? 82 * 1.5 : 82,
-    flex: 1,
     justifyContent: 'center',
   },
   tlcContainer: {
     backgroundColor: '#231e1f',
     borderWidth: 1,
     borderColor: 'white',
-    borderRadius: isTablet ? 16 : 14,
-    paddingVertical: isTablet ? 8 : 4,
-    paddingHorizontal: isTablet ? 8 : 4,
+    borderRadius: isTablet
+      ? Math.round(16 * TLC_SCALE)
+      : Math.round(14 * TLC_SCALE),
+    paddingVertical: isTablet
+      ? Math.round(8 * TLC_SCALE)
+      : Math.round(4 * TLC_SCALE),
+    paddingHorizontal: isTablet
+      ? Math.round(8 * TLC_SCALE)
+      : Math.round(4 * TLC_SCALE),
   },
   tlcText: {
     color: 'white',
     textAlign: 'center',
-    fontSize: isTablet ? 24 * 1.5 : 24,
+    fontSize: isTablet
+      ? Math.round(24 * 1.5 * TLC_SCALE)
+      : Math.round(24 * TLC_SCALE),
     fontFamily: FONTS.FrutigerNeueLTProBold,
     includeFontPadding: false,
-    lineHeight: isTablet ? 24 * 1.5 : 24,
+    lineHeight: isTablet
+      ? Math.round(24 * 1.5 * TLC_SCALE)
+      : Math.round(24 * TLC_SCALE),
+  },
+  tlcIconRoot: {
+    width: isTablet
+      ? Math.round(72 * 1.5 * TLC_SCALE)
+      : Math.round(72 * TLC_SCALE),
+    height: isTablet
+      ? Math.round(72 * 1.5 * TLC_SCALE)
+      : Math.round(72 * TLC_SCALE),
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    borderRadius: isTablet
+      ? Math.round(12 * TLC_SCALE)
+      : Math.round(8 * TLC_SCALE),
+    borderWidth: isTablet
+      ? Math.round(7 * 1.5 * TLC_SCALE)
+      : Math.round(7 * TLC_SCALE),
+    backgroundColor: 'white',
+  },
+  tlcLineSymbol: {
+    lineHeight: isTablet
+      ? Math.round(24 * 1.5 * TLC_SCALE)
+      : Math.round(24 * TLC_SCALE),
+    fontSize: isTablet
+      ? Math.round(24 * 1.5 * TLC_SCALE)
+      : Math.round(24 * TLC_SCALE),
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    marginTop: Platform.OS === 'ios' ? Math.round(4 * TLC_SCALE) : 0,
+    color: '#231e1f',
+  },
+  tlcStationNumber: {
+    lineHeight: isTablet
+      ? Math.round(32 * 1.5 * TLC_SCALE)
+      : Math.round(32 * TLC_SCALE),
+    fontSize: isTablet
+      ? Math.round(32 * 1.5 * TLC_SCALE)
+      : Math.round(32 * TLC_SCALE),
+    marginTop: Math.round(-4 * TLC_SCALE),
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    color: '#231e1f',
+  },
+  // TLC LARGE: TransferLineMarkコンテナ(35x35 / 52.5x52.5)に収まるサイズ
+  tlcContainerCompact: {
+    backgroundColor: '#231e1f',
+    borderWidth: 1,
+    borderColor: 'white',
+    borderRadius: isTablet ? 6 : 4,
+    paddingVertical: isTablet ? 2 : 1,
+    paddingHorizontal: isTablet ? 2 : 1,
+  },
+  tlcTextCompact: {
+    color: 'white',
+    textAlign: 'center',
+    fontSize: isTablet ? 12 : 8,
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    includeFontPadding: false,
+    lineHeight: isTablet ? 12 : 8,
+  },
+  tlcIconRootCompact: {
+    width: isTablet ? 34 : 23,
+    height: isTablet ? 34 : 23,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    borderRadius: isTablet ? 4 : 2,
+    borderWidth: isTablet ? 3 : 2,
+    backgroundColor: 'white',
+  },
+  tlcLineSymbolCompact: {
+    lineHeight: isTablet ? 12 : 8,
+    fontSize: isTablet ? 12 : 8,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
+    color: '#231e1f',
+  },
+  tlcStationNumberCompact: {
+    lineHeight: isTablet ? 15 : 10,
+    fontSize: isTablet ? 15 : 10,
+    marginTop: isTablet ? -2 : -1,
+    textAlign: 'center',
+    fontFamily: FONTS.FrutigerNeueLTProBold,
+    color: '#231e1f',
   },
   rootSmall: {
     width: 20,
@@ -94,7 +189,6 @@ const styles = StyleSheet.create({
 
 type CommonCompProps = {
   lineColor: string;
-  threeLetterCode: string | undefined | null;
   lineSymbol: string;
   stationNumber: string;
   size?: NumberingIconSize;
@@ -138,23 +232,52 @@ const NumberingIconSquare: React.FC<Props> = ({
   const stationNumber = stationNumberRest.join('');
 
   if (threeLetterCode) {
+    // SMALL: TLCを表示するスペースがないため通常のSMALLアイコンを描画
+    if (size === NUMBERING_ICON_SIZE.SMALL) {
+      return (
+        <Common
+          lineColor={lineColor}
+          lineSymbol={lineSymbol}
+          stationNumber={stationNumber}
+          size={size}
+          withOutline={withOutline}
+        />
+      );
+    }
+
+    // LARGE/MEDIUM: TransferLineMarkコンテナに収まるコンパクトなTLC描画
+    if (
+      size === NUMBERING_ICON_SIZE.LARGE ||
+      size === NUMBERING_ICON_SIZE.MEDIUM
+    ) {
+      return (
+        <View style={styles.tlcContainerCompact}>
+          <Typography style={styles.tlcTextCompact}>
+            {threeLetterCode}
+          </Typography>
+          <View style={[styles.tlcIconRootCompact, { borderColor: lineColor }]}>
+            <Typography style={styles.tlcLineSymbolCompact}>
+              {lineSymbol}
+            </Typography>
+            <Typography style={styles.tlcStationNumberCompact}>
+              {stationNumber}
+            </Typography>
+          </View>
+        </View>
+      );
+    }
+
+    // デフォルト: ヘッダー等の大きなスペース用 (0.7xサイズ)
     return (
-      <View
-        style={[
-          styles.tlcRoot,
-          {
-            transformOrigin,
-          },
-        ]}
-      >
+      <View style={styles.tlcRoot}>
         <View style={styles.tlcContainer}>
           <Typography style={styles.tlcText}>{threeLetterCode}</Typography>
-          <Common
-            lineColor={lineColor}
-            threeLetterCode={threeLetterCode}
-            lineSymbol={lineSymbol}
-            stationNumber={stationNumber}
-          />
+          <View style={[styles.tlcIconRoot, { borderColor: lineColor }]}>
+            <Typography style={styles.tlcLineSymbol}>{lineSymbol}</Typography>
+            <Typography style={styles.tlcStationNumber}>
+              {stationNumber}
+            </Typography>
+          </View>
         </View>
       </View>
     );
@@ -164,7 +287,6 @@ const NumberingIconSquare: React.FC<Props> = ({
     return (
       <Common
         lineColor={lineColor}
-        threeLetterCode={threeLetterCode}
         lineSymbol={lineSymbol}
         stationNumber={stationNumber}
         size={size}
@@ -186,7 +308,6 @@ const NumberingIconSquare: React.FC<Props> = ({
     >
       <Common
         lineColor={lineColor}
-        threeLetterCode={threeLetterCode}
         lineSymbol={lineSymbol}
         stationNumber={stationNumber}
         withOutline={withOutline}

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -763,6 +763,7 @@ const PadArch: React.FC<Props> = ({
                       }
                       lineColor={numberingInfo[i]?.lineColor ?? '#000'}
                       stationNumber={numberingInfo[i]?.stationNumber ?? ''}
+                      threeLetterCode={s.threeLetterCode}
                       allowScaling={false}
                     />
                   </View>

--- a/src/components/TransferLineMark.tsx
+++ b/src/components/TransferLineMark.tsx
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
     marginRight: 4,
     justifyContent: 'center',
     alignItems: 'center',
+    overflow: 'visible',
   },
   signPathWrapper: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- NumberingIconSquareのThree Letter Code(TLC)の黒い枠が途中で切れて表示されるバグを修正
- LineBoardJO・PadArchでthreeLetterCodeが未適用だった問題を修正
- CommonCardでTLC付きアイコンが小さすぎる問題を修正

## 変更内容
- **NumberingIconSquare.tsx**: `transform: scale(0.7)` によるレイアウト/ビジュアル不一致を解消。TLCサイズをコンテキスト別に直接ピクセル値で定義（SMALL: TLC省略、LARGE/MEDIUM: コンパクトTLC、デフォルト: 0.7xサイズ）
- **LineBoardJRKyushu.tsx**: `numberingIconContainer` のサイズをTLCコンテンツに対応するよう拡大
- **CommonCard.tsx**: TLC付きアイコンに `scale: 0.5` を適用しないよう変更
- **TransferLineMark.tsx**: containerに `overflow: 'visible'` を追加
- **LineBoardJO.tsx**: NumberingIconに `threeLetterCode` propを追加
- **PadArch.tsx**: NumberingIconに `threeLetterCode` propを追加

## Test plan
- [x] LineBoardJRKyushuでTLC付き駅（新橋SMB、浜松町HMC、品川SGW等）の黒枠が正しく表示されること
- [x] CommonCardの行先選択ダイアログでTLC付きアイコンが適切なサイズで表示されること
- [x] PadArch（山手線iPad）でTLC付き駅の黒枠が横に伸びないこと
- [x] LineBoardJOでTLC付き駅が正しく表示されること
- [x] TLCなし駅のアイコン表示に影響がないこと
- [x] ヘッダー部分のTLCアイコン表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * 駅番号アイコンのサイズ・配置を大幅に調整し、表示位置と余白を最適化しました。
  * 一部マーカーとコンテナでオーバーフローを可視にして、はみ出す要素の表示を改善しました。
  * 構成により三文字コード（TLC）専用の小型／広域表示を導入し、見栄えを向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->