### PR TITLE
TTS関数でStandard音声以外を既定値へフォールバックする

### DIFF
--- a/functions/src/funcs/tts.ts
+++ b/functions/src/funcs/tts.ts
@@ -4,6 +4,7 @@ import * as admin from 'firebase-admin';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { GoogleAuth } from 'google-auth-library';
 import { normalizeRomanText } from '../utils/normalize';
+import { resolveStandardVoiceName } from '../utils/ttsVoice';
 
 process.env.TZ = 'Asia/Tokyo';
 
@@ -217,17 +218,16 @@ export const tts = onCall(
         e
       );
     }
-    const defaultJaVoice = ttsConfig?.jaVoiceName || DEFAULT_JA_VOICE_NAME;
-    const defaultEnVoice = ttsConfig?.enVoiceName || DEFAULT_EN_VOICE_NAME;
-
-    const jaVoiceName =
-      (typeof req.data.jaVoiceName === 'string' &&
-        req.data.jaVoiceName.trim()) ||
-      defaultJaVoice;
-    const enVoiceName =
-      (typeof req.data.enVoiceName === 'string' &&
-        req.data.enVoiceName.trim()) ||
-      defaultEnVoice;
+    const jaVoiceName = resolveStandardVoiceName(
+      req.data.jaVoiceName,
+      ttsConfig?.jaVoiceName,
+      DEFAULT_JA_VOICE_NAME
+    );
+    const enVoiceName = resolveStandardVoiceName(
+      req.data.enVoiceName,
+      ttsConfig?.enVoiceName,
+      DEFAULT_EN_VOICE_NAME
+    );
 
     const strippedJa = stripSsml(ssmlJa);
     const strippedEn = stripSsml(ssmlEn);

--- a/functions/src/utils/ttsVoice.test.ts
+++ b/functions/src/utils/ttsVoice.test.ts
@@ -1,0 +1,44 @@
+import {
+  isStandardVoiceName,
+  resolveStandardVoiceName,
+} from './ttsVoice';
+
+describe('ttsVoice', () => {
+  it('accepts Google Standard voices', () => {
+    expect(isStandardVoiceName('ja-JP-Standard-B')).toBe(true);
+  });
+
+  it('rejects voices that require a model name', () => {
+    expect(isStandardVoiceName('ja-JP-Chirp3-HD-Charon')).toBe(false);
+  });
+
+  it('prefers a requested standard voice', () => {
+    expect(
+      resolveStandardVoiceName(
+        'en-US-Standard-H',
+        'en-US-Chirp3-HD-Aoede',
+        'en-US-Standard-G'
+      )
+    ).toBe('en-US-Standard-H');
+  });
+
+  it('falls back to a configured standard voice when the request is invalid', () => {
+    expect(
+      resolveStandardVoiceName(
+        'en-US-Chirp3-HD-Aoede',
+        'en-US-Standard-F',
+        'en-US-Standard-G'
+      )
+    ).toBe('en-US-Standard-F');
+  });
+
+  it('falls back to the default standard voice when both inputs are invalid', () => {
+    expect(
+      resolveStandardVoiceName(
+        'ja-JP-Chirp3-HD-Charon',
+        'ja-JP-Neural2-B',
+        'ja-JP-Standard-B'
+      )
+    ).toBe('ja-JP-Standard-B');
+  });
+});

--- a/functions/src/utils/ttsVoice.ts
+++ b/functions/src/utils/ttsVoice.ts
@@ -1,0 +1,24 @@
+const STANDARD_VOICE_MARKER = '-Standard-';
+
+export const isStandardVoiceName = (voiceName: string): boolean =>
+  voiceName.includes(STANDARD_VOICE_MARKER);
+
+export const resolveStandardVoiceName = (
+  requestedVoiceName: unknown,
+  configuredVoiceName: unknown,
+  defaultVoiceName: string
+): string => {
+  const requested =
+    typeof requestedVoiceName === 'string' ? requestedVoiceName.trim() : '';
+  if (requested && isStandardVoiceName(requested)) {
+    return requested;
+  }
+
+  const configured =
+    typeof configuredVoiceName === 'string' ? configuredVoiceName.trim() : '';
+  if (configured && isStandardVoiceName(configured)) {
+    return configured;
+  }
+
+  return defaultVoiceName;
+};


### PR DESCRIPTION
## 概要
- TTS関数でStandard音声名だけを許可するよう修正
- リクエスト値やFirestore設定値がStandard以外なら既定のStandard音声へフォールバック
- 音声選択ロジックの単体テストを追加

## リスク
- FirestoreにStandard以外の音声名が残っていても既定のStandard音声で再生される
- 音声の種類は減るが、model指定不足による400は回避できる

## 確認
- npm test -- --runInBand src/utils/ttsVoice.test.ts
- npx tsc -p tsconfig.json --noEmit  # 既存のテストファイル重複定義で失敗

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * テキスト読み上げシステムの音声名処理ロジックを最適化しました。

* **Tests**
  * 音声名の検証と解決処理に関する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->