### PR TITLE
Add notification settings screen for wrong direction alerts

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -301,5 +301,8 @@
   "wrongDirectionLoopLineWarning": "You may be traveling in the wrong direction. As this is a loop line, you will still arrive, but it will take longer.",
   "wrongDirectionNotificationTitle": "Direction Alert",
   "trainTypeMismatchWarning": "The selected train type may not match your actual service. Please check your settings.",
-  "toeiBusBadge": "Toei Bus"
+  "toeiBusBadge": "Toei Bus",
+  "notificationSettings": "Notifications",
+  "wrongDirectionNotifyToggle": "Notify when traveling in wrong direction",
+  "wrongDirectionNotifyDescription": "Get notified when you are traveling in the opposite direction from the one set in the app."
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -302,5 +302,8 @@
   "wrongDirectionLoopLineWarning": "選択した行き先と逆方向に進んでいる可能性があります。環状線のため到着は可能ですが、遠回りになります。",
   "wrongDirectionNotificationTitle": "方向のお知らせ",
   "trainTypeMismatchWarning": "選択した列車種別と実際の運行種別が異なる可能性があります。設定をご確認ください。",
-  "toeiBusBadge": "都営バス"
+  "toeiBusBadge": "都営バス",
+  "notificationSettings": "通知",
+  "wrongDirectionNotifyToggle": "逆方向走行時に通知する",
+  "wrongDirectionNotifyDescription": "アプリで設定した方向と逆方向に進行している場合に通知でお知らせします。"
 }

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -34,6 +34,7 @@ import {
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import type { ThemePreference } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
+import notifyState from '../store/atoms/notify';
 import speechState from '../store/atoms/speech';
 import stationState from '../store/atoms/station';
 import { themePreferenceAtom } from '../store/atoms/theme';
@@ -54,6 +55,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const [{ autoModeEnabled, isAppLatest }, setNavigation] =
     useAtom(navigationState);
   const setSpeech = useSetAtom(speechState);
+  const setNotify = useSetAtom(notifyState);
   const setTuning = useSetAtom(tuningState);
   const setThemePreference = useSetAtom(themePreferenceAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
@@ -337,6 +339,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         headerTransitionDelayStr,
         bottomTransitionIntervalStr,
         untouchableModeEnabledStr,
+        wrongDirectionNotifyEnabledStr,
       ] = await Promise.all([
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.THEME_PREFERENCE),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PREVIOUS_THEME),
@@ -350,6 +353,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.HEADER_TRANSITION_DELAY),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.BOTTOM_TRANSITION_INTERVAL),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.UNTOUCHABLE_MODE_ENABLED),
+        AsyncStorage.getItem(
+          ASYNC_STORAGE_KEYS.WRONG_DIRECTION_NOTIFY_ENABLED
+        ),
       ]);
 
       if (themePreferenceKey) {
@@ -447,10 +453,17 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           untouchableModeEnabled: untouchableModeEnabledStr === 'true',
         }));
       }
+      if (wrongDirectionNotifyEnabledStr) {
+        setNotify((prev) => ({
+          ...prev,
+          wrongDirectionNotifyEnabled:
+            wrongDirectionNotifyEnabledStr === 'true',
+        }));
+      }
     };
 
     loadSettings();
