### PR TITLE
[codex] 駅詳細のGraphQLフラグメントを整理して取得項目を軽量化

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -407,16 +407,9 @@ export type TtsSegment = {
 export type CompanyFieldsFragment = {
   __typename: 'Company';
   id: number | null | undefined;
-  name: string | null | undefined;
-  nameEnglishFull: string | null | undefined;
   nameEnglishShort: string | null | undefined;
-  nameFull: string | null | undefined;
   nameKatakana: string | null | undefined;
   nameShort: string | null | undefined;
-  railroadId: number | null | undefined;
-  status: OperationStatus | null | undefined;
-  type: CompanyType | null | undefined;
-  url: string | null | undefined;
 };
 
 export type LineSymbolFieldsFragment = {
@@ -434,6 +427,16 @@ export type StationNumberFieldsFragment = {
   stationNumber: string | null | undefined;
 };
 
+export type TtsSegmentFieldsFragment = {
+  __typename: 'TtsSegment';
+  alphabet: TtsAlphabet | null | undefined;
+  fallbackText: string | null | undefined;
+  lang: string | null | undefined;
+  pronunciation: string | null | undefined;
+  separator: string | null | undefined;
+  surface: string | null | undefined;
+};
+
 export type TinyTrainTypeFieldsFragment = {
   __typename: 'TrainTypeNested';
   id: number | null | undefined;
@@ -448,12 +451,23 @@ export type TinyTrainTypeFieldsFragment = {
   color: string | null | undefined;
   direction: TrainDirection | null | undefined;
   kind: TrainTypeKind | null | undefined;
+  nameTtsSegments:
+    | Array<{
+        __typename: 'TtsSegment';
+        alphabet: TtsAlphabet | null | undefined;
+        fallbackText: string | null | undefined;
+        lang: string | null | undefined;
+        pronunciation: string | null | undefined;
+        separator: string | null | undefined;
+        surface: string | null | undefined;
+      }>
+    | null
+    | undefined;
 };
 
 export type LineNestedFieldsFragment = {
   __typename: 'LineNested';
   id: number | null | undefined;
-  averageDistance: number | null | undefined;
   color: string | null | undefined;
   lineType: LineType | null | undefined;
   nameFull: string | null | undefined;
@@ -469,16 +483,9 @@ export type LineNestedFieldsFragment = {
     | {
         __typename: 'Company';
         id: number | null | undefined;
-        name: string | null | undefined;
-        nameEnglishFull: string | null | undefined;
         nameEnglishShort: string | null | undefined;
-        nameFull: string | null | undefined;
         nameKatakana: string | null | undefined;
         nameShort: string | null | undefined;
-        railroadId: number | null | undefined;
-        status: OperationStatus | null | undefined;
-        type: CompanyType | null | undefined;
-        url: string | null | undefined;
       }
     | null
     | undefined;
@@ -502,6 +509,18 @@ export type LineNestedFieldsFragment = {
         nameChinese: string | null | undefined;
         nameKorean: string | null | undefined;
         hasTrainTypes: boolean | null | undefined;
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
+          | null
+          | undefined;
         stationNumbers:
           | Array<{
               __typename: 'StationNumber';
@@ -530,7 +549,94 @@ export type LineNestedFieldsFragment = {
         color: string | null | undefined;
         direction: TrainDirection | null | undefined;
         kind: TrainTypeKind | null | undefined;
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
+          | null
+          | undefined;
       }
+    | null
+    | undefined;
+  nameTtsSegments:
+    | Array<{
+        __typename: 'TtsSegment';
+        alphabet: TtsAlphabet | null | undefined;
+        fallbackText: string | null | undefined;
+        lang: string | null | undefined;
+        pronunciation: string | null | undefined;
+        separator: string | null | undefined;
+        surface: string | null | undefined;
+      }>
+    | null
+    | undefined;
+};
+
+export type LineInStationFieldsFragment = {
+  __typename: 'LineNested';
+  id: number | null | undefined;
+  color: string | null | undefined;
+  lineType: LineType | null | undefined;
+  nameKatakana: string | null | undefined;
+  nameRoman: string | null | undefined;
+  nameShort: string | null | undefined;
+  transportType: TransportType | null | undefined;
+  company:
+    | {
+        __typename: 'Company';
+        id: number | null | undefined;
+        nameEnglishShort: string | null | undefined;
+        nameKatakana: string | null | undefined;
+        nameShort: string | null | undefined;
+      }
+    | null
+    | undefined;
+  lineSymbols:
+    | Array<{
+        __typename: 'LineSymbol';
+        color: string | null | undefined;
+        shape: string | null | undefined;
+        symbol: string | null | undefined;
+      }>
+    | null
+    | undefined;
+  station:
+    | {
+        __typename: 'StationNested';
+        id: number | null | undefined;
+        groupId: number | null | undefined;
+        name: string | null | undefined;
+        nameRoman: string | null | undefined;
+        hasTrainTypes: boolean | null | undefined;
+        stationNumbers:
+          | Array<{
+              __typename: 'StationNumber';
+              lineSymbol: string | null | undefined;
+              lineSymbolColor: string | null | undefined;
+              lineSymbolShape: string | null | undefined;
+              stationNumber: string | null | undefined;
+            }>
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
+  nameTtsSegments:
+    | Array<{
+        __typename: 'TtsSegment';
+        alphabet: TtsAlphabet | null | undefined;
+        fallbackText: string | null | undefined;
+        lang: string | null | undefined;
+        pronunciation: string | null | undefined;
+        separator: string | null | undefined;
+        surface: string | null | undefined;
+      }>
     | null
     | undefined;
 };
@@ -549,11 +655,22 @@ export type TrainTypeNestedFieldsFragment = {
   color: string | null | undefined;
   direction: TrainDirection | null | undefined;
   kind: TrainTypeKind | null | undefined;
+  nameTtsSegments:
+    | Array<{
+        __typename: 'TtsSegment';
+        alphabet: TtsAlphabet | null | undefined;
+        fallbackText: string | null | undefined;
+        lang: string | null | undefined;
+        pronunciation: string | null | undefined;
+        separator: string | null | undefined;
+        surface: string | null | undefined;
+      }>
+    | null
+    | undefined;
   line:
     | {
         __typename: 'LineNested';
         id: number | null | undefined;
-        averageDistance: number | null | undefined;
         color: string | null | undefined;
         lineType: LineType | null | undefined;
         nameFull: string | null | undefined;
@@ -569,16 +686,9 @@ export type TrainTypeNestedFieldsFragment = {
           | {
               __typename: 'Company';
               id: number | null | undefined;
-              name: string | null | undefined;
-              nameEnglishFull: string | null | undefined;
               nameEnglishShort: string | null | undefined;
-              nameFull: string | null | undefined;
               nameKatakana: string | null | undefined;
               nameShort: string | null | undefined;
-              railroadId: number | null | undefined;
-              status: OperationStatus | null | undefined;
-              type: CompanyType | null | undefined;
-              url: string | null | undefined;
             }
           | null
           | undefined;
@@ -602,6 +712,18 @@ export type TrainTypeNestedFieldsFragment = {
               nameChinese: string | null | undefined;
               nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
+                | null
+                | undefined;
               stationNumbers:
                 | Array<{
                     __typename: 'StationNumber';
@@ -630,7 +752,31 @@ export type TrainTypeNestedFieldsFragment = {
               color: string | null | undefined;
               direction: TrainDirection | null | undefined;
               kind: TrainTypeKind | null | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
+                | null
+                | undefined;
             }
+          | null
+          | undefined;
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
           | null
           | undefined;
       }
@@ -640,7 +786,6 @@ export type TrainTypeNestedFieldsFragment = {
     | Array<{
         __typename: 'LineNested';
         id: number | null | undefined;
-        averageDistance: number | null | undefined;
         color: string | null | undefined;
         lineType: LineType | null | undefined;
         nameFull: string | null | undefined;
@@ -656,16 +801,9 @@ export type TrainTypeNestedFieldsFragment = {
           | {
               __typename: 'Company';
               id: number | null | undefined;
-              name: string | null | undefined;
-              nameEnglishFull: string | null | undefined;
               nameEnglishShort: string | null | undefined;
-              nameFull: string | null | undefined;
               nameKatakana: string | null | undefined;
               nameShort: string | null | undefined;
-              railroadId: number | null | undefined;
-              status: OperationStatus | null | undefined;
-              type: CompanyType | null | undefined;
-              url: string | null | undefined;
             }
           | null
           | undefined;
@@ -689,6 +827,18 @@ export type TrainTypeNestedFieldsFragment = {
               nameChinese: string | null | undefined;
               nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
+                | null
+                | undefined;
               stationNumbers:
                 | Array<{
                     __typename: 'StationNumber';
@@ -717,7 +867,31 @@ export type TrainTypeNestedFieldsFragment = {
               color: string | null | undefined;
               direction: TrainDirection | null | undefined;
               kind: TrainTypeKind | null | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
+                | null
+                | undefined;
             }
+          | null
+          | undefined;
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
           | null
           | undefined;
       }>
@@ -732,22 +906,26 @@ export type StationFieldsFragment = {
   name: string | null | undefined;
   nameKatakana: string | null | undefined;
   nameRoman: string | null | undefined;
-  nameRomanIpa: string | null | undefined;
   nameChinese: string | null | undefined;
   nameKorean: string | null | undefined;
   threeLetterCode: string | null | undefined;
   latitude: number | null | undefined;
   longitude: number | null | undefined;
-  address: string | null | undefined;
-  postalCode: string | null | undefined;
   prefectureId: number | null | undefined;
-  openedAt: string | null | undefined;
-  closedAt: string | null | undefined;
-  status: OperationStatus | null | undefined;
-  distance: number | null | undefined;
   hasTrainTypes: boolean | null | undefined;
   stopCondition: StopCondition | null | undefined;
-  transportType: TransportType | null | undefined;
+  nameTtsSegments:
+    | Array<{
+        __typename: 'TtsSegment';
+        alphabet: TtsAlphabet | null | undefined;
+        fallbackText: string | null | undefined;
+        lang: string | null | undefined;
+        pronunciation: string | null | undefined;
+        separator: string | null | undefined;
+        surface: string | null | undefined;
+      }>
+    | null
+    | undefined;
   stationNumbers:
     | Array<{
         __typename: 'StationNumber';
@@ -762,32 +940,19 @@ export type StationFieldsFragment = {
     | {
         __typename: 'LineNested';
         id: number | null | undefined;
-        averageDistance: number | null | undefined;
         color: string | null | undefined;
         lineType: LineType | null | undefined;
-        nameFull: string | null | undefined;
         nameKatakana: string | null | undefined;
         nameRoman: string | null | undefined;
-        nameRomanIpa: string | null | undefined;
         nameShort: string | null | undefined;
-        nameChinese: string | null | undefined;
-        nameKorean: string | null | undefined;
-        status: OperationStatus | null | undefined;
         transportType: TransportType | null | undefined;
         company:
           | {
               __typename: 'Company';
               id: number | null | undefined;
-              name: string | null | undefined;
-              nameEnglishFull: string | null | undefined;
               nameEnglishShort: string | null | undefined;
-              nameFull: string | null | undefined;
               nameKatakana: string | null | undefined;
               nameShort: string | null | undefined;
-              railroadId: number | null | undefined;
-              status: OperationStatus | null | undefined;
-              type: CompanyType | null | undefined;
-              url: string | null | undefined;
             }
           | null
           | undefined;
@@ -807,9 +972,6 @@ export type StationFieldsFragment = {
               groupId: number | null | undefined;
               name: string | null | undefined;
               nameRoman: string | null | undefined;
-              nameRomanIpa: string | null | undefined;
-              nameChinese: string | null | undefined;
-              nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
               stationNumbers:
                 | Array<{
@@ -824,22 +986,16 @@ export type StationFieldsFragment = {
             }
           | null
           | undefined;
-        trainType:
-          | {
-              __typename: 'TrainTypeNested';
-              id: number | null | undefined;
-              typeId: number | null | undefined;
-              groupId: number | null | undefined;
-              name: string | null | undefined;
-              nameKatakana: string | null | undefined;
-              nameRoman: string | null | undefined;
-              nameRomanIpa: string | null | undefined;
-              nameChinese: string | null | undefined;
-              nameKorean: string | null | undefined;
-              color: string | null | undefined;
-              direction: TrainDirection | null | undefined;
-              kind: TrainTypeKind | null | undefined;
-            }
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
           | null
           | undefined;
       }
@@ -849,32 +1005,19 @@ export type StationFieldsFragment = {
     | Array<{
         __typename: 'LineNested';
         id: number | null | undefined;
-        averageDistance: number | null | undefined;
         color: string | null | undefined;
         lineType: LineType | null | undefined;
-        nameFull: string | null | undefined;
         nameKatakana: string | null | undefined;
         nameRoman: string | null | undefined;
-        nameRomanIpa: string | null | undefined;
         nameShort: string | null | undefined;
-        nameChinese: string | null | undefined;
-        nameKorean: string | null | undefined;
-        status: OperationStatus | null | undefined;
         transportType: TransportType | null | undefined;
         company:
           | {
               __typename: 'Company';
               id: number | null | undefined;
-              name: string | null | undefined;
-              nameEnglishFull: string | null | undefined;
               nameEnglishShort: string | null | undefined;
-              nameFull: string | null | undefined;
               nameKatakana: string | null | undefined;
               nameShort: string | null | undefined;
-              railroadId: number | null | undefined;
-              status: OperationStatus | null | undefined;
-              type: CompanyType | null | undefined;
-              url: string | null | undefined;
             }
           | null
           | undefined;
@@ -894,9 +1037,6 @@ export type StationFieldsFragment = {
               groupId: number | null | undefined;
               name: string | null | undefined;
               nameRoman: string | null | undefined;
-              nameRomanIpa: string | null | undefined;
-              nameChinese: string | null | undefined;
-              nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
               stationNumbers:
                 | Array<{
@@ -911,22 +1051,16 @@ export type StationFieldsFragment = {
             }
           | null
           | undefined;
-        trainType:
-          | {
-              __typename: 'TrainTypeNested';
-              id: number | null | undefined;
-              typeId: number | null | undefined;
-              groupId: number | null | undefined;
-              name: string | null | undefined;
-              nameKatakana: string | null | undefined;
-              nameRoman: string | null | undefined;
-              nameRomanIpa: string | null | undefined;
-              nameChinese: string | null | undefined;
-              nameKorean: string | null | undefined;
-              color: string | null | undefined;
-              direction: TrainDirection | null | undefined;
-              kind: TrainTypeKind | null | undefined;
-            }
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
           | null
           | undefined;
       }>
@@ -947,11 +1081,22 @@ export type StationFieldsFragment = {
         color: string | null | undefined;
         direction: TrainDirection | null | undefined;
         kind: TrainTypeKind | null | undefined;
+        nameTtsSegments:
+          | Array<{
+              __typename: 'TtsSegment';
+              alphabet: TtsAlphabet | null | undefined;
+              fallbackText: string | null | undefined;
+              lang: string | null | undefined;
+              pronunciation: string | null | undefined;
+              separator: string | null | undefined;
+              surface: string | null | undefined;
+            }>
+          | null
+          | undefined;
         line:
           | {
               __typename: 'LineNested';
               id: number | null | undefined;
-              averageDistance: number | null | undefined;
               color: string | null | undefined;
               lineType: LineType | null | undefined;
               nameFull: string | null | undefined;
@@ -967,16 +1112,9 @@ export type StationFieldsFragment = {
                 | {
                     __typename: 'Company';
                     id: number | null | undefined;
-                    name: string | null | undefined;
-                    nameEnglishFull: string | null | undefined;
                     nameEnglishShort: string | null | undefined;
-                    nameFull: string | null | undefined;
                     nameKatakana: string | null | undefined;
                     nameShort: string | null | undefined;
-                    railroadId: number | null | undefined;
-                    status: OperationStatus | null | undefined;
-                    type: CompanyType | null | undefined;
-                    url: string | null | undefined;
                   }
                 | null
                 | undefined;
@@ -1000,6 +1138,18 @@ export type StationFieldsFragment = {
                     nameChinese: string | null | undefined;
                     nameKorean: string | null | undefined;
                     hasTrainTypes: boolean | null | undefined;
+                    nameTtsSegments:
+                      | Array<{
+                          __typename: 'TtsSegment';
+                          alphabet: TtsAlphabet | null | undefined;
+                          fallbackText: string | null | undefined;
+                          lang: string | null | undefined;
+                          pronunciation: string | null | undefined;
+                          separator: string | null | undefined;
+                          surface: string | null | undefined;
+                        }>
+                      | null
+                      | undefined;
                     stationNumbers:
                       | Array<{
                           __typename: 'StationNumber';
@@ -1028,7 +1178,31 @@ export type StationFieldsFragment = {
                     color: string | null | undefined;
                     direction: TrainDirection | null | undefined;
                     kind: TrainTypeKind | null | undefined;
+                    nameTtsSegments:
+                      | Array<{
+                          __typename: 'TtsSegment';
+                          alphabet: TtsAlphabet | null | undefined;
+                          fallbackText: string | null | undefined;
+                          lang: string | null | undefined;
+                          pronunciation: string | null | undefined;
+                          separator: string | null | undefined;
+                          surface: string | null | undefined;
+                        }>
+                      | null
+                      | undefined;
                   }
+                | null
+                | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
                 | null
                 | undefined;
             }
@@ -1038,7 +1212,6 @@ export type StationFieldsFragment = {
           | Array<{
               __typename: 'LineNested';
               id: number | null | undefined;
-              averageDistance: number | null | undefined;
               color: string | null | undefined;
               lineType: LineType | null | undefined;
               nameFull: string | null | undefined;
@@ -1054,16 +1227,9 @@ export type StationFieldsFragment = {
                 | {
                     __typename: 'Company';
                     id: number | null | undefined;
-                    name: string | null | undefined;
-                    nameEnglishFull: string | null | undefined;
                     nameEnglishShort: string | null | undefined;
-                    nameFull: string | null | undefined;
                     nameKatakana: string | null | undefined;
                     nameShort: string | null | undefined;
-                    railroadId: number | null | undefined;
-                    status: OperationStatus | null | undefined;
-                    type: CompanyType | null | undefined;
-                    url: string | null | undefined;
                   }
                 | null
                 | undefined;
@@ -1087,6 +1253,18 @@ export type StationFieldsFragment = {
                     nameChinese: string | null | undefined;
                     nameKorean: string | null | undefined;
                     hasTrainTypes: boolean | null | undefined;
+                    nameTtsSegments:
+                      | Array<{
+                          __typename: 'TtsSegment';
+                          alphabet: TtsAlphabet | null | undefined;
+                          fallbackText: string | null | undefined;
+                          lang: string | null | undefined;
+                          pronunciation: string | null | undefined;
+                          separator: string | null | undefined;
+                          surface: string | null | undefined;
+                        }>
+                      | null
+                      | undefined;
                     stationNumbers:
                       | Array<{
                           __typename: 'StationNumber';
@@ -1115,7 +1293,31 @@ export type StationFieldsFragment = {
                     color: string | null | undefined;
                     direction: TrainDirection | null | undefined;
                     kind: TrainTypeKind | null | undefined;
+                    nameTtsSegments:
+                      | Array<{
+                          __typename: 'TtsSegment';
+                          alphabet: TtsAlphabet | null | undefined;
+                          fallbackText: string | null | undefined;
+                          lang: string | null | undefined;
+                          pronunciation: string | null | undefined;
+                          separator: string | null | undefined;
+                          surface: string | null | undefined;
+                        }>
+                      | null
+                      | undefined;
                   }
+                | null
+                | undefined;
+              nameTtsSegments:
+                | Array<{
+                    __typename: 'TtsSegment';
+                    alphabet: TtsAlphabet | null | undefined;
+                    fallbackText: string | null | undefined;
+                    lang: string | null | undefined;
+                    pronunciation: string | null | undefined;
+                    separator: string | null | undefined;
+                    surface: string | null | undefined;
+                  }>
                 | null
                 | undefined;
             }>
@@ -1141,22 +1343,26 @@ export type GetStationsNearbyQuery = {
     name: string | null | undefined;
     nameKatakana: string | null | undefined;
     nameRoman: string | null | undefined;
-    nameRomanIpa: string | null | undefined;
     nameChinese: string | null | undefined;
     nameKorean: string | null | undefined;
     threeLetterCode: string | null | undefined;
     latitude: number | null | undefined;
     longitude: number | null | undefined;
-    address: string | null | undefined;
-    postalCode: string | null | undefined;
     prefectureId: number | null | undefined;
-    openedAt: string | null | undefined;
-    closedAt: string | null | undefined;
-    status: OperationStatus | null | undefined;
-    distance: number | null | undefined;
     hasTrainTypes: boolean | null | undefined;
     stopCondition: StopCondition | null | undefined;
-    transportType: TransportType | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
     stationNumbers:
       | Array<{
           __typename: 'StationNumber';
@@ -1171,32 +1377,19 @@ export type GetStationsNearbyQuery = {
       | {
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -1216,9 +1409,6 @@ export type GetStationsNearbyQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -1233,22 +1423,16 @@ export type GetStationsNearbyQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }
@@ -1258,32 +1442,19 @@ export type GetStationsNearbyQuery = {
       | Array<{
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -1303,9 +1474,6 @@ export type GetStationsNearbyQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -1320,22 +1488,16 @@ export type GetStationsNearbyQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }>
@@ -1356,11 +1518,22 @@ export type GetStationsNearbyQuery = {
           color: string | null | undefined;
           direction: TrainDirection | null | undefined;
           kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
           line:
             | {
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -1376,16 +1549,9 @@ export type GetStationsNearbyQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -1409,6 +1575,18 @@ export type GetStationsNearbyQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -1437,7 +1615,31 @@ export type GetStationsNearbyQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }
@@ -1447,7 +1649,6 @@ export type GetStationsNearbyQuery = {
             | Array<{
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -1463,16 +1664,9 @@ export type GetStationsNearbyQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -1496,6 +1690,18 @@ export type GetStationsNearbyQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -1524,7 +1730,31 @@ export type GetStationsNearbyQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }>
@@ -1794,35 +2024,38 @@ export type GetLineListStationsLightQuery = {
   }>;
 };
 
-export type GetLineStationsQueryVariables = Exact<{
-  lineId: Scalars['Int']['input'];
-  stationId: InputMaybe<Scalars['Int']['input']>;
+export type GetLineListStationsQueryVariables = Exact<{
+  lineIds: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
 }>;
 
-export type GetLineStationsQuery = {
-  lineStations: Array<{
+export type GetLineListStationsQuery = {
+  lineListStations: Array<{
     __typename: 'Station';
     id: number | null | undefined;
     groupId: number | null | undefined;
     name: string | null | undefined;
     nameKatakana: string | null | undefined;
     nameRoman: string | null | undefined;
-    nameRomanIpa: string | null | undefined;
     nameChinese: string | null | undefined;
     nameKorean: string | null | undefined;
     threeLetterCode: string | null | undefined;
     latitude: number | null | undefined;
     longitude: number | null | undefined;
-    address: string | null | undefined;
-    postalCode: string | null | undefined;
     prefectureId: number | null | undefined;
-    openedAt: string | null | undefined;
-    closedAt: string | null | undefined;
-    status: OperationStatus | null | undefined;
-    distance: number | null | undefined;
     hasTrainTypes: boolean | null | undefined;
     stopCondition: StopCondition | null | undefined;
-    transportType: TransportType | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
     stationNumbers:
       | Array<{
           __typename: 'StationNumber';
@@ -1837,32 +2070,19 @@ export type GetLineStationsQuery = {
       | {
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -1882,9 +2102,6 @@ export type GetLineStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -1899,22 +2116,16 @@ export type GetLineStationsQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }
@@ -1924,32 +2135,19 @@ export type GetLineStationsQuery = {
       | Array<{
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -1969,9 +2167,6 @@ export type GetLineStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -1986,22 +2181,16 @@ export type GetLineStationsQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }>
@@ -2022,11 +2211,22 @@ export type GetLineStationsQuery = {
           color: string | null | undefined;
           direction: TrainDirection | null | undefined;
           kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
           line:
             | {
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2042,16 +2242,9 @@ export type GetLineStationsQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2075,6 +2268,18 @@ export type GetLineStationsQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -2103,7 +2308,31 @@ export type GetLineStationsQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }
@@ -2113,7 +2342,6 @@ export type GetLineStationsQuery = {
             | Array<{
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2129,16 +2357,9 @@ export type GetLineStationsQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2162,6 +2383,18 @@ export type GetLineStationsQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -2190,7 +2423,467 @@ export type GetLineStationsQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }>
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+  }>;
+};
+
+export type GetLineStationsQueryVariables = Exact<{
+  lineId: Scalars['Int']['input'];
+  stationId: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+export type GetLineStationsQuery = {
+  lineStations: Array<{
+    __typename: 'Station';
+    id: number | null | undefined;
+    groupId: number | null | undefined;
+    name: string | null | undefined;
+    nameKatakana: string | null | undefined;
+    nameRoman: string | null | undefined;
+    nameChinese: string | null | undefined;
+    nameKorean: string | null | undefined;
+    threeLetterCode: string | null | undefined;
+    latitude: number | null | undefined;
+    longitude: number | null | undefined;
+    prefectureId: number | null | undefined;
+    hasTrainTypes: boolean | null | undefined;
+    stopCondition: StopCondition | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
+    stationNumbers:
+      | Array<{
+          __typename: 'StationNumber';
+          lineSymbol: string | null | undefined;
+          lineSymbolColor: string | null | undefined;
+          lineSymbolShape: string | null | undefined;
+          stationNumber: string | null | undefined;
+        }>
+      | null
+      | undefined;
+    line:
+      | {
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+    lines:
+      | Array<{
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+        }>
+      | null
+      | undefined;
+    trainType:
+      | {
+          __typename: 'TrainTypeNested';
+          id: number | null | undefined;
+          typeId: number | null | undefined;
+          groupId: number | null | undefined;
+          name: string | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameRomanIpa: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          color: string | null | undefined;
+          direction: TrainDirection | null | undefined;
+          kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          line:
+            | {
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameRomanIpa: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          lines:
+            | Array<{
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameRomanIpa: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }>
@@ -2216,22 +2909,26 @@ export type GetStationsByNameQuery = {
     name: string | null | undefined;
     nameKatakana: string | null | undefined;
     nameRoman: string | null | undefined;
-    nameRomanIpa: string | null | undefined;
     nameChinese: string | null | undefined;
     nameKorean: string | null | undefined;
     threeLetterCode: string | null | undefined;
     latitude: number | null | undefined;
     longitude: number | null | undefined;
-    address: string | null | undefined;
-    postalCode: string | null | undefined;
     prefectureId: number | null | undefined;
-    openedAt: string | null | undefined;
-    closedAt: string | null | undefined;
-    status: OperationStatus | null | undefined;
-    distance: number | null | undefined;
     hasTrainTypes: boolean | null | undefined;
     stopCondition: StopCondition | null | undefined;
-    transportType: TransportType | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
     stationNumbers:
       | Array<{
           __typename: 'StationNumber';
@@ -2246,32 +2943,19 @@ export type GetStationsByNameQuery = {
       | {
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -2291,9 +2975,6 @@ export type GetStationsByNameQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2308,22 +2989,16 @@ export type GetStationsByNameQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }
@@ -2333,32 +3008,19 @@ export type GetStationsByNameQuery = {
       | Array<{
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -2378,9 +3040,6 @@ export type GetStationsByNameQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2395,22 +3054,16 @@ export type GetStationsByNameQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }>
@@ -2431,11 +3084,22 @@ export type GetStationsByNameQuery = {
           color: string | null | undefined;
           direction: TrainDirection | null | undefined;
           kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
           line:
             | {
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2451,16 +3115,9 @@ export type GetStationsByNameQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2484,6 +3141,18 @@ export type GetStationsByNameQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -2512,7 +3181,31 @@ export type GetStationsByNameQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }
@@ -2522,7 +3215,6 @@ export type GetStationsByNameQuery = {
             | Array<{
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2538,16 +3230,9 @@ export type GetStationsByNameQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2571,6 +3256,18 @@ export type GetStationsByNameQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -2599,7 +3296,31 @@ export type GetStationsByNameQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }>
@@ -2623,22 +3344,26 @@ export type GetLineGroupStationsQuery = {
     name: string | null | undefined;
     nameKatakana: string | null | undefined;
     nameRoman: string | null | undefined;
-    nameRomanIpa: string | null | undefined;
     nameChinese: string | null | undefined;
     nameKorean: string | null | undefined;
     threeLetterCode: string | null | undefined;
     latitude: number | null | undefined;
     longitude: number | null | undefined;
-    address: string | null | undefined;
-    postalCode: string | null | undefined;
     prefectureId: number | null | undefined;
-    openedAt: string | null | undefined;
-    closedAt: string | null | undefined;
-    status: OperationStatus | null | undefined;
-    distance: number | null | undefined;
     hasTrainTypes: boolean | null | undefined;
     stopCondition: StopCondition | null | undefined;
-    transportType: TransportType | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
     stationNumbers:
       | Array<{
           __typename: 'StationNumber';
@@ -2653,32 +3378,19 @@ export type GetLineGroupStationsQuery = {
       | {
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -2698,9 +3410,6 @@ export type GetLineGroupStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2715,22 +3424,16 @@ export type GetLineGroupStationsQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }
@@ -2740,32 +3443,19 @@ export type GetLineGroupStationsQuery = {
       | Array<{
           __typename: 'LineNested';
           id: number | null | undefined;
-          averageDistance: number | null | undefined;
           color: string | null | undefined;
           lineType: LineType | null | undefined;
-          nameFull: string | null | undefined;
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
-          nameRomanIpa: string | null | undefined;
           nameShort: string | null | undefined;
-          nameChinese: string | null | undefined;
-          nameKorean: string | null | undefined;
-          status: OperationStatus | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
                 __typename: 'Company';
                 id: number | null | undefined;
-                name: string | null | undefined;
-                nameEnglishFull: string | null | undefined;
                 nameEnglishShort: string | null | undefined;
-                nameFull: string | null | undefined;
                 nameKatakana: string | null | undefined;
                 nameShort: string | null | undefined;
-                railroadId: number | null | undefined;
-                status: OperationStatus | null | undefined;
-                type: CompanyType | null | undefined;
-                url: string | null | undefined;
               }
             | null
             | undefined;
@@ -2785,9 +3475,6 @@ export type GetLineGroupStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2802,22 +3489,16 @@ export type GetLineGroupStationsQuery = {
               }
             | null
             | undefined;
-          trainType:
-            | {
-                __typename: 'TrainTypeNested';
-                id: number | null | undefined;
-                typeId: number | null | undefined;
-                groupId: number | null | undefined;
-                name: string | null | undefined;
-                nameKatakana: string | null | undefined;
-                nameRoman: string | null | undefined;
-                nameRomanIpa: string | null | undefined;
-                nameChinese: string | null | undefined;
-                nameKorean: string | null | undefined;
-                color: string | null | undefined;
-                direction: TrainDirection | null | undefined;
-                kind: TrainTypeKind | null | undefined;
-              }
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
             | null
             | undefined;
         }>
@@ -2838,11 +3519,22 @@ export type GetLineGroupStationsQuery = {
           color: string | null | undefined;
           direction: TrainDirection | null | undefined;
           kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
           line:
             | {
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2858,16 +3550,9 @@ export type GetLineGroupStationsQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2891,6 +3576,18 @@ export type GetLineGroupStationsQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -2919,7 +3616,31 @@ export type GetLineGroupStationsQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }
@@ -2929,7 +3650,6 @@ export type GetLineGroupStationsQuery = {
             | Array<{
                 __typename: 'LineNested';
                 id: number | null | undefined;
-                averageDistance: number | null | undefined;
                 color: string | null | undefined;
                 lineType: LineType | null | undefined;
                 nameFull: string | null | undefined;
@@ -2945,16 +3665,9 @@ export type GetLineGroupStationsQuery = {
                   | {
                       __typename: 'Company';
                       id: number | null | undefined;
-                      name: string | null | undefined;
-                      nameEnglishFull: string | null | undefined;
                       nameEnglishShort: string | null | undefined;
-                      nameFull: string | null | undefined;
                       nameKatakana: string | null | undefined;
                       nameShort: string | null | undefined;
-                      railroadId: number | null | undefined;
-                      status: OperationStatus | null | undefined;
-                      type: CompanyType | null | undefined;
-                      url: string | null | undefined;
                     }
                   | null
                   | undefined;
@@ -2978,6 +3691,18 @@ export type GetLineGroupStationsQuery = {
                       nameChinese: string | null | undefined;
                       nameKorean: string | null | undefined;
                       hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                       stationNumbers:
                         | Array<{
                             __typename: 'StationNumber';
@@ -3006,7 +3731,31 @@ export type GetLineGroupStationsQuery = {
                       color: string | null | undefined;
                       direction: TrainDirection | null | undefined;
                       kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
                     }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
                   | null
                   | undefined;
               }>
@@ -3236,6 +3985,7 @@ export type GetRouteTypesLightQuery = {
           groupId: number | null | undefined;
           name: string | null | undefined;
           nameRoman: string | null | undefined;
+          color: string | null | undefined;
           kind: TrainTypeKind | null | undefined;
           line:
             | {
@@ -3381,6 +4131,7 @@ export type GetStationTrainTypesLightQuery = {
     groupId: number | null | undefined;
     name: string | null | undefined;
     nameRoman: string | null | undefined;
+    color: string | null | undefined;
     kind: TrainTypeKind | null | undefined;
     line:
       | {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -117,10 +117,7 @@ export const LINE_IN_STATION_FRAGMENT = gql`
     id
     color
     company {
-      id
-      nameEnglishShort
-      nameKatakana
-      nameShort
+      ...CompanyFields
     }
     lineSymbols {
       ...LineSymbolFields

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -108,6 +108,44 @@ export const LINE_NESTED_FRAGMENT = gql`
   }
 `;
 
+export const LINE_IN_STATION_FRAGMENT = gql`
+  ${COMPANY_FRAGMENT}
+  ${LINE_SYMBOL_FRAGMENT}
+  ${STATION_NUMBER_FRAGMENT}
+  ${TTS_SEGMENT_FRAGMENT}
+  fragment LineInStationFields on LineNested {
+    id
+    color
+    company {
+      id
+      nameEnglishShort
+      nameKatakana
+      nameShort
+    }
+    lineSymbols {
+      ...LineSymbolFields
+    }
+    station {
+      id
+      groupId
+      name
+      nameRoman
+      hasTrainTypes
+      stationNumbers {
+        ...StationNumberFields
+      }
+    }
+    lineType
+    nameKatakana
+    nameRoman
+    nameShort
+    nameTtsSegments {
+      ...TtsSegmentFields
+    }
+    transportType
+  }
+`;
+
 export const TRAIN_TYPE_NESTED_FRAGMENT = gql`
   ${LINE_NESTED_FRAGMENT}
   fragment TrainTypeNestedFields on TrainTypeNested {
@@ -136,7 +174,7 @@ export const TRAIN_TYPE_NESTED_FRAGMENT = gql`
 `;
 
 export const STATION_FRAGMENT = gql`
-  ${LINE_NESTED_FRAGMENT}
+  ${LINE_IN_STATION_FRAGMENT}
   ${STATION_NUMBER_FRAGMENT}
   ${TRAIN_TYPE_NESTED_FRAGMENT}
   fragment StationFields on Station {
@@ -145,7 +183,6 @@ export const STATION_FRAGMENT = gql`
     name
     nameKatakana
     nameRoman
-    nameRomanIpa
     nameChinese
     nameKorean
     nameTtsSegments {
@@ -155,19 +192,16 @@ export const STATION_FRAGMENT = gql`
     latitude
     longitude
     prefectureId
-    status
-    distance
     hasTrainTypes
     stopCondition
-    transportType
     stationNumbers {
       ...StationNumberFields
     }
     line {
-      ...LineNestedFields
+      ...LineInStationFields
     }
     lines {
-      ...LineNestedFields
+      ...LineInStationFields
     }
     trainType {
       ...TrainTypeNestedFields


### PR DESCRIPTION
## 概要
- `StationFields` で参照する `line` / `lines` 向けに `LineInStationFields` を追加しました
- 駅詳細で不要な項目を外し、駅画面向けに必要なフィールドへ取得内容を整理しました
- 生成された GraphQL 型定義を更新し、Biome で整形しました

## 変更理由
駅詳細で使う `LineNested` フラグメントが広すぎたため、不要なフィールドまで取得していました。駅画面で必要な項目に絞ることで、クエリと生成型の両方を軽量化します。

## 影響
- 駅詳細系クエリの取得項目が縮小されます
- `StationFields` に依存する型定義が更新されます
- UI の期待値は維持したまま、不要なデータ取得を減らします

## 確認
- `npm run lint`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ステーション関連のデータ取得を最適化し、路線データの取得効率が向上して応答がより高速になりました。
  * ステーション詳細の表示項目を整理しました（ステータス・距離・ローマ字発音などの一部項目を削減）。路線レベルの交通種別は維持しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->