### PR TITLE
[codex] 小田急線テーマで乗換路線アイコンの誤表示を修正

### DIFF
--- a/src/components/TransferLineMark.test.tsx
+++ b/src/components/TransferLineMark.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react-native';
+import TransferLineMark from './TransferLineMark';
+
+const mockImage = jest.fn((_props?: unknown) => null);
+
+jest.mock('expo-image', () => ({
+  Image: (props: unknown) => mockImage(props),
+}));
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+describe('TransferLineMark', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('同一路線IDでも画像ソースが変わればrecyclingKeyを更新する', () => {
+    const line = {
+      id: 11321,
+      company: { id: 2 },
+      color: '#00ac9a',
+      nameShort: '埼京線',
+    };
+
+    const { rerender } = render(
+      <TransferLineMark
+        line={line as never}
+        mark={{ signPath: 101 }}
+        size={undefined}
+      />
+    );
+
+    expect(mockImage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        recyclingKey: '11321:101:::::color',
+        source: 101,
+      })
+    );
+
+    rerender(
+      <TransferLineMark
+        line={line as never}
+        mark={{ signPath: 202 }}
+        size={undefined}
+      />
+    );
+
+    expect(mockImage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        recyclingKey: '11321:202:::::color',
+        source: 202,
+      })
+    );
+  });
+});

--- a/src/components/TransferLineMark.tsx
+++ b/src/components/TransferLineMark.tsx
@@ -165,8 +165,23 @@ const TransferLineMark: React.FC<Props> = ({
   }, [isBus, busSymbol, stationNumber, mark.sign, mark.signShape]);
 
   const fallbackImageSrc = mark.btUnionSignPaths?.[0] ?? mark.signPath;
+  const imageSourceKey = useMemo(() => {
+    if (mark.btUnionSignPaths?.length) {
+      return mark.btUnionSignPaths.join(',');
+    }
+
+    return fallbackImageSrc != null ? String(fallbackImageSrc) : 'no-image';
+  }, [fallbackImageSrc, mark.btUnionSignPaths]);
   const recyclingKey = String(
-    line?.id ?? mark.sign ?? fallbackImageSrc ?? 'unknown-mark'
+    [
+      line?.id ?? 'unknown-line',
+      imageSourceKey,
+      stationNumber ?? '',
+      threeLetterCode ?? '',
+      mark.sign ?? '',
+      mark.signShape ?? '',
+      shouldGrayscale ? 'grayscale' : 'color',
+    ].join(':')
   );
 
   if (mark.btUnionSignPaths && !stationNumber) {
@@ -177,6 +192,7 @@ const TransferLineMark: React.FC<Props> = ({
         ) : null}
 
         <Image
+          key={recyclingKey}
           style={imageStyle}
           source={mark.btUnionSignPaths[0]}
           cachePolicy="memory-disk"
@@ -195,6 +211,7 @@ const TransferLineMark: React.FC<Props> = ({
         ) : null}
 
         <Image
+          key={recyclingKey}
           style={imageStyle}
           source={mark.signPath}
           cachePolicy="memory-disk"


### PR DESCRIPTION
## 概要
小田急線テーマで乗換路線アイコンが誤った画像として再利用されることがある問題を修正しました。

## 変更内容
- `TransferLineMark` の `expo-image` 用 `recyclingKey` を、路線IDだけでなく実際の画像ソース、駅番号、3レターコード、色状態まで含めた値に変更
- 画像切り替え時に確実に再マウントされるよう `Image` にも `key` を付与
- 同一路線IDでも画像ソース変更時に `recyclingKey` が更新されることを確認するテストを追加

## 原因
`TransferLineMark` の画像再利用キーが粗く、セル再利用時に別路線の画像が残るケースがありました。

## 影響
- 小田急線テーマで乗換案内に表示される路線画像の誤表示を抑止します
- 埼京線なのに中央・総武線各駅停車の画像が出るような取り違えを防ぎます

## 確認内容
- `npm test -- --runInBand src/components/TransferLineMark.test.tsx`
- `npx biome check src/components/TransferLineMark.tsx src/components/TransferLineMark.test.tsx`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * コンポーネントの包括的なテストを追加しました。

* **改善**
  * 画像の表示・キャッシング機構を改善し、より効率的な画像更新処理を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->