### PR TITLE
小田急テーマの停車中バー灰色表示とヘッダーデザインを改善

### DIFF
--- a/src/components/HeaderOdakyu.tsx
+++ b/src/components/HeaderOdakyu.tsx
@@ -2,20 +2,17 @@ import React from 'react';
 import type { CommonHeaderProps } from './Header.types';
 import type { HeaderEastThemeConfig } from './HeaderEast';
 import { HeaderEast, tokyoMetroConfig } from './HeaderEast';
+import isTablet from '~/utils/isTablet';
 
 const odakyuConfig: HeaderEastThemeConfig = {
   ...tokyoMetroConfig,
-  gradientColors: [
-    '#b0b0b0',
-    '#a0a0a0',
-    '#808080',
-    '#b8b8b8',
-    '#c8c8c8',
-  ] as const,
+  gradientColors: ['#fcfcfc', '#a0a0a0', '#808080', '#dedede'] as const,
+  gradientLocations: [0, 0.2, 0.21, 1] as const,
   textColor: '#1a1a1a',
   rootStyle: {},
   divider: {
     ...tokyoMetroConfig.divider,
+    height: isTablet ? 8 : 6,
     color: 'dynamic',
   },
   secondaryDivider: {

--- a/src/components/HeaderOdakyu.tsx
+++ b/src/components/HeaderOdakyu.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import isTablet from '~/utils/isTablet';
 import type { CommonHeaderProps } from './Header.types';
 import type { HeaderEastThemeConfig } from './HeaderEast';
 import { HeaderEast, tokyoMetroConfig } from './HeaderEast';
-import isTablet from '~/utils/isTablet';
 
 const odakyuConfig: HeaderEastThemeConfig = {
   ...tokyoMetroConfig,

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -61,7 +61,10 @@ const localStyles = StyleSheet.create({
   },
 });
 
-const NumberingIconView: React.FC<{ station: Station }> = ({ station }) => {
+const NumberingIconView: React.FC<{
+  station: Station;
+  shouldGrayscale: boolean;
+}> = ({ station, shouldGrayscale }) => {
   const numberingObj = useMemo(
     () => station.stationNumbers?.[0],
     [station.stationNumbers]
@@ -79,6 +82,7 @@ const NumberingIconView: React.FC<{ station: Station }> = ({ station }) => {
         stationNumber={numberingObj.stationNumber}
         threeLetterCode={station.threeLetterCode}
         transformOrigin="center"
+        shouldGrayscale={shouldGrayscale}
       />
     </View>
   );
@@ -374,7 +378,12 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             passed={getIsPass(station) || shouldGrayscale}
           />
         </View>
-        {isOdakyu ? <NumberingIconView station={station} /> : null}
+        {isOdakyu ? (
+          <NumberingIconView
+            station={station}
+            shouldGrayscale={shouldGrayscale}
+          />
+        ) : null}
         {renderBarGradients({
           barLeft,
           barWidth,

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -118,7 +118,6 @@ const isSplitAtCurrentStation = (
   stations: Station[]
 ) =>
   arrived &&
-  currentStationIndex !== 0 &&
   currentStationIndex === index &&
   currentStationIndex !== stations.length - 1;
 
@@ -233,19 +232,26 @@ const renderBarGradients = ({
   }
 
   if (splitHere) {
+    // index 0ではバー左端からドット中心までの距離を灰色幅に使う
+    const dotCenterOffset = isTablet ? 24 : 16;
+    const splitWidth =
+      index === 0 ? Math.abs(barLeft) + dotCenterOffset : barWidth / 2.5;
     gradients.push(
       createBarGradient(
         'bar-main-half',
         getMainBarColors(line),
         barLeft,
-        barWidth / 2.5
+        splitWidth
       )
     );
   }
 
   if (secondaryVisible) {
-    const left = splitHere ? barLeft + barWidth / 2.5 : barLeft;
-    const width = splitHere ? barWidth / 2.5 : barWidth;
+    const dotCenterOffset = isTablet ? 24 : 16;
+    const splitWidth =
+      index === 0 ? Math.abs(barLeft) + dotCenterOffset : barWidth / 2.5;
+    const left = splitHere ? barLeft + splitWidth : barLeft;
+    const width = splitHere ? barWidth - splitWidth : barWidth;
     gradients.push(
       createBarGradient(
         'bar-color',

--- a/src/components/NumberingIcon.tsx
+++ b/src/components/NumberingIcon.tsx
@@ -51,6 +51,7 @@ const NumberingIconOriginal: React.FC<Props> = ({
   size,
   allowScaling,
   withDarkTheme,
+  shouldGrayscale,
   transformOrigin,
   withOutline,
 }: Props) => {
@@ -234,6 +235,7 @@ const NumberingIconOriginal: React.FC<Props> = ({
           stationNumber={stationNumber}
           hakone={shape === MARK_SHAPE.HAKONE}
           withOutline={withOutline}
+          shouldGrayscale={shouldGrayscale ?? false}
         />
       );
     case MARK_SHAPE.KEIO:

--- a/src/components/NumberingIconOdakyu.tsx
+++ b/src/components/NumberingIconOdakyu.tsx
@@ -8,6 +8,7 @@ type Props = {
   stationNumber: string;
   hakone: boolean;
   withOutline?: boolean;
+  shouldGrayscale?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -46,30 +47,35 @@ const styles = StyleSheet.create({
   },
 });
 
+const GRAYSCALE_COLOR = '#aaa';
+
 const NumberingIconOdakyu: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
   hakone,
   withOutline,
+  shouldGrayscale,
 }: Props) => {
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('');
 
+  const borderColor = shouldGrayscale
+    ? GRAYSCALE_COLOR
+    : hakone
+      ? '#EA4D15'
+      : '#0D82C7';
+  const textColor = shouldGrayscale
+    ? GRAYSCALE_COLOR
+    : hakone
+      ? '#6A3906'
+      : '#0D82C7';
+
   return (
     <View style={withOutline ? styles.optionalBorder : undefined}>
-      <View
-        style={[styles.root, { borderColor: hakone ? '#EA4D15' : '#0D82C7' }]}
-      >
-        <Typography
-          style={[styles.lineSymbol, { color: hakone ? '#6A3906' : '#0D82C7' }]}
-        >
+      <View style={[styles.root, { borderColor }]}>
+        <Typography style={[styles.lineSymbol, { color: textColor }]}>
           {lineSymbol}
         </Typography>
-        <Typography
-          style={[
-            styles.stationNumber,
-            { color: hakone ? '#6A3906' : '#0D82C7' },
-          ]}
-        >
+        <Typography style={[styles.stationNumber, { color: textColor }]}>
           {stationNumber}
         </Typography>
       </View>


### PR DESCRIPTION
## Summary
- 停車中（arrived）に `LineBoardEast` のバーがchevron位置まで灰色になるように修正
- `isSplitAtCurrentStation` の `currentStationIndex !== 0` 条件を削除し、最初の駅（index 0）でもバー分割が有効に
- index 0 では `Math.abs(barLeft) + dotCenterOffset` でドット中心までの距離を灰色幅として使用
- カラーバー幅を `barWidth - splitWidth` にして、分割後の残り領域を正しくカバー

## Test plan
- [ ] 小田急テーマで最初の駅に停車中、chevron位置まで灰色バーが表示されることを確認
- [ ] 中間駅に停車中のバー分割表示が崩れていないことを確認
- [ ] タブレット・スマホ両方で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ヘッダーのグラデーション配色を新しい4色パレットと位置調整で更新しました。
  * タブレット環境向けに区切り線の高さを最適化し表示を改善しました。
  * 駅分割表示で先頭駅も分割対象に対応し、分割時のバー幅・位置計算を端末に応じて調整しました。
  * 駅番号アイコンにグレースケール表示オプションを追加し、表示色の選択を一元化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->