### PR TITLE
地下鉄でも精度安定時はスムージングを適用する

### DIFF
--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -1,0 +1,122 @@
+import type * as Location from 'expo-location';
+import { LineType, type Station } from '~/@types/graphql';
+import { store } from '..';
+import { accuracyHistoryAtom, locationAtom, setLocation } from './location';
+import stationState from './station';
+
+const makeLocation = (
+  lat: number,
+  lon: number,
+  accuracy: number,
+  timestamp = Date.now()
+): Location.LocationObject => ({
+  coords: {
+    latitude: lat,
+    longitude: lon,
+    accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: 0,
+  },
+  timestamp,
+});
+
+const setStationLineType = (lineType: LineType | null) => {
+  store.set(stationState, {
+    arrived: true,
+    approaching: false,
+    station: lineType ? ({ line: { lineType } } as Station) : null,
+    stations: [],
+    stationsCache: [],
+    pendingStation: null,
+    pendingStations: [],
+    selectedDirection: null,
+    selectedBound: null,
+    wantedDestination: null,
+  });
+};
+
+describe('setLocation', () => {
+  beforeEach(() => {
+    store.set(locationAtom, null);
+    store.set(accuracyHistoryAtom, []);
+    setStationLineType(null);
+  });
+
+  describe('非地下鉄路線', () => {
+    it('スムージングが適用される（座標が生の値と異なる）', () => {
+      setStationLineType(LineType.Normal);
+
+      const first = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(first);
+
+      const second = makeLocation(35.001, 139.001, 30, 4000);
+      setLocation(second);
+
+      const result = store.get(locationAtom);
+      // EMAが適用されるため、生の座標(35.001)とは異なる値になるはず
+      expect(result?.coords.latitude).not.toBe(35.001);
+      expect(result?.coords.longitude).not.toBe(139.001);
+    });
+  });
+
+  describe('地下鉄路線', () => {
+    it('精度が不安定な場合はスムージングをスキップする', () => {
+      setStationLineType(LineType.Subway);
+      // 高い変動の精度履歴をセット
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      const loc = makeLocation(35.0, 139.0, 500, 1000);
+      setLocation(loc);
+
+      const result = store.get(locationAtom);
+      // スキップされたので生の座標がそのまま入る
+      expect(result?.coords.latitude).toBe(35.0);
+      expect(result?.coords.longitude).toBe(139.0);
+    });
+
+    it('精度が安定している場合はスムージングを適用する', () => {
+      setStationLineType(LineType.Subway);
+      // 安定した精度履歴をセット（低CV、平均200m未満）
+      store.set(accuracyHistoryAtom, [30, 35, 28, 32]);
+
+      const first = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(first);
+
+      const second = makeLocation(35.001, 139.001, 30, 4000);
+      setLocation(second);
+
+      const result = store.get(locationAtom);
+      // EMAが適用されるため、生の座標とは異なる値になるはず
+      expect(result?.coords.latitude).not.toBe(35.001);
+      expect(result?.coords.longitude).not.toBe(139.001);
+    });
+
+    it('サンプル数が不足している場合はスムージングをスキップする', () => {
+      setStationLineType(LineType.Subway);
+      // 2サンプルのみ（新しい値を追加しても3で MIN_STABILITY_SAMPLES=4 未満）
+      store.set(accuracyHistoryAtom, [30, 35]);
+
+      const loc = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(loc);
+
+      const result = store.get(locationAtom);
+      expect(result?.coords.latitude).toBe(35.0);
+      expect(result?.coords.longitude).toBe(139.0);
+    });
+
+    it('精度が安定していても平均が200m以上の場合はスムージングをスキップする', () => {
+      setStationLineType(LineType.Subway);
+      // 安定だが高い値（平均250m）
+      store.set(accuracyHistoryAtom, [240, 250, 260, 250]);
+
+      const loc = makeLocation(35.0, 139.0, 250, 1000);
+      setLocation(loc);
+
+      const result = store.get(locationAtom);
+      expect(result?.coords.latitude).toBe(35.0);
+      expect(result?.coords.longitude).toBe(139.0);
+    });
+  });
+});

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -1,7 +1,12 @@
 import type * as Location from 'expo-location';
 import { LineType, type Station } from '~/@types/graphql';
 import { store } from '..';
