### PR TITLE
バージョンバンプ用自動PRのAssigneeに@TinyKittenを追加

### DIFF
--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -56,3 +56,4 @@ jobs:
           labels: |
             automated
             version-bump
+          assignees: TinyKitten

--- a/.github/workflows/bump_version_on_release_pr.yml
+++ b/.github/workflows/bump_version_on_release_pr.yml
@@ -143,3 +143,4 @@ jobs:
           labels: |
             automated
             version-bump
+          assignees: TinyKitten


### PR DESCRIPTION
## 概要

バージョンバンプを自動作成する GitHub Actions ワークフローが生成する PR に、Assignee として `@TinyKitten` を自動付与するよう設定。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.github/workflows/bump_version_on_canary_pr.yml` の `peter-evans/create-pull-request` ステップに `assignees: TinyKitten` を追加。
- `.github/workflows/bump_version_on_release_pr.yml` の `peter-evans/create-pull-request` ステップに `assignees: TinyKitten` を追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* キャナリーおよびリリース向けバージョンバンプのワークフローで、自動生成されるプルリクエストの割り当て設定を更新しました。これにより、プルリクエストがより効率的に処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->