### PR TITLE
小田急テーマのTypeChangeNotify対応と直通運転時の路線名表示バグ修正

### DIFF
--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -76,6 +76,10 @@ jest.mock('./BarTerminalEast', () => ({
   BarTerminalEast: jest.fn(() => null),
 }));
 
+jest.mock('./BarTerminalOdakyu', () => ({
+  BarTerminalOdakyu: jest.fn(() => null),
+}));
+
 jest.mock('./BarTerminalSaikyo', () => ({
   BarTerminalSaikyo: jest.fn(() => null),
 }));
@@ -148,5 +152,163 @@ describe('TypeChangeNotify', () => {
     expect(() => {
       render(<TypeChangeNotify />);
     }).not.toThrow();
+  });
+
+  it('ODAKYUテーマでクラッシュしない', () => {
+    const { useAtomValue } = require('jotai');
+    useAtomValue.mockImplementation((atom: unknown) => {
+      if (atom === require('../store/atoms/station').default) {
+        return {
+          selectedDirection: 'INBOUND',
+          stations: [],
+          selectedBound: null,
+        };
+      }
+      if (atom === require('../store/atoms/theme').themeAtom) {
+        return 'ODAKYU';
+      }
+      return {};
+    });
+
+    expect(() => {
+      render(<TypeChangeNotify />);
+    }).not.toThrow();
+  });
+
+  it('直通運転時に中間路線名が正しく表示される（小田急多摩線→千代田線→常磐線）', () => {
+    const { useAtomValue } = require('jotai');
+    const {
+      useCurrentLine,
+      useCurrentStation,
+      useCurrentTrainType,
+      useNextTrainType,
+    } = require('~/hooks');
+
+    const odakyuTamaLine = {
+      id: 100,
+      nameShort: '小田急多摩線',
+      nameRoman: 'Odakyu Tama Line',
+      color: '#0D82C7',
+    };
+
+    const chiyodaLine = {
+      id: 200,
+      nameShort: '千代田線',
+      nameRoman: 'Chiyoda Line',
+      color: '#009944',
+    };
+
+    const jobanLine = {
+      id: 300,
+      nameShort: '常磐線',
+      nameRoman: 'Joban Line',
+      color: '#00B264',
+    };
+
+    // 直通運転時、station.lineは全て選択路線(小田急多摩線)になるが、
+    // station.linesには実際の路線が含まれる
+    const stations = [
+      {
+        id: 1,
+        groupId: 1,
+        name: '新百合ヶ丘',
+        nameRoman: 'Shin-Yurigaoka',
+        line: odakyuTamaLine,
+        lines: [odakyuTamaLine],
+        trainType: { typeId: 1, name: '急行', nameRoman: 'Express' },
+        stopCondition: 'STOP',
+      },
+      {
+        id: 2,
+        groupId: 2,
+        name: '代々木上原',
+        nameRoman: 'Yoyogi-Uehara',
+        line: odakyuTamaLine,
+        lines: [odakyuTamaLine, chiyodaLine],
+        trainType: { typeId: 2, name: '準急', nameRoman: 'Semi Express' },
+        stopCondition: 'STOP',
+      },
+      {
+        id: 3,
+        groupId: 3,
+        name: '表参道',
+        nameRoman: 'Omote-sando',
+        line: odakyuTamaLine,
+        lines: [chiyodaLine],
+        trainType: { typeId: 2, name: '準急', nameRoman: 'Semi Express' },
+        stopCondition: 'STOP',
+      },
+      {
+        id: 4,
+        groupId: 4,
+        name: '綾瀬',
+        nameRoman: 'Ayase',
+        line: odakyuTamaLine,
+        lines: [chiyodaLine, jobanLine],
+        trainType: { typeId: 2, name: '準急', nameRoman: 'Semi Express' },
+        stopCondition: 'STOP',
+      },
+      {
+        id: 5,
+        groupId: 4,
+        name: '綾瀬',
+        nameRoman: 'Ayase',
+        line: jobanLine,
+        lines: [chiyodaLine, jobanLine],
+        trainType: { typeId: 3, name: '各停', nameRoman: 'Local' },
+        stopCondition: 'STOP',
+      },
+      {
+        id: 6,
+        groupId: 5,
+        name: '取手',
+        nameRoman: 'Toride',
+        line: jobanLine,
+        lines: [jobanLine],
+        trainType: { typeId: 3, name: '各停', nameRoman: 'Local' },
+        stopCondition: 'STOP',
+      },
+    ];
+
+    useCurrentLine.mockReturnValue(odakyuTamaLine);
+    useCurrentStation.mockReturnValue(stations[3]);
+    useCurrentTrainType.mockReturnValue({
+      typeId: 2,
+      name: '準急',
+      nameRoman: 'Semi Express',
+      color: '#009944',
+      line: odakyuTamaLine,
+    });
+    useNextTrainType.mockReturnValue({
+      typeId: 3,
+      name: '各停',
+      nameRoman: 'Local',
+      color: '#00B264',
+      line: jobanLine,
+    });
+
+    useAtomValue.mockImplementation((atom: unknown) => {
+      if (atom === require('../store/atoms/station').default) {
+        return {
+          selectedDirection: 'INBOUND',
+          stations,
+          selectedBound: { name: '取手', nameRoman: 'Toride' },
+        };
+      }
+      if (atom === require('../store/atoms/theme').themeAtom) {
+        return 'TOKYO_METRO';
+      }
+      return {};
+    });
+
+    const { queryAllByText } = render(<TypeChangeNotify />);
+
+    // 左側のバーの路線名が千代田線（中間路線）であること
+    // 小田急多摩線（選択路線）ではないこと
+    const chiyodaTexts = queryAllByText(/千代田線/);
+    expect(chiyodaTexts.length).toBeGreaterThan(0);
+
+    const odakyuTexts = queryAllByText(/小田急多摩線/);
+    expect(odakyuTexts).toHaveLength(0);
   });
 });

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1273,6 +1273,26 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
+  // バー表示用: 現在の種別の駅の.linesから、選択路線(currentLine)でもnextLineでもない路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、.linesから千代田線を取得する
+  const displayCurrentLine = useMemo(() => {
+    if (!nextLine) {
+      return currentLine;
+    }
+    for (const s of stations) {
+      if (s.trainType?.typeId !== trainType?.typeId) {
+        continue;
+      }
+      const found = s.lines?.find(
+        (l) => l.id !== nextLine.id && l.id !== currentLine?.id
+      );
+      if (found) {
+        return found as Line;
+      }
+    }
+    return currentLine;
+  }, [stations, trainType, nextLine, currentLine]);
+
   const aOrAn = useMemo(() => {
     if (!nextTrainType || !trainType) {
       return '';
@@ -1335,7 +1355,13 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
   ]);
 
   const BarsComponent = useCallback(() => {
-    if (!currentLine || !nextLine || !trainType || !nextTrainType) {
+    if (
+      !currentLine ||
+      !displayCurrentLine ||
+      !nextLine ||
+      !trainType ||
+      !nextTrainType
+    ) {
       return null;
     }
 
@@ -1343,7 +1369,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       case 'SAIKYO':
         return (
           <SaikyoBars
-            currentLine={currentLine}
+            currentLine={displayCurrentLine}
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
@@ -1354,7 +1380,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       case 'JL':
         return (
           <JOBars
-            currentLine={currentLine}
+            currentLine={displayCurrentLine}
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
@@ -1363,7 +1389,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       case 'ODAKYU':
         return (
           <OdakyuBars
-            currentLine={currentLine}
+            currentLine={displayCurrentLine}
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
@@ -1372,7 +1398,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       default:
         return (
           <EastBars
-            currentLine={currentLine}
+            currentLine={displayCurrentLine}
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
@@ -1383,6 +1409,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     }
   }, [
     currentLine,
+    displayCurrentLine,
     nextLine,
     trainType,
     nextTrainType,

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -18,6 +18,7 @@ import { themeAtom } from '../store/atoms/theme';
 import isTablet from '../utils/isTablet';
 import truncateTrainType from '../utils/truncateTrainType';
 import { BarTerminalEast } from './BarTerminalEast';
+import { BarTerminalOdakyu } from './BarTerminalOdakyu';
 import { BarTerminalSaikyo } from './BarTerminalSaikyo';
 import Typography from './Typography';
 
@@ -408,6 +409,289 @@ const EastBars = React.memo(function EastBars({
                 color: nextLine.color ?? '#000000',
               },
             ]}
+          >
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
+            {(nextLine.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          </Typography>
+        )}
+      </View>
+    </View>
+  );
+});
+
+const ODAKYU_HIGHLIGHT_OFFSET = 0.35;
+
+const odakyuBarGradient: ColorGradientFn = (color) => [
+  `${color}ff`,
+  `${color}bb`,
+];
+const odakyuBoxGradient: ColorGradientFn = (color) => [
+  `${color}ee`,
+  `${color}aa`,
+];
+
+// BarTerminalOdakyu の viewBox(24x48) に合わせたアスペクト比
+const odakyuTerminalWidth = barHeight / 2;
+
+const OdakyuBars = React.memo(function OdakyuBars({
+  currentLine,
+  nextLine,
+  trainType,
+  nextTrainType,
+}: {
+  currentLine: Line;
+  nextLine: Line;
+  trainType: TrainType;
+  nextTrainType: TrainType;
+}) {
+  const dim = useWindowDimensions();
+  const barWidth = useBarWidth();
+  const rightBarWidth = Math.max(0, barWidth - odakyuTerminalWidth);
+
+  if (!trainType || !nextTrainType) {
+    return null;
+  }
+
+  const leftColor = (nextLine ? currentLine : trainType)?.color ?? '#000000';
+  const rightColor = (nextLine ?? nextTrainType)?.color ?? '#000000';
+
+  return (
+    <View style={[styles.linesContainer, { width: dim.width }]}>
+      {/* Current line - background */}
+      <LinearGradient
+        colors={['#fff', '#000', '#000', '#fff']}
+        locations={[
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          0.9,
+        ]}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+      <LinearGradient
+        colors={odakyuBarGradient('#aaaaaa')}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+      {/* Current line - color overlay */}
+      <LinearGradient
+        colors={['#fff', '#000', '#000', '#fff']}
+        locations={[
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          0.9,
+        ]}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+      <LinearGradient
+        colors={odakyuBarGradient(leftColor)}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+      {/* Current line - shadow */}
+      <LinearGradient
+        colors={['#00000000', '#00000033', '#00000000']}
+        locations={[ODAKYU_HIGHLIGHT_OFFSET, 0.55, 0.85]}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+      {/* Current line - gloss */}
+      <LinearGradient
+        colors={['#ffffff44', '#ffffff11', '#00000000']}
+        locations={[0, ODAKYU_HIGHLIGHT_OFFSET, ODAKYU_HIGHLIGHT_OFFSET]}
+        style={[styles.bar, { left: edgeOffset, width: barWidth }]}
+      />
+
+      <View style={styles.centerCircle} />
+
+      {/* Next line - background */}
+      <LinearGradient
+        colors={['#fff', '#000', '#000', '#fff']}
+        locations={[
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          0.9,
+        ]}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      <LinearGradient
+        colors={odakyuBarGradient('#aaaaaa')}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      {/* Next line - color overlay */}
+      <LinearGradient
+        colors={['#fff', '#000', '#000', '#fff']}
+        locations={[
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          ODAKYU_HIGHLIGHT_OFFSET,
+          0.9,
+        ]}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      <LinearGradient
+        colors={odakyuBarGradient(rightColor)}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      {/* Next line - shadow */}
+      <LinearGradient
+        colors={['#00000000', '#00000033', '#00000000']}
+        locations={[ODAKYU_HIGHLIGHT_OFFSET, 0.55, 0.85]}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      {/* Next line - gloss */}
+      <LinearGradient
+        colors={['#ffffff44', '#ffffff11', '#00000000']}
+        locations={[0, ODAKYU_HIGHLIGHT_OFFSET, ODAKYU_HIGHLIGHT_OFFSET]}
+        style={[
+          styles.bar,
+          { right: edgeOffset + odakyuTerminalWidth, width: rightBarWidth },
+        ]}
+      />
+      <BarTerminalOdakyu
+        width={odakyuTerminalWidth}
+        height={barHeight}
+        style={[
+          styles.barTerminal,
+          { left: edgeOffset + barWidth + rightBarWidth },
+        ]}
+        lineColor={rightColor}
+        hasTerminus={false}
+        barHighlightOffset={ODAKYU_HIGHLIGHT_OFFSET}
+      />
+
+      {/* Train type boxes */}
+      <View style={styles.trainTypeLeft}>
+        <LinearGradient
+          colors={['#aaa', '#000', '#000', '#aaa']}
+          locations={[
+            ODAKYU_HIGHLIGHT_OFFSET,
+            ODAKYU_HIGHLIGHT_OFFSET,
+            ODAKYU_HIGHLIGHT_OFFSET,
+            0.9,
+          ]}
+          style={styles.trainTypeBoxGradient}
+        />
+        <LinearGradient
+          colors={odakyuBoxGradient(trainType.color ?? '#000000')}
+          style={styles.trainTypeBoxGradient}
+        />
+        {/* Box shadow */}
+        <LinearGradient
+          colors={['#00000000', '#00000033', '#00000000']}
+          locations={[ODAKYU_HIGHLIGHT_OFFSET, 0.55, 0.85]}
+          style={styles.trainTypeBoxGradient}
+        />
+        {/* Box gloss */}
+        <LinearGradient
+          colors={['#ffffff44', '#ffffff11', '#00000000']}
+          locations={[0, ODAKYU_HIGHLIGHT_OFFSET, ODAKYU_HIGHLIGHT_OFFSET]}
+          style={styles.trainTypeBoxGradient}
+        />
+
+        <View style={styles.textWrapper}>
+          <Typography
+            style={styles.text}
+            adjustsFontSizeToFit
+            numberOfLines={1}
+          >
+            {(trainType.name ?? '')
+              .replace('\n', '')
+              .replace(parenthesisRegexp, '')}
+          </Typography>
+          <Typography
+            adjustsFontSizeToFit
+            style={styles.textEn}
+            numberOfLines={1}
+          >
+            {truncateTrainType(
+              (trainType.nameRoman ?? '')
+                .replace('\n', '')
+                .replace(parenthesisRegexp, '')
+            )}
+          </Typography>
+        </View>
+        {nextLine && (
+          <Typography
+            style={[
+              styles.lineText,
+              { color: currentLine?.color ?? '#000000' },
+            ]}
+          >
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            {(currentLine?.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
+            {(currentLine?.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          </Typography>
+        )}
+      </View>
+      <View style={styles.trainTypeRight}>
+        <LinearGradient
+          colors={['#aaa', '#000', '#000', '#aaa']}
+          locations={[
+            ODAKYU_HIGHLIGHT_OFFSET,
+            ODAKYU_HIGHLIGHT_OFFSET,
+            ODAKYU_HIGHLIGHT_OFFSET,
+            0.9,
+          ]}
+          style={styles.trainTypeBoxGradient}
+        />
+        <LinearGradient
+          colors={odakyuBoxGradient(nextTrainType.color ?? '#000000')}
+          style={styles.trainTypeBoxGradient}
+        />
+        {/* Box shadow */}
+        <LinearGradient
+          colors={['#00000000', '#00000033', '#00000000']}
+          locations={[ODAKYU_HIGHLIGHT_OFFSET, 0.55, 0.85]}
+          style={styles.trainTypeBoxGradient}
+        />
+        {/* Box gloss */}
+        <LinearGradient
+          colors={['#ffffff44', '#ffffff11', '#00000000']}
+          locations={[0, ODAKYU_HIGHLIGHT_OFFSET, ODAKYU_HIGHLIGHT_OFFSET]}
+          style={styles.trainTypeBoxGradient}
+        />
+
+        <View style={styles.textWrapper}>
+          <Typography
+            style={styles.text}
+            adjustsFontSizeToFit
+            numberOfLines={1}
+          >
+            {(nextTrainType.name ?? '')
+              .replace('\n', '')
+              .replace(parenthesisRegexp, '')}
+          </Typography>
+          <Typography
+            adjustsFontSizeToFit
+            style={styles.textEn}
+            numberOfLines={1}
+          >
+            {truncateTrainType(
+              (nextTrainType.nameRoman ?? '')
+                .replace('\n', '')
+                .replace(parenthesisRegexp, '')
+            )}
+          </Typography>
+        </View>
+        {nextLine && (
+          <Typography
+            style={[styles.lineText, { color: nextLine.color ?? '#000000' }]}
           >
             {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
             {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
@@ -1070,6 +1354,15 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       case 'JL':
         return (
           <JOBars
+            currentLine={currentLine}
+            nextLine={nextLine}
+            trainType={trainType}
+            nextTrainType={nextTrainType}
+          />
+        );
+      case 'ODAKYU':
+        return (
+          <OdakyuBars
             currentLine={currentLine}
             nextLine={nextLine}
             trainType={trainType}


### PR DESCRIPTION
## Summary
- 小田急テーマ(ODAKYU)のTypeChangeNotifyに独自グラデーションデザインを追加（ハイライトオフセット0.35、シャドウ・グロスグラデーション、BarTerminalOdakyu使用）
- 直通運転時（例: 小田急多摩線→千代田線→常磐線）にTypeChangeNotifyの左側バーの路線名が選択路線（小田急多摩線）のまま表示されるバグを修正。`station.lines`（複数形）から中間路線を特定するロジックを追加
- 回帰テストを追加（ODAKYUテーマレンダリング、直通運転時の中間路線名表示）

### バグの原因
- `useCurrentLine()` は直通運転時に全区間で選択路線を返す
- `station.line`（単数）も同様に選択路線が設定される
- `dropEitherJunctionStation` により接続駅の前路線側データが除去される
- `station.lines`（複数形）には実際の所属路線が含まれるため、ここからnextLineでもcurrentLineでもない路線を探索することで正しい中間路線名を取得

## Test plan
- [x] `npm run typecheck` パス
- [x] `npx biome check ./src` パス
- [x] `npm test -- src/components/TypeChangeNotify.test.tsx` 6/6パス
- [x] 小田急多摩線→千代田線→常磐線ルートで左側バーに「千代田線」が表示されること
- [x] 小田急テーマでTypeChangeNotify画面のバーが正しくグラデーション表示されること
- [ ] 他テーマ（TOKYO_METRO, SAIKYO, JO等）で既存動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)