### PR TITLE
路線推定の候補路線駅取得をlineListStationsに変更しN+1問題を解消

### DIFF
--- a/src/hooks/useRouteEstimation.test.tsx
+++ b/src/hooks/useRouteEstimation.test.tsx
@@ -84,7 +84,12 @@ const setupAtoms = (stateOverrides: Partial<RouteEstimationState> = {}) => {
   const setters = [mockSetLineState, mockSetStationState];
   let setterIndex = 0;
   mockUseSetAtom.mockImplementation(() => {
-    const setter = setters[setterIndex % setters.length];
+    if (setterIndex >= setters.length) {
+      throw new Error(
+        `useSetAtom called more times than expected: ${setterIndex + 1}`
+      );
+    }
+    const setter = setters[setterIndex];
     setterIndex++;
     return setter;
   });
@@ -104,7 +109,12 @@ const setupQueries = () => {
   ];
   let queryIndex = 0;
   mockUseLazyQuery.mockImplementation(() => {
-    const result = queryResults[queryIndex % queryResults.length];
+    if (queryIndex >= queryResults.length) {
+      throw new Error(
+        `useLazyQuery called more times than expected: ${queryIndex + 1}`
+      );
+    }
+    const result = queryResults[queryIndex];
     queryIndex++;
     return result;
   });

--- a/src/hooks/useRouteEstimation.test.tsx
+++ b/src/hooks/useRouteEstimation.test.tsx
@@ -1,0 +1,379 @@
+import { useLazyQuery } from '@apollo/client/react';
+import { act, render } from '@testing-library/react-native';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import type React from 'react';
+import type { RouteEstimationState } from '~/store/atoms/routeEstimation';
+import type {
+  EstimationResult,
+  RouteCandidate,
+} from '~/utils/routeEstimation/types';
+import { createLine, createStation } from '~/utils/test/factories';
+import {
+  useRouteEstimation,
+  useRouteEstimationControl,
+} from './useRouteEstimation';
+
+jest.mock('@apollo/client/react', () => ({
+  useLazyQuery: jest.fn(),
+}));
+jest.mock('jotai', () => ({
+  useAtom: jest.fn(),
+  useAtomValue: jest.fn(),
+  useSetAtom: jest.fn(),
+  atom: jest.fn(),
+}));
+jest.mock('~/utils/routeEstimation/estimateRoute', () => ({
+  estimateRoutes: jest.fn(() => []),
+}));
+jest.mock('~/utils/routeEstimation/preprocessLogs', () => ({
+  appendToBuffer: jest.fn((_buf, log) => [..._buf, log]),
+  preprocessLogs: jest.fn((buf) => buf),
+  getTotalDistance: jest.fn(() => 0),
+  getAvgSpeed: jest.fn(() => 0),
+  isMoving: jest.fn(() => false),
+  isTransferStop: jest.fn(() => false),
+  MIN_POINTS_FOR_ESTIMATION: 5,
+}));
+
+const mockUseLazyQuery = useLazyQuery as unknown as jest.Mock;
+const mockUseAtom = useAtom as unknown as jest.Mock;
+const mockUseAtomValue = useAtomValue as unknown as jest.Mock;
+const mockUseSetAtom = useSetAtom as unknown as jest.Mock;
+
+type HookResult = EstimationResult | null;
+
+const HookBridge: React.FC<{ onReady: (value: HookResult) => void }> = ({
+  onReady,
+}) => {
+  onReady(useRouteEstimation());
+  return null;
+};
+
+type ControlResult = ReturnType<typeof useRouteEstimationControl> | null;
+
+const ControlHookBridge: React.FC<{
+  onReady: (value: ControlResult) => void;
+}> = ({ onReady }) => {
+  onReady(useRouteEstimationControl());
+  return null;
+};
+
+const createRouteEstimationState = (
+  overrides: Partial<RouteEstimationState> = {}
+): RouteEstimationState => ({
+  status: 'idle',
+  candidates: [],
+  locationBuffer: [],
+  isEstimating: false,
+  ...overrides,
+});
+
+const setupAtoms = (stateOverrides: Partial<RouteEstimationState> = {}) => {
+  const state = createRouteEstimationState(stateOverrides);
+  const mockSetState = jest.fn();
+  const mockSetLineState = jest.fn();
+  const mockSetStationState = jest.fn();
+
+  // useAtomValue(locationAtom) → null
+  mockUseAtomValue.mockReturnValue(null);
+
+  // useAtom(routeEstimationState)
+  mockUseAtom.mockReturnValue([state, mockSetState]);
+
+  // useSetAtom: lineState, stationState の順
+  const setters = [mockSetLineState, mockSetStationState];
+  let setterIndex = 0;
+  mockUseSetAtom.mockImplementation(() => {
+    const setter = setters[setterIndex % setters.length];
+    setterIndex++;
+    return setter;
+  });
+
+  return { state, mockSetState, mockSetLineState, mockSetStationState };
+};
+
+const setupQueries = () => {
+  const mockFetchNearbyStart = jest.fn();
+  const mockFetchNearbyEnd = jest.fn();
+  const mockFetchLineListStations = jest.fn();
+
+  const queryResults = [
+    [mockFetchNearbyStart],
+    [mockFetchNearbyEnd],
+    [mockFetchLineListStations],
+  ];
+  let queryIndex = 0;
+  mockUseLazyQuery.mockImplementation(() => {
+    const result = queryResults[queryIndex % queryResults.length];
+    queryIndex++;
+    return result;
+  });
+
+  return {
+    mockFetchNearbyStart,
+    mockFetchNearbyEnd,
+    mockFetchLineListStations,
+  };
+};
+
+describe('useRouteEstimation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('初期状態で idle を返す', () => {
+    setupAtoms();
+    setupQueries();
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.status).toBe('idle');
+    expect(hookRef.current?.candidates).toEqual([]);
+    expect(hookRef.current?.bufferInfo).toEqual({
+      pointCount: 0,
+      totalDistance: 0,
+      avgSpeed: 0,
+      isMoving: false,
+    });
+  });
+
+  it('selectCandidate が lineState と stationState を更新し推定を停止する', () => {
+    const { mockSetState, mockSetLineState, mockSetStationState } = setupAtoms({
+      isEstimating: true,
+      status: 'ready',
+    });
+    setupQueries();
+
+    const line = createLine(100);
+    const stations = [
+      createStation(1, { line: { id: 100 } }),
+      createStation(2, { line: { id: 100 } }),
+    ];
+    const candidate: RouteCandidate = {
+      line,
+      direction: 'INBOUND',
+      currentStation: stations[0],
+      nextStation: stations[1],
+      boundStation: stations[1],
+      stations,
+      score: 0.9,
+      confidence: 0.85,
+      scoreBreakdown: { routeFitScore: 0.9, orderScore: 0.9, speedScore: 0.9 },
+    };
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    act(() => {
+      hookRef.current?.selectCandidate(candidate);
+    });
+
+    // lineState 更新
+    expect(mockSetLineState).toHaveBeenCalled();
+    const lineSetter = mockSetLineState.mock.calls[0][0];
+    const lineResult = lineSetter({ selectedLine: null, pendingLine: null });
+    expect(lineResult.selectedLine).toBe(line);
+
+    // stationState 更新
+    expect(mockSetStationState).toHaveBeenCalled();
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const stationResult = stationSetter({
+      station: null,
+      stations: [],
+      selectedDirection: null,
+      selectedBound: null,
+    });
+    expect(stationResult.station).toBe(stations[0]);
+    expect(stationResult.stations).toBe(stations);
+    expect(stationResult.selectedDirection).toBe('INBOUND');
+    expect(stationResult.selectedBound).toBe(stations[1]);
+
+    // 推定状態リセット
+    expect(mockSetState).toHaveBeenCalled();
+    const stateSetter = mockSetState.mock.calls[0][0];
+    const stateResult = stateSetter(
+      createRouteEstimationState({ isEstimating: true, status: 'ready' })
+    );
+    expect(stateResult.isEstimating).toBe(false);
+    expect(stateResult.locationBuffer).toEqual([]);
+    expect(stateResult.candidates).toEqual([]);
+    expect(stateResult.status).toBe('idle');
+  });
+
+  it('reset が状態を初期化する', () => {
+    const { mockSetState } = setupAtoms({
+      isEstimating: true,
+      status: 'estimating',
+      locationBuffer: [
+        {
+          latitude: 35.68,
+          longitude: 139.76,
+          accuracy: 10,
+          timestamp: 1000,
+          speed: 5,
+        },
+      ],
+    });
+    setupQueries();
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    act(() => {
+      hookRef.current?.reset();
+    });
+
+    expect(mockSetState).toHaveBeenCalledWith({
+      status: 'idle',
+      candidates: [],
+      locationBuffer: [],
+      isEstimating: false,
+    });
+  });
+
+  it('bufferInfo がバッファの統計情報を返す', () => {
+    const { preprocessLogs, getTotalDistance, getAvgSpeed, isMoving } =
+      jest.requireMock('~/utils/routeEstimation/preprocessLogs');
+
+    const buffer = [
+      {
+        latitude: 35.68,
+        longitude: 139.76,
+        accuracy: 10,
+        timestamp: 1000,
+        speed: 15,
+      },
+      {
+        latitude: 35.69,
+        longitude: 139.77,
+        accuracy: 10,
+        timestamp: 2000,
+        speed: 15,
+      },
+    ];
+
+    preprocessLogs.mockReturnValue(buffer);
+    getTotalDistance.mockReturnValue(500);
+    getAvgSpeed.mockReturnValue(12);
+    isMoving.mockReturnValue(true);
+
+    setupAtoms({ locationBuffer: buffer });
+    setupQueries();
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.bufferInfo).toEqual({
+      pointCount: 2,
+      totalDistance: 500,
+      avgSpeed: 12,
+      isMoving: true,
+    });
+  });
+});
+
+describe('useRouteEstimationControl', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setupControlAtoms = (
+    stateOverrides: Partial<RouteEstimationState> = {}
+  ) => {
+    const state = createRouteEstimationState(stateOverrides);
+    const mockSetState = jest.fn();
+    mockUseAtom.mockReturnValue([state, mockSetState]);
+    return { state, mockSetState };
+  };
+
+  it('isEstimating が初期状態で false を返す', () => {
+    setupControlAtoms();
+
+    const hookRef: { current: ControlResult } = { current: null };
+    render(
+      <ControlHookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    expect(hookRef.current?.isEstimating).toBe(false);
+  });
+
+  it('startEstimation が isEstimating を true に、status を collecting にする', () => {
+    const { mockSetState } = setupControlAtoms();
+
+    const hookRef: { current: ControlResult } = { current: null };
+    render(
+      <ControlHookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    act(() => {
+      hookRef.current?.startEstimation();
+    });
+
+    expect(mockSetState).toHaveBeenCalled();
+    const setter = mockSetState.mock.calls[0][0];
+    const result = setter(createRouteEstimationState());
+    expect(result.isEstimating).toBe(true);
+    expect(result.status).toBe('collecting');
+  });
+
+  it('stopEstimation が isEstimating を false に、status を idle にする', () => {
+    const { mockSetState } = setupControlAtoms({
+      isEstimating: true,
+      status: 'estimating',
+    });
+
+    const hookRef: { current: ControlResult } = { current: null };
+    render(
+      <ControlHookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    act(() => {
+      hookRef.current?.stopEstimation();
+    });
+
+    expect(mockSetState).toHaveBeenCalled();
+    const setter = mockSetState.mock.calls[0][0];
+    const result = setter(
+      createRouteEstimationState({ isEstimating: true, status: 'estimating' })
+    );
+    expect(result.isEstimating).toBe(false);
+    expect(result.status).toBe('idle');
+  });
+});

--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -2,7 +2,10 @@ import { useLazyQuery } from '@apollo/client/react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Line, Station } from '~/@types/graphql';
-import { GET_LINE_STATIONS, GET_STATIONS_NEARBY } from '~/lib/graphql/queries';
+import {
+  GET_LINE_LIST_STATIONS,
+  GET_STATIONS_NEARBY,
+} from '~/lib/graphql/queries';
 import lineState from '~/store/atoms/line';
 import { locationAtom } from '~/store/atoms/location';
 import routeEstimationState from '~/store/atoms/routeEstimation';
@@ -35,13 +38,12 @@ type GetStationsNearbyVariables = {
   limit?: number;
 };
 
-type GetLineStationsData = {
-  lineStations: Station[];
+type GetLineListStationsData = {
+  lineListStations: Station[];
 };
 
-type GetLineStationsVariables = {
-  lineId: number;
-  stationId?: number;
+type GetLineListStationsVariables = {
+  lineIds: number[];
 };
 
 /**
@@ -73,10 +75,10 @@ export const useRouteEstimation = (): EstimationResult => {
     GetStationsNearbyVariables
   >(GET_STATIONS_NEARBY);
 
-  const [fetchLineStations] = useLazyQuery<
-    GetLineStationsData,
-    GetLineStationsVariables
-  >(GET_LINE_STATIONS);
+  const [fetchLineListStations] = useLazyQuery<
+    GetLineListStationsData,
+    GetLineListStationsVariables
+  >(GET_LINE_LIST_STATIONS);
 
   // 新しいGPSポイントをバッファに追加
   useEffect(() => {
@@ -173,23 +175,30 @@ export const useRouteEstimation = (): EstimationResult => {
           }
         }
 
-        // 各候補路線の駅リストを取得
-        const candidates: CandidateLine[] = [];
-        const lineStationResults = await Promise.all(
-          Array.from(lineIdSet).map(async (lineId) => {
-            const result = await fetchLineStations({
-              variables: { lineId },
-            });
-            return {
-              lineId,
-              stations: result.data?.lineStations ?? [],
-            };
-          })
-        );
+        // 全候補路線の駅リストを一括取得
+        const lineIds = Array.from(lineIdSet);
+        const lineListResult = await fetchLineListStations({
+          variables: { lineIds },
+        });
+        const allStations = lineListResult.data?.lineListStations ?? [];
 
-        for (const { lineId, stations } of lineStationResults) {
+        // 路線IDごとに駅を振り分け
+        const stationsByLineId = new Map<number, Station[]>();
+        for (const station of allStations) {
+          for (const line of station.lines ?? []) {
+            if (line?.id != null && lineIdSet.has(line.id)) {
+              const list = stationsByLineId.get(line.id) ?? [];
+              list.push(station);
+              stationsByLineId.set(line.id, list);
+            }
+          }
+        }
+
+        const candidates: CandidateLine[] = [];
+        for (const lineId of lineIds) {
           const line = lineMap.get(lineId);
-          if (line && stations.length > 0) {
+          const stations = stationsByLineId.get(lineId);
+          if (line && stations && stations.length > 0) {
             candidates.push({ line, stations });
           }
         }
@@ -217,7 +226,7 @@ export const useRouteEstimation = (): EstimationResult => {
     setState,
     fetchNearbyStart,
     fetchNearbyEnd,
-    fetchLineStations,
+    fetchLineListStations,
   ]);
 
   // 候補選択: 既存のstationState / lineStateに反映

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -285,6 +285,16 @@ export const GET_LINE_LIST_STATIONS_LIGHT = gql`
   }
 `;
 
+// Query for getting stations by multiple line IDs
+export const GET_LINE_LIST_STATIONS = gql`
+  ${STATION_FRAGMENT}
+  query GetLineListStations($lineIds: [Int!]!) {
+    lineListStations(lineIds: $lineIds) {
+      ...StationFields
+    }
+  }
+`;
+
 // Query for getting stations by line ID
 export const GET_LINE_STATIONS = gql`
   ${STATION_FRAGMENT}


### PR DESCRIPTION
## Summary
- `useRouteEstimation`で候補路線の駅リスト取得に`lineStations`を路線数分ループ呼び出し（N+1）していたのを、`lineListStations`による一括取得に変更
- `GET_LINE_LIST_STATIONS`クエリ（`StationFields`フラグメント使用）を新規追加
- 返却されたフラットな駅リストを路線IDごとに振り分けて`CandidateLine[]`を構築

## Test plan
- [ ] 路線推定デバッグモーダルで推定が正常に動作すること
- [ ] 候補路線と駅リストが従来と同じ結果になること
- [x] `npm run typecheck` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 複数路線の駅情報取得を一括化し、駅データ取得と推定処理の効率を向上しました（検索応答速度と処理効率が向上）。
* **新機能**
  * 複数路線向けの一括駅取得APIを利用するようになりました。
* **テスト**
  * ルート推定の初期状態、開始・停止、候補選択、リセット、および統計算出を検証する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->