### PR TITLE
意味もなくTextコンポーネントを使用している箇所をTypographyに置換

### DIFF
--- a/src/components/FatalErrorScreen.tsx
+++ b/src/components/FatalErrorScreen.tsx
@@ -2,13 +2,12 @@
 import * as Linking from 'expo-linking';
 import type React from 'react';
 import { useCallback } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { isDevApp } from '~/utils/isDevApp';
 import { STATUS_URL } from '../constants';
 import { translate } from '../translation';
 import { RFValue } from '../utils/rfValue';
-import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {
@@ -77,30 +76,24 @@ const FatalErrorScreen: React.FC<Props> = ({
 
   return (
     <SafeAreaView style={styles.root}>
-      <Typography style={[styles.text, styles.headingText]}>{title}</Typography>
-      <Typography style={styles.text}>{text}</Typography>
-      {reason ? <Typography style={styles.text}>{reason}</Typography> : null}
+      <Text style={[styles.text, styles.headingText]}>{title}</Text>
+      <Text style={styles.text}>{text}</Text>
+      {reason ? <Text style={styles.text}>{reason}</Text> : null}
 
       <View style={styles.buttons}>
         {onRetryPress ? (
           <TouchableOpacity onPress={onRetryPress} style={styles.button}>
-            <Typography style={styles.buttonText}>
-              {translate('retry')}
-            </Typography>
+            <Text style={styles.buttonText}>{translate('retry')}</Text>
           </TouchableOpacity>
         ) : null}
         {showStatus ? (
           <TouchableOpacity onPress={openStatusPage} style={styles.button}>
-            <Typography style={styles.buttonText}>
-              {translate('openStatusText')}
-            </Typography>
+            <Text style={styles.buttonText}>{translate('openStatusText')}</Text>
           </TouchableOpacity>
         ) : null}
         {stacktrace ? (
           <TouchableOpacity onPress={showStacktrace} style={styles.button}>
-            <Typography style={styles.buttonText}>
-              {translate('stacktrace')}
-            </Typography>
+            <Text style={styles.buttonText}>{translate('stacktrace')}</Text>
           </TouchableOpacity>
         ) : null}
       </View>

--- a/src/components/FatalErrorScreen.tsx
+++ b/src/components/FatalErrorScreen.tsx
@@ -2,12 +2,13 @@
 import * as Linking from 'expo-linking';
 import type React from 'react';
 import { useCallback } from 'react';
-import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { isDevApp } from '~/utils/isDevApp';
 import { STATUS_URL } from '../constants';
 import { translate } from '../translation';
 import { RFValue } from '../utils/rfValue';
+import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {
@@ -76,24 +77,30 @@ const FatalErrorScreen: React.FC<Props> = ({
 
   return (
     <SafeAreaView style={styles.root}>
-      <Text style={[styles.text, styles.headingText]}>{title}</Text>
-      <Text style={styles.text}>{text}</Text>
-      {reason ? <Text style={styles.text}>{reason}</Text> : null}
+      <Typography style={[styles.text, styles.headingText]}>{title}</Typography>
+      <Typography style={styles.text}>{text}</Typography>
+      {reason ? <Typography style={styles.text}>{reason}</Typography> : null}
 
       <View style={styles.buttons}>
         {onRetryPress ? (
           <TouchableOpacity onPress={onRetryPress} style={styles.button}>
-            <Text style={styles.buttonText}>{translate('retry')}</Text>
+            <Typography style={styles.buttonText}>
+              {translate('retry')}
+            </Typography>
           </TouchableOpacity>
         ) : null}
         {showStatus ? (
           <TouchableOpacity onPress={openStatusPage} style={styles.button}>
-            <Text style={styles.buttonText}>{translate('openStatusText')}</Text>
+            <Typography style={styles.buttonText}>
+              {translate('openStatusText')}
+            </Typography>
           </TouchableOpacity>
         ) : null}
         {stacktrace ? (
           <TouchableOpacity onPress={showStacktrace} style={styles.button}>
-            <Text style={styles.buttonText}>{translate('stacktrace')}</Text>
+            <Typography style={styles.buttonText}>
+              {translate('stacktrace')}
+            </Typography>
           </TouchableOpacity>
         ) : null}
       </View>

--- a/src/components/HeaderE231.test.tsx
+++ b/src/components/HeaderE231.test.tsx
@@ -4,6 +4,9 @@ import HeaderE231 from './HeaderE231';
 
 jest.mock('jotai', () => ({
   useAtomValue: jest.fn(() => ({})),
+  atom: jest.fn((initialValue) => initialValue),
+  useAtom: jest.fn((val) => [val, jest.fn()]),
+  useSetAtom: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('~/hooks', () => ({

--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { useClock } from '../hooks';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
@@ -7,6 +7,7 @@ import { RFValue } from '../utils/rfValue';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBoxE231';
+import Typography from './Typography';
 
 const BOUND_AREA_HEIGHT = isTablet ? 64 : 48;
 const BOTTOM_HEIGHT = isTablet ? 128 : 84;
@@ -206,21 +207,25 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
         <View style={styles.boundWrapper}>
           <View style={styles.spacer} />
           <View style={styles.boundInner}>
-            <Text
+            <Typography
               style={styles.boundText}
               numberOfLines={2}
               adjustsFontSizeToFit
             >
               {firstStop ? '' : boundText}
-            </Text>
+            </Typography>
           </View>
           <View style={styles.spacer} />
         </View>
         <View style={styles.bottom}>
           <View style={styles.stateWrapper}>
-            <Text style={styles.state} adjustsFontSizeToFit numberOfLines={2}>
+            <Typography
+              style={styles.state}
+              adjustsFontSizeToFit
+              numberOfLines={2}
+            >
               {resolvedStateText}
-            </Text>
+            </Typography>
           </View>
 
           <View style={styles.stationArea}>
@@ -235,27 +240,29 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
               />
             ) : null}
             <View style={styles.stationNameWrapper}>
-              <Text
+              <Typography
                 adjustsFontSizeToFit
                 numberOfLines={1}
                 style={styles.stationName}
               >
                 {stationText}
-              </Text>
+              </Typography>
             </View>
           </View>
           <View style={styles.spacer}>
             {boundSuffixText ? (
-              <Text style={styles.boundSuffix}>{boundSuffixText}</Text>
+              <Typography style={styles.boundSuffix}>
+                {boundSuffixText}
+              </Typography>
             ) : null}
           </View>
         </View>
         <View style={styles.clockContainer}>
-          <Text style={styles.clockLabel}>{clockLabelText}</Text>
+          <Typography style={styles.clockLabel}>{clockLabelText}</Typography>
           <View style={styles.clockBox}>
-            <Text style={styles.clockText}>{hours}</Text>
-            <Text style={styles.clockText}>:</Text>
-            <Text style={styles.clockText}>{minutes}</Text>
+            <Typography style={styles.clockText}>{hours}</Typography>
+            <Typography style={styles.clockText}>:</Typography>
+            <Typography style={styles.clockText}>{minutes}</Typography>
           </View>
         </View>
       </View>

--- a/src/components/HeaderJRKyushu.test.tsx
+++ b/src/components/HeaderJRKyushu.test.tsx
@@ -17,6 +17,9 @@ jest.mock('jotai', () => ({
     }
     return {};
   }),
+  atom: jest.fn((initialValue) => initialValue),
+  useAtom: jest.fn((val) => [val, jest.fn()]),
+  useSetAtom: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('react-native-reanimated', () => {

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import { Animated as RNAnimated, StyleSheet, Text, View } from 'react-native';
+import { Animated as RNAnimated, StyleSheet, View } from 'react-native';
 import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useHeaderAnimation } from '../hooks';
 import isTablet from '../utils/isTablet';
@@ -8,6 +8,7 @@ import { RFValue } from '../utils/rfValue';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBoxJRKyushu from './TrainTypeBoxJRKyushu';
+import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {
@@ -159,7 +160,7 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
                   styles.boundTextContainer,
                 ]}
               >
-                <Text
+                <Typography
                   adjustsFontSizeToFit
                   numberOfLines={1}
                   style={styles.connectedLines}
@@ -167,8 +168,8 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
                   {connectedLines?.length && isJapaneseState
                     ? `${connectionText}直通 `
                     : null}
-                </Text>
-                <Text style={styles.boundText}>{boundText}</Text>
+                </Typography>
+                <Typography style={styles.boundText}>{boundText}</Typography>
               </RNAnimated.Text>
               <RNAnimated.Text
                 style={[
@@ -176,7 +177,7 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
                   styles.boundTextContainer,
                 ]}
               >
-                <Text
+                <Typography
                   adjustsFontSizeToFit
                   numberOfLines={1}
                   style={styles.connectedLines}
@@ -184,8 +185,10 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
                   {connectedLines?.length && animation.prevIsJapaneseState
                     ? `${animation.prevConnectionText}直通 `
                     : null}
-                </Text>
-                <Text style={styles.boundText}>{animation.prevBoundText}</Text>
+                </Typography>
+                <Typography style={styles.boundText}>
+                  {animation.prevBoundText}
+                </Typography>
               </RNAnimated.Text>
             </View>
           ) : null}

--- a/src/components/LineBoardLED.tsx
+++ b/src/components/LineBoardLED.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { StopCondition } from '~/@types/graphql';
 import { FONTS, parenthesisRegexp, STATION_NAME_FONT_SIZE } from '../constants';
 import {
@@ -17,6 +17,7 @@ import type { HeaderStoppingState } from '../models/HeaderTransitionState';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import Marquee from './Marquee';
+import Typography from './Typography';
 
 const styles = StyleSheet.create({
   container: {
@@ -34,19 +35,19 @@ const styles = StyleSheet.create({
 });
 
 const GreenText = ({ children }: { children: React.ReactNode }) => (
-  <Text numberOfLines={1} style={[styles.text, styles.green]}>
+  <Typography numberOfLines={1} style={[styles.text, styles.green]}>
     {children}
-  </Text>
+  </Typography>
 );
 const OrangeText = ({ children }: { children: React.ReactNode }) => (
-  <Text numberOfLines={1} style={[styles.text, styles.orange]}>
+  <Typography numberOfLines={1} style={[styles.text, styles.orange]}>
     {children}
-  </Text>
+  </Typography>
 );
 const CrimsonText = ({ children }: { children: React.ReactNode }) => (
-  <Text numberOfLines={1} style={[styles.text, styles.crimson]}>
+  <Typography numberOfLines={1} style={[styles.text, styles.crimson]}>
     {children}
-  </Text>
+  </Typography>
 );
 
 // Helper component for arriving state content
@@ -93,28 +94,28 @@ const ArrivingContent = ({
     ) : null}
 
     <GreenText>The next stop is</GreenText>
-    <Text numberOfLines={1}>
+    <Typography numberOfLines={1}>
       <OrangeText>
         {nextStation?.nameRoman}
         {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
       </OrangeText>
       <GreenText>.</GreenText>
-    </Text>
+    </Typography>
 
     {afterNextStation ? (
       <>
         <GreenText>The stop after</GreenText>
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {nextStation?.nameRoman}
             {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
           </OrangeText>
           <GreenText>,</GreenText>
-        </Text>
+        </Typography>
 
         <GreenText>will be</GreenText>
 
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {afterNextStation?.nameRoman}
             {afterNextStation?.stationNumbers?.[0]
@@ -122,14 +123,14 @@ const ArrivingContent = ({
               : ''}
           </OrangeText>
           <GreenText>.</GreenText>
-        </Text>
+        </Typography>
       </>
     ) : null}
     {transferLines.length > 0 ? (
       <>
         <GreenText>Please change here for</GreenText>
 
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {transferLines
               .map((l) => l.nameRoman)
@@ -144,7 +145,7 @@ const ArrivingContent = ({
               .join('')}
           </OrangeText>
           <GreenText>.</GreenText>
-        </Text>
+        </Typography>
       </>
     ) : null}
   </>
@@ -173,10 +174,10 @@ const CurrentContent = ({
     </GreenText>
     <OrangeText>{trainTypeTexts[1]}</OrangeText>
     <GreenText>train for</GreenText>
-    <Text numberOfLines={1}>
+    <Typography numberOfLines={1}>
       <OrangeText>{boundTexts[1]}</OrangeText>
       <GreenText>.</GreenText>
-    </Text>
+    </Typography>
   </>
 );
 
@@ -222,26 +223,26 @@ const NextStopContent = ({
       </>
     ) : null}
     <GreenText>The next stop is</GreenText>
-    <Text numberOfLines={1}>
+    <Typography numberOfLines={1}>
       <OrangeText>
         {nextStation?.nameRoman}
         {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
       </OrangeText>
       <GreenText>.</GreenText>
-    </Text>
+    </Typography>
     {afterNextStation ? (
       <>
         <GreenText>The stop after</GreenText>
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {nextStation?.nameRoman}
             {nextStationNumber ? `(${nextStationNumber.stationNumber})` : ''}
           </OrangeText>
           <GreenText>,</GreenText>
-        </Text>
+        </Typography>
 
         <GreenText>will be</GreenText>
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {afterNextStation?.nameRoman}
             {afterNextStation?.stationNumbers?.[0]
@@ -249,13 +250,13 @@ const NextStopContent = ({
               : ''}
           </OrangeText>
           <GreenText>.</GreenText>
-        </Text>
+        </Typography>
       </>
     ) : null}
     {transferLines.length > 0 ? (
       <>
         <GreenText>Please change here for</GreenText>
-        <Text numberOfLines={1}>
+        <Typography numberOfLines={1}>
           <OrangeText>
             {transferLines
               .map((l) => l.nameRoman)
@@ -270,7 +271,7 @@ const NextStopContent = ({
               .join('')}
           </OrangeText>
           <GreenText>.</GreenText>
-        </Text>
+        </Typography>
       </>
     ) : null}
   </>


### PR DESCRIPTION
## Summary
- `HeaderE231.tsx` / `HeaderJRKyushu.tsx` / `LineBoardLED.tsx` / `FatalErrorScreen.tsx` で意味もなく `react-native` の `Text` を使っていた箇所を `Typography` に置き換え
- `HeaderJRKyushu.tsx` の `RNAnimated.Text` はアニメーションに必要なためそのまま残し、内側にネストされていた `Text` のみ `Typography` へ
- `src/index.tsx` の `Text.defaultProps` セットアップは保険として残存、テストファイル内の `Text` 参照も未変更

## Test plan
- [x] \`npx biome check --unsafe --fix\` （対象4ファイル）
- [x] \`npx tsc --noEmit\`
- [x] \`npx jest src/components/LineBoardLED.test.tsx\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * テキスト表示コンポーネントを統一し、複数の画面コンポーネントで一貫性を向上しました。

* **Tests**
  * テスト環境のモック設定を拡張し、より包括的なテストケースに対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->