### PR TITLE
みなとみらい線の自動テーマをTY(東急)に修正

### DIFF
--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -113,6 +113,14 @@ describe('resolveThemeForLine', () => {
     ).toBe(APP_THEME.JR_KYUSHU);
   });
 
+  it('みなとみらい線(99310)はTYを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 99310, company: makeCompany('横浜高速鉄道') })
+      )
+    ).toBe(APP_THEME.TY);
+  });
+
   it('不明な路線はTOKYO_METROにフォールバックする', () => {
     expect(
       resolveThemeForLine(

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -8,6 +8,7 @@ const LINE_ID_TO_THEME: Record<number, AppTheme> = {
   11308: APP_THEME.JO,
   11314: APP_THEME.JO,
   11344: APP_THEME.JL,
+  99310: APP_THEME.TY, // みなとみらい線（東急東横線と直通）
 };
 
 const COMPANY_PREFIX_TO_THEME: [string, AppTheme][] = [


### PR DESCRIPTION
## Summary
- 東急東横線→みなとみらい線の直通運転時に、テーマが東急(TY)ではなくデフォルトの東京メトロにフォールバックしていた不具合を修正
- みなとみらい線(line id: 99310)は横浜高速鉄道が運営しているため、会社名プレフィックスマッチ(`東急`)に該当せずデフォルトテーマになっていた
- `LINE_ID_TO_THEME` にみなとみらい線のマッピングを追加し、TYテーマが適用されるように修正

## Test plan
- [x] `resolveThemeForLine` のユニットテストにみなとみらい線のケースを追加・パス確認済み
- [ ] 東急東横線→みなとみらい線の直通運転シナリオで、テーマがTYのまま維持されることを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 追加の路線に対応し、適切なテーマ表示を実装しました。

* **テスト**
  * 路線テーマの検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->