### PR TITLE
逆走通知の初期値をオフに変更

### DIFF
--- a/src/store/atoms/notify.ts
+++ b/src/store/atoms/notify.ts
@@ -7,7 +7,7 @@ export interface NotifyState {
 
 const notifyState = atom<NotifyState>({
   targetStationIds: [],
-  wrongDirectionNotifyEnabled: true,
+  wrongDirectionNotifyEnabled: false,
 });
 
 export default notifyState;


### PR DESCRIPTION
## Summary
- 逆走通知（`wrongDirectionNotifyEnabled`）の初期値を `true` から `false` に変更し、デフォルトでオフにした

## Test plan
- [x] 初回起動時に逆走通知がオフになっていることを確認
- [x] 通知設定画面からオンに切り替え、再起動後もオンのままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 誤った方向の通知がデフォルトで無効になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->