### PR TITLE
列車種別ボックスをreact-native-svgで実装し直し

### DIFF
--- a/src/components/TrainTypeBoxE231.tsx
+++ b/src/components/TrainTypeBoxE231.tsx
@@ -1,50 +1,56 @@
 import { useAtomValue } from 'jotai';
 import { getLuminance } from 'polished';
 import React, { useMemo } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import Svg, { G, Text as SvgText } from 'react-native-svg';
 import type { TrainType } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
-import { parenthesisRegexp } from '~/constants';
+import { FONTS, parenthesisRegexp } from '~/constants';
 import { useCurrentLine } from '~/hooks';
 import type { HeaderLangState } from '~/models/HeaderTransitionState';
 import navigationState from '~/store/atoms/navigation';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
 import { RFValue } from '~/utils/rfValue';
 import { getIsLocal } from '~/utils/trainTypeString';
 import truncateTrainType from '~/utils/truncateTrainType';
-import Typography from './Typography';
 
 type Props = {
   trainType: TrainType | null;
 };
 
+const CONTAINER_HEIGHT = Math.round(RFValue(28) * 1.1) * 2;
+const SVG_STROKE_WIDTH = (isTablet ? 3 : 2) * 2;
+const STROKE_PAD = SVG_STROKE_WIDTH;
+// skewX(-7.5)はSVG原点基準で適用されるため、y座標に比例して左にズレる。その分translateで補正する
+const SKEW_SHIFT = Math.ceil(
+  (CONTAINER_HEIGHT + STROKE_PAD * 2) * Math.tan((7.5 * Math.PI) / 180)
+);
+
+// CJK文字はほぼ正方形、Latin文字は約0.62倍幅で推定
+const estimateLineWidth = (
+  text: string,
+  size: number,
+  spacing: number
+): number => {
+  let w = 0;
+  for (const ch of text) {
+    w += ch.charCodeAt(0) > 0x2e80 ? size : size * 0.62;
+  }
+  const charCount = [...text].length;
+  return w + spacing * Math.max(0, charCount - 1) + SVG_STROKE_WIDTH;
+};
+
 const styles = StyleSheet.create({
-  container: {
-    position: 'relative',
-    overflow: 'visible',
-  },
   outerContainer: {
-    height: Math.round(RFValue(28) * 1.1) * 2,
+    height: CONTAINER_HEIGHT,
     justifyContent: 'center',
-    overflow: 'visible',
   },
-  enOverrideContainer: {
-    alignItems: 'center',
-  },
-  textBase: {
-    textAlign: 'left',
-    fontWeight: 'bold',
-    fontSize: RFValue(36),
-    letterSpacing: 0,
-  },
-  strokeBase: {
-    position: 'absolute',
-    textAlign: 'left',
-    fontWeight: 'bold',
-    fontSize: RFValue(36),
-    color: '#fff',
+  svg: {
+    marginTop: -STROKE_PAD,
+    marginLeft: -STROKE_PAD,
   },
 });
 
@@ -127,6 +133,7 @@ const formatCjk = (
 const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
   const { headerState } = useAtomValue(navigationState);
   const currentLine = useCurrentLine();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   const isBus = isBusLine(currentLine);
 
@@ -239,12 +246,14 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
     return 0;
   }, [trainTypeName?.length, isEn]);
 
