### PR TITLE
設定モーダルの列車種別選択で直近の停車駅の列車種別を取得する

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -1,4 +1,3 @@
-import { useLazyQuery } from '@apollo/client/react';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StackActions, useNavigation } from '@react-navigation/native';
@@ -7,22 +6,13 @@ import * as Haptics from 'expo-haptics';
 import { addScreenshotListener } from 'expo-screen-capture';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Linking, Platform, StyleSheet, View } from 'react-native';
 import { LongPressGestureHandler, State } from 'react-native-gesture-handler';
 import Share from 'react-native-share';
 import ViewShot from 'react-native-view-shot';
-import type { Station, TrainType } from '~/@types/graphql';
-import { GET_LINE_GROUP_STATIONS } from '~/lib/graphql/queries';
 import reportModalVisibleAtom from '~/store/atoms/reportModal';
 import tuningState from '~/store/atoms/tuning';
-import { findNearestStation } from '~/utils/findNearestStation';
 import { isDevApp } from '~/utils/isDevApp';
 import {
   ALL_AVAILABLE_LANGUAGES,
@@ -41,10 +31,10 @@ import {
   useFeedback,
   useWarningInfo,
 } from '../hooks';
+import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import type { AppTheme } from '../models/Theme';
-import lineState from '../store/atoms/line';
 import navigationState from '../store/atoms/navigation';
-import speechState, { resetFirstSpeechAtom } from '../store/atoms/speech';
+import speechState from '../store/atoms/speech';
 import stationState from '../store/atoms/station';
 import { themeAtom } from '../store/atoms/theme';
 import { isJapanese, translate } from '../translation';
@@ -58,32 +48,17 @@ type Props = {
 };
 
 const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
-  const [
-    { selectedBound, station: currentStation, selectedDirection },
-    setStationState,
-  ] = useAtom(stationState);
-  const { selectedLine } = useAtomValue(lineState);
+  const { selectedBound } = useAtomValue(stationState);
   const { untouchableModeEnabled, devOverlayEnabled } =
     useAtomValue(tuningState);
-  const [
-    {
-      autoModeEnabled,
-      isAppLatest,
-      fetchedTrainTypes,
-      trainType: activeTrainType,
-    },
-    setNavigation,
-  ] = useAtom(navigationState);
+  const [{ autoModeEnabled, isAppLatest }, setNavigation] =
+    useAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
-  const setResetFirstSpeech = useSetAtom(resetFirstSpeechAtom);
   const setTuning = useSetAtom(tuningState);
   const setTheme = useSetAtom(themeAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
   const [sendingReport, setSendingReport] = useState(false);
   const [screenShotBase64, setScreenShotBase64] = useState('');
-  const [isSettingListModalOpen, setIsSettingListModalOpen] = useState(false);
-  const [isTrainTypeModalVisible, setIsTrainTypeModalVisible] = useState(false);
-  const pendingTrainTypeModalRef = useRef(false);
 
   useCheckStoreVersion();
   useAppleWatch();
@@ -95,10 +70,21 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const { showActionSheetWithOptions } = useActionSheet();
   const { sendReport, descriptionLowerLimit } = useFeedback(user);
   const { warningInfo, clearWarningInfo } = useWarningInfo();
-  const [fetchStationsByLineGroupId, { loading: trainTypeSelectLoading }] =
-    useLazyQuery<{ lineGroupStations: Station[] }, { lineGroupId: number }>(
-      GET_LINE_GROUP_STATIONS
-    );
+  const {
+    isSettingListModalOpen,
+    isTrainTypeModalVisible,
+    trainTypeName,
+    trainTypeColor,
+    trainTypeSelectLoading,
+    trainTypeDisabled,
+    trainTypeModalLine,
+    openSettingListModal,
+    closeSettingListModal,
+    handleTrainTypePress,
+    handleSettingListCloseAnimationEnd,
+    closeTrainTypeModal,
+    handleTrainTypeModalSelect,
+  } = useTrainTypeModal();
 
   const viewShotRef = useRef<ViewShot>(null);
 
@@ -268,9 +254,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
 
       actions.push({
         label: translate('settings'),
-        handler: () => {
-          setIsSettingListModalOpen(true);
-        },
+        handler: openSettingListModal,
       });
 
       if (isDevApp) {
@@ -329,6 +313,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       handleReport,
       handleShare,
       navigation,
+      openSettingListModal,
       selectedBound,
       setTuning,
       showActionSheetWithOptions,
@@ -474,79 +459,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     }));
   }, [setNavigation]);
 
