### PR TITLE
乗換時にSelectBoundModalで方面ボタンが表示されない不具合を修正

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -184,19 +184,30 @@ export const SelectBoundModal: React.FC<Props> = ({
       ? station
       : (stations[0] ?? null);
 
+  // wantedDestinationが現在のstationsに存在しない場合（乗換先の路線など）は
+  // 表示上無効として扱い、通常の方面表示にする
+  const applicableWantedDestination = useMemo(
+    () =>
+      wantedDestination &&
+      stations.some((s) => s.groupId === wantedDestination.groupId)
+        ? wantedDestination
+        : null,
+    [wantedDestination, stations]
+  );
+
   const effectiveStations = useMemo(() => {
-    if (!wantedDestination || !effectiveStation) return stations;
+    if (!applicableWantedDestination || !effectiveStation) return stations;
     const currentIdx = stations.findIndex(
       (s) => s.groupId === effectiveStation.groupId
     );
     const destIdx = stations.findIndex(
-      (s) => s.groupId === wantedDestination.groupId
+      (s) => s.groupId === applicableWantedDestination.groupId
     );
     if (currentIdx === -1 || destIdx === -1) return stations;
     return currentIdx <= destIdx
       ? stations.slice(0, destIdx + 1)
       : stations.slice(destIdx);
-  }, [stations, wantedDestination, effectiveStation]);
+  }, [stations, applicableWantedDestination, effectiveStation]);
 
   const currentIndex = stations.findIndex(
     (s) => s.groupId === effectiveStation?.groupId
@@ -224,7 +235,7 @@ export const SelectBoundModal: React.FC<Props> = ({
   } = usePresetStops({
     savedRouteDirection: savedRoute?.direction,
     stations,
-    wantedDestination,
+    wantedDestination: applicableWantedDestination,
     confirmedStation,
   });
 
@@ -309,10 +320,10 @@ export const SelectBoundModal: React.FC<Props> = ({
 
   const normalLineDirectionText = useCallback(
     (boundStations: Station[]) => {
-      if (wantedDestination) {
+      if (applicableWantedDestination) {
         return isJapanese
-          ? `${wantedDestination.name}方面`
-          : `for ${wantedDestination.nameRoman}`;
+          ? `${applicableWantedDestination.name}方面`
+          : `for ${applicableWantedDestination.nameRoman}`;
       }
 
       if (isJapanese) {
@@ -327,7 +338,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         .filter(Boolean);
       return names.length ? `for ${names.join(' and ')}` : '';
     },
-    [wantedDestination]
+    [applicableWantedDestination]
   );
 
   const inboundNames = useMemo(
@@ -389,7 +400,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         return trainTypeName ? `${lineName} ${trainTypeName}` : lineName;
       };
       const finalStop =
-        wantedDestination ??
+        applicableWantedDestination ??
         (direction === 'INBOUND' ? boundStations[0] : boundStations.at(-1));
 
       const lineForCard = finalStop?.line;
@@ -400,7 +411,7 @@ export const SelectBoundModal: React.FC<Props> = ({
       }
 
       // targetDestination が設定されている場合、その方向のボタンのみ表示（終点としては扱わない）
-      if (targetDestination && !isLoopLine && !wantedDestination) {
+      if (targetDestination && !isLoopLine && !applicableWantedDestination) {
         const currentStationIndex = stations.findIndex(
           (s) => s.groupId === effectiveStation?.groupId
         );
@@ -421,17 +432,13 @@ export const SelectBoundModal: React.FC<Props> = ({
         }
       }
 
-      if (wantedDestination && !isLoopLine) {
+      if (applicableWantedDestination && !isLoopLine) {
         const currentStationIndex = stations.findIndex(
           (s) => s.groupId === effectiveStation?.groupId
         );
         const wantedStationIndex = stations.findIndex(
-          (s) => s.groupId === wantedDestination.groupId
+          (s) => s.groupId === applicableWantedDestination.groupId
         );
-
-        if (wantedStationIndex === -1) {
-          return <></>;
-        }
 
         // 現在駅が経路内にない場合は savedRoute.direction から方向を決定
         const canDetermineFromIndex =
@@ -452,9 +459,9 @@ export const SelectBoundModal: React.FC<Props> = ({
               line={lineForCard ?? line}
               onPress={() =>
                 handleBoundSelected(
-                  wantedDestination,
+                  applicableWantedDestination,
                   dir,
-                  !!wantedDestination,
+                  true,
                   presetStops
                 )
               }
@@ -545,7 +552,7 @@ export const SelectBoundModal: React.FC<Props> = ({
       isTransitioning,
       effectiveStation?.groupId,
       stations,
-      wantedDestination,
+      applicableWantedDestination,
       targetDestination,
       line,
       loopLineDirectionText,


### PR DESCRIPTION
## Summary
- プリセットから使用を開始した後、乗換ボタンで別路線に切り替えた際にSelectBoundModalで方面ボタンが両方とも表示されない不具合を修正
- `wantedDestination` が前のプリセットの駅を保持したまま乗換先の路線のモーダルが開き、その駅が新路線の `stations` に存在しないため `renderButton` が空を返していた
- `wantedDestination` をstateからクリアするのではなく、SelectBoundModal内で `applicableWantedDestination`（現在のstationsに存在する場合のみ有効）を導入し、表示ロジックで使用するように変更。これにより乗換をキャンセルして閉じた場合でもプリセットの行先情報が失われない

## Test plan
- [x] `wantedDestination` 付きプリセットを読み込む → 方面選択 → Main画面 → 乗換ボタンで別路線に切替 → SelectBoundModalで方面ボタンが正しく表示されること
- [x] 上記の状態でモーダルを閉じる → 元の路線の `wantedDestination` が保持されていること
- [x] 通常のプリセット使用フロー（乗換なし）に影響がないこと
- [x] ループ路線（山手線等）での方面選択が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 駅選択画面で、現在の駅情報に対応していない目的地が表示・選択される問題を修正しました。目的地フィルタリングロジックが改善され、より正確な駅検索体験を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->