### PR TITLE
TrainTypeBox下の次の種別テキストが1行で収まるようにadjustsFontSizeToFitを追加

### DIFF
--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -73,13 +73,17 @@ const styles = StyleSheet.create({
     width: isTablet ? 175 : 96.25,
     height: isTablet ? 55 : 30.25,
   },
-  nextTrainType: {
-    fontWeight: 'bold',
-    fontSize: isTablet ? 18 : 12,
-    marginTop: 4,
+  nextTrainTypeWrapper: {
     position: 'absolute',
     top: isTablet ? 55 : 30.25,
     width: '100%',
+    alignItems: 'center',
+    overflow: 'visible',
+    marginTop: 4,
+  },
+  nextTrainType: {
+    fontWeight: 'bold',
+    fontSize: isTablet ? 18 : 12,
   },
 });
 
@@ -329,24 +333,25 @@ const TrainTypeBox: React.FC<Props> = ({
         </RNAnimated.Text>
       </View>
       {showNextTrainType && nextTrainType?.nameRoman ? (
-        <Typography
-          style={[
-            styles.nextTrainType,
-            {
-              color: nextTrainTypeColor,
-            },
-          ]}
-          numberOfLines={1}
-        >
-          {headerState.split('_')[1] === 'EN'
-            ? `${nextLine?.company?.nameEnglishShort} Line ${truncateTrainType(
-                nextTrainType?.nameRoman?.replace(parenthesisRegexp, ''),
-                true
-              )}`
-            : `${
-                nextLine?.company?.nameShort
-              }線内 ${nextTrainType?.name?.replace(parenthesisRegexp, '')}`}
-        </Typography>
+        <View style={styles.nextTrainTypeWrapper}>
+          <Typography
+            style={[
+              styles.nextTrainType,
+              {
+                color: nextTrainTypeColor,
+              },
+            ]}
+          >
+            {headerState.split('_')[1] === 'EN'
+              ? `${nextLine?.company?.nameEnglishShort} Line ${truncateTrainType(
+                  nextTrainType?.nameRoman?.replace(parenthesisRegexp, ''),
+                  true
+                )}`
+              : `${
+                  nextLine?.company?.nameShort
+                }線内 ${nextTrainType?.name?.replace(parenthesisRegexp, '')}`}
+          </Typography>
+        </View>
       ) : null}
     </View>
   );

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -336,6 +336,8 @@ const TrainTypeBox: React.FC<Props> = ({
               color: nextTrainTypeColor,
             },
           ]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
         >
           {headerState.split('_')[1] === 'EN'
             ? `${nextLine?.company?.nameEnglishShort} Line ${truncateTrainType(

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -76,8 +76,7 @@ const styles = StyleSheet.create({
   nextTrainTypeWrapper: {
     position: 'absolute',
     top: isTablet ? 55 : 30.25,
-    width: '100%',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     overflow: 'visible',
     marginTop: 4,
   },

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -337,7 +337,6 @@ const TrainTypeBox: React.FC<Props> = ({
             },
           ]}
           numberOfLines={1}
-          adjustsFontSizeToFit
         >
           {headerState.split('_')[1] === 'EN'
             ? `${nextLine?.company?.nameEnglishShort} Line ${truncateTrainType(


### PR DESCRIPTION
https://claude.ai/code/session_01AjvvoDzBxFXE7offduqWWm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 次の列車タイプ表示のレイアウトと描画領域を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->