### PR TITLE
小田急ナンバリングアイコンのグレースケール色を黒に変更

### DIFF
--- a/src/components/NumberingIconOdakyu.tsx
+++ b/src/components/NumberingIconOdakyu.tsx
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const GRAYSCALE_COLOR = '#aaa';
+const BLACK_COLOR = '#000';
 
 const NumberingIconOdakyu: React.FC<Props> = ({
   stationNumber: stationNumberRaw,
@@ -59,12 +59,12 @@ const NumberingIconOdakyu: React.FC<Props> = ({
   const stationNumber = stationNumberRest.join('');
 
   const borderColor = shouldGrayscale
-    ? GRAYSCALE_COLOR
+    ? BLACK_COLOR
     : hakone
       ? '#EA4D15'
       : '#0D82C7';
   const textColor = shouldGrayscale
-    ? GRAYSCALE_COLOR
+    ? BLACK_COLOR
     : hakone
       ? '#6A3906'
       : '#0D82C7';


### PR DESCRIPTION
## Summary
- 小田急ナンバリングアイコン(`NumberingIconOdakyu`)のグレースケール表示時の色を `#aaa`（灰色）から `#000`（黒）に変更
- `borderColor` と `textColor` の両方に適用

## Test plan
- [ ] 小田急線の駅でグレースケール表示が黒色で正しく表示されることを確認
- [ ] 箱根登山鉄道の駅で通常表示が影響を受けていないことを確認
- [ ] 小田急線の駅で通常（非グレースケール）表示が影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 番号アイコンの表示色を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->