### PR TITLE
都営プレフィックスを東京都交通局に変更してnameShortと整合性を取る

### DIFF
--- a/src/__fixtures__/line.ts
+++ b/src/__fixtures__/line.ts
@@ -96,7 +96,7 @@ export const TOEI_SHINJUKU_LINE_LOCAL: Line = {
     __typename: 'Company',
     id: 119,
     railroadId: 99,
-    nameShort: '都営',
+    nameShort: '東京都交通局',
     nameKatakana: 'トウキョウトコウツウキョク',
     nameFull: '東京都交通局',
     nameEnglishShort: 'Toei',

--- a/src/__fixtures__/station.ts
+++ b/src/__fixtures__/station.ts
@@ -849,7 +849,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -925,7 +925,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -1030,7 +1030,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -1267,7 +1267,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -1372,7 +1372,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -1452,7 +1452,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -1557,7 +1557,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -1865,7 +1865,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -1970,7 +1970,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -2202,7 +2202,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -2307,7 +2307,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -2463,7 +2463,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -2539,7 +2539,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -2644,7 +2644,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -2803,7 +2803,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -2908,7 +2908,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -2988,7 +2988,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3093,7 +3093,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -3249,7 +3249,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3325,7 +3325,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3430,7 +3430,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -3510,7 +3510,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3615,7 +3615,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -3695,7 +3695,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3771,7 +3771,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -3876,7 +3876,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -3956,7 +3956,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -4061,7 +4061,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -4217,7 +4217,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -4322,7 +4322,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -4402,7 +4402,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -4507,7 +4507,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -4587,7 +4587,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -4692,7 +4692,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -4772,7 +4772,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -4877,7 +4877,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -4957,7 +4957,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -5062,7 +5062,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -5142,7 +5142,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -5247,7 +5247,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -5327,7 +5327,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -5432,7 +5432,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -5512,7 +5512,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -5617,7 +5617,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',
@@ -5849,7 +5849,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
         company: {
           id: 119,
           railroadId: 99,
-          nameShort: '都営',
+          nameShort: '東京都交通局',
           nameKatakana: 'トウキョウトコウツウキョク',
           nameFull: '東京都交通局',
           nameEnglishShort: 'Toei',
@@ -5954,7 +5954,7 @@ export const TOEI_SHINJUKU_LINE_STATIONS: Station[] = [
       company: {
         id: 119,
         railroadId: 99,
-        nameShort: '都営',
+        nameShort: '東京都交通局',
         nameKatakana: 'トウキョウトコウツウキョク',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',

--- a/src/utils/__fixtures__/search.ts
+++ b/src/utils/__fixtures__/search.ts
@@ -705,7 +705,7 @@ export const OCHIAI_STATIONS_FROM_SEARCH: Station[] = [
         __typename: 'Company',
         id: 19,
         railroadId: 29,
-        nameShort: '都営地下鉄',
+        nameShort: '東京都交通局',
         nameKatakana: 'トエイチカテツ',
         nameFull: '東京都交通局',
         nameEnglishShort: 'Toei',

--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -85,6 +85,14 @@ describe('resolveThemeForLine', () => {
     ).toBe(APP_THEME.TOEI);
   });
 
+  it('東京都交通局地下鉄の路線もTOEIを返す', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({ id: 99302, company: makeCompany('東京都交通局地下鉄') })
+      )
+    ).toBe(APP_THEME.TOEI);
+  });
+
   it('JR西日本の路線はJR_WESTを返す', () => {
     expect(
       resolveThemeForLine(

--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -77,16 +77,10 @@ describe('resolveThemeForLine', () => {
     ).toBe(APP_THEME.TOKYO_METRO);
   });
 
-  it('都営の路線はTOEIを返す', () => {
-    expect(
-      resolveThemeForLine(makeLine({ id: 99301, company: makeCompany('都営') }))
-    ).toBe(APP_THEME.TOEI);
-  });
-
-  it('都営地下鉄の路線もTOEIを返す', () => {
+  it('東京都交通局の路線はTOEIを返す', () => {
     expect(
       resolveThemeForLine(
-        makeLine({ id: 99302, company: makeCompany('都営地下鉄') })
+        makeLine({ id: 99301, company: makeCompany('東京都交通局') })
       )
     ).toBe(APP_THEME.TOEI);
   });

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -17,7 +17,7 @@ const LINE_ID_TO_THEME: Record<number, AppTheme> = {
 
 const COMPANY_PREFIX_TO_THEME: [string, AppTheme][] = [
   ['東京メトロ', APP_THEME.TOKYO_METRO],
-  ['都営', APP_THEME.TOEI],
+  ['東京都交通局', APP_THEME.TOEI],
   ['JR西日本', APP_THEME.JR_WEST],
   ['JR九州', APP_THEME.JR_KYUSHU],
   ['東急', APP_THEME.TY],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 東京都交通局の正式な社名表記に合わせてテーマ判定ルールを更新し、該当路線で正しいTOEIテーマが適用されるようにしました。

* **テスト**
  * 判定ロジックに対応するテストと固定データを社名表記の変更に合わせて更新し、期待するテーマ適用を継続的に検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->