### PR TITLE
NowHeaderにバス停の場合「都営バス」バッジを表示

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -300,5 +300,6 @@
   "wrongDirectionWarning": "You may be traveling in the wrong direction. Please check your app settings.",
   "wrongDirectionLoopLineWarning": "You may be traveling in the wrong direction. As this is a loop line, you will still arrive, but it will take longer.",
   "wrongDirectionNotificationTitle": "Direction Alert",
-  "trainTypeMismatchWarning": "The selected train type may not match your actual service. Please check your settings."
+  "trainTypeMismatchWarning": "The selected train type may not match your actual service. Please check your settings.",
+  "toeiBusBadge": "Toei Bus"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -301,5 +301,6 @@
   "wrongDirectionWarning": "選択した行き先と逆方向に進んでいる可能性があります。アプリの設定をご確認ください。",
   "wrongDirectionLoopLineWarning": "選択した行き先と逆方向に進んでいる可能性があります。環状線のため到着は可能ですが、遠回りになります。",
   "wrongDirectionNotificationTitle": "方向のお知らせ",
-  "trainTypeMismatchWarning": "選択した列車種別と実際の運行種別が異なる可能性があります。設定をご確認ください。"
+  "trainTypeMismatchWarning": "選択した列車種別と実際の運行種別が異なる可能性があります。設定をご確認ください。",
+  "toeiBusBadge": "都営バス"
 }

--- a/src/components/NowHeader.tsx
+++ b/src/components/NowHeader.tsx
@@ -21,6 +21,7 @@ import stationState from '~/store/atoms/station';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
+import { isBusLine } from '~/utils/line';
 import { StationSearchModal } from './StationSearchModal';
 import Typography from './Typography';
 
@@ -74,6 +75,22 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     transformOrigin: 'left bottom',
   },
+  busStationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  busBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+  },
+  busBadgeText: {
+    fontSize: isTablet ? 16 : 12,
+    fontWeight: '600',
+    color: '#fff',
+  },
 });
 
 export type HeaderLayout = {
@@ -111,13 +128,22 @@ export const NowHeader = ({
     const label = locationPermissionsGranted
       ? translate('nowAtLabel')
       : translate('welcomeLabel');
-    if (!station) return { label, name: '' };
+    if (!station) return { label, name: '', isBus: false };
     const re = /\([^()]*\)/g;
     const name = isJapanese
       ? (station.name ?? '').replaceAll(re, '')
       : (station.nameRoman ?? station.name ?? '').replaceAll(re, '');
-    return { label, name };
+    const isBus = isBusLine(station.line);
+    return { label, name, isBus };
   }, [station, locationPermissionsGranted]);
+
+  const busBadgeStyle: ViewStyle = useMemo(
+    () => ({
+      backgroundColor: isLEDTheme ? '#2E7D32' : '#388E3C',
+      borderColor: isLEDTheme ? '#43A047' : '#2E7D32',
+    }),
+    [isLEDTheme]
+  );
 
   const COLLAPSE_RANGE = 64;
   const stackedOpacity = scrollY.interpolate({
@@ -226,13 +252,22 @@ export const NowHeader = ({
                     { transform: [{ scale: stationScale }] },
                   ]}
                 >
-                  <Typography
-                    style={styles.nowStation}
-                    numberOfLines={1}
-                    adjustsFontSizeToFit
-                  >
-                    {nowHeader.name ?? ''}
-                  </Typography>
+                  <View style={styles.busStationRow}>
+                    <Typography
+                      style={styles.nowStation}
+                      numberOfLines={1}
+                      adjustsFontSizeToFit
+                    >
+                      {nowHeader.name ?? ''}
+                    </Typography>
+                    {nowHeader.isBus ? (
+                      <View style={[styles.busBadge, busBadgeStyle]}>
+                        <Typography style={styles.busBadgeText}>
+                          {translate('toeiBusBadge')}
+                        </Typography>
+                      </View>
+                    ) : null}
+                  </View>
                 </RNAnimated.View>
               ) : locationPermissionsGranted ? (
                 <SkeletonPlaceholder borderRadius={4} speed={1500}>
@@ -260,6 +295,13 @@ export const NowHeader = ({
                   ? (nowHeader.name ?? '')
                   : translate('searchByStationName')}
               </Typography>
+              {nowHeader.isBus ? (
+                <View style={[styles.busBadge, busBadgeStyle]}>
+                  <Typography style={styles.busBadgeText}>
+                    {translate('toeiBusBadge')}
+                  </Typography>
+                </View>
+              ) : null}
             </RNAnimated.View>
           </View>
         </View>


### PR DESCRIPTION
## Summary
- バス停が表示されている場合、NowHeaderの駅名右側に「都営バス」（英語: "Toei Bus"）のバッジを表示
- Stacked layout（通常表示）とInline layout（スクロール後）の両方に対応
- LEDテーマ対応の配色（都営バスのコーポレートグリーン系）

## Test plan
- [ ] バス停データが入った状態でNowHeaderに「都営バス」バッジが表示されること
- [ ] スクロール後のInline layoutでもバッジが表示されること
- [ ] 鉄道駅の場合はバッジが表示されないこと
- [ ] LEDテーマでも視認性が確保されていること
- [ ] 英語環境で "Toei Bus" と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 駅情報ヘッダーに都営バスバッジを追加しました。都営バスの路線を利用する際、駅名の隣に「都営バス」が表示されるようになり、路線の種類をより簡単に識別できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->