### PR TITLE
逆走通知トグルのラベルを簡潔な文言に変更

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -303,6 +303,6 @@
   "trainTypeMismatchWarning": "The selected train type may not match your actual service. Please check your settings.",
   "toeiBusBadge": "Toei Bus",
   "notificationSettings": "Notifications",
-  "wrongDirectionNotifyToggle": "Notify when traveling in wrong direction",
+  "wrongDirectionNotifyToggle": "Reverse direction alert",
   "wrongDirectionNotifyDescription": "Get notified when you are traveling in the opposite direction from the one set in the app."
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -304,6 +304,6 @@
   "trainTypeMismatchWarning": "選択した列車種別と実際の運行種別が異なる可能性があります。設定をご確認ください。",
   "toeiBusBadge": "都営バス",
   "notificationSettings": "通知",
-  "wrongDirectionNotifyToggle": "逆方向走行時に通知する",
+  "wrongDirectionNotifyToggle": "逆走通知",
   "wrongDirectionNotifyDescription": "アプリで設定した方向と逆方向に進行している場合に通知でお知らせします。"
 }


### PR DESCRIPTION
## Summary
- 逆走通知トグルのラベルを簡潔な文言に変更
  - 日本語: 「逆方向走行時に通知する」→「逆走通知」
  - 英語: "Notify when traveling in wrong direction" → "Reverse direction alert"

## Test plan
- [x] 日本語設定で通知設定画面を開き、トグルラベルが「逆走通知」と表示されることを確認
- [x] 英語設定で通知設定画面を開き、トグルラベルが "Reverse direction alert" と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **翻訳・ローカライゼーション**
  * 逆走通知機能のUIラベルテキストを更新しました。英語および日本語の複数言語で、ユーザーインターフェースの表示がより簡潔に改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->