### PR TITLE
Transfersの乗換路線画像がAndroidで別路線のwebpになる問題を修正

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -1,12 +1,6 @@
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
-import {
-  FlatList,
-  Platform,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import { NUMBERING_ICON_SIZE, parenthesisRegexp } from '../constants';
 import { useGetLineMark, useTransferLines } from '../hooks';
@@ -278,7 +272,6 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
         data={lines}
         keyExtractor={(l) => (l.id ?? 0).toString()}
         renderItem={renderTransferLine}
-        removeClippedSubviews={Platform.OS === 'android'}
       />
     </TouchableOpacity>
   );


### PR DESCRIPTION
## 概要
`Transfers` コンポーネントの乗換路線リストで、主にAndroid端末において別路線のwebp画像が一時的に表示される不具合を修正。

## 原因
`FlatList` に指定していた `removeClippedSubviews={Platform.OS === 'android'}` が原因。
この最適化フラグはAndroidで画面外のネイティブViewをデタッチ／再アタッチするが、`expo-image` と組み合わせた際に再アタッチ時に古い `source` のwebpが残存して表示されるという既知の描画不具合がある。

乗換路線リストはそもそも数件〜十数件程度のため、この最適化の恩恵は薄く、削除することで解決。

## 変更点
- `src/components/Transfers.tsx`
  - `FlatList` の `removeClippedSubviews` 指定を削除
  - 使用されなくなった `Platform` の import を削除

## リグレッションリスク
- 低。乗換路線リストは短尺のため、`removeClippedSubviews` 削除によるパフォーマンス劣化はほぼ発生しない想定。

## ローカル実行コマンド
- `npx biome check --unsafe --fix ./src/components/Transfers.tsx`

## 動作確認
- [ ] Android実機で乗換表示を複数駅分スクロールし、別路線のwebpが混入しないことを確認
- [x] iOSで従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * コンポーネントのインポート文を簡潔にしました。
  * リスト表示の動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->