### PR TITLE
ThemeConfirmModalのプレビュー画像に別テーマのwebpが残る問題を修正

### DIFF
--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -166,6 +166,7 @@ export const ThemeConfirmModal: React.FC<Props> = ({
               <Typography style={styles.autoPreviewEmoji}>❓</Typography>
             ) : (
               <Image
+                recyclingKey={themeId}
                 source={previewImage}
                 style={styles.previewImage}
                 contentFit="contain"


### PR DESCRIPTION
## 概要
`ThemeConfirmModal` のプレビュー画像で、テーマを切り替えた際に前回選択していたテーマのwebpが一瞬表示される不具合を修正。#5795 と同根の `expo-image` 由来の問題。

## 原因
`<Image>` コンポーネントは内部的にネイティブViewを再利用するため、`source` プロップだけが変わってもView自体は前回のインスタンスのままになり、古い画像のピクセルが一瞬残ってしまう。特にAndroidで発生しやすい。

## 変更点
- `src/components/ThemeConfirmModal.tsx`
  - プレビュー用 `<Image>` に `recyclingKey={themeId}` を追加し、テーマ切り替え時にImageが内部的にクリアされるようにした

## recyclingKey について
`expo-image` 公式がまさにこの問題のために用意したプロップで、キーが変わると内部の画像バッファをクリアして再マウント相当の挙動になる。`themeId` をキーにすることで、別テーマを選択した際に前のプレビューが残らない。

## リグレッションリスク
- 低。`recyclingKey` は `expo-image` の標準プロップで、追加コストはテーマ切替時の再マウントのみ。

## ローカル実行コマンド
- `npx biome check --unsafe --fix ./src/components/ThemeConfirmModal.tsx`

## 動作確認
- [ ] Android実機でテーマ選択モーダルを複数テーマで開き直し、前回のプレビュー画像が残らないことを確認
- [x] iOSで従来通り表示されることを確認

## 関連PR
- #5795 (Transfers側の類似問題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * テーマ確認モーダルのプレビュー表示の適切な更新を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->