### PR TITLE
bump-version.jsでpackage-lock.jsonのバージョンも同期するよう修正

### DIFF
--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -5,6 +5,7 @@ const path = require('path');
 const rootDir = path.resolve(__dirname, '..');
 const appConfigPath = path.join(rootDir, 'app.config.ts');
 const packageJsonPath = path.join(rootDir, 'package.json');
+const packageLockJsonPath = path.join(rootDir, 'package-lock.json');
 const pbxprojPath = path.join(rootDir, 'ios', 'TrainLCD.xcodeproj', 'project.pbxproj');
 const androidBuildGradlePath = path.join(rootDir, 'android', 'app', 'build.gradle');
 
@@ -350,6 +351,15 @@ if (versionChanged || androidVersionCodeChanged || iosBuildNumberChanged) {
 if (versionChanged) {
   packageJson.version = nextVersion;
   writeJson(packageJsonPath, packageJson);
+
+  if (fs.existsSync(packageLockJsonPath)) {
+    const packageLockJson = readJson(packageLockJsonPath);
+    packageLockJson.version = nextVersion;
+    if (packageLockJson.packages?.['']) {
+      packageLockJson.packages[''].version = nextVersion;
+    }
+    writeJson(packageLockJsonPath, packageLockJson);
+  }
 }
 
 // MARKETING_VERSIONはバージョンが変更された場合のみ更新


### PR DESCRIPTION
## 概要

`scripts/bump-version.js` はバージョンアップ時に `app.config.ts` / `package.json` / `project.pbxproj` / `android/app/build.gradle` を書き換えるが、`package-lock.json` の `version` は更新されないため、`package.json` と `package-lock.json` のバージョンが乖離していた。本 PR でバージョン変更時に `package-lock.json` のバージョンも同期するよう修正する。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `scripts/bump-version.js` にバージョン変更時のみ `package-lock.json` を更新する処理を追加
- `package-lock.json` のトップレベル `version` と `packages[""].version` の両方を書き換える
- `package-lock.json` が存在しない場合はスキップ

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョン管理スクリプトの内部処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->