### PR TITLE
HeaderJLでTLC付きナンバリングアイコンが上にずれるバグを修正

### DIFF
--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -39,7 +39,6 @@ const styles = StyleSheet.create({
   // TLC デフォルト: ヘッダー等の大きなスペース用 (0.7x)
   tlcRoot: {
     justifyContent: 'center',
-    alignSelf: 'flex-start',
   },
   tlcContainer: {
     backgroundColor: '#231e1f',


### PR DESCRIPTION
## Summary
- HeaderJL ヘッダーで Three Letter Code (TLC) 付きのナンバリングアイコン（例: SMB + JT 02）が上にはみ出して表示されるバグを修正
- `NumberingIconSquare` の `tlcRoot` スタイルにある `alignSelf: 'flex-start'` が親コンテナの `alignItems: 'flex-end'` を上書きしていたのが原因
- `alignSelf: 'flex-start'` を削除し、親の下揃え指定が正しく適用されるように修正

## Test plan
- [x] TLC 付き路線（JT 東海道線など）で HeaderJL のナンバリングアイコンが駅名と同じ高さに下揃えで表示されることを確認
- [x] TLC なしの路線でも表示が崩れないことを確認
- [x] タブレット・スマホ両方で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル修正**
  * コンポーネントのレイアウト配置の動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->