-  const trainTypeName = useMemo(
-    () =>
-      activeTrainType
-        ? isJapanese
-          ? (activeTrainType.name ?? '')
-          : (activeTrainType.nameRoman ?? '')
-        : undefined,
-    [activeTrainType]
-  );
-
-  const handleTrainTypeSelect = useCallback(
-    async (trainType: TrainType) => {
-      if (trainType.groupId == null) return;
-      const res = await fetchStationsByLineGroupId({
-        variables: { lineGroupId: trainType.groupId },
-      });
-      if (!res.data?.lineGroupStations) return;
-      const newStations = res.data.lineGroupStations;
-
-      if (selectedBound) {
-        // Main画面で動作中: アクティブなstateを直接更新
-        const currentInNewList = newStations.some(
-          (s) => s.groupId === currentStation?.groupId
-        );
-
-        setStationState((prev) => {
-          if (currentInNewList) {
-            return { ...prev, stations: newStations };
-          }
-
-          const nearest = findNearestStation(
-            prev.stations,
-            newStations,
-            currentStation?.groupId,
-            selectedDirection
-          );
-
-          return {
-            ...prev,
-            stations: newStations,
-            ...(nearest ? { station: nearest } : {}),
-          };
-        });
-
-        setNavigation((prev) => ({
-          ...prev,
-          trainType,
-          leftStations: [],
-        }));
-        setResetFirstSpeech((prev) => prev + 1);
-      } else {
-        // 方面選択前: pendingに保持
-        setStationState((prev) => ({
-          ...prev,
-          pendingStations: newStations,
-        }));
-        setNavigation((prev) => ({
-          ...prev,
-          pendingTrainType: trainType,
-        }));
-      }
-    },
-    [
-      fetchStationsByLineGroupId,
-      setStationState,
-      setNavigation,
-      setResetFirstSpeech,
-      selectedBound,
-      currentStation?.groupId,
-      selectedDirection,
-    ]
-  );
-
   const handleNewReportModalClose = useCallback(() => {
     setScreenShotBase64('');
     setReportModalShow(false);
@@ -630,32 +542,21 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       </LongPressGestureHandler>
       <SelectBoundSettingListModal
         visible={isSettingListModalOpen}
-        onClose={() => setIsSettingListModalOpen(false)}
+        onClose={closeSettingListModal}
         autoModeEnabled={autoModeEnabled}
         toggleAutoModeEnabled={toggleAutoModeEnabled}
         trainTypeName={trainTypeName}
-        trainTypeColor={activeTrainType?.color ?? undefined}
+        trainTypeColor={trainTypeColor}
         trainTypeLoading={trainTypeSelectLoading}
-        onTrainTypePress={() => {
-          pendingTrainTypeModalRef.current = true;
-          setIsSettingListModalOpen(false);
-        }}
-        onCloseAnimationEnd={() => {
-          if (pendingTrainTypeModalRef.current) {
-            pendingTrainTypeModalRef.current = false;
-            setIsTrainTypeModalVisible(true);
-          }
-        }}
-        trainTypeDisabled={!fetchedTrainTypes.length}
+        onTrainTypePress={handleTrainTypePress}
+        onCloseAnimationEnd={handleSettingListCloseAnimationEnd}
+        trainTypeDisabled={trainTypeDisabled}
       />
       <TrainTypeListModal
         visible={isTrainTypeModalVisible}
-        line={selectedLine ?? currentLine}
-        onClose={() => setIsTrainTypeModalVisible(false)}
-        onSelect={(trainType) => {
-          setIsTrainTypeModalVisible(false);
-          handleTrainTypeSelect(trainType);
-        }}
+        line={trainTypeModalLine}
+        onClose={closeTrainTypeModal}
+        onSelect={handleTrainTypeModalSelect}
       />
       {/* NOTE: このViewを外すとフィードバックモーダルのレイアウトが崩御する */}
       <View>

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -76,6 +76,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     trainTypeName,
     trainTypeColor,
     trainTypeSelectLoading,
+    fetchTrainTypesLoading,
     trainTypeDisabled,
     trainTypeModalLine,
     openSettingListModal,
@@ -555,6 +556,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       <TrainTypeListModal
         visible={isTrainTypeModalVisible}
         line={trainTypeModalLine}
+        loading={fetchTrainTypesLoading}
         onClose={closeTrainTypeModal}
         onSelect={handleTrainTypeModalSelect}
       />

--- a/src/hooks/useTrainTypeModal.test.tsx
+++ b/src/hooks/useTrainTypeModal.test.tsx
@@ -1,0 +1,413 @@
+import { useLazyQuery } from '@apollo/client/react';
+import { act, render } from '@testing-library/react-native';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import type React from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import { StopCondition } from '~/@types/graphql';
+import { createLine, createStation } from '~/utils/test/factories';
+import { useCurrentLine } from './useCurrentLine';
+import { useCurrentStation } from './useCurrentStation';
+import { useTrainTypeModal } from './useTrainTypeModal';
+
+jest.mock('react-native-device-info', () => ({
+  getBundleId: jest.fn(() => 'com.test'),
+}));
+
+jest.mock('@apollo/client/react', () => ({
+  useLazyQuery: jest.fn(),
+}));
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  useAtom: jest.fn(),
+  useAtomValue: jest.fn(),
+  useSetAtom: jest.fn(() => jest.fn()),
+  atom: jest.fn(),
+}));
+
+jest.mock('./useCurrentLine', () => ({
+  useCurrentLine: jest.fn(),
+}));
+
+jest.mock('./useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+
+jest.mock('../translation', () => ({
+  isJapanese: true,
+}));
+
+jest.mock('../store/atoms/station', () => ({
+  __esModule: true,
+  default: Symbol('stationState'),
+}));
+
+jest.mock('../store/atoms/navigation', () => ({
+  __esModule: true,
+  default: Symbol('navigationState'),
+}));
+
+jest.mock('../store/atoms/line', () => ({
+  __esModule: true,
+  default: Symbol('lineState'),
+}));
+
+jest.mock('../store/atoms/speech', () => ({
+  __esModule: true,
+  default: Symbol('speechState'),
+  resetFirstSpeechAtom: Symbol('resetFirstSpeechAtom'),
+}));
+
+jest.mock('~/lib/graphql/queries', () => ({
+  GET_LINE_GROUP_STATIONS: Symbol('GET_LINE_GROUP_STATIONS'),
+  GET_STATION_TRAIN_TYPES_LIGHT: Symbol('GET_STATION_TRAIN_TYPES_LIGHT'),
+}));
+
+jest.mock('~/utils/findNearestStation', () => ({
+  findNearestStation: jest.fn(),
+}));
+
+const mockUseLazyQuery = useLazyQuery as unknown as jest.Mock;
+const mockUseAtom = useAtom as unknown as jest.Mock;
+const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+  typeof useAtomValue
+>;
+const mockUseSetAtom = useSetAtom as unknown as jest.Mock;
+const mockUseCurrentLine = useCurrentLine as jest.MockedFunction<
+  typeof useCurrentLine
+>;
+const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
+  typeof useCurrentStation
+>;
+
+type HookResult = ReturnType<typeof useTrainTypeModal> | null;
+
+const HookBridge: React.FC<{ onReady: (value: HookResult) => void }> = ({
+  onReady,
+}) => {
+  onReady(useTrainTypeModal());
+  return null;
+};
+
+const createTrainType = (
+  id: number,
+  overrides: Partial<TrainType> = {}
+): TrainType => ({
+  __typename: 'TrainType',
+  color: '#ff0000',
+  direction: null,
+  groupId: id,
+  id,
+  kind: null,
+  line: null,
+  lines: null,
+  name: `TrainType${id}`,
+  nameChinese: null,
+  nameIpa: null,
+  nameKatakana: `トレインタイプ${id}`,
+  nameKorean: null,
+  nameRoman: `TrainType${id}`,
+  nameRomanIpa: null,
+  nameTtsSegments: null,
+  typeId: id,
+  ...overrides,
+});
+
+describe('useTrainTypeModal', () => {
+  let mockFetchStationsByLineGroupId: jest.Mock;
+  let mockFetchTrainTypes: jest.Mock;
+  let mockSetStationState: jest.Mock;
+  let mockSetNavigation: jest.Mock;
+  let mockSetResetFirstSpeech: jest.Mock;
+
+  const selectedLine = createLine(1, { nameShort: 'JR Central' });
+  const currentLineValue = createLine(2, { nameShort: 'Metro' });
+
+  const defaultStoppingStation = createStation(1);
+
+  const setupMocks = (
+    options: {
+      stationStateValue?: {
+        selectedBound: Station;
+        station: Station;
+        selectedDirection: 'INBOUND' | 'OUTBOUND';
+      };
+      lineStateValue?: { selectedLine: Line };
+      navigationStateValue?: {
+        fetchedTrainTypes: TrainType[];
+        trainType: TrainType | null;
+      };
+      currentLine?: Line | null;
+      currentStoppingStation?: Station | undefined;
+    } = {}
+  ) => {
+    const {
+      stationStateValue = {
+        selectedBound: createStation(100),
+        station: createStation(1),
+        selectedDirection: 'INBOUND' as const,
+      },
+      lineStateValue = { selectedLine },
+      navigationStateValue = {
+        fetchedTrainTypes: [createTrainType(1), createTrainType(2)],
+        trainType: createTrainType(1),
+      },
+      currentLine = currentLineValue as Line | null,
+    } = options;
+    const currentStoppingStation =
+      'currentStoppingStation' in options
+        ? options.currentStoppingStation
+        : defaultStoppingStation;
+    mockFetchStationsByLineGroupId = jest.fn();
+    mockFetchTrainTypes = jest.fn();
+    mockSetStationState = jest.fn();
+    mockSetNavigation = jest.fn();
+    mockSetResetFirstSpeech = jest.fn();
+
+    const stationAtom = require('../store/atoms/station').default;
+    const navigationAtom = require('../store/atoms/navigation').default;
+
+    mockUseAtom.mockImplementation((atom: unknown) => {
+      if (atom === stationAtom) {
+        return [stationStateValue, mockSetStationState];
+      }
+      if (atom === navigationAtom) {
+        return [navigationStateValue, mockSetNavigation];
+      }
+      return [undefined, jest.fn()];
+    });
+
+    mockUseAtomValue.mockReturnValue(lineStateValue);
+    mockUseSetAtom.mockReturnValue(mockSetResetFirstSpeech);
+
+    const lineGroupQuery =
+      require('~/lib/graphql/queries').GET_LINE_GROUP_STATIONS;
+    const trainTypesQuery =
+      require('~/lib/graphql/queries').GET_STATION_TRAIN_TYPES_LIGHT;
+
+    mockUseLazyQuery.mockImplementation((query: unknown) => {
+      if (query === lineGroupQuery) {
+        return [mockFetchStationsByLineGroupId, { loading: false }];
+      }
+      if (query === trainTypesQuery) {
+        return [mockFetchTrainTypes, { loading: false }];
+      }
+      return [jest.fn(), { loading: false }];
+    });
+
+    mockUseCurrentLine.mockReturnValue(currentLine);
+    mockUseCurrentStation.mockReturnValue(currentStoppingStation);
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('handleTrainTypePress で停車駅のIDを使って列車種別を取得する', async () => {
+    const stoppingStation = createStation(10);
+    setupMocks({ currentStoppingStation: stoppingStation });
+
+    const newTrainTypes = [createTrainType(3), createTrainType(4)];
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: newTrainTypes },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypePress();
+    });
+
+    expect(mockFetchTrainTypes).toHaveBeenCalledWith({
+      variables: { stationId: 10 },
+    });
+    expect(mockSetNavigation).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('handleTrainTypePress で通過駅ではなく直近の停車駅を使う', async () => {
+    const passStation = createStation(5, {
+      stopCondition: StopCondition.Not,
+    });
+    const stoppingStation = createStation(3);
+
+    // useCurrentStation(true) は通過駅をスキップして停車駅を返す
+    setupMocks({
+      stationStateValue: {
+        selectedBound: createStation(100),
+        station: passStation,
+        selectedDirection: 'INBOUND' as const,
+      },
+      currentStoppingStation: stoppingStation,
+    });
+
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: [createTrainType(1)] },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypePress();
+    });
+
+    // 通過駅(id:5)ではなく停車駅(id:3)でフェッチされること
+    expect(mockFetchTrainTypes).toHaveBeenCalledWith({
+      variables: { stationId: 3 },
+    });
+  });
+
+  it('handleTrainTypePress で停車駅がない場合はフェッチしない', () => {
+    setupMocks({ currentStoppingStation: undefined });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    hookRef.current?.handleTrainTypePress();
+
+    expect(mockFetchTrainTypes).not.toHaveBeenCalled();
+  });
+
+  it('handleTrainTypePress でフェッチ結果が空の場合はfetchedTrainTypesを更新しない', async () => {
+    setupMocks({ currentStoppingStation: createStation(10) });
+
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: [] },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypePress();
+    });
+
+    expect(mockFetchTrainTypes).toHaveBeenCalled();
+    expect(mockSetNavigation).not.toHaveBeenCalled();
+  });
+
+  it('trainTypeModalLine は currentLine を selectedLine より優先する', () => {
+    setupMocks({ currentLine: currentLineValue });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.trainTypeModalLine).toBe(currentLineValue);
+  });
+
+  it('trainTypeModalLine は currentLine が null の場合 selectedLine にフォールバックする', () => {
+    setupMocks({ currentLine: null });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.trainTypeModalLine).toBe(selectedLine);
+  });
+
+  it('useCurrentStation を skipPassStation=true で呼び出す', () => {
+    setupMocks();
+
+    render(<HookBridge onReady={() => {}} />);
+
+    expect(mockUseCurrentStation).toHaveBeenCalledWith(true);
+  });
+
+  it('trainTypeDisabled は fetchedTrainTypes が1件以下の場合 true になる', () => {
+    setupMocks({
+      navigationStateValue: {
+        fetchedTrainTypes: [createTrainType(1)],
+        trainType: createTrainType(1),
+      },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.trainTypeDisabled).toBe(true);
+  });
+
+  it('trainTypeDisabled は fetchedTrainTypes が2件以上の場合 false になる', () => {
+    setupMocks();
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.trainTypeDisabled).toBe(false);
+  });
+
+  it('handleTrainTypeModalSelect で列車種別選択後にモーダルを閉じてstateを更新する', async () => {
+    const trainType = createTrainType(5);
+    const newStations = [createStation(10), createStation(11)];
+    setupMocks();
+
+    mockFetchStationsByLineGroupId.mockResolvedValue({
+      data: { lineGroupStations: newStations },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypeModalSelect(trainType);
+    });
+
+    expect(mockFetchStationsByLineGroupId).toHaveBeenCalledWith({
+      variables: { lineGroupId: 5 },
+    });
+  });
+});

