### PR TITLE
HeaderE231の時刻表示のコロン点滅を削除

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
-import { useClock, useInterval } from '../hooks';
+import { useClock } from '../hooks';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
@@ -149,11 +149,6 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
   } = props;
 
   const [hours, minutes] = useClock();
-  const [colonOpacity, setColonOpacity] = useState(0);
-  useInterval(
-    useCallback(() => setColonOpacity((prev) => (prev === 0 ? 1 : 0)), []),
-    500
-  );
 
   const boundSuffixText = useMemo(() => {
     switch (headerLangState) {
@@ -259,7 +254,7 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
           <Text style={styles.clockLabel}>{clockLabelText}</Text>
           <View style={styles.clockBox}>
             <Text style={styles.clockText}>{hours}</Text>
-            <Text style={[styles.clockText, { opacity: colonOpacity }]}>:</Text>
+            <Text style={styles.clockText}>:</Text>
             <Text style={styles.clockText}>{minutes}</Text>
           </View>
         </View>


### PR DESCRIPTION
## 概要
- `HeaderE231` の時計表示でコロン (`:`) を 500ms 間隔で点滅させていた処理を削除
- 不要になった `useState` / `useCallback` / `useInterval` のインポートも整理

## 変更理由
時刻表示にblinkは不要との指摘のため。

## 動作確認
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] 実機でHeaderE231の時計表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * クロック表示のコロン記号（：）のアニメーション効果を削除しました。コロンが常時表示されるようになり、時刻表示がより安定した表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->