### PR TITLE
テーマの路線別自動適用機能を追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -52,6 +52,8 @@
   "subwayAlertTitle": "Out of operation guarantee",
   "subwayAlertText": "Operation is not guaranteed because it is difficult for radio waves to enter the subway line. Please be careful.",
   "selectThemeTitle": "Themes",
+  "autoTheme": "Auto",
+  "themeDescriptionAuto": "Theme changes automatically based on the current line.",
   "tokyoMetroLike": "Tokyo Metro",
   "toeiLike": "Toei Subway",
   "yamanoteLineLike": "Yamanote Line",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -52,6 +52,8 @@
   "subwayAlertTitle": "動作保証外",
   "subwayAlertText": "地下鉄線内は電波が入りづらいため、動作保証外となります。ご注意ください。",
   "selectThemeTitle": "テーマ設定",
+  "autoTheme": "自動",
+  "themeDescriptionAuto": "路線に応じて自動的にテーマが変わります。",
   "tokyoMetroLike": "東京メトロ風",
   "toeiLike": "都営地下鉄風",
   "yamanoteLineLike": "山手線風",

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -32,11 +32,11 @@ import {
   useWarningInfo,
 } from '../hooks';
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
-import type { AppTheme } from '../models/Theme';
+import type { ThemePreference } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import speechState from '../store/atoms/speech';
 import stationState from '../store/atoms/station';
-import { themeAtom } from '../store/atoms/theme';
+import { themePreferenceAtom } from '../store/atoms/theme';
 import { isJapanese, translate } from '../translation';
 import NewReportModal from './NewReportModal';
 import { SelectBoundSettingListModal } from './SelectBoundSettingListModal';
@@ -55,7 +55,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     useAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
   const setTuning = useSetAtom(tuningState);
-  const setTheme = useSetAtom(themeAtom);
+  const setThemePreference = useSetAtom(themePreferenceAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
   const [sendingReport, setSendingReport] = useState(false);
   const [screenShotBase64, setScreenShotBase64] = useState('');
@@ -325,6 +325,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   useEffect(() => {
     const loadSettings = async () => {
       const [
+        themePreferenceKey,
         prevThemeKey,
         enabledLanguagesStr,
         speechEnabledStr,
@@ -337,6 +338,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         bottomTransitionIntervalStr,
         untouchableModeEnabledStr,
       ] = await Promise.all([
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.THEME_PREFERENCE),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PREVIOUS_THEME),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.ENABLED_LANGUAGES),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.SPEECH_ENABLED),
@@ -350,8 +352,15 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.UNTOUCHABLE_MODE_ENABLED),
       ]);
 
