### PR TITLE
逆方向警告の文言を改善

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -297,7 +297,7 @@
   "save": "Save",
   "selectStartStationTitle": "Select starting station",
   "departure": "Dep.",
-  "wrongDirectionWarning": "You may be traveling in the wrong direction. Please check your train.",
+  "wrongDirectionWarning": "You may be traveling in the wrong direction. Please check your app settings.",
   "wrongDirectionLoopLineWarning": "You may be traveling in the wrong direction. As this is a loop line, you will still arrive, but it will take longer.",
   "wrongDirectionNotificationTitle": "Direction Alert"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -298,7 +298,7 @@
   "save": "保存",
   "selectStartStationTitle": "始発駅を選択",
   "departure": "始発",
-  "wrongDirectionWarning": "選択した行き先と逆方向に進んでいる可能性があります。電車をお確かめください。",
+  "wrongDirectionWarning": "選択した行き先と逆方向に進んでいる可能性があります。アプリの設定をご確認ください。",
   "wrongDirectionLoopLineWarning": "選択した行き先と逆方向に進んでいる可能性があります。環状線のため到着は可能ですが、遠回りになります。",
   "wrongDirectionNotificationTitle": "方向のお知らせ"
 }


### PR DESCRIPTION
## Summary
- 逆方向警告メッセージの文言を日本語・英語ともに改善
  - 日本語: 「電車をお確かめください」→「アプリの設定をご確認ください」
  - 英語: "Please check your train." → "Please check your app settings."

## Test plan
- [ ] 逆方向に進んだ際の警告メッセージが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 警告メッセージの案内文を改善。ユーザーへの指示が「電車を確認」から「アプリ設定を確認」に変更されました。英語版および日本語版の両方が更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->