### PR TITLE
乗換画面の路線名が駅ナンバリングに被らないように修正

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
     flexBasis: '50%',
   },
   lineNameContainer: {
+    flex: 1,
     marginLeft: isTablet ? 4 : 2,
   },
   lineName: {


### PR DESCRIPTION
## Summary
- 乗換画面で路線名が長い場合（例：「富山地鉄不二越・上滝線」「富山地鉄市内線【１・２系統】」）に、右側の駅ナンバリングアイコンや駅名に被ってしまう問題を修正
- `lineNameContainer` に `flex: 1` を追加し、路線名テキストが左側の50%領域内で折り返されるようにした

## Test plan
- [x] 路線名が長い乗換路線（富山地鉄不二越・上滝線など）で右側に被らないことを確認
- [x] 路線名が短い乗換路線で表示が崩れないことを確認
- [x] タブレットでも同様に問題ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 転送表示のレイアウト動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->