-  const paddingLeft = useMemo(() => {
-    if (trainTypeName?.length === 2 && isEn && Platform.OS === 'ios') {
-      return 8;
+  const fontFamily = useMemo(() => {
+    if (isLEDTheme) {
+      return FONTS.JFDotJiskan24h;
     }
-    return 0;
-  }, [trainTypeName?.length, isEn]);
+    return FONTS.RobotoBold;
+  }, [isLEDTheme]);
+
+  const fontWeight = isLEDTheme ? ('normal' as const) : ('bold' as const);
 
   if (!trainTypeName) {
     return null;
@@ -253,104 +262,124 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
   const rawLength = trainTypeName.replace('\n', '').length;
   const fontSize =
     headerLangState === 'EN' || rawLength <= 2 ? RFValue(36) : RFValue(28);
-  const numberOfLines = trainTypeName.includes('\n') ? 2 : 1;
-  const strokeWidth = isTablet ? 3 : 2;
-  const strokeOffsets = [
-    { width: strokeWidth, height: 0 },
-    { width: -strokeWidth, height: 0 },
-    { width: 0, height: strokeWidth },
-    { width: 0, height: -strokeWidth },
-    { width: strokeWidth, height: strokeWidth },
-    { width: -strokeWidth, height: -strokeWidth },
-    { width: strokeWidth, height: -strokeWidth },
-    { width: -strokeWidth, height: strokeWidth },
-  ];
 
-  const renderStrokedText = (
-    text: string,
-    size: number,
-    color: string,
-    lines: number,
-    align: 'left' | 'center' = 'left'
+  const SKEW_TRANSFORM = `translate(${SKEW_SHIFT}, 0) skewX(-7.5)`;
+
+  const renderLines = (
+    lines: { text: string; size: number }[],
+    fillColor: string,
+    textAnchor: 'start' | 'middle' = 'start',
+    x: number | string = STROKE_PAD
   ) => {
-    const lh = Math.round(size * 1.1);
-    const skew = isEn ? [{ skewX: '-7.5deg' }] : [];
+    const lineHeights = lines.map(({ size }) => Math.round(size * 1.1));
+    const totalH = lineHeights.reduce((sum, lh) => sum + lh, 0);
+    const topY = (CONTAINER_HEIGHT - totalH) / 2 + STROKE_PAD;
+
+    let accY = topY;
+    const positions = lines.map(({ size }, i) => {
+      // dominantBaselineが型にないため、baselineからの補正で垂直中央を再現
+      const baselineY = accY + size * 0.78;
+      accY += lineHeights[i];
+      return baselineY;
+    });
+
     return (
-      <View style={styles.container}>
-        {strokeOffsets.map((offset) => (
-          <Typography
-            key={`${offset.width}_${offset.height}`}
-            numberOfLines={lines}
-            style={[
-              styles.strokeBase,
-              {
-                fontSize: size,
-                lineHeight: lh,
-                color: strokeColor,
-                paddingLeft: align === 'left' ? paddingLeft : 0,
-                letterSpacing: align === 'left' ? letterSpacing : 0,
-                textAlign: align,
-                transform: [
-                  { translateX: offset.width },
-                  { translateY: offset.height },
-                  ...skew,
-                ],
-              },
-            ]}
+      <>
+        {lines.map(({ text, size }, i) => (
+          <SvgText
+            key={`s_${text}`}
+            x={x}
+            y={positions[i]}
+            fontSize={size}
+            fontFamily={fontFamily}
+            fontWeight={fontWeight}
+            textAnchor={textAnchor}
+            fill="none"
+            stroke={strokeColor}
+            strokeWidth={SVG_STROKE_WIDTH}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            letterSpacing={textAnchor === 'start' ? letterSpacing : 0}
           >
             {text}
-          </Typography>
+          </SvgText>
         ))}
-        <Typography
-          numberOfLines={lines}
-          style={[
-            styles.textBase,
-            {
-              fontSize: size,
-              lineHeight: lh,
-              paddingLeft: align === 'left' ? paddingLeft : 0,
-              letterSpacing: align === 'left' ? letterSpacing : 0,
-              color,
-              textAlign: align,
-              transform: skew,
-            },
-          ]}
-        >
-          {text}
-        </Typography>
-      </View>
+        {lines.map(({ text, size }, i) => (
+          <SvgText
+            key={`f_${text}`}
+            x={x}
+            y={positions[i]}
+            fontSize={size}
+            fontFamily={fontFamily}
+            fontWeight={fontWeight}
+            textAnchor={textAnchor}
+            fill={fillColor}
+            letterSpacing={textAnchor === 'start' ? letterSpacing : 0}
+          >
+            {text}
+          </SvgText>
+        ))}
+      </>
     );
   };
 
   if (enOverride) {
+    const headingSize = RFValue(enOverride.headingFontSize ?? 24);
+    const bodySize = RFValue(enOverride.bodyFontSize ?? 16);
+    const svgWidth = Math.max(
+      estimateLineWidth(enOverride.heading, headingSize, 0),
+      estimateLineWidth(enOverride.body, bodySize, 0)
+    );
+
     return (
       <View style={styles.outerContainer}>
-        <View style={styles.enOverrideContainer}>
-          {renderStrokedText(
-            enOverride.heading,
-            RFValue(enOverride.headingFontSize ?? 24),
-            trainTypeColor,
-            1
-          )}
-          {renderStrokedText(
-            enOverride.body,
-            RFValue(enOverride.bodyFontSize ?? 16),
-            trainTypeColor,
-            1
-          )}
-        </View>
+        <Svg
+          width={svgWidth + STROKE_PAD * 2 + SKEW_SHIFT}
+          height={CONTAINER_HEIGHT + STROKE_PAD * 2}
+          style={styles.svg}
+        >
+          <G transform={SKEW_TRANSFORM}>
+            {renderLines(
+              [
+                { text: enOverride.heading, size: headingSize },
+                { text: enOverride.body, size: bodySize },
+              ],
+              trainTypeColor,
+              'middle',
+              svgWidth / 2
+            )}
+          </G>
+        </Svg>
       </View>
     );
   }
 
+  const textLines = trainTypeName.split('\n');
+  const svgWidth = Math.max(
+    ...textLines.map((text) => estimateLineWidth(text, fontSize, letterSpacing))
+  );
+
   return (
     <View style={styles.outerContainer}>
-      {renderStrokedText(
-        trainTypeName,
-        fontSize,
-        trainTypeColor,
-        numberOfLines
-      )}
+      <Svg
+        width={svgWidth + STROKE_PAD * 2 + (isEn ? SKEW_SHIFT : 0)}
+        height={CONTAINER_HEIGHT + STROKE_PAD * 2}
+        style={styles.svg}
+      >
+        {isEn ? (
+          <G transform={SKEW_TRANSFORM}>
+            {renderLines(
+              textLines.map((text) => ({ text, size: fontSize })),
+              trainTypeColor
+            )}
+          </G>
+        ) : (
+          renderLines(
+            textLines.map((text) => ({ text, size: fontSize })),
+            trainTypeColor
+          )
+        )}
+      </Svg>
     </View>
   );
 };

--- a/src/components/TrainTypeBoxJL.tsx
+++ b/src/components/TrainTypeBoxJL.tsx
@@ -1,21 +1,30 @@
 import { useAtomValue } from 'jotai';
-import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import Svg, { G, Text as SvgText } from 'react-native-svg';
 import type { TrainType } from '~/@types/graphql';
-import { japaneseRegexp, parenthesisRegexp } from '~/constants';
+import { FONTS, japaneseRegexp, parenthesisRegexp } from '~/constants';
 import { useCurrentLine } from '~/hooks';
 import type { HeaderLangState } from '~/models/HeaderTransitionState';
 import navigationState from '~/store/atoms/navigation';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
 import truncateTrainType from '~/utils/truncateTrainType';
-import Typography from './Typography';
 
 type Props = {
   trainType: TrainType | null;
   trainTypeColor?: string | null;
 };
+
+const BOX_HEIGHT = isTablet ? 55 : 35;
+const FONT_SIZE = isTablet ? 36 : 24;
+const SKEW_ANGLE = 5;
+const SKEW_SHIFT = Math.ceil(
+  BOX_HEIGHT * Math.tan((SKEW_ANGLE * Math.PI) / 180)
+);
+const SKEW_TRANSFORM = `translate(${SKEW_SHIFT / 2}, 0) skewX(-${SKEW_ANGLE})`;
 
 const styles = StyleSheet.create({
   box: {
@@ -23,7 +32,7 @@ const styles = StyleSheet.create({
     top: isTablet ? 24 : 12,
     borderRadius: 4,
     width: '100%',
-    height: isTablet ? 55 : 35,
+    height: BOX_HEIGHT,
     backgroundColor: 'white',
     zIndex: 9999,
     elevation: 2,
@@ -31,20 +40,8 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.5,
     shadowRadius: 1,
     shadowOffset: { height: 1, width: 0 },
-  },
-  innerBox: {
-    flexDirection: 'row',
-    justifyContent: 'space-evenly',
+    justifyContent: 'center',
     alignItems: 'center',
-    transform: [{ skewX: '-5deg' }],
-  },
-  text: {
-    color: '#fff',
-    textAlign: 'center',
-    fontWeight: 'bold',
-    fontSize: isTablet ? 36 : 24,
-    lineHeight: isTablet ? 55 : 35,
-    flex: 1,
   },
 });
 
@@ -54,6 +51,7 @@ const TrainTypeBoxJL: React.FC<Props> = ({
 }: Props) => {
   const { headerState } = useAtomValue(navigationState);
   const currentLine = useCurrentLine();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   const headerLangState = useMemo((): HeaderLangState => {
     return headerState.split('_')[1] as HeaderLangState;
@@ -114,49 +112,77 @@ const TrainTypeBoxJL: React.FC<Props> = ({
     trainTypeNameZh,
   ]);
 
-  const numberOfLines = useMemo(
-    // trainTypeNameがundefined/nullの場合のクラッシュを防ぐためのオプショナルチェーニング
-    () => (trainTypeName?.split('\n').length === 1 ? 1 : 2),
-    [trainTypeName]
-  );
+  const fontFamily = useMemo(() => {
+    if (isLEDTheme) {
+      return FONTS.JFDotJiskan24h;
+    }
+    return FONTS.RobotoBold;
+  }, [isLEDTheme]);
+
+  const fontWeight = isLEDTheme ? ('normal' as const) : ('800' as const);
+
+  const [boxWidth, setBoxWidth] = useState(0);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    setBoxWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const isJapaneseChars =
+    headerLangState !== 'EN' && japaneseRegexp.test(trainTypeName ?? '');
+
+  const chars = isJapaneseChars ? (trainTypeName ?? '').split('') : null;
+
+  const adjustedFontSize = useMemo(() => {
+    if (!trainTypeName || boxWidth === 0 || chars) {
+      return FONT_SIZE;
+    }
+    let estimatedWidth = 0;
+    for (const ch of trainTypeName) {
+      estimatedWidth +=
+        ch.charCodeAt(0) > 0x2e80 ? FONT_SIZE : FONT_SIZE * 0.52;
+    }
+    const available = boxWidth * 0.9;
+    if (estimatedWidth > available) {
+      return Math.floor(FONT_SIZE * (available / estimatedWidth));
+    }
+    return FONT_SIZE;
+  }, [trainTypeName, boxWidth, chars]);
 
   return (
-    <View style={styles.box}>
-      <View style={styles.innerBox}>
-        {headerLangState !== 'EN' &&
-        japaneseRegexp.test(trainTypeName ?? '') ? (
-          (trainTypeName ?? '').split('').map((char, idx) => (
-            <Typography
-              numberOfLines={numberOfLines}
-              adjustsFontSizeToFit
-              style={[
-                styles.text,
-                {
-                  color: trainTypeColor ?? '#000',
-                  fontFamily: undefined,
-                  fontWeight: '800',
-                },
-              ]}
-              key={`${char}${idx.toString()}`}
-            >
-              {char}
-            </Typography>
-          ))
-        ) : (
-          <Typography
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            style={[
-              styles.text,
-              {
-                color: trainTypeColor ?? '#000',
-              },
-            ]}
-          >
-            {trainTypeName}
-          </Typography>
-        )}
-      </View>
+    <View style={styles.box} onLayout={handleLayout}>
+      <Svg width="100%" height={BOX_HEIGHT}>
+        <G transform={SKEW_TRANSFORM}>
+          {chars
+            ? chars.map((char, i) => (
+                <SvgText
+                  key={`${char}_${i.toString()}`}
+                  x={`${((i + 0.5) / chars.length) * 100}%`}
+                  y={BOX_HEIGHT / 2}
+                  fontSize={FONT_SIZE}
+                  fontWeight={fontWeight}
+                  fill={trainTypeColor ?? '#000'}
+                  textAnchor="middle"
+                  alignmentBaseline="central"
+                >
+                  {char}
+                </SvgText>
+              ))
+            : trainTypeName && (
+                <SvgText
+                  x="50%"
+                  y={BOX_HEIGHT / 2}
+                  fontSize={adjustedFontSize}
+                  fontFamily={fontFamily}
+                  fontWeight="bold"
+                  fill={trainTypeColor ?? '#000'}
+                  textAnchor="middle"
+                  alignmentBaseline="central"
+                >
+                  {trainTypeName}
+                </SvgText>
+              )}
+        </G>
+      </Svg>
     </View>
   );
 };

--- a/src/components/TrainTypeBoxJO.tsx
+++ b/src/components/TrainTypeBoxJO.tsx
@@ -1,21 +1,30 @@
 import { useAtomValue } from 'jotai';
-import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import Svg, { G, Text as SvgText } from 'react-native-svg';
 import type { TrainType } from '~/@types/graphql';
-import { japaneseRegexp, parenthesisRegexp } from '../constants';
+import { FONTS, japaneseRegexp, parenthesisRegexp } from '../constants';
 import { useCurrentLine } from '../hooks';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import navigationState from '../store/atoms/navigation';
+import { isLEDThemeAtom } from '../store/atoms/theme';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
 import { isBusLine } from '../utils/line';
 import { getIsLocal, getIsRapid } from '../utils/trainTypeString';
 import truncateTrainType from '../utils/truncateTrainType';
-import Typography from './Typography';
 
 type Props = {
   trainType: TrainType | null;
 };
+
+const BOX_HEIGHT = isTablet ? 55 : 35;
+const FONT_SIZE = isTablet ? 36 : 24;
+const SKEW_ANGLE = 5;
+const SKEW_SHIFT = Math.ceil(
+  BOX_HEIGHT * Math.tan((SKEW_ANGLE * Math.PI) / 180)
+);
+const SKEW_TRANSFORM = `translate(${SKEW_SHIFT / 2}, 0) skewX(-${SKEW_ANGLE})`;
 
 const styles = StyleSheet.create({
   box: {
@@ -23,26 +32,18 @@ const styles = StyleSheet.create({
     top: isTablet ? 24 : 12,
     borderRadius: 4,
     width: '100%',
-    height: isTablet ? 55 : 35,
-    justifyContent: 'space-evenly',
+    height: BOX_HEIGHT,
+    justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'white',
-    flexDirection: 'row',
     zIndex: 9999,
-  },
-  text: {
-    color: '#fff',
-    textAlign: 'center',
-    fontWeight: 'bold',
-    transform: [{ skewX: '-5deg' }],
-    fontSize: isTablet ? 36 : 24,
-    flex: 1,
   },
 });
 
 const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
   const { headerState } = useAtomValue(navigationState);
   const currentLine = useCurrentLine();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   const headerLangState = useMemo((): HeaderLangState => {
     return headerState.split('_')[1] as HeaderLangState;
@@ -113,48 +114,79 @@ const TrainTypeBoxJO: React.FC<Props> = ({ trainType }: Props) => {
     return trainType?.color ?? '#222';
   }, [trainType]);
 
-  const numberOfLines = useMemo(
-    // trainTypeNameがundefined/nullの場合のクラッシュを防ぐためのオプショナルチェーニング
-    () => (trainTypeName?.split('\n').length === 1 ? 1 : 2),
-    [trainTypeName]
-  );
+  const fontFamily = useMemo(() => {
+    if (isLEDTheme) {
+      return FONTS.JFDotJiskan24h;
+    }
+    return FONTS.RobotoBold;
+  }, [isLEDTheme]);
+
+  const fontWeight = isLEDTheme ? ('normal' as const) : ('800' as const);
+
+  const [boxWidth, setBoxWidth] = useState(0);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    setBoxWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const isJapaneseChars =
+    headerLangState !== 'EN' &&
+    trainTypeName != null &&
+    japaneseRegexp.test(trainTypeName);
+
+  const chars = isJapaneseChars ? trainTypeName.split('') : null;
+
+  const adjustedFontSize = useMemo(() => {
+    if (!trainTypeName || boxWidth === 0 || chars) {
+      return FONT_SIZE;
+    }
+    let estimatedWidth = 0;
+    for (const ch of trainTypeName) {
+      estimatedWidth +=
+        ch.charCodeAt(0) > 0x2e80 ? FONT_SIZE : FONT_SIZE * 0.52;
+    }
+    const available = boxWidth * 0.9;
+    if (estimatedWidth > available) {
+      return Math.floor(FONT_SIZE * (available / estimatedWidth));
+    }
+    return FONT_SIZE;
+  }, [trainTypeName, boxWidth, chars]);
 
   return (
-    <View style={styles.box}>
-      {headerLangState !== 'EN' &&
-      trainTypeName &&
-      japaneseRegexp.test(trainTypeName) ? (
-        trainTypeName.split('').map((char, idx) => (
-          <Typography
-            numberOfLines={numberOfLines}
-            adjustsFontSizeToFit
-            style={[
-              styles.text,
-              {
-                color: trainTypeColor,
-                fontFamily: undefined,
-                fontWeight: '800',
-              },
-            ]}
-            key={`${char}${idx.toString()}`}
-          >
-            {char}
-          </Typography>
-        ))
-      ) : (
-        <Typography
-          numberOfLines={1}
-          adjustsFontSizeToFit
-          style={[
-            styles.text,
-            {
-              color: trainTypeColor,
-            },
-          ]}
-        >
-          {trainTypeName}
-        </Typography>
-      )}
+    <View style={styles.box} onLayout={handleLayout}>
+      <Svg width="100%" height={BOX_HEIGHT}>
+        <G transform={SKEW_TRANSFORM}>
+          {chars
+            ? chars.map((char, i) => (
+                <SvgText
+                  key={`${char}_${i.toString()}`}
+                  x={`${((i + 0.5) / chars.length) * 100}%`}
+                  y={BOX_HEIGHT / 2}
+                  fontSize={FONT_SIZE}
+                  fontWeight={fontWeight}
+                  fill={trainTypeColor}
+                  textAnchor="middle"
+                  alignmentBaseline="central"
+                >
+                  {char}
+                </SvgText>
+              ))
+            : trainTypeName && (
+                <SvgText
+                  x="50%"
+                  y={BOX_HEIGHT / 2}
+                  fontSize={adjustedFontSize}
+                  fontFamily={fontFamily}
+                  fontWeight="bold"
+                  fill={trainTypeColor}
+                  textAnchor="middle"
+                  alignmentBaseline="central"
+                >
+                  {trainTypeName}
+                </SvgText>
+              )}
+        </G>
+      </Svg>
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- TrainTypeBoxE231/JO/JLの描画をreact-native-svgベースに置き換え、iOS/Android間の描画差異を解消
- E231: 8方向オフセットによる擬似ストロークをSVG `stroke`/`fill` 2レイヤー方式に変更
- JO/JL: RN `transform: skewX`（Androidで無視される）をSVG `<G transform="skewX(...)">` に変更
- 日本語文字の均等配置をflex `space-evenly`からSVGパーセンテージ座標に変更
- 長い列車種別名（Saphir Odoriko等）の自動フォントサイズ調整を`onLayout`ベースで再実装

## Test plan
- [ ] E231テーマ: 日本語/英語/中国語/韓国語の各言語で列車種別表示を確認
- [ ] E231テーマ: enOverride（中央特快、通勤快速等）の2行表示を確認
- [ ] JOテーマ: 日本語文字の均等配置とskew表示を確認
- [ ] JOテーマ: 長い英語列車種別名（Saphir Odoriko等）が収まることを確認
- [ ] JLテーマ: 同上
- [ ] Android実機/エミュレータでskewが正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * LEDテーマと通常テーマに対応した列車タイプ表示の改善

* **スタイル**
  * 列車タイプボックスのテキストレンダリング精度向上。複数の列車種別表示コンポーネントの表示ロジックを統一し、テーマ切り替え時の一貫性を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->