-  }, [setNavigation, setSpeech, setTuning, setThemePreference]);
+  }, [setNavigation, setSpeech, setTuning, setThemePreference, setNotify]);
 
   useEffect(() => {
     const { remove } = addScreenshotListener(() => {

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -353,9 +353,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.HEADER_TRANSITION_DELAY),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.BOTTOM_TRANSITION_INTERVAL),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.UNTOUCHABLE_MODE_ENABLED),
-        AsyncStorage.getItem(
-          ASYNC_STORAGE_KEYS.WRONG_DIRECTION_NOTIFY_ENABLED
-        ),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.WRONG_DIRECTION_NOTIFY_ENABLED),
       ]);
 
       if (themePreferenceKey) {

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -29,6 +29,7 @@ export const ASYNC_STORAGE_KEYS = {
   ROUTE_SEARCH_WALKTHROUGH_COMPLETED:
     '@TrainLCD:routeSearchWalkthroughCompleted',
   SETTINGS_WALKTHROUGH_COMPLETED: '@TrainLCD:settingsWalkthroughCompleted',
+  WRONG_DIRECTION_NOTIFY_ENABLED: '@TrainLCD:wrongDirectionNotifyEnabled',
 } as const;
 
 export type AsyncStorageKeys =

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -46,7 +46,8 @@ export const useRefreshStation = (): void => {
   const arrivedNotifiedIdRef = useRef<number | null>(null);
   const lastArrivedTimeRef = useRef<number>(0);
   const lastArrivedStationIdRef = useRef<number | null>(null);
-  const { targetStationIds } = useAtomValue(notifyState);
+  const { targetStationIds, wrongDirectionNotifyEnabled } =
+    useAtomValue(notifyState);
 
   const nearestStation = useNearestStation();
   const canGoForward = useCanGoForward();
@@ -186,6 +187,7 @@ export const useRefreshStation = (): void => {
 
   useEffect(() => {
     if (
+      wrongDirectionNotifyEnabled &&
       (isWrongDirection || isLoopLineWrongDirection) &&
       !wrongDirectionNotifiedRef.current
     ) {
@@ -201,7 +203,7 @@ export const useRefreshStation = (): void => {
     if (!isWrongDirection && !isLoopLineWrongDirection) {
       wrongDirectionNotifiedRef.current = false;
     }
-  }, [isWrongDirection, isLoopLineWrongDirection]);
+  }, [isWrongDirection, isLoopLineWrongDirection, wrongDirectionNotifyEnabled]);
 
   useEffect(() => {
     if (!nearestStation) {

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -41,6 +41,7 @@ const SETTING_ITEM_ID_MAP = {
   personalize_theme: 'personalize_theme',
   personalize_tts: 'personalize_tts',
   personalize_languages: 'personalize_languages',
+  personalize_notifications: 'personalize_notifications',
   about_app_licenses: 'about_app_licenses',
   developer_tuning: 'developer_tuning',
 } as const;
@@ -107,6 +108,8 @@ const SettingsItem = ({
         return 'volume-high';
       case 'personalize_languages':
         return 'globe';
+      case 'personalize_notifications':
+        return 'notifications';
       case 'about_app_licenses':
         return 'key';
       case 'developer_tuning':
@@ -299,6 +302,13 @@ const AppSettingsScreen: React.FC = () => {
           onPress: () =>
             navigation.navigate('EnabledLanguagesSettings' as never),
         },
+        {
+          id: SETTING_ITEM_ID_MAP.personalize_notifications,
+          title: translate('notificationSettings'),
+          color: '#FF3B30',
+          onPress: () =>
+            navigation.navigate('NotificationSettings' as never),
+        },
       ].filter((dat) =>
         isClip() ? dat.id !== SETTING_ITEM_ID_MAP.personalize_tts : true
       ) as SettingsSectionData[],
@@ -381,10 +391,16 @@ const AppSettingsScreen: React.FC = () => {
               <SettingsItem
                 item={personalizeItems[showTtsItem ? 2 : 1]}
                 isFirst={false}
-                isLast={true}
+                isLast={false}
                 onPress={personalizeItems[showTtsItem ? 2 : 1].onPress}
               />
             </View>
+            <SettingsItem
+              item={personalizeItems[showTtsItem ? 3 : 2]}
+              isFirst={false}
+              isLast={true}
+              onPress={personalizeItems[showTtsItem ? 3 : 2].onPress}
+            />
           </View>
 
           {/* アプリについてセクション */}

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -306,8 +306,7 @@ const AppSettingsScreen: React.FC = () => {
           id: SETTING_ITEM_ID_MAP.personalize_notifications,
           title: translate('notificationSettings'),
           color: '#FF3B30',
-          onPress: () =>
-            navigation.navigate('NotificationSettings' as never),
+          onPress: () => navigation.navigate('NotificationSettings' as never),
         },
       ].filter((dat) =>
         isClip() ? dat.id !== SETTING_ITEM_ID_MAP.personalize_tts : true

--- a/src/screens/NotificationSettings.tsx
+++ b/src/screens/NotificationSettings.tsx
@@ -55,10 +55,7 @@ const NotificationSettingsScreen: React.FC = () => {
       }));
     } catch (error) {
       console.error('Failed to toggle wrong direction notify setting', error);
-      Alert.alert(
-        translate('errorTitle'),
-        translate('failedToSavePreference')
-      );
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }
   }, [wrongDirectionNotifyEnabled, setNotifyState]);
 

--- a/src/screens/NotificationSettings.tsx
+++ b/src/screens/NotificationSettings.tsx
@@ -1,0 +1,132 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import { useAtom, useAtomValue } from 'jotai';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  Animated as RNAnimated,
+  StyleSheet,
+  View,
+} from 'react-native';
+import Animated from 'react-native-reanimated';
+import Button from '~/components/Button';
+import FooterTabBar from '~/components/FooterTabBar';
+import { SettingsHeader } from '~/components/SettingsHeader';
+import { StatePanel } from '~/components/ToggleButton';
+import Typography from '~/components/Typography';
+import notifyState from '~/store/atoms/notify';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+import { ASYNC_STORAGE_KEYS } from '../constants';
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 24,
+    flex: 1,
+  },
+  screenBg: {
+    backgroundColor: '#FAFAFA',
+  },
+});
+
+const NotificationSettingsScreen: React.FC = () => {
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const [{ wrongDirectionNotifyEnabled }, setNotifyState] =
+    useAtom(notifyState);
+
+  const navigation = useNavigation();
+
+  const handleToggleWrongDirectionNotify = useCallback(async () => {
+    const newValue = !wrongDirectionNotifyEnabled;
+    try {
+      await AsyncStorage.setItem(
+        ASYNC_STORAGE_KEYS.WRONG_DIRECTION_NOTIFY_ENABLED,
+        newValue ? 'true' : 'false'
+      );
+      setNotifyState((prev) => ({
+        ...prev,
+        wrongDirectionNotifyEnabled: newValue,
+      }));
+    } catch (error) {
+      console.error('Failed to toggle wrong direction notify setting', error);
+      Alert.alert(
+        translate('errorTitle'),
+        translate('failedToSavePreference')
+      );
+    }
+  }, [wrongDirectionNotifyEnabled, setNotifyState]);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollY.setValue(e.nativeEvent.contentOffset.y);
+    },
+    [scrollY]
+  );
+
+  return (
+    <>
+      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
+        <Animated.ScrollView
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          contentContainerStyle={[
+            headerHeight
+              ? { marginTop: headerHeight, paddingBottom: headerHeight }
+              : null,
+          ]}
+        >
+          <Pressable
+            accessibilityRole="switch"
+            accessibilityLabel={translate('wrongDirectionNotifyToggle')}
+            accessibilityState={{ checked: wrongDirectionNotifyEnabled }}
+            onPress={handleToggleWrongDirectionNotify}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingHorizontal: 24,
+              paddingVertical: 16,
+              backgroundColor: isLEDTheme ? '#333' : 'white',
+              borderRadius: isLEDTheme ? 0 : 12,
+            }}
+          >
+            <Typography style={{ flex: 1, fontSize: 21, fontWeight: 'bold' }}>
+              {translate('wrongDirectionNotifyToggle')}
+            </Typography>
+            <StatePanel state={wrongDirectionNotifyEnabled} />
+          </Pressable>
+          <Typography
+            style={{
+              marginTop: 16,
+              textAlign: 'center',
+              color: '#8B8B8B',
+            }}
+          >
+            {translate('wrongDirectionNotifyDescription')}
+          </Typography>
+          <Button
+            style={{ width: 128, alignSelf: 'center', marginTop: 32 }}
+            textStyle={{ fontWeight: 'bold' }}
+            onPress={() => navigation.goBack()}
+          >
+            OK
+          </Button>
+        </Animated.ScrollView>
+      </View>
+      <SettingsHeader
+        title={translate('notificationSettings')}
+        onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height + 32)}
+        scrollY={scrollY}
+      />
+      <FooterTabBar active="settings" />
+    </>
+  );
+};
+
+export default React.memo(NotificationSettingsScreen);

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
 import Licenses from '~/screens/Licenses';
 import RouteSearchScreen from '~/screens/RouteSearchScreen';
