### PR TITLE
isDevAppがfalseの場合に路線推定を無効化

### DIFF
--- a/src/hooks/useRouteEstimation.test.tsx
+++ b/src/hooks/useRouteEstimation.test.tsx
@@ -22,6 +22,9 @@ jest.mock('jotai', () => ({
   useSetAtom: jest.fn(),
   atom: jest.fn(),
 }));
+jest.mock('~/utils/isDevApp', () => ({
+  isDevApp: true,
+}));
 jest.mock('~/utils/routeEstimation/estimateRoute', () => ({
   estimateRoutes: jest.fn(() => []),
 }));

--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -285,7 +285,7 @@ const useRouteEstimationImpl = (): EstimationResult => {
   };
 };
 
-const useRouteEstimationNoop = (): EstimationResult => ({
+const NOOP_ESTIMATION_RESULT: EstimationResult = {
   status: 'idle',
   candidates: [],
   selectCandidate: () => {},
@@ -296,7 +296,9 @@ const useRouteEstimationNoop = (): EstimationResult => ({
     avgSpeed: 0,
     isMoving: false,
   },
-});
+};
+
+const useRouteEstimationNoop = (): EstimationResult => NOOP_ESTIMATION_RESULT;
 
 /**
  * 路線推定のメインフック
@@ -334,11 +336,13 @@ const useRouteEstimationControlImpl = () => {
   };
 };
 
-const useRouteEstimationControlNoop = () => ({
+const NOOP_ESTIMATION_CONTROL = {
   isEstimating: false as const,
   startEstimation: () => {},
   stopEstimation: () => {},
-});
+};
+
+const useRouteEstimationControlNoop = () => NOOP_ESTIMATION_CONTROL;
 
 export const useRouteEstimationControl = isDevApp
   ? useRouteEstimationControlImpl

--- a/src/hooks/useRouteEstimation.ts
+++ b/src/hooks/useRouteEstimation.ts
@@ -10,6 +10,7 @@ import lineState from '~/store/atoms/line';
 import { locationAtom } from '~/store/atoms/location';
 import routeEstimationState from '~/store/atoms/routeEstimation';
 import stationState from '~/store/atoms/station';
+import { isDevApp } from '~/utils/isDevApp';
 import { estimateRoutes } from '~/utils/routeEstimation/estimateRoute';
 import {
   appendToBuffer,
@@ -46,11 +47,7 @@ type GetLineListStationsVariables = {
   lineIds: number[];
 };
 
-/**
- * 路線推定のメインフック
- * isDevApp限定のデバッグモーダルから呼び出される
- */
-export const useRouteEstimation = (): EstimationResult => {
+const useRouteEstimationImpl = (): EstimationResult => {
   const location = useAtomValue(locationAtom);
   const [state, setState] = useAtom(routeEstimationState);
   const setLineState = useSetAtom(lineState);
@@ -288,10 +285,30 @@ export const useRouteEstimation = (): EstimationResult => {
   };
 };
 
+const useRouteEstimationNoop = (): EstimationResult => ({
+  status: 'idle',
+  candidates: [],
+  selectCandidate: () => {},
+  reset: () => {},
+  bufferInfo: {
+    pointCount: 0,
+    totalDistance: 0,
+    avgSpeed: 0,
+    isMoving: false,
+  },
+});
+
+/**
+ * 路線推定のメインフック
+ */
+export const useRouteEstimation = isDevApp
+  ? useRouteEstimationImpl
+  : useRouteEstimationNoop;
+
 /**
  * 推定の開始/停止を制御するフック
  */
-export const useRouteEstimationControl = () => {
+const useRouteEstimationControlImpl = () => {
   const [state, setState] = useAtom(routeEstimationState);
 
   const startEstimation = useCallback(() => {
@@ -316,3 +333,13 @@ export const useRouteEstimationControl = () => {
     stopEstimation,
   };
 };
+
+const useRouteEstimationControlNoop = () => ({
+  isEstimating: false as const,
+  startEstimation: () => {},
+  stopEstimation: () => {},
+});
+
+export const useRouteEstimationControl = isDevApp
+  ? useRouteEstimationControlImpl
+  : useRouteEstimationControlNoop;


### PR DESCRIPTION
## Summary
- `useRouteEstimation`と`useRouteEstimationControl`を、`isDevApp`がfalseの場合にnoop実装に切り替えるようにガード
- 本番ビルドでは路線推定関連のhooks・GraphQLクエリ・GPSバッファリングが一切実行されなくなる

## Test plan
- [ ] dev appビルドで路線推定が従来通り動作すること
- [ ] 本番ビルドで路線推定の処理が実行されないこと
- [ ] `npm run typecheck`が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * ルート推定の実装を再構成し、開発環境では詳細な推定・制御が動作し、本番では軽量なフォールバック動作が使われるようになりました。
* **Tests**
  * テスト環境を調整し、開発モードの動作を確実に検証できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->