### PR TITLE
E231系テーマの列車種別表示を改善

### DIFF
--- a/src/components/TrainTypeBoxE231.tsx
+++ b/src/components/TrainTypeBoxE231.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { getLuminance } from 'polished';
 import React, { useMemo } from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
@@ -12,8 +12,9 @@ import { translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
-import { getIsLocal, getIsRapid } from '~/utils/trainTypeString';
+import { getIsLocal } from '~/utils/trainTypeString';
 import truncateTrainType from '~/utils/truncateTrainType';
+import Typography from './Typography';
 
 type Props = {
   trainType: TrainType | null;
@@ -22,11 +23,21 @@ type Props = {
 const styles = StyleSheet.create({
   container: {
     position: 'relative',
+    overflow: 'visible',
+  },
+  outerContainer: {
+    height: Math.round(RFValue(28) * 1.1) * 2,
+    justifyContent: 'center',
+    overflow: 'visible',
+  },
+  enOverrideContainer: {
+    alignItems: 'center',
   },
   textBase: {
     textAlign: 'left',
     fontWeight: 'bold',
     fontSize: RFValue(36),
+    letterSpacing: 0,
   },
   strokeBase: {
     position: 'absolute',
@@ -64,6 +75,30 @@ const SHORT_NAME_KO: Record<string, string> = {
   [TrainTypeKind.LimitedExpress]: '특급',
 };
 
+type EnOverride = {
+  heading: string;
+  body: string;
+  headingFontSize?: number;
+  bodyFontSize?: number;
+};
+
+const SHORT_NAME_EN: Record<string, EnOverride> = {
+  中央特快: { heading: 'Chūō', body: 'Special Rapid' },
+  青梅特快: { heading: 'Ōme', body: 'Special Rapid' },
+  通勤特快: {
+    heading: 'Commuter',
+    body: 'Special Rapid',
+    headingFontSize: 21,
+    bodyFontSize: 16,
+  },
+  通勤快速: {
+    heading: 'Commuter',
+    body: 'Rapid',
+    headingFontSize: 21,
+    bodyFontSize: 21,
+  },
+};
+
 const formatCjk = (
   name: string | undefined | null,
   kind: TrainTypeKind | null | undefined,
@@ -98,9 +133,6 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
   const trainTypeColor = useMemo(() => {
     if (getIsLocal(trainType)) {
       return '#FFD400';
-    }
-    if (getIsRapid(trainType)) {
-      return '#f15a22';
     }
     return trainType?.color ?? '#FFD400';
   }, [trainType]);
@@ -152,7 +184,13 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
       return lineNameJa;
     }
     switch (headerLangState) {
-      case 'EN':
+      case 'EN': {
+        const enOverride = trainTypeNameJa
+          ? SHORT_NAME_EN[trainTypeNameJa]
+          : null;
+        if (enOverride) {
+          return `${enOverride.heading}\n${enOverride.body}`;
+        }
         if (
           trainType?.kind === TrainTypeKind.Express ||
           trainType?.kind === TrainTypeKind.LimitedExpress
@@ -166,6 +204,7 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
           return 'Rapid';
         }
         return trainTypeNameR;
+      }
       case 'ZH':
         return formatCjk(trainTypeNameZh, trainType?.kind, 'ZH');
       case 'KO':
@@ -184,19 +223,28 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
     trainType?.kind,
   ]);
 
+  const isEn = headerLangState === 'EN';
+
+  const enOverride = useMemo(() => {
+    if (!isEn || !trainTypeNameJa) {
+      return null;
+    }
+    return SHORT_NAME_EN[trainTypeNameJa] ?? null;
+  }, [isEn, trainTypeNameJa]);
+
   const letterSpacing = useMemo(() => {
-    if (trainTypeName?.length === 2) {
+    if (trainTypeName?.length === 2 && isEn) {
       return 8;
     }
     return 0;
-  }, [trainTypeName?.length]);
+  }, [trainTypeName?.length, isEn]);
 
   const paddingLeft = useMemo(() => {
-    if (trainTypeName?.length === 2 && Platform.OS === 'ios') {
+    if (trainTypeName?.length === 2 && isEn && Platform.OS === 'ios') {
       return 8;
     }
     return 0;
-  }, [trainTypeName?.length]);
+  }, [trainTypeName?.length, isEn]);
 
   if (!trainTypeName) {
     return null;
@@ -205,7 +253,6 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
   const rawLength = trainTypeName.replace('\n', '').length;
   const fontSize =
     headerLangState === 'EN' || rawLength <= 2 ? RFValue(36) : RFValue(28);
-  const lineHeight = Math.round(fontSize * 1.05);
   const numberOfLines = trainTypeName.includes('\n') ? 2 : 1;
   const strokeWidth = isTablet ? 3 : 2;
   const strokeOffsets = [
@@ -219,45 +266,91 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
     { width: -strokeWidth, height: strokeWidth },
   ];
 
-  return (
-    <View style={styles.container}>
-      {strokeOffsets.map((offset) => (
-        <Text
-          key={`${offset.width}_${offset.height}`}
-          numberOfLines={numberOfLines}
+  const renderStrokedText = (
+    text: string,
+    size: number,
+    color: string,
+    lines: number,
+    align: 'left' | 'center' = 'left'
+  ) => {
+    const lh = Math.round(size * 1.1);
+    const skew = isEn ? [{ skewX: '-7.5deg' }] : [];
+    return (
+      <View style={styles.container}>
+        {strokeOffsets.map((offset) => (
+          <Typography
+            key={`${offset.width}_${offset.height}`}
+            numberOfLines={lines}
+            style={[
+              styles.strokeBase,
+              {
+                fontSize: size,
+                lineHeight: lh,
+                color: strokeColor,
+                paddingLeft: align === 'left' ? paddingLeft : 0,
+                letterSpacing: align === 'left' ? letterSpacing : 0,
+                textAlign: align,
+                transform: [
+                  { translateX: offset.width },
+                  { translateY: offset.height },
+                  ...skew,
+                ],
+              },
+            ]}
+          >
+            {text}
+          </Typography>
+        ))}
+        <Typography
+          numberOfLines={lines}
           style={[
-            styles.strokeBase,
+            styles.textBase,
             {
-              fontSize,
-              lineHeight,
-              color: strokeColor,
-              paddingLeft,
-              letterSpacing,
-              transform: [
-                { translateX: offset.width },
-                { translateY: offset.height },
-              ],
+              fontSize: size,
+              lineHeight: lh,
+              paddingLeft: align === 'left' ? paddingLeft : 0,
+              letterSpacing: align === 'left' ? letterSpacing : 0,
+              color,
+              textAlign: align,
+              transform: skew,
             },
           ]}
         >
-          {trainTypeName}
-        </Text>
-      ))}
-      <Text
-        numberOfLines={numberOfLines}
-        style={[
-          styles.textBase,
-          {
-            fontSize,
-            lineHeight,
-            paddingLeft,
-            letterSpacing,
-            color: trainTypeColor,
-          },
-        ]}
-      >
-        {trainTypeName}
-      </Text>
+          {text}
+        </Typography>
+      </View>
+    );
+  };
+
+  if (enOverride) {
+    return (
+      <View style={styles.outerContainer}>
+        <View style={styles.enOverrideContainer}>
+          {renderStrokedText(
+            enOverride.heading,
+            RFValue(enOverride.headingFontSize ?? 24),
+            trainTypeColor,
+            1
+          )}
+          {renderStrokedText(
+            enOverride.body,
+            RFValue(enOverride.bodyFontSize ?? 16),
+            trainTypeColor,
+            1
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.outerContainer}>
+      {renderStrokedText(
+        trainTypeName,
+        fontSize,
+        trainTypeColor,
+        numberOfLines
+      )}
     </View>
   );
 };

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -3,6 +3,7 @@ import { APP_THEME, type AppTheme } from '../models/Theme';
 export const TYPE_CHANGE_HIDE_THEMES: AppTheme[] = [
   APP_THEME.JR_WEST,
   APP_THEME.YAMANOTE,
+  APP_THEME.E231,
 ] as const;
 
 export const IN_USE_COLOR_MAP: Record<AppTheme, string> = {


### PR DESCRIPTION
## Summary
- CJK表示時のletterSpacingを0に変更し、文字間の余計なスペースを除去
- 英語表示時にskewXトランスフォームで斜体風表示を追加
- 中央特快・青梅特快・通勤特快・通勤快速の英語種別表示を2段構成でマッピング
- 快速のハードコードオレンジカラーを削除し、trainType.colorを使用するように変更
- 列車種別テキストの縦中央揃えを実装（1段・2段表示の位置統一）
- CJK文字の上部見切れを修正（lineHeight倍率調整・overflow: visible追加）
- E231系テーマをTYPE_CHANGE_HIDE_THEMESに追加

## Test plan
- [ ] 各停・快速・特快・急行・特急の日本語表示を確認
- [x] 英語表示でExp./Rapid/中央特快/青梅特快/通勤特快/通勤快速の表示を確認
- [x] 簡体字・韓国語表示で文字の見切れがないことを確認
- [x] 1段表示と2段表示で縦位置が揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * E231列車タイプの英語表示に対応し、二段階の見出し・本文表示を実装しました。

* **Bug Fixes**
  * E231列車タイプの色表示ロジックを改善しました。

* **Chores**
  * テーマ設定にE231対応を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->