### PR TITLE
乗換の中国語・韓国語路線名が表示されないバグを修正

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -586,6 +586,8 @@ export type LineInStationFieldsFragment = {
   nameKatakana: string | null | undefined;
   nameRoman: string | null | undefined;
   nameShort: string | null | undefined;
+  nameChinese: string | null | undefined;
+  nameKorean: string | null | undefined;
   transportType: TransportType | null | undefined;
   company:
     | {
@@ -947,6 +949,8 @@ export type StationFieldsFragment = {
         nameKatakana: string | null | undefined;
         nameRoman: string | null | undefined;
         nameShort: string | null | undefined;
+        nameChinese: string | null | undefined;
+        nameKorean: string | null | undefined;
         transportType: TransportType | null | undefined;
         company:
           | {
@@ -1014,6 +1018,8 @@ export type StationFieldsFragment = {
         nameKatakana: string | null | undefined;
         nameRoman: string | null | undefined;
         nameShort: string | null | undefined;
+        nameChinese: string | null | undefined;
+        nameKorean: string | null | undefined;
         transportType: TransportType | null | undefined;
         company:
           | {
@@ -1388,6 +1394,8 @@ export type GetStationsNearbyQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -1455,6 +1463,8 @@ export type GetStationsNearbyQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -2085,6 +2095,8 @@ export type GetLineListStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -2152,6 +2164,8 @@ export type GetLineListStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -2525,6 +2539,8 @@ export type GetLineStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -2592,6 +2608,8 @@ export type GetLineStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -2966,6 +2984,8 @@ export type GetStationsByNameQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -3033,6 +3053,8 @@ export type GetStationsByNameQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -3405,6 +3427,8 @@ export type GetLineGroupStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {
@@ -3472,6 +3496,8 @@ export type GetLineGroupStationsQuery = {
           nameKatakana: string | null | undefined;
           nameRoman: string | null | undefined;
           nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
           transportType: TransportType | null | undefined;
           company:
             | {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -138,6 +138,8 @@ export const LINE_IN_STATION_FRAGMENT = gql`
     nameKatakana
     nameRoman
     nameShort
+    nameChinese
+    nameKorean
     nameTtsSegments {
       ...TtsSegmentFields
     }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 駅の路線表示に中国語・韓国語の名称表記を追加
  * 駅一覧、路線ページ、近隣駅検索や名称検索などの表示で中国語・韓国語表記が利用可能（存在しない場合は省略されます）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->