### PR TITLE
小田急テーマに次停車駅案内バナーを追加

### DIFF
--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -16,6 +16,14 @@ jest.mock('~/hooks', () => ({
   useTransferLinesFromStation: jest.fn(() => []),
 }));
 
+jest.mock('~/hooks/useAfterNextStation', () => ({
+  useAfterNextStation: jest.fn(() => undefined),
+}));
+
+jest.mock('~/hooks/useNextStation', () => ({
+  useNextStation: jest.fn(() => undefined),
+}));
+
 jest.mock('~/hooks/useScale', () => ({
   useScale: jest.fn(() => ({ widthScale: jest.fn((val) => val) })),
 }));

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -8,6 +8,8 @@ import {
   useInterval,
   useTransferLinesFromStation,
 } from '~/hooks';
+import { useAfterNextStation } from '~/hooks/useAfterNextStation';
+import { useNextStation } from '~/hooks/useNextStation';
 import { useScale } from '~/hooks/useScale';
 import { isEnAtom } from '~/store/selectors/isEn';
 import lineState from '../store/atoms/line';
@@ -17,6 +19,7 @@ import isTablet from '../utils/isTablet';
 import { BarTerminalEast } from './BarTerminalEast';
 import { BarTerminalOdakyu } from './BarTerminalOdakyu';
 import { type ChevronColor, ChevronTY } from './ChevronTY';
+import { Heading } from './Heading';
 import {
   EmptyStationNameCell,
   LineDot,
@@ -44,6 +47,17 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'visible',
+  },
+  nextStopBanner: {
+    position: 'absolute',
+    bottom: 12,
+    left: '12.5%',
+    right: '12.5%',
+  },
+  nextStopBannerText: {
+    color: '#212121',
+    fontWeight: 'bold',
+    textAlign: 'center',
   },
 });
 
@@ -446,12 +460,29 @@ const LineBoardEast: React.FC<Props> = ({
   );
   const { selectedLine } = useAtomValue(lineState);
   const currentLine = useCurrentLine();
+  const nextStation = useNextStation();
+  const afterNextStation = useAfterNextStation();
 
   const dim = useWindowDimensions();
 
   const line = useMemo(
     () => currentLine || selectedLine,
     [currentLine, selectedLine]
+  );
+
+  const hasPassStation = useMemo(
+    () => stations.some((s) => getIsPass(s)),
+    [stations]
+  );
+
+  const showNextStopBanner = useMemo(
+    () =>
+      isOdakyu &&
+      isTablet &&
+      hasPassStation &&
+      !!nextStation?.name &&
+      !!afterNextStation?.name,
+    [isOdakyu, hasPassStation, nextStation?.name, afterNextStation?.name]
   );
 
   const intervalStep = useCallback(
@@ -523,6 +554,19 @@ const LineBoardEast: React.FC<Props> = ({
       ]}
     >
       {stationsWithEmpty.map(stationNameCellForMap)}
+      {showNextStopBanner ? (
+        <LinearGradient
+          colors={['white', '#ccc', '#ccc', 'white']}
+          start={[0, 1]}
+          end={[1, 0]}
+          locations={[0, 0.1, 0.9, 1]}
+          style={localStyles.nextStopBanner}
+        >
+          <Heading style={localStyles.nextStopBannerText}>
+            {`${nextStation?.name}のつぎは${afterNextStation?.name}にとまります`}
+          </Heading>
+        </LinearGradient>
+      ) : null}
     </View>
   );
 };

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -50,7 +50,7 @@ const localStyles = StyleSheet.create({
   },
   nextStopBanner: {
     position: 'absolute',
-    bottom: 12,
+    bottom: 0,
     left: '12.5%',
     right: '12.5%',
   },


### PR DESCRIPTION
## Summary
- 小田急テーマかつタブレット表示で、直近の区間に通過駅がある場合に「○○のつぎは○○にとまります」バナーをLineBoardEastの下部に表示
- `useNextStation`/`useAfterNextStation`の既存hookを活用
- `TransfersHeading`の埼京線テーマと同じLinearGradientスタイルを流用

## Test plan
- [x] 小田急テーマ+タブレットで快速急行など通過駅のある種別を選択し、バナーが表示されることを確認
- [x] 各駅停車など通過駅がない場合にバナーが表示されないことを確認
- [x] 小田急テーマ以外ではバナーが表示されないことを確認
- [ ] スマートフォン表示ではバナーが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タブレット等の特定表示環境で、画面下部に進行方向の次駅・次々駅の駅名を表示するバナーが追加されました（日本語表記）。
* **Tests**
  * テスト環境で次駅情報を明示的に未設定とするモックを導入し、レンダリング挙動の安定化を図りました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->