### PR TITLE
release PR作成スキルでmasterからブランチを切るよう変更

### DIFF
--- a/.claude/skills/create-release-pr/SKILL.md
+++ b/.claude/skills/create-release-pr/SKILL.md
@@ -20,7 +20,7 @@ description: Cut a production release branch, bump the app version, run quality 
 - カレントディレクトリがリポジトリルート。
 - `gh` CLI 認証済み、`git` と `npm` が使える。
 - 作業ツリーがクリーン（未コミット変更なし）。残っている場合はユーザーに確認してから退避する。
-- `dev` ブランチが origin と同期済み。差分があれば pull 可否をユーザーに確認する。
+- `master` ブランチが origin と同期済み。差分があれば pull 可否をユーザーに確認する。
 
 ## 手順
 
@@ -29,16 +29,16 @@ description: Cut a production release branch, bump the app version, run quality 
    - 入力の先頭 `v` / `V` を取り除き、`MAJOR.MINOR.PATCH` 形式かを検証。
    - 同名のブランチ（ローカル or origin）がすでに存在する場合は中断し、既存ブランチでの進行可否をユーザーに確認する。
 
-2. **dev から切り出し**
+2. **master から切り出し**
 
    ```bash
-   git fetch origin dev master
-   git switch dev
-   git pull --ff-only origin dev
+   git fetch origin master
+   git switch master
+   git pull --ff-only origin master
    git switch -c release/v<version>
    ```
 
-   - `dev` の head が CI 的に緑であることは呼び出し側で担保する前提（このスキルでは確認しない）。
+   - `master` の head が CI 的に緑であることは呼び出し側で担保する前提（このスキルでは確認しない）。
 
 3. **バージョンバンプ**
 


### PR DESCRIPTION
## 概要

`create-release-pr` スキルがリリースブランチを `dev` から切り出していたのを `master` から切り出すように変更。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 前提条件の同期チェック対象を `dev` → `master` に変更
- 手順 2 のタイトルを「master から切り出し」に変更し、`git fetch` / `git switch` / `git pull` の対象ブランチを `master` に変更

## テスト

<!-- スキル定義(.md)のみの変更のため、テスト実行は省略 -->

- [ ] \`npm run lint\` が通ること
- [ ] \`npm test\` が通ること
- [ ] \`npm run typecheck\` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリースプロセスのターゲットブランチを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->