### PR TITLE
乗り換え判定の偽陽性を防止

### DIFF
--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -98,7 +98,11 @@ export const useRouteEstimation = (): EstimationResult => {
   useEffect(() => {
     if (!state.isEstimating) return;
 
-    const logs = preprocessLogs(bufferRef.current);
+    const buffer = bufferRef.current;
+    // ポイントが少なすぎる段階では乗り換え判定を行わない（偽陽性を防止）
+    if (buffer.length < MIN_POINTS_FOR_ESTIMATION) return;
+
+    const logs = preprocessLogs(buffer);
     if (logs.length > 0 && isTransferStop(logs)) {
       bufferRef.current = [];
       setState((prev) => ({

--- a/src/utils/routeEstimation/__tests__/preprocessLogs.test.ts
+++ b/src/utils/routeEstimation/__tests__/preprocessLogs.test.ts
@@ -146,4 +146,23 @@ describe('isTransferStop', () => {
     ];
     expect(isTransferStop(logs)).toBe(false);
   });
+
+  it('2点で先頭エントリのspeed=0による偽陽性を起こさない', () => {
+    // 先頭エントリはdistFromPrev=0,dtFromPrev=0のためspeed=0になるが、
+    // これは前処理の仕様であり実際の停車ではない
+    const logs: FilteredLocationLog[] = [
+      { ...mkLog(35.68, 139.76, 0), distFromPrev: 0, dtFromPrev: 0 },
+      { ...mkLog(35.68, 139.76, 15_000), distFromPrev: 0, dtFromPrev: 15 },
+    ];
+    expect(isTransferStop(logs)).toBe(false);
+  });
+
+  it('先頭以降のエントリが停車状態なら検知する', () => {
+    const logs: FilteredLocationLog[] = [
+      { ...mkLog(35.68, 139.76, 0), distFromPrev: 0, dtFromPrev: 0 },
+      { ...mkLog(35.68, 139.76, 1000), distFromPrev: 0, dtFromPrev: 1 },
+      { ...mkLog(35.68, 139.76, 12_000), distFromPrev: 0, dtFromPrev: 11 },
+    ];
+    expect(isTransferStop(logs)).toBe(true);
+  });
 });

--- a/src/utils/routeEstimation/preprocessLogs.ts
+++ b/src/utils/routeEstimation/preprocessLogs.ts
@@ -127,7 +127,10 @@ export const isTransferStop = (logs: FilteredLocationLog[]): boolean => {
 
   let stopStart: number | null = null;
 
-  for (const log of logs) {
+  // index=0はdistFromPrev=0,dtFromPrev=0のため常にspeed=0になる（前処理の仕様）。
+  // これを含めると停車タイマーが常に即座に開始され、低速移動時に偽陽性が発生するためスキップする。
+  for (let i = 1; i < logs.length; i++) {
+    const log = logs[i];
     const speed = log.dtFromPrev > 0 ? log.distFromPrev / log.dtFromPrev : 0;
     if (speed < STOP_SPEED_THRESHOLD) {
       if (stopStart == null) {


### PR DESCRIPTION
## 概要

ルート推定時の乗り換え判定（`isTransferStop`）で、先頭エントリの速度が常に0になることによる偽陽性を防止します。また、ポイント数が少ない段階での判定を回避することで、低速移動時の誤検知を削減します。

## 変更の種類

- [x] バグ修正

## 変更内容

### 1. `isTransferStop`の判定ロジック修正
- **問題**: 前処理により先頭エントリは`distFromPrev=0, dtFromPrev=0`となるため、常に`speed=0`になります。これは仕様上の制約であり実際の停車ではないのに、停車判定の開始トリガーになっていました。
- **対策**: ループを`index=1`から開始し、先頭エントリをスキップするように変更しました。

### 2. 推定開始前の最小ポイント数チェック
- **問題**: ポイント数が少ない段階で乗り換え判定を行うと、低速移動時に偽陽性が発生しやすくなります。
- **対策**: `preprocessLogs`呼び出し前に、バッファのポイント数が`MIN_POINTS_FOR_ESTIMATION`以上であることを確認するようにしました。

### 3. テストケースの追加
- 先頭エントリのspeed=0による偽陽性を起こさないことを確認するテスト
- 先頭以降のエントリが停車状態の場合に正しく検知することを確認するテスト

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（新規テストケース2つを追加）
- [x] `npm run typecheck` が通ること

https://claude.ai/code/session_016392JPYsBVtG4ESh75qRWB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ルート推定の精度向上 - データが不足している場合の不要な処理を削減し、転送停止の誤検出を防ぐようになりました。

* **テスト**
  * ルート推定における転送停止検出のエッジケーステストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->