-      if (prevThemeKey) {
-        setTheme(prevThemeKey as AppTheme);
+      if (themePreferenceKey) {
+        setThemePreference(themePreferenceKey as ThemePreference);
+      } else if (prevThemeKey) {
+        // 既存ユーザーの移行: 明示的に選択していたテーマを維持
+        setThemePreference(prevThemeKey as ThemePreference);
+        await AsyncStorage.setItem(
+          ASYNC_STORAGE_KEYS.THEME_PREFERENCE,
+          prevThemeKey
+        );
       }
       if (enabledLanguagesStr) {
         setNavigation((prev) => ({
@@ -441,7 +450,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     };
 
     loadSettings();
-  }, [setNavigation, setSpeech, setTuning, setTheme]);
+  }, [setNavigation, setSpeech, setTuning, setThemePreference]);
 
   useEffect(() => {
     const { remove } = addScreenshotListener(() => {

--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -5,7 +5,7 @@ import { lighten } from 'polished';
 import type React from 'react';
 import { useMemo } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import type { AppTheme } from '~/models/Theme';
+import { THEME_PREFERENCE, type ThemePreference } from '~/models/Theme';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
@@ -75,11 +75,15 @@ const styles = StyleSheet.create({
   buttonText: {
     fontWeight: 'bold',
   },
+  autoPreviewEmoji: {
+    fontSize: RFValue(64),
+    textAlign: 'center',
+  },
 });
 
 type Props = {
   visible: boolean;
-  themeId: AppTheme | null;
+  themeId: ThemePreference | null;
   themeTitle: string;
   onClose: () => void;
   onConfirm: () => void;
@@ -96,12 +100,16 @@ export const ThemeConfirmModal: React.FC<Props> = ({
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
-  const themeInfo = useMemo(() => themeId && getThemeInfo(themeId), [themeId]);
+  const isAuto = themeId === THEME_PREFERENCE.AUTO;
+  const themeInfo = useMemo(
+    () => (themeId && !isAuto ? getThemeInfo(themeId) : null),
+    [themeId, isAuto]
+  );
   const previewImage = useMemo(
     () => (isTablet ? themeInfo?.tabletImage : themeInfo?.spImage),
     [themeInfo]
   );
-  const themeColor = themeId ? IN_USE_COLOR_MAP[themeId] : '#ccc';
+  const themeColor = themeId && !isAuto ? IN_USE_COLOR_MAP[themeId] : null;
   const borderRadius = isLEDTheme ? 0 : 8;
 
   return (
@@ -120,14 +128,20 @@ export const ThemeConfirmModal: React.FC<Props> = ({
         <View style={styles.header}>
           <View style={[styles.colorSwatch, { borderRadius }]}>
             <LinearGradient
-              colors={[themeColor, lighten(0.1, themeColor)]}
+              colors={
+                themeColor
+                  ? [themeColor, lighten(0.1, themeColor)]
+                  : ['#5B9BD5', '#A78BCA']
+              }
               style={{ flex: 1 }}
             />
           </View>
           <Typography style={styles.title}>{themeTitle}</Typography>
         </View>
         <Typography style={styles.description}>
-          {themeInfo?.description ?? ''}
+          {isAuto
+            ? translate('themeDescriptionAuto')
+            : (themeInfo?.description ?? '')}
         </Typography>
         <View
           style={[
@@ -144,11 +158,15 @@ export const ThemeConfirmModal: React.FC<Props> = ({
               },
             ]}
           >
-            <Image
-              source={previewImage}
-              style={styles.previewImage}
-              contentFit="contain"
-            />
+            {isAuto ? (
+              <Typography style={styles.autoPreviewEmoji}>❓</Typography>
+            ) : (
+              <Image
+                source={previewImage}
+                style={styles.previewImage}
+                contentFit="contain"
+              />
+            )}
           </View>
         </View>
         <View style={styles.buttonsRow}>

--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -11,7 +11,11 @@ import { translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import { getThemeInfo } from '~/utils/themeInfo';
-import { IN_USE_COLOR_MAP, LED_THEME_BG_COLOR } from '../constants';
+import {
+  AUTO_THEME_GRADIENT_COLORS,
+  IN_USE_COLOR_MAP,
+  LED_THEME_BG_COLOR,
+} from '../constants';
 import Button from './Button';
 import { CustomModal } from './CustomModal';
 import Typography from './Typography';
@@ -131,7 +135,7 @@ export const ThemeConfirmModal: React.FC<Props> = ({
               colors={
                 themeColor
                   ? [themeColor, lighten(0.1, themeColor)]
-                  : ['#5B9BD5', '#A78BCA']
+                  : AUTO_THEME_GRADIENT_COLORS
               }
               style={{ flex: 1 }}
             />

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -1,6 +1,7 @@
 export const ASYNC_STORAGE_KEYS = {
   FIRST_LAUNCH_PASSED: '@TrainLCD:firstLaunchPassed',
   PREVIOUS_THEME: '@TrainLCD:previousTheme',
+  THEME_PREFERENCE: '@TrainLCD:themePreference',
   ENABLED_LANGUAGES: '@TrainLCD:enabledLanguages',
   SPEECH_ENABLED: '@TrainLCD:speechEnabled',
   TTS_ENABLED_LANGUAGES: '@TrainLCD:ttsEnabledLanguages',

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -17,3 +17,8 @@ export const IN_USE_COLOR_MAP: Record<AppTheme, string> = {
   JL: '#808080',
   JR_KYUSHU: '#E50012',
 } as const;
+
+export const AUTO_THEME_GRADIENT_COLORS: [string, string] = [
+  '#5B9BD5',
+  '#A78BCA',
+];

--- a/src/hooks/useBusTTSText.test.tsx
+++ b/src/hooks/useBusTTSText.test.tsx
@@ -13,7 +13,7 @@ import type { AppTheme } from '~/models/Theme';
 import { store } from '~/store';
 import lineState from '~/store/atoms/line';
 import stationState from '~/store/atoms/station';
-import { themeAtom } from '~/store/atoms/theme';
+import { themePreferenceAtom } from '~/store/atoms/theme';
 
 jest.mock('~/translation', () => ({ isJapanese: true }));
 jest.mock('~/hooks/useNextStation', () => ({
@@ -39,7 +39,7 @@ const useBusTTSTextWithJotai = (
     const arrived = headerState === 'CURRENT';
     const approaching = headerState === 'ARRIVING';
 
-    store.set(themeAtom, theme);
+    store.set(themePreferenceAtom, theme);
     setStationState((prev) => ({
       ...prev,
       station,
@@ -91,7 +91,7 @@ describe('useBusTTSText', () => {
                 TOEI_SHINJUKU_LINE_STATIONS.length - 1
               ];
 
-            store.set(themeAtom, 'TOKYO_METRO');
+            store.set(themePreferenceAtom, 'TOKYO_METRO');
             setStationState((prev) => ({
               ...prev,
               station,

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -9,12 +9,12 @@ import {
   GET_LINE_STATIONS,
 } from '~/lib/graphql/queries';
 import type { LineDirection } from '../models/Bound';
-import { APP_THEME, type AppTheme } from '../models/Theme';
+import { APP_THEME, type ThemePreference } from '../models/Theme';
 import { navigationRef } from '../stacks/rootNavigation';
 import lineState from '../store/atoms/line';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
-import { themeAtom } from '../store/atoms/theme';
+import { themePreferenceAtom } from '../store/atoms/theme';
 
 const MAX_NAV_RETRIES = 5;
 const INITIAL_RETRY_DELAY_MS = 100;
@@ -63,7 +63,7 @@ export const useDeepLink = () => {
   const setStationState = useSetAtom(stationState);
   const setNavigationState = useSetAtom(navigationState);
   const setLineState = useSetAtom(lineState);
-  const setTheme = useSetAtom(themeAtom);
+  const setThemePreference = useSetAtom(themePreferenceAtom);
 
   const [
     fetchStationsByLineGroupId,
@@ -147,10 +147,10 @@ export const useDeepLink = () => {
       lineGroupId: number | undefined;
       lineId: number;
       autoMode: boolean;
-      theme: AppTheme | undefined;
+      theme: ThemePreference | undefined;
     }) => {
       if (theme) {
-        setTheme(theme);
+        setThemePreference(theme);
       }
       const lineDirection: LineDirection =
         direction === 0 ? 'INBOUND' : 'OUTBOUND';
@@ -196,7 +196,7 @@ export const useDeepLink = () => {
       fetchStationsByLineId,
       navigateToMain,
       setNavigationState,
-      setTheme,
+      setThemePreference,
     ]
   );
 
@@ -223,8 +223,9 @@ export const useDeepLink = () => {
       const autoMode = auto === '1';
       const parsedTheme =
         typeof theme === 'string' &&
-        Object.values(APP_THEME).includes(theme as AppTheme)
-          ? (theme as AppTheme)
+        (theme === 'AUTO' ||
+          (Object.values(APP_THEME) as string[]).includes(theme))
+          ? (theme as ThemePreference)
           : undefined;
 
       await openLink({

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -13,7 +13,7 @@ import type { AppTheme } from '~/models/Theme';
 import { store } from '~/store';
 import lineState from '~/store/atoms/line';
 import stationState from '~/store/atoms/station';
-import { themeAtom } from '~/store/atoms/theme';
+import { themePreferenceAtom } from '~/store/atoms/theme';
 
 jest.mock('~/translation', () => ({ isJapanese: true }));
 jest.mock('~/hooks/useNumbering', () => ({
@@ -41,7 +41,7 @@ const useTTSTextWithJotaiAndNumbering = (
     const arrived = headerState === 'CURRENT';
     const approaching = headerState === 'ARRIVING';
 
-    store.set(themeAtom, theme);
+    store.set(themePreferenceAtom, theme);
     setStationState((prev) => ({
       ...prev,
       station,

--- a/src/models/Theme.ts
+++ b/src/models/Theme.ts
@@ -12,3 +12,11 @@ export const APP_THEME = {
 } as const;
 
 export type AppTheme = (typeof APP_THEME)[keyof typeof APP_THEME];
+
+export const THEME_PREFERENCE = {
+  AUTO: 'AUTO',
+  ...APP_THEME,
+} as const;
+
+export type ThemePreference =
+  (typeof THEME_PREFERENCE)[keyof typeof THEME_PREFERENCE];

--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -22,18 +22,18 @@ import { SettingsHeader } from '~/components/SettingsHeader';
 import { ThemeConfirmModal } from '~/components/ThemeConfirmModal';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
-import {
-  APP_THEME,
-  THEME_PREFERENCE,
-  type ThemePreference,
-} from '~/models/Theme';
+import { THEME_PREFERENCE, type ThemePreference } from '~/models/Theme';
 import { isLEDThemeAtom, themePreferenceAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { isDevApp } from '~/utils/isDevApp';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import { getSettingsThemes } from '~/utils/theme';
-import { ASYNC_STORAGE_KEYS, IN_USE_COLOR_MAP } from '../constants';
+import {
+  ASYNC_STORAGE_KEYS,
+  AUTO_THEME_GRADIENT_COLORS,
+  IN_USE_COLOR_MAP,
+} from '../constants';
 
 type SettingItem = {
   id: ThemePreference;
@@ -56,8 +56,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const AUTO_THEME_COLORS: [string, string, ...string[]] = ['#5B9BD5', '#A78BCA'];
-
 const SettingsItem = ({
   item,
   isFirst,
@@ -74,7 +72,7 @@ const SettingsItem = ({
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const isAuto = item.id === THEME_PREFERENCE.AUTO;
   const themeColor = isAuto
-    ? AUTO_THEME_COLORS[0]
+    ? AUTO_THEME_GRADIENT_COLORS[0]
     : IN_USE_COLOR_MAP[item.id as keyof typeof IN_USE_COLOR_MAP];
 
   return (
@@ -107,7 +105,9 @@ const SettingsItem = ({
       >
         <LinearGradient
           colors={
-            isAuto ? AUTO_THEME_COLORS : [themeColor, lighten(0.1, themeColor)]
+            isAuto
+              ? AUTO_THEME_GRADIENT_COLORS
+              : [themeColor, lighten(0.1, themeColor)]
           }
           style={{
             flex: 1,
@@ -135,6 +135,7 @@ const ThemeSettingsScreen: React.FC = () => {
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
   const currentPreference = useAtomValue(themePreferenceAtom);
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const setThemePreference = useSetAtom(themePreferenceAtom);
 
   const navigation = useNavigation();
@@ -232,12 +233,7 @@ const ThemeSettingsScreen: React.FC = () => {
 
   return (
     <>
-      <View
-        style={[
-          styles.root,
-          currentPreference !== APP_THEME.LED && styles.screenBg,
-        ]}
-      >
+      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
         <Animated.FlatList
           data={visibleItems}
           keyExtractor={keyExtractor}

--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -22,8 +22,12 @@ import { SettingsHeader } from '~/components/SettingsHeader';
 import { ThemeConfirmModal } from '~/components/ThemeConfirmModal';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
-import { APP_THEME, type AppTheme } from '~/models/Theme';
-import { isLEDThemeAtom, themeAtom } from '~/store/atoms/theme';
+import {
+  APP_THEME,
+  THEME_PREFERENCE,
+  type ThemePreference,
+} from '~/models/Theme';
+import { isLEDThemeAtom, themePreferenceAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { isDevApp } from '~/utils/isDevApp';
 import isTablet from '~/utils/isTablet';
@@ -32,7 +36,7 @@ import { getSettingsThemes } from '~/utils/theme';
 import { ASYNC_STORAGE_KEYS, IN_USE_COLOR_MAP } from '../constants';
 
 type SettingItem = {
-  id: AppTheme;
+  id: ThemePreference;
   title: string;
   hidden: boolean;
 };
@@ -52,6 +56,8 @@ const styles = StyleSheet.create({
   },
 });
 
+const AUTO_THEME_COLORS: [string, string, ...string[]] = ['#5B9BD5', '#A78BCA'];
+
 const SettingsItem = ({
   item,
   isFirst,
@@ -66,7 +72,10 @@ const SettingsItem = ({
   onToggle: (event: GestureResponderEvent) => void;
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
-  const themeColor = IN_USE_COLOR_MAP[item.id];
+  const isAuto = item.id === THEME_PREFERENCE.AUTO;
+  const themeColor = isAuto
+    ? AUTO_THEME_COLORS[0]
+    : IN_USE_COLOR_MAP[item.id as keyof typeof IN_USE_COLOR_MAP];
 
   return (
     <Pressable
@@ -97,7 +106,9 @@ const SettingsItem = ({
         }}
       >
         <LinearGradient
-          colors={[themeColor, lighten(0.1, themeColor)]}
+          colors={
+            isAuto ? AUTO_THEME_COLORS : [themeColor, lighten(0.1, themeColor)]
+          }
           style={{
             flex: 1,
             justifyContent: 'center',
@@ -123,8 +134,8 @@ const ThemeSettingsScreen: React.FC = () => {
 
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
-  const currentTheme = useAtomValue(themeAtom);
-  const setTheme = useSetAtom(themeAtom);
+  const currentPreference = useAtomValue(themePreferenceAtom);
+  const setThemePreference = useSetAtom(themePreferenceAtom);
 
   const navigation = useNavigation();
 
@@ -143,10 +154,13 @@ const ThemeSettingsScreen: React.FC = () => {
   );
 
   const handleApplyTheme = useCallback(
-    async (theme: AppTheme) => {
+    async (preference: ThemePreference) => {
       try {
-        await AsyncStorage.setItem(ASYNC_STORAGE_KEYS.PREVIOUS_THEME, theme);
-        setTheme(theme);
+        await AsyncStorage.setItem(
+          ASYNC_STORAGE_KEYS.THEME_PREFERENCE,
+          preference
+        );
+        setThemePreference(preference);
       } catch (error) {
         console.error('Failed to toggle theme setting', error);
         Alert.alert(
@@ -155,7 +169,7 @@ const ThemeSettingsScreen: React.FC = () => {
         );
       }
     },
-    [setTheme]
+    [setThemePreference]
   );
 
   const handleConfirmThemeChange = useCallback(() => {
@@ -175,7 +189,7 @@ const ThemeSettingsScreen: React.FC = () => {
 
   const renderItem = useCallback(
     ({ item, index }: { item: SettingItem; index: number }) => {
-      const state = currentTheme === item.id;
+      const state = currentPreference === item.id;
 
       const onToggle = () => {
         if (state) {
@@ -195,7 +209,7 @@ const ThemeSettingsScreen: React.FC = () => {
         />
       );
     },
-    [visibleItems.length, currentTheme]
+    [visibleItems.length, currentPreference]
   );
 
   const keyExtractor = useCallback((item: SettingItem) => item.id, []);
@@ -219,7 +233,10 @@ const ThemeSettingsScreen: React.FC = () => {
   return (
     <>
       <View
-        style={[styles.root, currentTheme !== APP_THEME.LED && styles.screenBg]}
+        style={[
+          styles.root,
+          currentPreference !== APP_THEME.LED && styles.screenBg,
+        ]}
       >
         <Animated.FlatList
           data={visibleItems}

--- a/src/store/atoms/theme.ts
+++ b/src/store/atoms/theme.ts
@@ -1,7 +1,23 @@
 import { atom } from 'jotai';
-import { APP_THEME, type AppTheme } from '../../models/Theme';
+import {
+  APP_THEME,
+  type AppTheme,
+  THEME_PREFERENCE,
+  type ThemePreference,
+} from '../../models/Theme';
+import { resolveThemeForLine } from '../../utils/resolveThemeForLine';
+import lineState from './line';
 
-export const themeAtom = atom<AppTheme>(APP_THEME.TOKYO_METRO);
+export const themePreferenceAtom = atom<ThemePreference>(THEME_PREFERENCE.AUTO);
+
+export const themeAtom = atom<AppTheme>((get) => {
+  const preference = get(themePreferenceAtom);
+  if (preference !== THEME_PREFERENCE.AUTO) {
+    return preference as AppTheme;
+  }
+  const { selectedLine } = get(lineState);
+  return resolveThemeForLine(selectedLine);
+});
 
 // 派生atom: LEDテーマかどうか
 export const isLEDThemeAtom = atom((get) => get(themeAtom) === APP_THEME.LED);

--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -1,4 +1,5 @@
 import type { Line } from '~/@types/graphql';
+import { YAMANOTE_LINE_ID } from '~/constants/line';
 import { APP_THEME } from '~/models/Theme';
 import { resolveThemeForLine } from './resolveThemeForLine';
 
@@ -47,7 +48,7 @@ describe('resolveThemeForLine', () => {
   });
 
   it('山手線(11302)はYAMANOTEを返す', () => {
-    expect(resolveThemeForLine(makeLine({ id: 11302 }))).toBe(
+    expect(resolveThemeForLine(makeLine({ id: YAMANOTE_LINE_ID }))).toBe(
       APP_THEME.YAMANOTE
     );
   });
@@ -124,7 +125,7 @@ describe('resolveThemeForLine', () => {
     // 山手線はJR東日本だが、company matchではなくline ID matchでYAMANOTEになる
     expect(
       resolveThemeForLine(
-        makeLine({ id: 11302, company: makeCompany('JR東日本') })
+        makeLine({ id: YAMANOTE_LINE_ID, company: makeCompany('JR東日本') })
       )
     ).toBe(APP_THEME.YAMANOTE);
   });

--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -1,0 +1,131 @@
+import type { Line } from '~/@types/graphql';
+import { APP_THEME } from '~/models/Theme';
+import { resolveThemeForLine } from './resolveThemeForLine';
+
+const makeLine = (overrides: Partial<Line> & { id?: number | null }): Line => ({
+  __typename: 'Line',
+  id: null,
+  averageDistance: null,
+  color: null,
+  company: null,
+  lineSymbols: null,
+  lineType: null,
+  nameChinese: null,
+  nameFull: null,
+  nameIpa: null,
+  nameKatakana: null,
+  nameKorean: null,
+  nameRoman: null,
+  nameRomanIpa: null,
+  nameShort: null,
+  nameTtsSegments: null,
+  station: null,
+  status: null,
+  trainType: null,
+  transportType: null,
+  ...overrides,
+});
+
+const makeCompany = (nameShort: string) => ({
+  __typename: 'Company' as const,
+  id: null,
+  name: null,
+  nameEnglishFull: null,
+  nameEnglishShort: null,
+  nameFull: null,
+  nameKatakana: null,
+  nameShort,
+  railroadId: null,
+  status: null,
+  type: null,
+  url: null,
+});
+
+describe('resolveThemeForLine', () => {
+  it('nullの場合TOKYO_METROを返す', () => {
+    expect(resolveThemeForLine(null)).toBe(APP_THEME.TOKYO_METRO);
+  });
+
+  it('山手線(11302)はYAMANOTEを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11302 }))).toBe(
+      APP_THEME.YAMANOTE
+    );
+  });
+
+  it('埼京線(11321)はSAIKYOを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11321 }))).toBe(APP_THEME.SAIKYO);
+  });
+
+  it('横須賀線(11308)はJOを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11308 }))).toBe(APP_THEME.JO);
+  });
+
+  it('総武本線(11314)はJOを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11314 }))).toBe(APP_THEME.JO);
+  });
+
+  it('常磐線各停(11344)はJLを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11344 }))).toBe(APP_THEME.JL);
+  });
+
+  it('東京メトロの路線はTOKYO_METROを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 28001, company: makeCompany('東京メトロ') })
+      )
+    ).toBe(APP_THEME.TOKYO_METRO);
+  });
+
+  it('都営の路線はTOEIを返す', () => {
+    expect(
+      resolveThemeForLine(makeLine({ id: 99301, company: makeCompany('都営') }))
+    ).toBe(APP_THEME.TOEI);
+  });
+
+  it('都営地下鉄の路線もTOEIを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 99302, company: makeCompany('都営地下鉄') })
+      )
+    ).toBe(APP_THEME.TOEI);
+  });
+
+  it('JR西日本の路線はJR_WESTを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 11601, company: makeCompany('JR西日本') })
+      )
+    ).toBe(APP_THEME.JR_WEST);
+  });
+
+  it('東急の路線はTYを返す', () => {
+    expect(
+      resolveThemeForLine(makeLine({ id: 26001, company: makeCompany('東急') }))
+    ).toBe(APP_THEME.TY);
+  });
+
+  it('JR九州の路線はJR_KYUSHUを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 11901, company: makeCompany('JR九州') })
+      )
+    ).toBe(APP_THEME.JR_KYUSHU);
+  });
+
+  it('不明な路線はTOKYO_METROにフォールバックする', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 99999, company: makeCompany('不明な会社') })
+      )
+    ).toBe(APP_THEME.TOKYO_METRO);
+  });
+
+  it('Line IDのマッピングはCompanyより優先される', () => {
+    // 山手線はJR東日本だが、company matchではなくline ID matchでYAMANOTEになる
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 11302, company: makeCompany('JR東日本') })
+      )
+    ).toBe(APP_THEME.YAMANOTE);
+  });
+});

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -25,8 +25,11 @@ export const resolveThemeForLine = (line: Line | null): AppTheme => {
     return DEFAULT_THEME;
   }
 
-  if (line.id != null && LINE_ID_TO_THEME[line.id]) {
-    return LINE_ID_TO_THEME[line.id];
+  if (line.id != null) {
+    const theme = LINE_ID_TO_THEME[line.id];
+    if (theme) {
+      return theme;
+    }
   }
 
   const companyName = line.company?.nameShort;

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -1,0 +1,43 @@
+import type { Line } from '~/@types/graphql';
+import { YAMANOTE_LINE_ID } from '~/constants/line';
+import { APP_THEME, type AppTheme } from '~/models/Theme';
+
+const LINE_ID_TO_THEME: Record<number, AppTheme> = {
+  [YAMANOTE_LINE_ID]: APP_THEME.YAMANOTE,
+  11321: APP_THEME.SAIKYO,
+  11308: APP_THEME.JO,
+  11314: APP_THEME.JO,
+  11344: APP_THEME.JL,
+};
+
+const COMPANY_PREFIX_TO_THEME: [string, AppTheme][] = [
+  ['東京メトロ', APP_THEME.TOKYO_METRO],
+  ['都営', APP_THEME.TOEI],
+  ['JR西日本', APP_THEME.JR_WEST],
+  ['JR九州', APP_THEME.JR_KYUSHU],
+  ['東急', APP_THEME.TY],
+];
+
+const DEFAULT_THEME = APP_THEME.TOKYO_METRO;
+
+export const resolveThemeForLine = (line: Line | null): AppTheme => {
+  if (!line) {
+    return DEFAULT_THEME;
+  }
+
+  if (line.id != null && LINE_ID_TO_THEME[line.id]) {
+    return LINE_ID_TO_THEME[line.id];
+  }
+
+  const companyName = line.company?.nameShort;
+  if (companyName) {
+    const match = COMPANY_PREFIX_TO_THEME.find(([prefix]) =>
+      companyName.startsWith(prefix)
+    );
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return DEFAULT_THEME;
+};

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,15 +1,24 @@
 import { isClip } from 'react-native-app-clip';
-import { APP_THEME, type AppTheme } from '~/models/Theme';
+import {
+  APP_THEME,
+  THEME_PREFERENCE,
+  type ThemePreference,
+} from '~/models/Theme';
 import { translate } from '~/translation';
 
 export interface SettingsTheme {
   label: string;
-  value: AppTheme;
+  value: ThemePreference;
   devOnly: boolean;
 }
 
 export const getSettingsThemes = (): SettingsTheme[] =>
   [
+    {
+      label: translate('autoTheme'),
+      value: THEME_PREFERENCE.AUTO,
+      devOnly: false,
+    },
     {
       label: translate('tokyoMetroLike'),
       value: APP_THEME.TOKYO_METRO,


### PR DESCRIPTION
## Summary
- テーマ設定に「自動」オプションを追加。路線の会社やLine IDに基づいてテーマを自動的に切り替える
- 既存ユーザーは明示的に選択したテーマを維持、新規ユーザーはデフォルトで「自動」が適用される
- 直通運転で路線が変わった際もテーマが動的に追従する

### 主な変更
- `themePreferenceAtom`（AUTO or 具体テーマ）を導入し、`themeAtom`をderived atomに変更
- `resolveThemeForLine()` で路線→テーマの2段階マッピング（Line ID → Company名前方一致）
- 対応テーマ: 東京メトロ, 都営, 山手線, 埼京線, JO, JL, JR西日本, 東急, JR九州
- フォールバック: TOKYO_METRO

## Test plan
- [x] `npx biome check --unsafe --fix ./src`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (143 suites, 1344 tests passed)
- [x] 手動確認: 設定画面で「自動」が先頭に表示されること
- [x] 手動確認: 路線選択時にテーマが動的に変わること
- [ ] 手動確認: 直通運転で路線が変わった際にテーマが追従すること

Closes #5682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーマ設定に新しい「自動」オプションを追加。表示中の路線に応じてテーマが自動で切り替わります。
  * 設定画面や確認モーダルに「自動」選択用の表示（説明文・プレビュー・グラデーション）が追加されました。

* **ドキュメント（翻訳）**
  * 「自動」ラベルとその説明文の日本語／英語翻訳を追加しました。

* **テスト**
  * テーマ自動判定に関するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->