--- a/src/hooks/useTrainTypeModal.test.tsx
+++ b/src/hooks/useTrainTypeModal.test.tsx
@@ -200,7 +200,7 @@ describe('useTrainTypeModal', () => {
   };
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('handleTrainTypePress で停車駅のIDを使って列車種別を取得する', async () => {
@@ -228,7 +228,8 @@ describe('useTrainTypeModal', () => {
     expect(mockFetchTrainTypes).toHaveBeenCalledWith({
       variables: { stationId: 10 },
     });
-    expect(mockSetNavigation).toHaveBeenCalledWith(expect.any(Function));
+    // フェッチ開始時のクリア + 結果の上書き
+    expect(mockSetNavigation).toHaveBeenCalledTimes(2);
   });
 
   it('handleTrainTypePress で通過駅ではなく直近の停車駅を使う', async () => {
@@ -287,7 +288,7 @@ describe('useTrainTypeModal', () => {
     expect(mockFetchTrainTypes).not.toHaveBeenCalled();
   });
 
-  it('handleTrainTypePress でフェッチ結果が空の場合はfetchedTrainTypesを更新しない', async () => {
+  it('handleTrainTypePress でフェッチ開始時にfetchedTrainTypesをクリアし、結果で常に上書きする', async () => {
     setupMocks({ currentStoppingStation: createStation(10) });
 
     mockFetchTrainTypes.mockResolvedValue({
@@ -308,7 +309,16 @@ describe('useTrainTypeModal', () => {
     });
 
     expect(mockFetchTrainTypes).toHaveBeenCalled();
-    expect(mockSetNavigation).not.toHaveBeenCalled();
+    // フェッチ開始時のクリアと、結果の上書きで2回呼ばれる
+    expect(mockSetNavigation).toHaveBeenCalledTimes(2);
+    const clearCall = mockSetNavigation.mock.calls[0][0];
+    expect(clearCall({ fetchedTrainTypes: [createTrainType(1)] })).toEqual(
+      expect.objectContaining({ fetchedTrainTypes: [] })
+    );
+    const updateCall = mockSetNavigation.mock.calls[1][0];
+    expect(updateCall({ fetchedTrainTypes: [createTrainType(1)] })).toEqual(
+      expect.objectContaining({ fetchedTrainTypes: [] })
+    );
   });
 
   it('trainTypeModalLine は currentLine を selectedLine より優先する', () => {

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -1,0 +1,177 @@
+import { useLazyQuery } from '@apollo/client/react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import {
+  GET_LINE_GROUP_STATIONS,
+  GET_STATION_TRAIN_TYPES_LIGHT,
+} from '~/lib/graphql/queries';
+import { findNearestStation } from '~/utils/findNearestStation';
+import lineState from '../store/atoms/line';
+import navigationState from '../store/atoms/navigation';
+import { resetFirstSpeechAtom } from '../store/atoms/speech';
+import stationState from '../store/atoms/station';
+import { isJapanese } from '../translation';
+import { useCurrentLine } from './useCurrentLine';
+import { useCurrentStation } from './useCurrentStation';
+
+export const useTrainTypeModal = () => {
+  const [
+    { selectedBound, station: currentStation, selectedDirection },
+    setStationState,
+  ] = useAtom(stationState);
+  const { selectedLine } = useAtomValue(lineState);
+  const [{ fetchedTrainTypes, trainType: activeTrainType }, setNavigation] =
+    useAtom(navigationState);
+  const setResetFirstSpeech = useSetAtom(resetFirstSpeechAtom);
+
+  const currentLine = useCurrentLine();
+  const currentStoppingStation = useCurrentStation(true);
+
+  const [isSettingListModalOpen, setIsSettingListModalOpen] = useState(false);
+  const [isTrainTypeModalVisible, setIsTrainTypeModalVisible] = useState(false);
+  const pendingTrainTypeModalRef = useRef(false);
+
+  const [fetchStationsByLineGroupId, { loading: trainTypeSelectLoading }] =
+    useLazyQuery<{ lineGroupStations: Station[] }, { lineGroupId: number }>(
+      GET_LINE_GROUP_STATIONS
+    );
+  const [fetchTrainTypes] = useLazyQuery<
+    { stationTrainTypes: TrainType[] },
+    { stationId: number }
+  >(GET_STATION_TRAIN_TYPES_LIGHT);
+
+  const trainTypeName = useMemo(
+    () =>
+      activeTrainType
+        ? isJapanese
+          ? (activeTrainType.name ?? '')
+          : (activeTrainType.nameRoman ?? '')
+        : undefined,
+    [activeTrainType]
+  );
+
+  const trainTypeModalLine: Line | null = currentLine ?? selectedLine;
+
+  const handleTrainTypeSelect = useCallback(
+    async (trainType: TrainType) => {
+      if (trainType.groupId == null) return;
+      const res = await fetchStationsByLineGroupId({
+        variables: { lineGroupId: trainType.groupId },
+      });
+      if (!res.data?.lineGroupStations) return;
+      const newStations = res.data.lineGroupStations;
+
+      if (selectedBound) {
+        const currentInNewList = newStations.some(
+          (s) => s.groupId === currentStation?.groupId
+        );
+
+        setStationState((prev) => {
+          if (currentInNewList) {
+            return { ...prev, stations: newStations };
+          }
+
+          const nearest = findNearestStation(
+            prev.stations,
+            newStations,
+            currentStation?.groupId,
+            selectedDirection
+          );
+
+          return {
+            ...prev,
+            stations: newStations,
+            ...(nearest ? { station: nearest } : {}),
+          };
+        });
+
+        setNavigation((prev) => ({
+          ...prev,
+          trainType,
+          leftStations: [],
+        }));
+        setResetFirstSpeech((prev) => prev + 1);
+      } else {
+        setStationState((prev) => ({
+          ...prev,
+          pendingStations: newStations,
+        }));
+        setNavigation((prev) => ({
+          ...prev,
+          pendingTrainType: trainType,
+        }));
+      }
+    },
+    [
+      fetchStationsByLineGroupId,
+      setStationState,
+      setNavigation,
+      setResetFirstSpeech,
+      selectedBound,
+      currentStation?.groupId,
+      selectedDirection,
+    ]
+  );
+
+  const openSettingListModal = useCallback(() => {
+    setIsSettingListModalOpen(true);
+  }, []);
+
+  const closeSettingListModal = useCallback(() => {
+    setIsSettingListModalOpen(false);
+  }, []);
+
+  const handleTrainTypePress = useCallback(() => {
+    pendingTrainTypeModalRef.current = true;
+    setIsSettingListModalOpen(false);
+    if (currentStoppingStation?.id) {
+      fetchTrainTypes({
+        variables: { stationId: currentStoppingStation.id as number },
+      }).then((res) => {
+        const trainTypes = res.data?.stationTrainTypes ?? [];
+        if (trainTypes.length) {
+          setNavigation((prev) => ({
+            ...prev,
+            fetchedTrainTypes: trainTypes,
+          }));
+        }
+      });
+    }
+  }, [currentStoppingStation?.id, fetchTrainTypes, setNavigation]);
+
+  const handleSettingListCloseAnimationEnd = useCallback(() => {
+    if (pendingTrainTypeModalRef.current) {
+      pendingTrainTypeModalRef.current = false;
+      setIsTrainTypeModalVisible(true);
+    }
+  }, []);
+
+  const closeTrainTypeModal = useCallback(() => {
+    setIsTrainTypeModalVisible(false);
+  }, []);
+
+  const handleTrainTypeModalSelect = useCallback(
+    (trainType: TrainType) => {
+      setIsTrainTypeModalVisible(false);
+      handleTrainTypeSelect(trainType);
+    },
+    [handleTrainTypeSelect]
+  );
+
+  return {
+    isSettingListModalOpen,
+    isTrainTypeModalVisible,
+    trainTypeName,
+    trainTypeColor: activeTrainType?.color ?? undefined,
+    trainTypeSelectLoading,
+    trainTypeDisabled: fetchedTrainTypes.length <= 1,
+    trainTypeModalLine,
+    openSettingListModal,
+    closeSettingListModal,
+    handleTrainTypePress,
+    handleSettingListCloseAnimationEnd,
+    closeTrainTypeModal,
+    handleTrainTypeModalSelect,
+  };
+};

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -36,7 +36,7 @@ export const useTrainTypeModal = () => {
     useLazyQuery<{ lineGroupStations: Station[] }, { lineGroupId: number }>(
       GET_LINE_GROUP_STATIONS
     );
-  const [fetchTrainTypes] = useLazyQuery<
+  const [fetchTrainTypes, { loading: fetchTrainTypesLoading }] = useLazyQuery<
     { stationTrainTypes: TrainType[] },
     { stationId: number }
   >(GET_STATION_TRAIN_TYPES_LIGHT);
@@ -126,16 +126,17 @@ export const useTrainTypeModal = () => {
     pendingTrainTypeModalRef.current = true;
     setIsSettingListModalOpen(false);
     if (currentStoppingStation?.id) {
+      setNavigation((prev) => ({
+        ...prev,
+        fetchedTrainTypes: [],
+      }));
       fetchTrainTypes({
         variables: { stationId: currentStoppingStation.id as number },
       }).then((res) => {
-        const trainTypes = res.data?.stationTrainTypes ?? [];
-        if (trainTypes.length) {
-          setNavigation((prev) => ({
-            ...prev,
-            fetchedTrainTypes: trainTypes,
-          }));
-        }
+        setNavigation((prev) => ({
+          ...prev,
+          fetchedTrainTypes: res.data?.stationTrainTypes ?? [],
+        }));
       });
     }
   }, [currentStoppingStation?.id, fetchTrainTypes, setNavigation]);
@@ -165,6 +166,7 @@ export const useTrainTypeModal = () => {
     trainTypeName,
     trainTypeColor: activeTrainType?.color ?? undefined,
     trainTypeSelectLoading,
+    fetchTrainTypesLoading,
     trainTypeDisabled: fetchedTrainTypes.length <= 1,
     trainTypeModalLine,
     openSettingListModal,


### PR DESCRIPTION
## Summary
- 長押しメニューの設定モーダルから列車種別を選択する際、最初に選択した駅ではなく**直近で停車した駅**の列車種別を取得するように変更
- 列車種別モーダルに渡す路線も `currentLine`（現在の駅の路線）を優先するように変更
- 列車種別関連のロジックを `useTrainTypeModal` カスタムフックに切り出し、`Permitted.tsx` からビジネスロジックを分離
- 通過駅は `useCurrentStation(true)` でスキップし、停車駅のみを対象にフェッチ

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` 全1331テストパス（新規10テスト含む）
- [x] 直通運転中に設定モーダルから列車種別を変更し、現在の停車駅の列車種別が表示されることを確認
- [x] 通過駅通過中に列車種別を開いた場合、直近の停車駅の列車種別が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 列車種別選択の状態管理を担う新しいフックを公開しました（モーダル遷移とデータ取得の一元化）。

* **Refactor**
  * コンポーネント内の列車種別／モーダルロジックをフックへ移行し、UIがより簡潔に。

* **Tests**
  * 新フックの振る舞いを検証する単体テストを追加しました（選択・取得・遷移を網羅）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->