### PR TITLE
Androidタブレットでの各種LineBoard・Header表示改善

### DIFF
--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -17,6 +17,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     height: isTablet ? 200 : 128,
     flexDirection: 'row',
+    zIndex: 9999,
   },
   boundContainer: {
     width: '100%',

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -17,6 +17,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     height: isTablet ? 200 : 128,
     flexDirection: 'row',
+    zIndex: 9999,
   },
   boundContainer: {
     position: 'absolute',

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -18,6 +18,9 @@ import TransferLineMark from './TransferLineMark';
 import Typography from './Typography';
 
 const styles = StyleSheet.create({
+  root: {
+    zIndex: 9999,
+  },
   gradientRoot: {
     paddingRight: 21,
     paddingLeft: 21,
@@ -470,7 +473,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
   );
 
   return (
-    <View>
+    <View style={styles.root}>
       <LinearGradient
         colors={['#222222', '#212121']}
         style={styles.gradientRoot}

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -18,6 +18,9 @@ import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBoxSaikyo';
 
 const styles = StyleSheet.create({
+  root: {
+    zIndex: 9999,
+  },
   topBar: {
     backgroundColor: 'white',
     height: 2,
@@ -165,7 +168,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
   const lineColor = currentLine?.color ?? '#00ac9a';
 
   return (
-    <View>
+    <View style={styles.root}>
       <HeaderBar height={15} lineColor={lineColor} />
       <View style={styles.topBar} />
       <LinearGradient

--- a/src/components/HeaderTY.tsx
+++ b/src/components/HeaderTY.tsx
@@ -16,6 +16,9 @@ import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBox';
 
 const styles = StyleSheet.create({
+  root: {
+    zIndex: 9999,
+  },
   gradientRoot: {
     paddingTop: 14,
     paddingRight: 21,
@@ -146,7 +149,7 @@ const HeaderTY: React.FC<CommonHeaderProps> = (props) => {
   const dim = useWindowDimensions();
 
   return (
-    <View>
+    <View style={styles.root}>
       <LinearGradient
         colors={['#333', '#212121', '#000']}
         locations={[0, 0.5, 0.5]}

--- a/src/components/LineBoard/shared/components/StationName.tsx
+++ b/src/components/LineBoard/shared/components/StationName.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo } from 'react';
-import { useWindowDimensions, View } from 'react-native';
+import {
+  type StyleProp,
+  type TextStyle,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import type { Station } from '~/@types/graphql';
 import getStationNameR from '~/utils/getStationNameR';
 import isTablet from '~/utils/isTablet';
@@ -12,10 +17,19 @@ export interface StationNameProps {
   horizontal?: boolean;
   passed?: boolean;
   marginBottom?: number;
+  /** 縦書き時の各文字に適用する追加スタイル */
+  charStyle?: StyleProp<TextStyle>;
 }
 
 export const StationName: React.FC<StationNameProps> = React.memo(
-  ({ station, en, horizontal, passed, marginBottom }: StationNameProps) => {
+  ({
+    station,
+    en,
+    horizontal,
+    passed,
+    marginBottom,
+    charStyle,
+  }: StationNameProps) => {
     const stationNameR = useMemo(() => getStationNameR(station), [station]);
     const characters = useMemo(
       () => station.name?.split('') ?? [],
@@ -64,7 +78,11 @@ export const StationName: React.FC<StationNameProps> = React.memo(
       <View style={styles.stationNameMapContainer}>
         {characters.map((c, j) => (
           <Typography
-            style={[styles.stationName, passed ? styles.grayColor : null]}
+            style={[
+              styles.stationName,
+              passed ? styles.grayColor : null,
+              charStyle,
+            ]}
             key={`${j + 1}${c}`}
           >
             {c}

--- a/src/components/LineBoard/shared/hooks/useIncludesLongStationName.ts
+++ b/src/components/LineBoard/shared/hooks/useIncludesLongStationName.ts
@@ -1,9 +1,13 @@
 import { useMemo } from 'react';
+import { Platform } from 'react-native';
 import type { Station } from '~/@types/graphql';
+import isTablet from '~/utils/isTablet';
+
+const LONG_NAME_THRESHOLD = Platform.OS === 'android' && isTablet ? 5 : 6;
 
 /**
  * Check if any station in the list has a long name
- * A station name is considered "long" if it contains 'ー' or has more than 6 characters
+ * A station name is considered "long" if it contains 'ー' or exceeds the threshold
  * @param stations - Array of stations to check
  * @returns true if any station has a long name
  */
@@ -11,7 +15,8 @@ export const useIncludesLongStationName = (stations: Station[]): boolean => {
   return useMemo(
     () =>
       !!stations.filter(
-        (s) => s.name?.includes('ー') || (s.name?.length ?? 0) > 6
+        (s) =>
+          s.name?.includes('ー') || (s.name?.length ?? 0) > LONG_NAME_THRESHOLD
       ).length,
     [stations]
   );

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -120,7 +120,7 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontSize: RFValue(18),
     fontWeight: 'bold',
     marginLeft: 5,
-    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
     ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   // Station name variant for West style
@@ -128,7 +128,7 @@ export const commonLineBoardStyles = StyleSheet.create({
     width: isTablet ? 48 : 32,
     fontSize: RFValue(18),
     fontWeight: 'bold',
-    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
     marginLeft: 5,
     ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
     bottom: isTablet ? 32 : 0,
@@ -138,7 +138,7 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontSize: RFValue(18),
     fontWeight: 'bold',
     marginLeft: 12,
-    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
     ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   stationNameHorizontal: {

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -138,7 +138,8 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontSize: RFValue(18),
     fontWeight: 'bold',
     marginLeft: 12,
-    marginBottom: Platform.select({ android: -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
+    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   stationNameHorizontal: {
     fontSize: RFValue(18),

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -8,6 +8,11 @@ export const BAR_BOTTOM_WEST = isTablet ? 32 : 48;
 export const BAR_BOTTOM_JO = isTablet ? 32 : 48;
 export const BAR_TERMINAL_BOTTOM_JO = isTablet ? 48 : 58;
 
+// Androidタブレットでは駅名がヘッダーに食い込むのを防ぐためbottomオフセットを縮小する
+export const STATION_NAME_CONTAINER_BOTTOM: number | undefined = isTablet
+  ? Platform.select({ android: 64, default: 84 })
+  : undefined;
+
 export const commonLineBoardStyles = StyleSheet.create({
   root: {
     height: '100%',
@@ -87,7 +92,7 @@ export const commonLineBoardStyles = StyleSheet.create({
   stationNameContainer: {
     flexWrap: 'wrap',
     justifyContent: 'flex-end',
-    bottom: isTablet ? 84 : undefined,
+    bottom: STATION_NAME_CONTAINER_BOTTOM,
   },
   // Station name container variant for West/JO style
   stationNameContainerWestJO: {
@@ -113,7 +118,8 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontSize: RFValue(18),
     fontWeight: 'bold',
     marginLeft: 5,
-    marginBottom: Platform.select({ android: -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
+    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   // Station name variant for West style
   stationNameWest: {

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -128,8 +128,9 @@ export const commonLineBoardStyles = StyleSheet.create({
     width: isTablet ? 48 : 32,
     fontSize: RFValue(18),
     fontWeight: 'bold',
-    marginBottom: Platform.select({ android: -6, ios: 0 }),
+    marginBottom: Platform.select({ android: isTablet ? -10 : -6, ios: 0 }),
     marginLeft: 5,
+    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
     bottom: isTablet ? 32 : 0,
   },
   // Station name variant for JO style

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -24,7 +24,9 @@ export const commonLineBoardStyles = StyleSheet.create({
   // Root variant for West/JO style
   rootWestJO: {
     flex: 1,
-    bottom: isTablet ? '40%' : undefined,
+    bottom: isTablet
+      ? Platform.select({ android: '30%', default: '40%' })
+      : undefined,
   },
   bar: {
     position: 'absolute',

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -26,7 +26,10 @@ import {
   useChevronPosition,
   useIncludesLongStationName,
 } from './LineBoard/shared/hooks/useBarStyles';
-import { commonLineBoardStyles as styles } from './LineBoard/shared/styles/commonStyles';
+import {
+  STATION_NAME_CONTAINER_BOTTOM,
+  commonLineBoardStyles as styles,
+} from './LineBoard/shared/styles/commonStyles';
 
 type Props = {
   lineColors: (string | null | undefined)[];
@@ -288,7 +291,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           styles.chevron,
           additionalChevronStyle,
           {
-            bottom: isTablet ? dim.height / 3.5 + 32 : 32,
+            bottom: isTablet
+              ? dim.height / 3.5 + (STATION_NAME_CONTAINER_BOTTOM ?? 0) - 52
+              : 32,
             marginLeft: widthScale(14),
           },
         ]}

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -165,7 +165,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
     const wrapperMarginLeft = barWidth / 2.5;
     const containerCenter =
       wrapperMarginLeft + index * containerWidth + containerWidth / 2;
-    return dotCenter - containerCenter + 12;
+    return dotCenter - containerCenter + 16;
   }, [barWidth, dim.width, index]);
 
   return (

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -132,7 +132,10 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   const dim = useWindowDimensions();
 
   const additionalPadLineMarksContainerStyle = useMemo(() => {
-    const androidOffset = Platform.OS === 'android' && isTablet ? 60 : 0;
+    // rootWestJOのbottomがAndroidでは'30%'、iPadでは'40%'のため、
+    // 差分の10%をdim.heightに基づいて動的に補正
+    const androidOffset =
+      Platform.OS === 'android' && isTablet ? Math.round(dim.height * 0.1) : 0;
     if (!stationInLoop.stationNumbers?.length) {
       return {
         top: dim.height - 130 + androidOffset,

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import type { Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
@@ -102,6 +102,7 @@ interface StationNameCellProps {
   stations: Station[];
   station: Station;
   hasNumberedStation: boolean;
+  index: number;
 }
 
 const StationNameCell: React.FC<StationNameCellProps> = ({
@@ -109,6 +110,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   arrived,
   station: stationInLoop,
   hasNumberedStation,
+  index,
 }: StationNameCellProps) => {
   const isEn = useAtomValue(isEnAtom);
 
@@ -130,13 +132,14 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   const dim = useWindowDimensions();
 
   const additionalPadLineMarksContainerStyle = useMemo(() => {
+    const androidOffset = Platform.OS === 'android' && isTablet ? 60 : 0;
     if (!stationInLoop.stationNumbers?.length) {
       return {
-        top: dim.height - 130,
+        top: dim.height - 130 + androidOffset,
       };
     }
     return {
-      top: dim.height - 90,
+      top: dim.height - 90 + androidOffset,
     };
   }, [stationInLoop.stationNumbers, dim.height]);
 
@@ -150,6 +153,21 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
       ),
     [arrived, numberingObj, stationInLoop]
   );
+
+  const barWidth = useBarWidth();
+  // ドット中央とstationNameContainer中央の水平位置差分を補正
+  const numberingLeftOffset = useMemo(() => {
+    if (!isTablet || Platform.OS !== 'android') {
+      return undefined;
+    }
+    const containerWidth = dim.width / 9;
+    const dotCenter = barWidth * (index + 1) - barWidth / 2;
+    const wrapperMarginLeft = barWidth / 2.5;
+    const containerCenter =
+      wrapperMarginLeft + index * containerWidth + containerWidth / 2;
+    return dotCenter - containerCenter + 12;
+  }, [barWidth, dim.width, index]);
+
   return (
     <View
       style={[
@@ -166,7 +184,12 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
         passed={isPass}
       />
 
-      <View style={styles.numberingIconContainerJO}>
+      <View
+        style={[
+          styles.numberingIconContainerJO,
+          numberingLeftOffset != null && { left: numberingLeftOffset },
+        ]}
+      >
         {numberingObj &&
         isTablet &&
         hasNumberedStation &&
@@ -217,10 +240,11 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
   );
 
   const stationNameCellForMap = useCallback(
-    (s: Station) => {
+    (s: Station, i: number) => {
       return (
         <StationNameCell
           key={s.id}
+          index={i}
           station={s}
           stations={stations}
           arrived={!isPassing}

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo, useState } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
@@ -34,6 +34,11 @@ type Props = {
   stations: Station[];
   hasTerminus: boolean;
 };
+
+// JRKyushuはヘッダーが他のテーマより高いため、独自のbottomオフセットを使用
+const JR_KYUSHU_CONTAINER_BOTTOM: number | undefined = isTablet
+  ? Platform.select({ android: 32, default: 84 })
+  : undefined;
 
 // Local style overrides specific to JRKyushu
 const localStyles = StyleSheet.create({
@@ -300,7 +305,12 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 
   return (
     <>
-      <View style={[styles.stationNameContainer, { width: dim.width / 9 }]}>
+      <View
+        style={[
+          styles.stationNameContainer,
+          { width: dim.width / 9, bottom: JR_KYUSHU_CONTAINER_BOTTOM },
+        ]}
+      >
         <View
           style={[
             nameCommonStyle,
@@ -362,7 +372,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           styles.chevron,
           additionalChevronStyle,
           {
-            bottom: isTablet ? dim.height / 3.5 + 32 : 32,
+            bottom: isTablet
+              ? dim.height / 3.5 + (JR_KYUSHU_CONTAINER_BOTTOM ?? 0) - 52
+              : 32,
             marginLeft: widthScale(14),
           },
         ]}

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -23,7 +23,10 @@ import {
   useChevronPosition,
   useIncludesLongStationName,
 } from './LineBoard/shared/hooks/useBarStyles';
-import { commonLineBoardStyles } from './LineBoard/shared/styles/commonStyles';
+import {
+  commonLineBoardStyles,
+  STATION_NAME_CONTAINER_BOTTOM,
+} from './LineBoard/shared/styles/commonStyles';
 
 interface Props {
   lineColors: (string | null | undefined)[];
@@ -278,7 +281,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           additionalChevronStyle,
           {
             marginLeft: widthScale(14),
-            bottom: isTablet ? dim.height / 3.5 + 32 : 32,
+            bottom: isTablet
+              ? dim.height / 3.5 + (STATION_NAME_CONTAINER_BOTTOM ?? 0) - 52
+              : 32,
           },
         ]}
       >

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -25,7 +25,10 @@ import {
   useChevronPosition,
   useIncludesLongStationName,
 } from './LineBoard/shared/hooks/useBarStyles';
-import { commonLineBoardStyles } from './LineBoard/shared/styles/commonStyles';
+import {
+  commonLineBoardStyles,
+  STATION_NAME_CONTAINER_BOTTOM,
+} from './LineBoard/shared/styles/commonStyles';
 import Typography from './Typography';
 
 type Props = {
@@ -428,7 +431,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           styles.chevron,
           additionalChevronStyle,
           {
-            bottom: isTablet ? dim.height / 3.5 + 32 : 32,
+            bottom: isTablet
+              ? dim.height / 3.5 + (STATION_NAME_CONTAINER_BOTTOM ?? 0) - 52
+              : 32,
             marginLeft: widthScale(15),
           },
         ]}

--- a/src/components/PadLineMarks.tsx
+++ b/src/components/PadLineMarks.tsx
@@ -46,7 +46,7 @@ const stylesWest = StyleSheet.create({
     height: 16,
     backgroundColor: '#212121',
     alignSelf: 'center',
-    marginTop: 6,
+    marginTop: Platform.select({ android: 16, default: 6 }),
   },
   lineMarkWrapper: {
     marginTop: 4,

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { japaneseRegexp, parenthesisRegexp } from '../constants';
 import { useCurrentLine } from '../hooks';
@@ -30,13 +30,40 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     zIndex: 9999,
   },
+  charWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    transform: Platform.select({
+      // AndroidではskewXが効かないためmatrixで同等の変形を再現
+      // skewX(-5deg): tan(-5°) ≈ -0.0875
+      android: [
+        {
+          matrix: [1, 0, 0, 0, -0.0875, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        },
+      ],
+      default: [{ skewX: '-5deg' }],
+    }),
+  },
   text: {
     color: '#fff',
     textAlign: 'center',
     fontWeight: 'bold',
-    transform: [{ skewX: '-5deg' }],
+    fontSize: isTablet ? 36 : 24,
+  },
+  singleText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: 'bold',
     fontSize: isTablet ? 36 : 24,
     flex: 1,
+    transform: Platform.select({
+      android: [
+        {
+          matrix: [1, 0, 0, 0, -0.0875, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        },
+      ],
+      default: [{ skewX: '-5deg' }],
+    }),
   },
 });
 
@@ -125,28 +152,33 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
       trainTypeName &&
       japaneseRegexp.test(trainTypeName) ? (
         trainTypeName.split('').map((char, idx) => (
-          <Typography
-            numberOfLines={numberOfLines}
-            adjustsFontSizeToFit
-            style={[
-              styles.text,
-              {
-                color: trainTypeColor,
-                fontFamily: undefined,
-                fontWeight: '800',
-              },
-            ]}
+          <View
+            collapsable={false}
+            style={styles.charWrapper}
             key={`${char}${idx.toString()}`}
           >
-            {char}
-          </Typography>
+            <Typography
+              numberOfLines={numberOfLines}
+              adjustsFontSizeToFit
+              style={[
+                styles.text,
+                {
+                  color: trainTypeColor,
+                  fontFamily: undefined,
+                  fontWeight: '800',
+                },
+              ]}
+            >
+              {char}
+            </Typography>
+          </View>
         ))
       ) : (
         <Typography
           numberOfLines={1}
           adjustsFontSizeToFit
           style={[
-            styles.text,
+            styles.singleText,
             {
               color: trainTypeColor,
             },


### PR DESCRIPTION
## Summary
- LineBoardWest/JOのAndroidタブレット表示位置調整（rootWestJO bottom: '30%'）
- LineBoardJOのナンバリング水平位置をドット基準で動的補正
- LineBoardJOのPadLineMarks位置をdim.height比率で動的補正（機種依存しない）
- PadLineMarksの下黒バー（stylesWest.topBar）のmarginTopをAndroid用に調整
- 全LineBoardの縦書き駅名行間をAndroidタブレットで調整（marginBottom: -8, includeFontPadding: false）
- TrainTypeBoxJOのskewXをAndroidで動作するようView wrapper化
- 全Header（LED除く）にzIndex: 9999を追加

## Test plan
- [ ] Androidタブレットで各テーマ（East, Saikyo, Toei, JRKyushu, West, JO）のLineBoard表示が正常なこと
- [ ] Androidタブレットで縦書き駅名の行間がiPadと同等であること
- [ ] LineBoardJOのナンバリングが白ドットの真下に表示されること
- [ ] LineBoardJOのPadLineMarksがナンバリングの下に適切に表示されること
- [ ] LineBoardWestの下黒バーがカラーバーに食い込まないこと
- [ ] iPadで表示が変わっていないこと（デグレなし）
- [ ] 各HeaderがzIndex: 9999でLineBoardより前面に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ヘッダーの表示順序を改善し、他の要素との重なりを正確に制御
  * タブレットおよびAndroidデバイス向けにレイアウト位置の調整と最適化を実施
  * 駅名表示をタブレットとAndroidプラットフォームに対応させ、より正確な配置を実現
  * 電車種別表示の描画品質を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->