### PR TITLE
乗換の中国語・韓国語駅名が表示されないバグを修正

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -613,6 +613,8 @@ export type LineInStationFieldsFragment = {
         groupId: number | null | undefined;
         name: string | null | undefined;
         nameRoman: string | null | undefined;
+        nameChinese: string | null | undefined;
+        nameKorean: string | null | undefined;
         hasTrainTypes: boolean | null | undefined;
         stationNumbers:
           | Array<{
@@ -972,6 +974,8 @@ export type StationFieldsFragment = {
               groupId: number | null | undefined;
               name: string | null | undefined;
               nameRoman: string | null | undefined;
+              nameChinese: string | null | undefined;
+              nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
               stationNumbers:
                 | Array<{
@@ -1037,6 +1041,8 @@ export type StationFieldsFragment = {
               groupId: number | null | undefined;
               name: string | null | undefined;
               nameRoman: string | null | undefined;
+              nameChinese: string | null | undefined;
+              nameKorean: string | null | undefined;
               hasTrainTypes: boolean | null | undefined;
               stationNumbers:
                 | Array<{
@@ -1409,6 +1415,8 @@ export type GetStationsNearbyQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -1474,6 +1482,8 @@ export type GetStationsNearbyQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2102,6 +2112,8 @@ export type GetLineListStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2167,6 +2179,8 @@ export type GetLineListStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2538,6 +2552,8 @@ export type GetLineStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2603,6 +2619,8 @@ export type GetLineStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -2975,6 +2993,8 @@ export type GetStationsByNameQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -3040,6 +3060,8 @@ export type GetStationsByNameQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -3410,6 +3432,8 @@ export type GetLineGroupStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{
@@ -3475,6 +3499,8 @@ export type GetLineGroupStationsQuery = {
                 groupId: number | null | undefined;
                 name: string | null | undefined;
                 nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
                 hasTrainTypes: boolean | null | undefined;
                 stationNumbers:
                   | Array<{

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -127,6 +127,8 @@ export const LINE_IN_STATION_FRAGMENT = gql`
       groupId
       name
       nameRoman
+      nameChinese
+      nameKorean
       hasTrainTypes
       stationNumbers {
         ...StationNumberFields


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 駅名に中国語および韓国語表記対応を追加しました。複数の駅検索機能や路線情報クエリで、新しい言語オプションが利用可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->