### PR TITLE
useRouteEstimationのAbortError多発を修正

### DIFF
--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -219,17 +219,27 @@ export const useRouteEstimation = (): EstimationResult => {
         // 推定実行
         const results = estimateRoutes(candidates, logs);
 
-        setState((prev) => ({
-          ...prev,
-          candidates: results,
-          status: results.length > 0 ? 'ready' : 'collecting',
-        }));
+        // この実行がまだアクティブな場合のみ状態を更新
+        if (abortControllerRef.current === controller) {
+          setState((prev) => ({
+            ...prev,
+            candidates: results,
+            status: results.length > 0 ? 'ready' : 'collecting',
+          }));
+        }
       } catch (err) {
         if (signal.aborted) return;
         console.error('useRouteEstimation: estimation failed', err);
-        setState((prev) => ({ ...prev, status: 'collecting' }));
+        // この実行がまだアクティブな場合のみ状態を更新
+        if (abortControllerRef.current === controller) {
+          setState((prev) => ({ ...prev, status: 'collecting' }));
+        }
       } finally {
-        estimatingRef.current = false;
+        // この実行がまだアクティブな場合のみクリーンアップ
+        if (abortControllerRef.current === controller) {
+          estimatingRef.current = false;
+          abortControllerRef.current = null;
+        }
       }
     };
 

--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -64,12 +64,16 @@ export const useRouteEstimation = (): EstimationResult => {
     bufferRef.current = state.locationBuffer;
   }, [state.locationBuffer]);
 
-  // アンマウント時に進行中のリクエストをキャンセル
+  // 推定停止時・アンマウント時に進行中のリクエストをキャンセル
   useEffect(() => {
+    if (!state.isEstimating) {
+      abortControllerRef.current?.abort();
+      estimatingRef.current = false;
+    }
     return () => {
       abortControllerRef.current?.abort();
     };
-  }, []);
+  }, [state.isEstimating]);
 
   // GraphQL queries
   const [fetchNearbyStart] = useLazyQuery<

