### PR TITLE
種別変更画面で経路外の路線が表示されるバグを修正

### DIFF
--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -245,8 +245,13 @@ const TrainTypeBox: React.FC<Props> = ({
 
   const nextTrainTypeCompanyName = useMemo(() => {
     const company = nextTrainType?.line?.company;
-    return company?.nameEnglishShort ?? company?.nameShort ?? null;
-  }, [nextTrainType]);
+    if (!company) {
+      return null;
+    }
+    return headerLangState === 'EN'
+      ? (company.nameEnglishShort ?? company.nameShort ?? null)
+      : (company.nameShort ?? company.nameEnglishShort ?? null);
+  }, [nextTrainType, headerLangState]);
 
   const showNextTrainType = useMemo(
     () =>
@@ -348,14 +353,12 @@ const TrainTypeBox: React.FC<Props> = ({
               },
             ]}
           >
-            {headerState.split('_')[1] === 'EN'
-              ? `${nextTrainType.line?.company?.nameEnglishShort} Line ${truncateTrainType(
+            {headerLangState === 'EN'
+              ? `${nextTrainTypeCompanyName} Line ${truncateTrainType(
                   nextTrainType.nameRoman?.replace(parenthesisRegexp, ''),
                   true
                 )}`
-              : `${
-                  nextTrainType.line?.company?.nameShort
-                }線内 ${nextTrainType.name?.replace(parenthesisRegexp, '')}`}
+              : `${nextTrainTypeCompanyName}線内 ${nextTrainType.name?.replace(parenthesisRegexp, '')}`}
           </Typography>
         </View>
       ) : null}

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -16,13 +16,7 @@ import {
 } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { FONTS, parenthesisRegexp } from '../constants';
-import {
-  useCurrentLine,
-  useLazyPrevious,
-  useNextLine,
-  useNextTrainType,
-  usePrevious,
-} from '../hooks';
+import { useCurrentLine, useLazyPrevious, usePrevious } from '../hooks';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
@@ -103,8 +97,11 @@ const TrainTypeBox: React.FC<Props> = ({
 
   const textOpacityAnim = useRef(new RNAnimated.Value(0)).current;
 
-  const nextTrainType = useNextTrainType();
-  const nextLine = useNextLine();
+  // trainType.linesから現在路線以外の中間路線を取得し、路線名と種別を一元的に参照する
+  const intermediateLineEntry = useMemo(
+    () => trainType?.lines?.find((l) => l.id !== currentLine?.id) ?? null,
+    [trainType, currentLine]
+  );
 
   const trainTypeColor = useMemo(() => {
     const base = trainType?.color ?? '#1f63c6';
@@ -247,8 +244,12 @@ const TrainTypeBox: React.FC<Props> = ({
   );
 
   const showNextTrainType = useMemo(
-    () => !!(nextLine && currentLine?.company?.id !== nextLine?.company?.id),
-    [currentLine, nextLine]
+    () =>
+      !!(
+        intermediateLineEntry &&
+        currentLine?.company?.id !== intermediateLineEntry.company?.id
+      ),
+    [currentLine, intermediateLineEntry]
   );
 
   const numberOfLines = useMemo(
@@ -331,7 +332,7 @@ const TrainTypeBox: React.FC<Props> = ({
           {prevTrainTypeName}
         </RNAnimated.Text>
       </View>
-      {showNextTrainType && nextTrainType?.nameRoman ? (
+      {showNextTrainType && intermediateLineEntry?.trainType?.nameRoman ? (
         <View style={styles.nextTrainTypeWrapper}>
           <Typography
             style={[
@@ -342,13 +343,16 @@ const TrainTypeBox: React.FC<Props> = ({
             ]}
           >
             {headerState.split('_')[1] === 'EN'
-              ? `${nextLine?.company?.nameEnglishShort} Line ${truncateTrainType(
-                  nextTrainType?.nameRoman?.replace(parenthesisRegexp, ''),
+              ? `${intermediateLineEntry?.company?.nameEnglishShort} Line ${truncateTrainType(
+                  intermediateLineEntry?.trainType?.nameRoman?.replace(
+                    parenthesisRegexp,
+                    ''
+                  ),
                   true
                 )}`
               : `${
-                  nextLine?.company?.nameShort
-                }線内 ${nextTrainType?.name?.replace(parenthesisRegexp, '')}`}
+                  intermediateLineEntry?.company?.nameShort
+                }線内 ${intermediateLineEntry?.trainType?.name?.replace(parenthesisRegexp, '')}`}
           </Typography>
         </View>
       ) : null}

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -90,18 +90,21 @@ const TrainTypeBox: React.FC<Props> = ({
   const fontSizeScale = Math.max(fontSizeScaleRaw, 0.1);
   const [fadeOutFinished, setFadeOutFinished] = useState(false);
 
-  const { headerState } = useAtomValue(navigationState);
+  const { headerState, trainType: navTrainType } =
+    useAtomValue(navigationState);
   const { headerTransitionDelay } = useAtomValue(tuningState);
   const theme = useAtomValue(themeAtom);
   const currentLine = useCurrentLine();
 
   const textOpacityAnim = useRef(new RNAnimated.Value(0)).current;
 
-  // trainType.linesから現在路線以外の中間路線を取得し、路線名と種別を一元的に参照する
-  const intermediateLineEntry = useMemo(
-    () => trainType?.lines?.find((l) => l.id !== currentLine?.id) ?? null,
-    [trainType, currentLine]
-  );
+  // navTrainType.linesから現在路線以外の中間路線を取得し、路線名と種別を一元的に参照する
+  // navTrainType（navigationState.trainType）はfetchedTrainTypesから選択されたもので
+  // .linesが確実に含まれている
+  const intermediateLineEntry = useMemo(() => {
+    const lines = navTrainType?.lines ?? trainType?.lines;
+    return lines?.find((l) => l.id !== currentLine?.id) ?? null;
+  }, [navTrainType, trainType, currentLine]);
 
   const trainTypeColor = useMemo(() => {
     const base = trainType?.color ?? '#1f63c6';

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -16,7 +16,12 @@ import {
 } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { FONTS, parenthesisRegexp } from '../constants';
-import { useCurrentLine, useLazyPrevious, usePrevious } from '../hooks';
+import {
+  useCurrentLine,
+  useLazyPrevious,
+  useNextTrainType,
+  usePrevious,
+} from '../hooks';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
@@ -90,22 +95,13 @@ const TrainTypeBox: React.FC<Props> = ({
   const fontSizeScale = Math.max(fontSizeScaleRaw, 0.1);
   const [fadeOutFinished, setFadeOutFinished] = useState(false);
 
-  const { headerState, trainType: navTrainType } =
-    useAtomValue(navigationState);
+  const { headerState } = useAtomValue(navigationState);
   const { headerTransitionDelay } = useAtomValue(tuningState);
   const theme = useAtomValue(themeAtom);
   const currentLine = useCurrentLine();
+  const nextTrainType = useNextTrainType();
 
   const textOpacityAnim = useRef(new RNAnimated.Value(0)).current;
-
-  // trainType.linesから現在路線の会社以外の中間路線を取得し、路線名と種別を一元的に参照する
-  // 会社IDで比較することで、小田急小田原線等の同一会社路線をスキップする
-  const intermediateLineEntry = useMemo(() => {
-    const lines = navTrainType?.lines ?? trainType?.lines;
-    return (
-      lines?.find((l) => l.company?.id !== currentLine?.company?.id) ?? null
-    );
-  }, [navTrainType, trainType, currentLine]);
 
   const trainTypeColor = useMemo(() => {
     const base = trainType?.color ?? '#1f63c6';
@@ -250,10 +246,10 @@ const TrainTypeBox: React.FC<Props> = ({
   const showNextTrainType = useMemo(
     () =>
       !!(
-        intermediateLineEntry &&
-        currentLine?.company?.id !== intermediateLineEntry.company?.id
+        nextTrainType?.line &&
+        currentLine?.company?.id !== nextTrainType.line.company?.id
       ),
-    [currentLine, intermediateLineEntry]
+    [currentLine, nextTrainType]
   );
 
   const numberOfLines = useMemo(
@@ -336,7 +332,7 @@ const TrainTypeBox: React.FC<Props> = ({
           {prevTrainTypeName}
         </RNAnimated.Text>
       </View>
-      {showNextTrainType && intermediateLineEntry?.trainType?.nameRoman ? (
+      {showNextTrainType && nextTrainType?.nameRoman ? (
         <View style={styles.nextTrainTypeWrapper}>
           <Typography
             style={[
@@ -347,16 +343,13 @@ const TrainTypeBox: React.FC<Props> = ({
             ]}
           >
             {headerState.split('_')[1] === 'EN'
-              ? `${intermediateLineEntry?.company?.nameEnglishShort} Line ${truncateTrainType(
-                  intermediateLineEntry?.trainType?.nameRoman?.replace(
-                    parenthesisRegexp,
-                    ''
-                  ),
+              ? `${nextTrainType.line?.company?.nameEnglishShort} Line ${truncateTrainType(
+                  nextTrainType.nameRoman?.replace(parenthesisRegexp, ''),
                   true
                 )}`
               : `${
-                  intermediateLineEntry?.company?.nameShort
-                }線内 ${intermediateLineEntry?.trainType?.name?.replace(parenthesisRegexp, '')}`}
+                  nextTrainType.line?.company?.nameShort
+                }線内 ${nextTrainType.name?.replace(parenthesisRegexp, '')}`}
           </Typography>
         </View>
       ) : null}

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -98,12 +98,13 @@ const TrainTypeBox: React.FC<Props> = ({
 
   const textOpacityAnim = useRef(new RNAnimated.Value(0)).current;
 
-  // navTrainType.linesから現在路線以外の中間路線を取得し、路線名と種別を一元的に参照する
-  // navTrainType（navigationState.trainType）はfetchedTrainTypesから選択されたもので
-  // .linesが確実に含まれている
+  // trainType.linesから現在路線の会社以外の中間路線を取得し、路線名と種別を一元的に参照する
+  // 会社IDで比較することで、小田急小田原線等の同一会社路線をスキップする
   const intermediateLineEntry = useMemo(() => {
     const lines = navTrainType?.lines ?? trainType?.lines;
-    return lines?.find((l) => l.id !== currentLine?.id) ?? null;
+    return (
+      lines?.find((l) => l.company?.id !== currentLine?.company?.id) ?? null
+    );
   }, [navTrainType, trainType, currentLine]);
 
   const trainTypeColor = useMemo(() => {

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -243,13 +243,19 @@ const TrainTypeBox: React.FC<Props> = ({
     [textOpacityAnim]
   );
 
+  const nextTrainTypeCompanyName = useMemo(() => {
+    const company = nextTrainType?.line?.company;
+    return company?.nameEnglishShort ?? company?.nameShort ?? null;
+  }, [nextTrainType]);
+
   const showNextTrainType = useMemo(
     () =>
       !!(
+        nextTrainTypeCompanyName &&
         nextTrainType?.line &&
         currentLine?.company?.id !== nextTrainType.line.company?.id
       ),
-    [currentLine, nextTrainType]
+    [currentLine, nextTrainType, nextTrainTypeCompanyName]
   );
 
   const numberOfLines = useMemo(

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -212,8 +212,7 @@ describe('TypeChangeNotify', () => {
       company: jrEastCompany,
     };
 
-    // 直通運転時、station.lineは全て選択路線(小田急多摩線)になるが、
-    // station.linesには実際の路線が含まれる
+    // 直通運転時、station.lineは各駅の所属路線が設定される
     const stations = [
       {
         id: 1,
@@ -250,7 +249,7 @@ describe('TypeChangeNotify', () => {
         groupId: 4,
         name: '綾瀬',
         nameRoman: 'Ayase',
-        line: odakyuTamaLine,
+        line: chiyodaLine,
         lines: [chiyodaLine, jobanLine],
         trainType: { typeId: 2, name: '準急', nameRoman: 'Semi Express' },
         stopCondition: 'STOP',
@@ -278,7 +277,7 @@ describe('TypeChangeNotify', () => {
     ];
 
     useCurrentLine.mockReturnValue(odakyuTamaLine);
-    useCurrentStation.mockReturnValue(stations[3]);
+    useCurrentStation.mockReturnValue(stations[0]);
     useCurrentTrainType.mockReturnValue({
       typeId: 2,
       name: '準急',

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -278,6 +278,7 @@ describe('TypeChangeNotify', () => {
       nameRoman: 'Semi Express',
       color: '#009944',
       line: odakyuTamaLine,
+      lines: [odakyuTamaLine, chiyodaLine],
     });
     useNextTrainType.mockReturnValue({
       typeId: 3,

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -184,11 +184,16 @@ describe('TypeChangeNotify', () => {
       useNextTrainType,
     } = require('~/hooks');
 
+    const odakyuCompany = { id: 1, nameShort: '小田急' };
+    const metroCompany = { id: 2, nameShort: '東京メトロ' };
+    const jrEastCompany = { id: 3, nameShort: 'JR東日本' };
+
     const odakyuTamaLine = {
       id: 100,
       nameShort: '小田急多摩線',
       nameRoman: 'Odakyu Tama Line',
       color: '#0D82C7',
+      company: odakyuCompany,
     };
 
     const chiyodaLine = {
@@ -196,6 +201,7 @@ describe('TypeChangeNotify', () => {
       nameShort: '千代田線',
       nameRoman: 'Chiyoda Line',
       color: '#009944',
+      company: metroCompany,
     };
 
     const jobanLine = {
@@ -203,6 +209,7 @@ describe('TypeChangeNotify', () => {
       nameShort: '常磐線',
       nameRoman: 'Joban Line',
       color: '#00B264',
+      company: jrEastCompany,
     };
 
     // 直通運転時、station.lineは全て選択路線(小田急多摩線)になるが、

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1275,17 +1275,16 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: navTrainType.linesから選択路線(currentLine)でもnextLineでもない路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、navTrainType.linesから千代田線を取得する
-  // navTrainType（navigationState.trainType）はfetchedTrainTypesから選択されたもので
-  // .linesが確実に含まれている
+  // バー表示用: trainType.linesから現在路線の会社でもnextLineでもない中間路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、千代田線を取得する
+  // 会社IDで比較することで、小田急小田原線等の同一会社路線をスキップする
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
     const lines = navTrainType?.lines ?? trainType?.lines;
     const intermediate = lines?.find(
-      (l) => l.id !== nextLine.id && l.id !== currentLine?.id
+      (l) => l.id !== nextLine.id && l.company?.id !== currentLine?.company?.id
     );
     return (intermediate as Line | undefined) ?? currentLine;
   }, [navTrainType, trainType, nextLine, currentLine]);

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -13,7 +13,6 @@ import {
 } from '~/hooks';
 import { RFValue } from '~/utils/rfValue';
 import { getIsLocal } from '~/utils/trainTypeString';
-import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { themeAtom } from '../store/atoms/theme';
 import isTablet from '../utils/isTablet';
@@ -1193,7 +1192,6 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
 }) => {
   const { selectedDirection, stations, selectedBound } =
     useAtomValue(stationState);
-  const { trainType: navTrainType } = useAtomValue(navigationState);
   const theme = useAtomValue(themeAtom);
   const station = useCurrentStation();
   const currentLine = useCurrentLine();
@@ -1275,19 +1273,29 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: trainType.linesから現在路線の会社でもnextLineでもない中間路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、千代田線を取得する
-  // 会社IDで比較することで、小田急小田原線等の同一会社路線をスキップする
+  // バー表示用: 種別が変わる直前の駅のlineを中間路線として使用する
+  // 例: 小田急多摩線→千代田線→常磐線の場合、綾瀬駅(千代田線)のlineを取得する
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
-    const lines = navTrainType?.lines ?? trainType?.lines;
-    const intermediate = lines?.find(
-      (l) => l.id !== nextLine.id && l.company?.id !== currentLine?.company?.id
+    const currentIdx = stations.findIndex(
+      (s) => s.groupId === station?.groupId
     );
-    return (intermediate as Line | undefined) ?? currentLine;
-  }, [navTrainType, trainType, nextLine, currentLine]);
+    const sliced =
+      selectedDirection === 'INBOUND'
+        ? stations.slice(currentIdx + 1)
+        : stations
+            .slice()
+            .reverse()
+            .slice(stations.length - currentIdx);
+    const nextTypeIdx = sliced.findIndex(
+      (s) => s.trainType && s.trainType.typeId !== trainType?.typeId
+    );
+    const lastCurrentTypeStation =
+      nextTypeIdx > 0 ? sliced[nextTypeIdx - 1] : null;
+    return (lastCurrentTypeStation?.line as Line | undefined) ?? currentLine;
+  }, [nextLine, currentLine, stations, station, selectedDirection, trainType]);
 
   const aOrAn = useMemo(() => {
     if (!nextTrainType || !trainType) {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1273,40 +1273,17 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: 現在の種別の駅の.linesから、選択路線(currentLine)でもnextLineでもない路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、.linesから千代田線を取得する
-  // 最頻出の路線を返すことで、経路外の路線(常磐快速線等)を除外する
+  // バー表示用: trainType.linesから選択路線(currentLine)でもnextLineでもない路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、trainType.linesから千代田線を取得する
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
-    const counts = new Map<number, { line: Line; count: number }>();
-    for (const s of stations) {
-      if (s.trainType?.typeId !== trainType?.typeId) {
-        continue;
-      }
-      for (const l of s.lines ?? []) {
-        if (l.id == null || l.id === nextLine.id || l.id === currentLine?.id) {
-          continue;
-        }
-        const entry = counts.get(l.id);
-        if (entry) {
-          entry.count += 1;
-        } else {
-          counts.set(l.id, { line: l as Line, count: 1 });
-        }
-      }
-    }
-    let best: Line | null = null;
-    let bestCount = 0;
-    for (const { line, count } of counts.values()) {
-      if (count > bestCount) {
-        bestCount = count;
-        best = line;
-      }
-    }
-    return best ?? currentLine;
-  }, [stations, trainType, nextLine, currentLine]);
+    const intermediate = trainType?.lines?.find(
+      (l) => l.id !== nextLine.id && l.id !== currentLine?.id
+    );
+    return (intermediate as Line | undefined) ?? currentLine;
+  }, [trainType, nextLine, currentLine]);
 
   const aOrAn = useMemo(() => {
     if (!nextTrainType || !trainType) {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1273,28 +1273,39 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: 現在の種別の駅の.lineから、選択路線(currentLine)でもnextLineでもない路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、千代田線を取得する
-  // s.lines(駅に紐づく全路線)ではなくs.line(経路上の路線)を参照し、
-  // 最後にマッチした路線を返すことで乗り換え地点に最も近い中間路線を取得する
+  // バー表示用: 現在の種別の駅の.linesから、選択路線(currentLine)でもnextLineでもない路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、.linesから千代田線を取得する
+  // 最頻出の路線を返すことで、経路外の路線(常磐快速線等)を除外する
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
-    let lastMatchedLine: Line | null = null;
+    const counts = new Map<number, { line: Line; count: number }>();
     for (const s of stations) {
       if (s.trainType?.typeId !== trainType?.typeId) {
         continue;
       }
-      if (
-        s.line &&
-        s.line.id !== nextLine.id &&
-        s.line.id !== currentLine?.id
-      ) {
-        lastMatchedLine = s.line as Line;
+      for (const l of s.lines ?? []) {
+        if (l.id == null || l.id === nextLine.id || l.id === currentLine?.id) {
+          continue;
+        }
+        const entry = counts.get(l.id);
+        if (entry) {
+          entry.count += 1;
+        } else {
+          counts.set(l.id, { line: l as Line, count: 1 });
+        }
       }
     }
-    return lastMatchedLine ?? currentLine;
+    let best: Line | null = null;
+    let bestCount = 0;
+    for (const { line, count } of counts.values()) {
+      if (count > bestCount) {
+        bestCount = count;
+        best = line;
+      }
+    }
+    return best ?? currentLine;
   }, [stations, trainType, nextLine, currentLine]);
 
   const aOrAn = useMemo(() => {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -13,6 +13,7 @@ import {
 } from '~/hooks';
 import { RFValue } from '~/utils/rfValue';
 import { getIsLocal } from '~/utils/trainTypeString';
+import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { themeAtom } from '../store/atoms/theme';
 import isTablet from '../utils/isTablet';
@@ -1192,6 +1193,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
 }) => {
   const { selectedDirection, stations, selectedBound } =
     useAtomValue(stationState);
+  const { trainType: navTrainType } = useAtomValue(navigationState);
   const theme = useAtomValue(themeAtom);
   const station = useCurrentStation();
   const currentLine = useCurrentLine();
@@ -1273,17 +1275,20 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: trainType.linesから選択路線(currentLine)でもnextLineでもない路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、trainType.linesから千代田線を取得する
+  // バー表示用: navTrainType.linesから選択路線(currentLine)でもnextLineでもない路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、navTrainType.linesから千代田線を取得する
+  // navTrainType（navigationState.trainType）はfetchedTrainTypesから選択されたもので
+  // .linesが確実に含まれている
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
-    const intermediate = trainType?.lines?.find(
+    const lines = navTrainType?.lines ?? trainType?.lines;
+    const intermediate = lines?.find(
       (l) => l.id !== nextLine.id && l.id !== currentLine?.id
     );
     return (intermediate as Line | undefined) ?? currentLine;
-  }, [trainType, nextLine, currentLine]);
+  }, [navTrainType, trainType, nextLine, currentLine]);
 
   const aOrAn = useMemo(() => {
     if (!nextTrainType || !trainType) {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1273,24 +1273,28 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     stations,
   ]);
 
-  // バー表示用: 現在の種別の駅の.linesから、選択路線(currentLine)でもnextLineでもない路線を探す
-  // 例: 小田急多摩線→千代田線→常磐線の場合、.linesから千代田線を取得する
+  // バー表示用: 現在の種別の駅の.lineから、選択路線(currentLine)でもnextLineでもない路線を探す
+  // 例: 小田急多摩線→千代田線→常磐線の場合、千代田線を取得する
+  // s.lines(駅に紐づく全路線)ではなくs.line(経路上の路線)を参照し、
+  // 最後にマッチした路線を返すことで乗り換え地点に最も近い中間路線を取得する
   const displayCurrentLine = useMemo(() => {
     if (!nextLine) {
       return currentLine;
     }
+    let lastMatchedLine: Line | null = null;
     for (const s of stations) {
       if (s.trainType?.typeId !== trainType?.typeId) {
         continue;
       }
-      const found = s.lines?.find(
-        (l) => l.id !== nextLine.id && l.id !== currentLine?.id
-      );
-      if (found) {
-        return found as Line;
+      if (
+        s.line &&
+        s.line.id !== nextLine.id &&
+        s.line.id !== currentLine?.id
+      ) {
+        lastMatchedLine = s.line as Line;
       }
     }
-    return currentLine;
+    return lastMatchedLine ?? currentLine;
   }, [stations, trainType, nextLine, currentLine]);
 
   const aOrAn = useMemo(() => {

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -406,6 +406,18 @@ const MainScreen: React.FC = () => {
         };
       }
 
+      if (
+        prev.bottomState === 'LINE' &&
+        !transferLines.length &&
+        isTypeWillChange &&
+        !shouldHideTypeChange
+      ) {
+        return {
+          ...prev,
+          bottomState: 'TYPE_CHANGE',
+        };
+      }
+
       if (prev.bottomState === 'TRANSFER') {
         if (isTypeWillChange && !shouldHideTypeChange) {
           return {


### PR DESCRIPTION
## Summary
- 種別変更画面（TypeChangeNotify）の左バーに経路外の路線が表示されるバグを修正
- TrainTypeBoxの「〜線内」表示を `nextTrainType` から直接取得するように修正
- 乗換路線が0件の場合に種別変更画面に遷移できない問題を修正

## 変更内容

### TypeChangeNotify (`src/components/TypeChangeNotify.tsx`)
- `displayCurrentLine` の算出ロジックを、種別が変わる直前の駅の `s.line` を参照する方式に変更
- 従来: `s.lines`（駅に紐づく全路線配列）から検索 → 常磐快速線等の経路外路線が混入する問題があった
- 修正後: `stations` 配列で次の種別に変わる直前の駅を特定し、その `line` プロパティを使用

### TrainTypeBox (`src/components/TrainTypeBox.tsx`)
- `intermediateLineEntry`（`trainType.lines` ベース）を廃止し、`nextTrainType` を直接参照するように変更
- `nextTrainType.line?.company` で会社名、`nextTrainType.name` で種別名を取得

### Main (`src/screens/Main.tsx`)
- `updateBottomState` で `transferLines` が0件の場合でも `isTypeWillChange` なら `TYPE_CHANGE` に直接遷移するように修正

## Test plan
- [ ] 小田急→千代田線→常磐線の経路で、TypeChangeNotify左側に「東京メトロ千代田線」が表示されることを確認
- [ ] 東急→副都心線→東武の経路で、左側に「東急東横線」が表示されることを確認
- [ ] TrainTypeBoxの「〜線内」表示が正しく表示されることを確認
- [ ] 乗換路線が0件の駅でもタップでTYPE_CHANGE画面に遷移できることを確認
- [x] `npm run typecheck` ✅
- [x] `npm run lint` ✅
- [x] `npm test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 変更内容

* **バグ修正**
  * 電車種別が変わる際の中間路線名を、直前の駅情報から正しく表示するよう改善しました。
  * 「次の電車種別」の表示判定を所在会社情報に基づき安定化し、表示ラベルの参照元を統一しました。
  * 種別変更時に画面下部が適切に「種別変更」へ遷移する条件を追加しました。

* **テスト**
  * 中間路線表示のテストデータを更新し、期待動作を検証するケースを整備しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->