### PR TITLE
Androidタブレットでの縦書き駅名の文字間詰まりとフォントサイズの調整

### DIFF
--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -121,7 +121,6 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontWeight: 'bold',
     marginLeft: 5,
     marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
-    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   // Station name variant for West style
   stationNameWest: {
@@ -130,7 +129,6 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
     marginLeft: 5,
-    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
     bottom: isTablet ? 32 : 0,
   },
   // Station name variant for JO style
@@ -139,7 +137,6 @@ export const commonLineBoardStyles = StyleSheet.create({
     fontWeight: 'bold',
     marginLeft: 12,
     marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
-    ...(Platform.OS === 'android' && isTablet && { includeFontPadding: false }),
   },
   stationNameHorizontal: {
     fontSize: RFValue(18),

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -85,11 +85,9 @@ const styles = StyleSheet.create({
   },
   expandableToggleTextLight: {
     color: '#333',
-    fontSize: isTablet ? RFValue(12) : RFValue(14),
   },
   expandableToggleTextLED: {
     color: '#fff',
-    fontSize: isTablet ? RFValue(12) : RFValue(14),
   },
 });
 

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   text: {
-    fontSize: RFValue(12),
+    fontSize: isTablet ? RFValue(12) : RFValue(14),
     color: '#fff',
   },
   textFill: {


### PR DESCRIPTION
## Summary
- LineBoardの縦書き駅名でAndroidタブレットにおいて`includeFontPadding: false`が原因で上下の文字がくっついてしまう問題を修正（`stationName`, `stationNameWest`, `stationNameJO`の3スタイル）
- RouteInfoModalのexpandableToggleTextから不要なfontSizeを削除
- ToggleButtonのtextフォントサイズをタブレット対応に変更

## Test plan
- [x] Androidタブレットで各種LineBoard（デフォルト/West/JO）の縦書き駅名の文字間隔を確認
- [ ] Androidスマホで表示が崩れていないことを確認
- [ ] iOSで表示に影響がないことを確認
- [x] RouteInfoModalの展開トグルテキスト表示を確認
- [x] ToggleButtonのテキスト表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * トグルボタンのテキスト表示がデバイスサイズに応じて最適化されました
  * 複数の UI 要素のスタイル設定を調整し、表示の一貫性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->