+import NotificationSettings from '~/screens/NotificationSettings';
 import TTSSettings from '~/screens/TTSSettings';
 import ErrorScreen from '../components/ErrorScreen';
 import Permitted from '../components/Permitted';
@@ -98,6 +99,11 @@ const MainStack: React.FC = () => {
           options={optionsWithCustomStyle}
           name="EnabledLanguagesSettings"
           component={EnabledLanguagesSettings}
+        />
+        <Stack.Screen
+          options={optionsWithCustomStyle}
+          name="NotificationSettings"
+          component={NotificationSettings}
         />
         <Stack.Screen
           options={optionsWithCustomStyle}

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -5,8 +5,8 @@ import {
 import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
 import Licenses from '~/screens/Licenses';
-import RouteSearchScreen from '~/screens/RouteSearchScreen';
 import NotificationSettings from '~/screens/NotificationSettings';
+import RouteSearchScreen from '~/screens/RouteSearchScreen';
 import TTSSettings from '~/screens/TTSSettings';
 import ErrorScreen from '../components/ErrorScreen';
 import Permitted from '../components/Permitted';

--- a/src/store/atoms/notify.ts
+++ b/src/store/atoms/notify.ts
@@ -2,10 +2,12 @@ import { atom } from 'jotai';
 
 export interface NotifyState {
   targetStationIds: number[];
+  wrongDirectionNotifyEnabled: boolean;
 }
 
 const notifyState = atom<NotifyState>({
   targetStationIds: [],
+  wrongDirectionNotifyEnabled: false,
 });
 
 export default notifyState;

--- a/src/store/atoms/notify.ts
+++ b/src/store/atoms/notify.ts
@@ -7,7 +7,7 @@ export interface NotifyState {
 
 const notifyState = atom<NotifyState>({
   targetStationIds: [],
-  wrongDirectionNotifyEnabled: false,
+  wrongDirectionNotifyEnabled: true,
 });
 
 export default notifyState;


### PR DESCRIPTION
## 概要

逆方向走行時の通知設定を管理する新しい設定画面を追加しました。ユーザーが逆方向走行時の通知のオン/オフを切り替えられるようになります。

## 変更の種類

- [x] 新機能
- [x] リファクタリング

## 変更内容

### 新規追加
- **NotificationSettingsScreen**: 逆方向走行時の通知設定を管理する新しい画面
  - トグルボタンで通知のオン/オフを切り替え可能
  - AsyncStorageに設定を永続化
  - LED テーマ対応
  - アクセシビリティ対応（switch role）

### 既存ファイルの変更
- **AppSettings.tsx**: 
  - 通知設定へのナビゲーションメニューを追加
  - 個人設定セクションに「通知」オプションを追加

- **Permitted.tsx**:
  - アプリ起動時に AsyncStorage から `wrongDirectionNotifyEnabled` 設定を読み込み
  - `notifyState` atom を初期化

- **MainStack.tsx**:
  - NotificationSettings 画面をスタックに登録

- **notify.ts**:
  - `NotifyState` インターフェースに `wrongDirectionNotifyEnabled` フィールドを追加

- **asyncStorage.ts**:
  - `WRONG_DIRECTION_NOTIFY_ENABLED` キーを定数として追加

- **翻訳ファイル** (en.json, ja.json):
  - 通知設定関連の翻訳文字列を追加

## テスト

- [x] `npm run lint` が通ること
- [x] `npm run typecheck` が通ること
- 既存の設定画面と同様の構造で実装されているため、既存テストで対応

https://claude.ai/code/session_01GTPWXRZfVMsQWVchRxFW6n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 「通知設定」画面を追加し、進行方向と逆方向の移動時に通知するかをオン/オフできるトグルを実装しました。設定は保存され、アプリ内で反映されます。
* **ローカライズ**
  * 上記UI用の日本語・英語の文言を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->