### PR TITLE
自動テーマが直通運転時に切り替わらない不具合を修正

### DIFF
--- a/src/store/atoms/theme.ts
+++ b/src/store/atoms/theme.ts
@@ -7,6 +7,7 @@ import {
 } from '../../models/Theme';
 import { resolveThemeForLine } from '../../utils/resolveThemeForLine';
 import lineState from './line';
+import stationState from './station';
 
 export const themePreferenceAtom = atom<ThemePreference>(THEME_PREFERENCE.AUTO);
 
@@ -15,8 +16,26 @@ export const themeAtom = atom<AppTheme>((get) => {
   if (preference !== THEME_PREFERENCE.AUTO) {
     return preference as AppTheme;
   }
+
   const { selectedLine } = get(lineState);
-  return resolveThemeForLine(selectedLine);
+  const { station, stations, selectedDirection } = get(stationState);
+
+  // useCurrentStation相当: stations内から現在駅を特定
+  const currentStation =
+    stations.find((s) => s.id === station?.id) ??
+    stations.find((s) => s.groupId === station?.groupId);
+
+  // useCurrentLine相当: 現在駅のgroupIdから実際の路線を取得（直通運転対応）
+  const orderedStations =
+    selectedDirection === 'INBOUND' ? stations.slice().reverse() : stations;
+  const actualCurrentStation = orderedStations.find(
+    (rs) => rs.groupId === currentStation?.groupId
+  );
+
+  // selectedLineがnullの場合はcurrentLineもnull（useCurrentLineと同じ挙動）
+  const currentLine =
+    (selectedLine && actualCurrentStation?.line) ?? selectedLine;
+  return resolveThemeForLine(currentLine);
 });
 
 // 派生atom: LEDテーマかどうか

--- a/src/store/atoms/theme.ts
+++ b/src/store/atoms/theme.ts
@@ -33,8 +33,7 @@ export const themeAtom = atom<AppTheme>((get) => {
   );
 
   // selectedLineがnullの場合はcurrentLineもnull（useCurrentLineと同じ挙動）
-  const currentLine =
-    (selectedLine && actualCurrentStation?.line) ?? selectedLine;
+  const currentLine = (selectedLine && actualCurrentStation?.line) ?? null;
   return resolveThemeForLine(currentLine);
 });
 


### PR DESCRIPTION
## Summary
- `themeAtom`が`lineState.selectedLine`のみを参照していたため、直通運転で路線が切り替わってもテーマが変更されなかった
- `stationState`も購読し、`useCurrentLine`フックと同等のロジックで現在駅が実際に属する路線を算出してテーマを解決するように修正
- 例: 東京メトロ副都心線→東急東横線の直通時、テーマがTOKYO_METRO→TYに自動切替される

## Test plan
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run lint` — Biomeチェック通過
- [x] `npm test` — 143 suites / 1345 tests 全パス
- [x] AUTOテーマ設定で直通運転（副都心線→東横線等）時にテーマが自動切替されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * テーマ自動選択を強化：現在地・駅情報と進行方向を組み合わせて適切な路線を判定し、テーマ表示をより正確に反映するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->