### PR TITLE
東京メトロテーマのヘッダー駅名・状態テキストの色をmasterと同じ黒に修正

### DIFF
--- a/src/components/HeaderEast/HeaderEast.tsx
+++ b/src/components/HeaderEast/HeaderEast.tsx
@@ -126,6 +126,8 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
 
   const dim = useWindowDimensions();
 
+  const stationNameColor = config.stationNameColor ?? config.textColor;
+
   const dividerBackgroundColor =
     config.divider.color === 'dynamic'
       ? (currentLine?.color ?? '#b5b5ac')
@@ -263,7 +265,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
               style={[
                 animation.stateTopAnimatedStyles,
                 selectedBound && firstStop ? styles.firstText : styles.state,
-                { color: config.textColor },
+                { color: stationNameColor },
               ]}
               adjustsFontSizeToFit
               numberOfLines={2}
@@ -274,7 +276,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
               style={[
                 animation.stateBottomAnimatedStyles,
                 selectedBound && firstStop ? styles.firstText : styles.state,
-                { color: config.textColor },
+                { color: stationNameColor },
               ]}
               adjustsFontSizeToFit
               numberOfLines={2}
@@ -304,7 +306,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                   {
                     fontSize: STATION_NAME_FONT_SIZE,
                     transformOrigin: 'top',
-                    color: config.textColor,
+                    color: stationNameColor,
                   },
                 ]}
               >
@@ -329,7 +331,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                   {
                     fontSize: STATION_NAME_FONT_SIZE,
                     transformOrigin: 'bottom',
-                    color: config.textColor,
+                    color: stationNameColor,
                   },
                 ]}
               >
@@ -346,7 +348,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 style={[
                   animation.stateTopAnimatedStylesRight,
                   styles.firstText,
-                  { color: config.textColor },
+                  { color: stationNameColor },
                 ]}
               >
                 {stateTextRight}
@@ -355,7 +357,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 style={[
                   animation.stateBottomAnimatedStylesRight,
                   styles.firstText,
-                  { color: config.textColor },
+                  { color: stationNameColor },
                 ]}
               >
                 {animation.prevStateTextRight}

--- a/src/components/HeaderEast/config.ts
+++ b/src/components/HeaderEast/config.ts
@@ -7,6 +7,7 @@ export type HeaderEastThemeConfig = {
   rootStyle: ViewStyle;
   gradientRootExtraStyle?: ViewStyle;
   textColor: string;
+  stationNameColor?: string;
   bottomPaddingBottom: number;
   divider: {
     height: number;
@@ -43,6 +44,7 @@ export const tokyoMetroConfig: HeaderEastThemeConfig = {
     paddingBottom: 4,
   },
   textColor: '#555',
+  stationNameColor: '#000',
   bottomPaddingBottom: 0,
   divider: {
     height: isTablet ? 6 : 4,


### PR DESCRIPTION
https://claude.ai/code/session_01Tnmkkjgw6qZ5RH6BxdvJfV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ステーション名の色をテキスト色から独立して設定できるようになりました。テーマのカスタマイズがより細かくできるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->