--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -1,4 +1,4 @@
-import { useLazyQuery } from '@apollo/client/react';
+import { useApolloClient, useLazyQuery } from '@apollo/client/react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Line, Station } from '~/@types/graphql';
@@ -49,6 +49,7 @@ type GetLineStationsVariables = {
  * isDevApp限定のデバッグモーダルから呼び出される
  */
 export const useRouteEstimation = (): EstimationResult => {
+  const client = useApolloClient();
   const location = useAtomValue(locationAtom);
   const [state, setState] = useAtom(routeEstimationState);
   const setLineState = useSetAtom(lineState);
@@ -56,11 +57,19 @@ export const useRouteEstimation = (): EstimationResult => {
 
   const bufferRef = useRef<LocationLog[]>(state.locationBuffer);
   const estimatingRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   // bufferRefをatomの値と同期する（外部からの変更に追従）
   useEffect(() => {
     bufferRef.current = state.locationBuffer;
   }, [state.locationBuffer]);
+
+  // アンマウント時に進行中のリクエストをキャンセル
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   // GraphQL queries
   const [fetchNearbyStart] = useLazyQuery<
@@ -72,11 +81,6 @@ export const useRouteEstimation = (): EstimationResult => {
     GetStationsNearbyData,
     GetStationsNearbyVariables
   >(GET_STATIONS_NEARBY);
-
-  const [fetchLineStations] = useLazyQuery<
-    GetLineStationsData,
-    GetLineStationsVariables
-  >(GET_LINE_STATIONS);
 
   // 新しいGPSポイントをバッファに追加
   useEffect(() => {
@@ -131,6 +135,12 @@ export const useRouteEstimation = (): EstimationResult => {
     }
 
     const runEstimation = async () => {
+      // 前回の推定リクエストが残っていればキャンセル
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const { signal } = controller;
+
       estimatingRef.current = true;
       setState((prev) => ({ ...prev, status: 'estimating' }));
 
@@ -139,6 +149,7 @@ export const useRouteEstimation = (): EstimationResult => {
         const startPoint = buffer[0];
         const endPoint = buffer[buffer.length - 1];
 
+        const fetchOptions = { signal };
         const [startResult, endResult] = await Promise.all([
           fetchNearbyStart({
             variables: {
@@ -146,6 +157,7 @@ export const useRouteEstimation = (): EstimationResult => {
               longitude: startPoint.longitude,
               limit: 10,
             },
+            context: { fetchOptions },
           }),
           fetchNearbyEnd({
             variables: {
@@ -153,6 +165,7 @@ export const useRouteEstimation = (): EstimationResult => {
               longitude: endPoint.longitude,
               limit: 10,
             },
+            context: { fetchOptions },
           }),
         ]);
 
@@ -177,8 +190,13 @@ export const useRouteEstimation = (): EstimationResult => {
         const candidates: CandidateLine[] = [];
         const lineStationResults = await Promise.all(
           Array.from(lineIdSet).map(async (lineId) => {
-            const result = await fetchLineStations({
+            const result = await client.query<
+              GetLineStationsData,
+              GetLineStationsVariables
+            >({
+              query: GET_LINE_STATIONS,
               variables: { lineId },
+              context: { fetchOptions },
             });
             return {
               lineId,
@@ -203,6 +221,7 @@ export const useRouteEstimation = (): EstimationResult => {
           status: results.length > 0 ? 'ready' : 'collecting',
         }));
       } catch (err) {
+        if (signal.aborted) return;
         console.error('useRouteEstimation: estimation failed', err);
         setState((prev) => ({ ...prev, status: 'collecting' }));
       } finally {
@@ -217,7 +236,7 @@ export const useRouteEstimation = (): EstimationResult => {
     setState,
     fetchNearbyStart,
     fetchNearbyEnd,
-    fetchLineStations,
+    client,
   ]);
 
   // 候補選択: 既存のstationState / lineStateに反映
@@ -235,7 +254,8 @@ export const useRouteEstimation = (): EstimationResult => {
         selectedBound: candidate.boundStation,
       }));
 
-      // 推定を停止
+      // 推定を停止（進行中のリクエストもキャンセル）
+      abortControllerRef.current?.abort();
       bufferRef.current = [];
       setState((prev) => ({
         ...prev,
@@ -250,6 +270,7 @@ export const useRouteEstimation = (): EstimationResult => {
 
   // リセット
   const reset = useCallback(() => {
+    abortControllerRef.current?.abort();
     bufferRef.current = [];
     setState({
       status: 'idle',


### PR DESCRIPTION
## Summary
- `fetchLineStations`（`useLazyQuery`）を`Promise.all`で並列呼び出ししていたことによるAbortErrorを修正。`useLazyQuery`は同時に1つのin-flightリクエストしか保持できないため、2回目以降の呼び出しが前回を内部的にabortしていた
- `client.query()`に置き換えることで各リクエストを独立させ、AbortErrorの連鎖を解消
- `AbortController`を導入し、リセット・候補選択・アンマウント時に進行中のリクエストを明示的にキャンセル

## 変更内容
- `fetchLineStations`（`useLazyQuery`）→ `useApolloClient().query()` に変更（並列呼び出し対応）
- `AbortController` による明示的なキャンセル制御を追加
- `catch`で`signal.aborted`時は早期リターンし、不要なエラーログ・state更新を抑制
- `selectCandidate`・`reset`・アンマウント時にも`abort()`を呼び出し

## Test plan
- [x] `npm run typecheck` パス確認済み
- [x] `npm run lint` パス確認済み
- [ ] デバッグモーダルから路線推定を開始→停止→再開始してAbortErrorが出ないことを確認
- [ ] 推定中にリセットしてもクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ルート推定処理のキャンセル制御を強化し、停止／リセット／候補選択時に進行中の推定処理と関連ネットワークリクエストが確実に中断されるようになりました。
  * GraphQLリクエストへ中断信号を伝播し、キャンセル時の不要なエラー報告や状態更新を抑制します。
  * キャンセル判定に基づく状態更新の回避と早期終了で、安定性と応答性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->