### PR TITLE
TOEIテーマのLineBoardで無効化された言語の併記表示を非表示にする

### DIFF
--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -114,24 +114,34 @@ describe('LineBoardToei', () => {
     } as unknown as Station,
   ];
 
-  const mockUseAtomValue = (atomVal: unknown) => {
-    if (atomVal && (atomVal as { __brand?: string }).__brand === 'isEnAtom') {
-      return false;
-    }
-    if (
-      atomVal &&
-      (atomVal as { __brand?: string }).__brand === 'navigationState'
-    ) {
-      return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
-    }
-    return {
-      station: mockStations[0],
-      arrived: true,
+  const createUseAtomValueMock =
+    ({
+      isEn = false,
+      enabledLanguages = ['JA', 'EN', 'ZH', 'KO'] as string[],
+      stationOverrides = {} as Record<string, unknown>,
+    } = {}) =>
+    (atomVal: unknown) => {
+      if (
+        atomVal &&
+        (atomVal as { __brand?: string }).__brand === 'isEnAtom'
+      ) {
+        return isEn;
+      }
+      if (
+        atomVal &&
+        (atomVal as { __brand?: string }).__brand === 'navigationState'
+      ) {
+        return { enabledLanguages };
+      }
+      return {
+        station: mockStations[0],
+        arrived: true,
+        ...stationOverrides,
+      };
     };
-  };
 
   beforeEach(() => {
-    useAtomValue.mockImplementation(mockUseAtomValue);
+    useAtomValue.mockImplementation(createUseAtomValueMock());
     useCurrentLine.mockReturnValue(mockLine);
   });
 
@@ -239,22 +249,9 @@ describe('LineBoardToei', () => {
 
   it('lineがnullの場合、駅セルがレンダリングされない', () => {
     useCurrentLine.mockReturnValue(null);
-    useAtomValue.mockImplementation((atomVal: unknown) => {
-      if (atomVal && (atomVal as { __brand?: string }).__brand === 'isEnAtom') {
-        return false;
-      }
-      if (
-        atomVal &&
-        (atomVal as { __brand?: string }).__brand === 'navigationState'
-      ) {
-        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
-      }
-      return {
-        station: mockStations[0],
-        arrived: true,
-        selectedLine: null,
-      };
-    });
+    useAtomValue.mockImplementation(
+      createUseAtomValueMock({ stationOverrides: { selectedLine: null } })
+    );
     const { LineDot } = require('./LineBoard/shared/components');
     LineDot.mockClear();
     render(
@@ -276,5 +273,66 @@ describe('LineBoardToei', () => {
       />
     );
     expect(result.toJSON()).toBeTruthy();
+  });
+
+  it('韓国語が無効の場合、韓国語の併記が表示されない', () => {
+    useAtomValue.mockImplementation(
+      createUseAtomValueMock({ enabledLanguages: ['JA', 'EN'] })
+    );
+    const { queryByText } = render(
+      <LineBoardToei
+        stations={mockStations}
+        lineColors={['#ed6d00', '#ed6d00']}
+        hasTerminus={false}
+      />
+    );
+    expect(queryByText('신바시')).toBeNull();
+    expect(queryByText('히가시긴자')).toBeNull();
+  });
+
+  it('中国語が無効の場合、英語モードで中国語の併記が表示されない', () => {
+    useAtomValue.mockImplementation(
+      createUseAtomValueMock({ isEn: true, enabledLanguages: ['JA', 'EN'] })
+    );
+    const { queryByText } = render(
+      <LineBoardToei
+        stations={mockStations}
+        lineColors={['#ed6d00', '#ed6d00']}
+        hasTerminus={false}
+      />
+    );
+    expect(queryByText('新桥')).toBeNull();
+    expect(queryByText('东银座')).toBeNull();
+  });
+
+  it('韓国語が有効の場合、韓国語の併記が表示される', () => {
+    useAtomValue.mockImplementation(
+      createUseAtomValueMock({ enabledLanguages: ['JA', 'EN', 'KO'] })
+    );
+    const { getByText } = render(
+      <LineBoardToei
+        stations={mockStations}
+        lineColors={['#ed6d00', '#ed6d00']}
+        hasTerminus={false}
+      />
+    );
+    expect(getByText('신')).toBeTruthy();
+  });
+
+  it('中国語が有効の場合、英語モードで中国語の併記が表示される', () => {
+    useAtomValue.mockImplementation(
+      createUseAtomValueMock({
+        isEn: true,
+        enabledLanguages: ['JA', 'EN', 'ZH'],
+      })
+    );
+    const { getByText } = render(
+      <LineBoardToei
+        stations={mockStations}
+        lineColors={['#ed6d00', '#ed6d00']}
+        hasTerminus={false}
+      />
+    );
+    expect(getByText('新桥')).toBeTruthy();
   });
 });

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -22,7 +22,12 @@ jest.mock('~/hooks/useScale', () => ({
 }));
 
 jest.mock('~/store/selectors/isEn', () => ({
-  isEnAtom: {},
+  isEnAtom: { __brand: 'isEnAtom' },
+}));
+
+jest.mock('~/store/atoms/navigation', () => ({
+  __esModule: true,
+  default: { __brand: 'navigationState' },
 }));
 
 jest.mock('~/utils/getStationNameR', () => ({
@@ -109,11 +114,24 @@ describe('LineBoardToei', () => {
     } as unknown as Station,
   ];
 
-  beforeEach(() => {
-    useAtomValue.mockReturnValue({
+  const mockUseAtomValue = (atomVal: unknown) => {
+    if (atomVal && (atomVal as { __brand?: string }).__brand === 'isEnAtom') {
+      return false;
+    }
+    if (
+      atomVal &&
+      (atomVal as { __brand?: string }).__brand === 'navigationState'
+    ) {
+      return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
+    }
+    return {
       station: mockStations[0],
       arrived: true,
-    });
+    };
+  };
+
+  beforeEach(() => {
+    useAtomValue.mockImplementation(mockUseAtomValue);
     useCurrentLine.mockReturnValue(mockLine);
   });
 
@@ -221,10 +239,21 @@ describe('LineBoardToei', () => {
 
   it('lineがnullの場合、駅セルがレンダリングされない', () => {
     useCurrentLine.mockReturnValue(null);
-    useAtomValue.mockReturnValue({
-      station: mockStations[0],
-      arrived: true,
-      selectedLine: null,
+    useAtomValue.mockImplementation((atomVal: unknown) => {
+      if (atomVal && (atomVal as { __brand?: string }).__brand === 'isEnAtom') {
+        return false;
+      }
+      if (
+        atomVal &&
+        (atomVal as { __brand?: string }).__brand === 'navigationState'
+      ) {
+        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
+      }
+      return {
+        station: mockStations[0],
+        arrived: true,
+        selectedLine: null,
+      };
     });
     const { LineDot } = require('./LineBoard/shared/components');
     LineDot.mockClear();

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -121,10 +121,7 @@ describe('LineBoardToei', () => {
       stationOverrides = {} as Record<string, unknown>,
     } = {}) =>
     (atomVal: unknown) => {
-      if (
-        atomVal &&
-        (atomVal as { __brand?: string }).__brand === 'isEnAtom'
-      ) {
+      if (atomVal && (atomVal as { __brand?: string }).__brand === 'isEnAtom') {
         return isEn;
       }
       if (

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -10,6 +10,7 @@ import {
   useTransferLinesFromStation,
 } from '~/hooks';
 import { useScale } from '~/hooks/useScale';
+import navigationState from '~/store/atoms/navigation';
 import { isEnAtom } from '~/store/selectors/isEn';
 import getStationNameR from '~/utils/getStationNameR';
 import { RFValue } from '~/utils/rfValue';
@@ -73,6 +74,8 @@ interface StationNameToeiProps {
   en?: boolean;
   horizontal?: boolean;
   passed?: boolean;
+  isKoEnabled?: boolean;
+  isZhEnabled?: boolean;
 }
 
 const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
@@ -80,6 +83,8 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
   en,
   horizontal,
   passed,
+  isKoEnabled,
+  isZhEnabled,
 }) => {
   const stationNameR = useMemo(() => getStationNameR(station), [station]);
   const dim = useWindowDimensions();
@@ -111,12 +116,19 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
         ]}
       >
         {stationNameR}
-        {'\n'}
-        <Typography
-          style={[styles.stationNameExtra, passed ? styles.grayColor : null]}
-        >
-          {station.nameChinese ?? ''}
-        </Typography>
+        {isZhEnabled ? (
+          <>
+            {'\n'}
+            <Typography
+              style={[
+                styles.stationNameExtra,
+                passed ? styles.grayColor : null,
+              ]}
+            >
+              {station.nameChinese ?? ''}
+            </Typography>
+          </>
+        ) : null}
       </Typography>
     );
   }
@@ -131,12 +143,19 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
         ]}
       >
         {station.name}
-        {'\n'}
-        <Typography
-          style={[styles.stationNameExtra, passed ? styles.grayColor : null]}
-        >
-          {station.nameKorean ?? ''}
-        </Typography>
+        {isKoEnabled ? (
+          <>
+            {'\n'}
+            <Typography
+              style={[
+                styles.stationNameExtra,
+                passed ? styles.grayColor : null,
+              ]}
+            >
+              {station.nameKorean ?? ''}
+            </Typography>
+          </>
+        ) : null}
       </Typography>
     );
   }
@@ -153,16 +172,21 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
           </Typography>
         ))}
       </View>
-      <View style={styles.splittedStationName}>
-        {(station.nameKorean ?? '').split('').map((c, j) => (
-          <Typography
-            style={[styles.stationNameExtra, passed ? styles.grayColor : null]}
-            key={`${station.id}-ko-${j}`}
-          >
-            {c}
-          </Typography>
-        ))}
-      </View>
+      {isKoEnabled ? (
+        <View style={styles.splittedStationName}>
+          {(station.nameKorean ?? '').split('').map((c, j) => (
+            <Typography
+              style={[
+                styles.stationNameExtra,
+                passed ? styles.grayColor : null,
+              ]}
+              key={`${station.id}-ko-${j}`}
+            >
+              {c}
+            </Typography>
+          ))}
+        </View>
+      ) : null}
     </View>
   );
 };
@@ -312,6 +336,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
 }: StationNameCellProps) => {
   const { station: currentStation, arrived } = useAtomValue(stationState);
   const isEn = useAtomValue(isEnAtom);
+  const { enabledLanguages } = useAtomValue(navigationState);
+  const isKoEnabled = enabledLanguages.includes('KO');
+  const isZhEnabled = enabledLanguages.includes('ZH');
 
   const currentStationIndex = useMemo(
     () => stations.findIndex((s) => s.groupId === currentStation?.groupId),
@@ -370,6 +397,8 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             en={isEn}
             horizontal={includesLongStationName}
             passed={getIsPass(station) || shouldGrayscale}
+            isKoEnabled={isKoEnabled}
+            isZhEnabled={isZhEnabled}
           />
         </View>
         <Typography


### PR DESCRIPTION
https://claude.ai/code/session_01NMDiHx11nf3BxZZ1tjAWMc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 設定に基づき韓国語・中国語の駅名表示を個別に有効/無効化できるようになりました。表示のカスタマイズが可能です。
* **テスト**
  * 韓国語・中国語の表示切替を検証する複数のテストを追加しました（有効時/無効時の表示確認）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->