### PR TITLE
TrainTypeBoxの〜線内表示の折り返しを修正

### DIFF
--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -266,7 +266,7 @@ const TrainTypeBox: React.FC<Props> = ({
   );
 
   const nextTrainTypeWrapperStyle = useMemo(
-    () => [styles.nextTrainTypeWrapper, { width: windowWidth }] as const,
+    () => [styles.nextTrainTypeWrapper, { width: windowWidth }],
     [windowWidth]
   );
 

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   Animated as RNAnimated,
   StyleSheet,
+  useWindowDimensions,
   View,
 } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
@@ -95,6 +96,7 @@ const TrainTypeBox: React.FC<Props> = ({
   const fontSizeScale = Math.max(fontSizeScaleRaw, 0.1);
   const [fadeOutFinished, setFadeOutFinished] = useState(false);
 
+  const { width: windowWidth } = useWindowDimensions();
   const { headerState } = useAtomValue(navigationState);
   const { headerTransitionDelay } = useAtomValue(tuningState);
   const theme = useAtomValue(themeAtom);
@@ -263,6 +265,11 @@ const TrainTypeBox: React.FC<Props> = ({
     [currentLine, nextTrainType, nextTrainTypeCompanyName]
   );
 
+  const nextTrainTypeWrapperStyle = useMemo(
+    () => [styles.nextTrainTypeWrapper, { width: windowWidth }] as const,
+    [windowWidth]
+  );
+
   const numberOfLines = useMemo(
     // trainTypeNameがundefined/nullの場合のクラッシュを防ぐためのオプショナルチェーニング
     () => (trainTypeName?.split('\n').length === 1 ? 1 : 2),
@@ -344,7 +351,7 @@ const TrainTypeBox: React.FC<Props> = ({
         </RNAnimated.Text>
       </View>
       {showNextTrainType && nextTrainType?.nameRoman ? (
-        <View style={styles.nextTrainTypeWrapper}>
+        <View style={nextTrainTypeWrapperStyle}>
           <Typography
             style={[
               styles.nextTrainType,


### PR DESCRIPTION
## Summary
- TrainTypeBoxの「〜線内 種別」テキストがboxの幅（96.25/175px）で折り返されていた問題を修正
- `useWindowDimensions`フックで画面幅を取得し、`nextTrainTypeWrapper`に適用することで1行表示に変更
- 画面回転時にも追従する動的な幅指定

## Test plan
- [x] 直通運転時に「〜線内 種別」が1行で表示されることを確認
- [x] 画面回転時にレイアウトが崩れないことを確認
- [x] タブレット端末での表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 次の電車タイプの表示がウィンドウサイズに応じて動的に調整されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->