### PR TITLE
ヘッダー系画像のキャッシュ衝突で無関係な画像が表示されるバグを修正

### DIFF
--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -481,6 +481,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
         <View style={[styles.top, { left: mark ? 64 : 32 }]}>
           {mark ? (
             <TransferLineMark
+              key={`transfer-line-mark-${currentLine?.id ?? 'unknown'}`}
               line={currentLine}
               mark={mark}
               color={numberingColor}
@@ -492,9 +493,11 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
           )}
           <View style={styles.trainTypeImageContainer}>
             <Image
+              key={`train-type-${trainTypeImage}`}
               style={styles.trainTypeImage}
               source={trainTypeImage}
               cachePolicy="memory-disk"
+              recyclingKey={`train-type-${trainTypeImage}`}
             />
           </View>
         </View>

--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -166,6 +166,7 @@ export const ThemeConfirmModal: React.FC<Props> = ({
               <Typography style={styles.autoPreviewEmoji}>❓</Typography>
             ) : (
               <Image
+                key={`theme-preview-${themeId ?? 'unknown'}`}
                 recyclingKey={themeId}
                 source={previewImage}
                 style={styles.previewImage}


### PR DESCRIPTION
## 概要

`HeaderJRWest` の列車種別画像 (`<Image />`) と `TransferLineMark` で、全く関係ない画像が表示される不具合を修正します。`ThemeConfirmModal` にも同様のキャッシュ衝突リスクがあったため予防的に修正しました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 原因
- `HeaderJRWest.tsx` の `<Image />` に `recyclingKey` が付いておらず、expo-image がビュー再利用時に前の画像を一瞬表示してしまうことがあった。
- `TransferLineMark` は内部で `recyclingKey` を使って制御していたが、親側で `currentLine` が切り替わったときに確実に再マウントさせるための `key` が無かった。

### 修正内容
- `HeaderJRWest.tsx`
  - `<Image />`（列車種別画像）に `key` と `recyclingKey` を追加（`trainTypeImage` のアセットIDベース）
  - `<TransferLineMark />` に `key={currentLine?.id}` を追加
- `ThemeConfirmModal.tsx`
  - 既に `recyclingKey` はあったが、一貫性のため `key` を追加

### 補足
`cachePolicy="memory-disk"` は Android でのローカルアセット表示遅延対策として引き続き必要（expo-image v55 のデフォルトは `'disk'` のため）。`ThemeConfirmModal` は表示頻度が低いためデフォルト `'disk'` のまま。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（`HeaderJRWest` / `TransferLineMark` の既存テスト 26件 全てパス）
- [x] `npm run typecheck` が通ること

## 関連Issue

なし

## スクリーンショット（任意）

UI ロジック自体の変更は無く、キャッシュ周りの修正のため割愛。

🤖 Generated with [Claude Code](https://claude.com/claude-code)