-import { accuracyHistoryAtom, locationAtom, setLocation } from './location';
+import {
+  accuracyHistoryAtom,
+  locationAtom,
+  resetLocationState,
+  setLocation,
+} from './location';
 import stationState from './station';
 
 const makeLocation = (
@@ -39,8 +44,7 @@ const setStationLineType = (lineType: LineType | null) => {
 
 describe('setLocation', () => {
   beforeEach(() => {
-    store.set(locationAtom, null);
-    store.set(accuracyHistoryAtom, []);
+    resetLocationState();
     setStationLineType(null);
   });
 
@@ -112,6 +116,19 @@ describe('setLocation', () => {
       store.set(accuracyHistoryAtom, [240, 250, 260, 250]);
 
       const loc = makeLocation(35.0, 139.0, 250, 1000);
+      setLocation(loc);
+
+      const result = store.get(locationAtom);
+      expect(result?.coords.latitude).toBe(35.0);
+      expect(result?.coords.longitude).toBe(139.0);
+    });
+
+    it('平均精度がちょうど200mの境界値の場合はスムージングをスキップする', () => {
+      setStationLineType(LineType.Subway);
+      // 平均がちょうど200m（mean >= BAD_ACCURACY_THRESHOLD で不安定扱い）
+      store.set(accuracyHistoryAtom, [200, 200, 200, 200]);
+
+      const loc = makeLocation(35.0, 139.0, 200, 1000);
       setLocation(loc);
 
       const result = store.get(locationAtom);

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -50,6 +50,13 @@ export const backgroundLocationTrackingAtom = atom(false);
 // 地下鉄モード中は更新しないため、モード復帰後にノイジーなprevで誤棄却されるのを防ぐ
 const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
 
+// テスト用: モジュール内部の状態をリセットする
+export const resetLocationState = () => {
+  store.set(locationAtom, null);
+  store.set(accuracyHistoryAtom, []);
+  store.set(lastFilteredLocationAtom, null);
+};
+
 export const setLocation = (location: Location.LocationObject) => {
   const filteredPrev = store.get(lastFilteredLocationAtom);
   const currentHistory = store.get(accuracyHistoryAtom);

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -2,6 +2,7 @@ import type * as Location from 'expo-location';
 import getDistance from 'geolib/es/getDistance';
 import { atom } from 'jotai';
 import { LineType } from '~/@types/graphql';
+import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import { store } from '..';
 import stationState from './station';
 
@@ -23,6 +24,24 @@ const getSmoothingAlpha = (accuracy: number | null): number => {
   return 0.3;
 };
 
+// 精度履歴の安定性を変動係数(CV)で判定する
+const MIN_STABILITY_SAMPLES = 4;
+const MAX_STABLE_CV = 0.5;
+
+const isAccuracyStable = (history: number[]): boolean => {
+  if (history.length < MIN_STABILITY_SAMPLES) {
+    return false;
+  }
+  const mean = history.reduce((sum, v) => sum + v, 0) / history.length;
+  if (mean <= 0 || mean >= BAD_ACCURACY_THRESHOLD) {
+    return false;
+  }
+  const variance =
+    history.reduce((sum, v) => sum + (v - mean) ** 2, 0) / history.length;
+  const stddev = Math.sqrt(variance);
+  return stddev / mean < MAX_STABLE_CV;
+};
+
 export const locationAtom = atom<Location.LocationObject | null>(null);
 export const accuracyHistoryAtom = atom<number[]>([]);
 export const backgroundLocationTrackingAtom = atom(false);
@@ -41,11 +60,13 @@ export const setLocation = (location: Location.LocationObject) => {
       ? [...currentHistory, newAccuracy].slice(-MAX_ACCURACY_HISTORY)
       : currentHistory;
 
-  // 地下鉄ではGPS信号が不安定なため、速度フィルタとEMAスムージングを含む位置フィルタ処理をスキップする
+  // 地下鉄ではGPS信号が不安定なため原則スムージングをスキップするが、
+  // 精度が安定している場合（地上区間など）はスムージングを適用する
   const currentLineType = store.get(stationState).station?.line?.lineType;
-  const skipSmoothing = currentLineType === LineType.Subway;
+  const skipSmoothing =
+    currentLineType === LineType.Subway && !isAccuracyStable(updatedHistory);
 
-  // 地下鉄ではGPS信号が不安定なため、フィルタ・スムージングを全てスキップする
+  // スムージングスキップ時はフィルタ・スムージングを全てスキップする
   // UIには生の座標を反映するが、フィルタ基準(lastFilteredLocationAtom)は更新しない
   if (skipSmoothing) {
     store.set(locationAtom, location);


### PR DESCRIPTION
## Summary
- 地下鉄（`LineType.Subway`）で無条件にスムージングをスキップしていた処理を、精度の安定性を判定した上で制御するように変更
- 精度履歴の変動係数（CV = 標準偏差/平均）が閾値未満かつ平均精度が200m未満の場合を「安定」と判定し、スムージングを適用
- 精度が不安定な場合は従来通りスムージングをスキップ（既存動作を維持）

## 変更内容
- `src/store/atoms/location.ts`: `isAccuracyStable()` 関数を追加し、`skipSmoothing` の条件を `Subway && !isAccuracyStable(history)` に変更
- `src/store/atoms/location.test.ts`: 新規テスト5件（非地下鉄、地下鉄+不安定、地下鉄+安定、サンプル不足、安定だが高精度）

## 安定性判定の仕様
| 定数 | 値 | 説明 |
|---|---|---|
| `MIN_STABILITY_SAMPLES` | 4 | 判定に必要な最小サンプル数 |
| `MAX_STABLE_CV` | 0.5 | 変動係数の閾値（これ未満で安定） |
| `BAD_ACCURACY_THRESHOLD` | 200m | 平均精度がこれ以上なら不安定扱い（既存定数を再利用） |

## リグレッションリスク
- 非地下鉄路線: `LineType.Subway` チェックで短絡評価されるため影響なし
- 地下鉄 + 精度不安定: 従来通りスキップされるため影響なし
- 地下鉄 + 精度安定: 新規動作（スムージング適用）

## ローカル実行コマンド
```
npx biome ci ./src/store/atoms/location.ts ./src/store/atoms/location.test.ts
TZ=UTC jest --testPathPattern='src/store/atoms/location.test' --no-coverage
```

## Test plan
- [x] 非地下鉄路線でスムージングが適用されることを確認
- [x] 地下鉄 + 精度不安定時にスムージングがスキップされることを確認
- [x] 地下鉄 + 精度安定時にスムージングが適用されることを確認
- [x] サンプル不足時にスムージングがスキップされることを確認
- [x] 平均精度200m以上の場合にスムージングがスキップされることを確認

https://claude.ai/code/session_0136uqgSRjobn4E4trATATDX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 概要

* **バグ修正**
  * GPS精度が安定している場合の位置情報スムージングロジックを改善しました。地下鉄などの環境で、安定した信号受信時にはより正確な座標が反映されます。
* **テスト**
  * 位置更新とスムージング挙動を検証する自動テストを追加しました（地下鉄／非地下鉄や精度履歴の境界条件を含む）。
* **その他**
  * テスト用に位置状態を初期化できるリセット機能を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->