### PR TITLE
リリース後工程を自動化するClaude Codeスキル（publish-release / sync-dev-from-master / finalize-release）を追加

### DIFF
--- a/.claude/skills/finalize-release/SKILL.md
+++ b/.claude/skills/finalize-release/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: finalize-release
+description: Run the full post-release finishing flow for TrainLCD MobileApp in one shot — tag origin/master HEAD, publish a GitHub Release with auto-generated notes, and open a dev<-master sync PR. Thin orchestrator over publish-release + sync-dev-from-master that consolidates mid-flow approvals into a single upfront confirmation. Use after a production release PR (release/vX.Y.Z → master) has been merged.
+---
+
+# finalize-release
+
+本番リリース PR が master にマージされた直後の仕上げを **一気通貫** で行うラッパー。`publish-release`（タグ作成・GitHub Release 公開）→ `sync-dev-from-master`（dev への同期PR作成）を順に走らせる。各スキルが持つ個別承認ゲートを **1 回の実行計画承認に統合** するのが主目的。
+
+## 委譲先
+
+1. **publish-release**: master HEAD に annotated tag を打ち、`gh release create --generate-notes --latest` で GitHub Release を即公開。
+2. **sync-dev-from-master**: `chore/dev-from-master` を master から切り出し、`dev<-master` タイトルのマージPRを作成。
+
+各スキル自体の仕様（安全弁・検証・本文テンプレ・squash merge 禁止警告）はそのまま流用する。このスキルは **差分情報の先読み** と **承認の統合** のみを担い、独自の破壊的操作は追加しない。
+
+## 入力
+
+| 項目 | 必須 | 既定値 |
+| ---- | ---- | ---- |
+| `version` | 任意 | 未指定なら `origin/master:package.json` の `version` を使う（先頭 `v` は剥がす） |
+
+sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自動スキップする。ユーザーが sync だけ飛ばしたい場合は `publish-release` を直接呼んでもらう（このスキルに skip オプションは持たせない）。
+
+## 前提条件
+
+- 本番リリース PR が **既に master にマージ済み**。未マージなら中断。
+- `gh` CLI 認証済み、`git` が使える。
+- 作業ツリーがクリーン（未コミット変更なし）。残っていればユーザーに確認。
+- リモート `origin/master` / `origin/dev` が存在する。
+
+## 手順
+
+1. **共通前処理（フェッチと version 解決）**
+
+   ```bash
+   git fetch origin dev master --tags
+   ```
+
+   `version` が未指定なら:
+   ```bash
+   git show origin/master:package.json | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])"
+   ```
+   で取得。`MAJOR.MINOR.PATCH` 形式（SemVer）でなければ中断。
+
+2. **プレフライト（全サブスキルの実行計画を先読み）**
+
+   **この段階では何も書き換え・push しない**。以下を全部先に確認し、実行計画を 1 本にまとめる。失敗条件（重複タグ・version 不一致・既存枝に未マージコミット等）はここで検知し、承認ゲート前に中断する。
+
+   **publish-release 側の先読み**:
+   - 既存タグ・Release 重複: `git tag --list "v<version>"`, `git ls-remote --tags origin "refs/tags/v<version>"`, `gh release view "v<version>" --json tagName 2>/dev/null` → いずれかヒットで中断。
+   - master HEAD SHA: `git rev-parse origin/master`
+   - master HEAD 件名: `git log -1 --format='%s' origin/master`
+   - package.json version 一致確認 → 不一致で中断。
+
+   **sync-dev-from-master 側の先読み**:
+   - master→dev 差分件数: `git rev-list --count origin/dev..origin/master` と `git log --pretty='- %s' origin/dev..origin/master`
+     - **0 件なら sync をスキップ** としてプランに記録（中断ではない）。
+   - 既存 open な dev<-master PR: `gh pr list --base dev --head chore/dev-from-master --state open --json number,url`
+     - 既に open なら **新規作成はスキップし既存 URL を流用** としてプランに記録。
+   - 既存 `chore/dev-from-master` の状態（open PR が無い前提で）:
+     - `git ls-remote --heads origin chore/dev-from-master` と `gh pr list --base dev --head chore/dev-from-master --state all --limit 1 --json number,state,url`
+     - 直近 PR が `MERGED` → 承認後に削除・再作成予定としてプランに記録。
+     - それ以外（`CLOSED` のみ、PR 無し、ローカル未 push コミット有り等）→ 中断してユーザーに確認（自動では削除しない）。
+
+3. **承認ゲート（一括）**
+
+   以下フォーマットで実行計画を要約し、**1 回だけ** ユーザー承認を取る。承認が出たら手順 4〜5 を連続実行し、途中で止めない。
+
+   ```
+   finalize-release 実行計画 (version=v<version>)
+
+   [publish-release]
+     - タグ: v<version> (annotated, メッセージ "v<version>")
+     - 対象 SHA: <origin/master SHA>
+     - master HEAD 件名: <件名>
+     - package.json version 一致: OK
+     - GitHub Release: --target master --generate-notes --latest
+
+   [sync-dev-from-master]
+     - master→dev 差分: <N> 件
+     - 既存 chore/dev-from-master: <有り (直近 PR #<M> MERGED) → 削除・再作成 | 無し → 新規作成>
+     - PR: base=dev, head=chore/dev-from-master, title="dev<-master"
+     - ⚠ Squash merge 禁止（マージ時は Create a merge commit）
+   ```
+
+   スキップ判定時は該当セクションを以下に差し替える:
+   - 差分 0 件: `[sync-dev-from-master] skip (master は dev と同期済み)`
+   - 既存 open PR あり: `[sync-dev-from-master] 既存 PR を流用 (URL: <url>)`
+
+   承認が得られなければ中断。
+
+4. **publish-release の実体を実行（承認済み前提）**
+
+   `publish-release` スキルの手順 4〜5 を走らせる:
+   ```bash
+   git tag -a "v<version>" -m "v<version>" <origin/master SHA>
+   git push origin "v<version>"
+   gh release create "v<version>" --target master --title "v<version>" --generate-notes --latest
+   ```
+
+   プレフライトで確認済みの項目（重複・version 一致・SHA）は **再確認しない**（ユーザーへの問い合わせも追加で発生させない）。
+
+5. **sync-dev-from-master の実体を実行（プレフライト判定に従う）**
+
+   - **スキップ判定** → 手順を飛ばす。
+   - **既存 open PR 流用** → その URL を完了報告に使い、ブランチ再作成や PR 新規作成はしない。
+   - **通常実行** → `sync-dev-from-master` スキルの手順 3〜6 を走らせる:
+     1. 必要なら `git push origin --delete chore/dev-from-master`（プレフライトで承認済み前提、再承認しない）。
+     2. `git switch -c chore/dev-from-master origin/master` → `git push -u origin chore/dev-from-master`
+     3. PR 本文をテンプレ準拠で組み立てて `gh pr create`（`release_version` には手順 1 の `version` を渡す）。
+
+6. **完了報告**
+
+   1 レスポンスで以下を報告する:
+
+   - **publish-release** の結果: タグ名、対象 SHA、Release URL、Latest 判定、Release 本文の冒頭数行サマリ
+   - **sync-dev-from-master** の結果:
+     - 通常実行時: PR URL、取り込みコミット件数、変更の種類・テスト欄チェック状態
+     - スキップ時: `skip (差分なし)`
+     - 流用時: `既存 PR を流用: <url>`
+   - **⚠ 警告**: sync の PR が新規作成または流用された場合のみ、以下を太字で明示:
+     > **sync の PR は必ず「Create a merge commit」でマージしてください。Squash / Rebase は禁止です。** （PR #5838 の教訓）
+
+## 注意事項
+
+- **承認の統合** がこのスキルの付加価値。プレフライトで危ない状態（タグ重複・version 不一致・未マージブランチ残存等）は **承認ゲートに到達させない** ことで、「承認したら止まらない」契約を守る。
+- 操作順は **タグ先・PR 後** で固定。publish-release 成功後に sync 側が失敗しても、タグと Release は既に公開済みで巻き戻さない。sync 失敗時は原因を修正して `sync-dev-from-master` を単独呼び直しで補完する（その旨を完了報告で案内する）。
+- `git push --delete` や annotated tag push は破壊的に見えるが、プレフライトで重複ガードと `MERGED` 確認を済ませた上で実行する前提。
+- Squash merge 禁止警告は sync 側 PR が絡んだ場合（新規作成 or 既存流用）のみ出す。スキップ時は不要。

--- a/.claude/skills/finalize-release/SKILL.md
+++ b/.claude/skills/finalize-release/SKILL.md
@@ -48,7 +48,8 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
    **この段階では何も書き換え・push しない**。以下を全部先に確認し、実行計画を 1 本にまとめる。失敗条件（重複タグ・version 不一致・既存枝に未マージコミット等）はここで検知し、承認ゲート前に中断する。
 
    **publish-release 側の先読み**:
-   - 既存タグ・Release 重複: `git tag --list "v<version>"`, `git ls-remote --tags origin "refs/tags/v<version>"`, `gh release view "v<version>" --json tagName 2>/dev/null` → いずれかヒットで中断。
+   - 既存タグ重複: `git tag --list "v<version>"` と `git ls-remote --tags origin "refs/tags/v<version>"` のいずれかに出力があれば中断。
+   - 既存 Release 重複: `gh release view "v<version>" --json tagName` を実行し、exit 0（=存在）なら中断。exit 1 かつ stderr に `release not found` を含む場合のみ「重複なし」として続行。それ以外の非 0 終了（認証エラー・レート制限・通信障害等）は判定不能なので中断し、stderr を報告する。
    - master HEAD SHA: `git rev-parse origin/master`
    - master HEAD 件名: `git log -1 --format='%s' origin/master`
    - package.json version 一致確認 → 不一致で中断。
@@ -68,7 +69,7 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
 
    以下フォーマットで実行計画を要約し、**1 回だけ** ユーザー承認を取る。承認が出たら手順 4〜5 を連続実行し、途中で止めない。
 
-   ```
+   ```text
    finalize-release 実行計画 (version=v<version>)
 
    [publish-release]

--- a/.claude/skills/finalize-release/SKILL.md
+++ b/.claude/skills/finalize-release/SKILL.md
@@ -26,7 +26,7 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
 
 - 本番リリース PR が **既に master にマージ済み**。未マージなら中断。
 - `gh` CLI 認証済み、`git` が使える。
-- 作業ツリーがクリーン（未コミット変更なし）。残っていればユーザーに確認。
+- 作業ツリーがクリーン（未コミット変更なし）。残っている場合は中断し、ユーザーにクリーンアップを依頼する。
 - リモート `origin/master` / `origin/dev` が存在する。
 
 ## 手順
@@ -60,8 +60,9 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
      - 既に open なら **新規作成はスキップし既存 URL を流用** としてプランに記録。
    - 既存 `chore/dev-from-master` の状態（open PR が無い前提で）:
      - `git ls-remote --heads origin chore/dev-from-master` と `gh pr list --base dev --head chore/dev-from-master --state all --limit 1 --json number,state,url`
+     - ローカル未 push コミット有無: `git show-ref --verify --quiet refs/heads/chore/dev-from-master` でローカル枝の存在を確認し、有るなら `git cherry origin/chore/dev-from-master` を実行。出力が空でなければ **中断** してユーザーに確認（自動では削除しない）。
      - 直近 PR が `MERGED` → 承認後に削除・再作成予定としてプランに記録。
-     - それ以外（`CLOSED` のみ、PR 無し、ローカル未 push コミット有り等）→ 中断してユーザーに確認（自動では削除しない）。
+     - それ以外（`CLOSED` のみ、PR 無し等）→ 中断してユーザーに確認（自動では削除しない）。
 
 3. **承認ゲート（一括）**
 
@@ -99,7 +100,7 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
    gh release create "v<version>" --target master --title "v<version>" --generate-notes --latest
    ```
 
-   プレフライトで確認済みの項目（重複・version 一致・SHA）は **再確認しない**（ユーザーへの問い合わせも追加で発生させない）。
+   プレフライトで確認済みの項目（タグ・Release 重複、version 一致、SHA）は、破壊操作直前に **非対話で再検証** する（追加承認は取らない）。再検証で不一致が出た場合（並行リリース等で状態が変わっている）は安全のため中断し、検知内容のみ報告する。
 
 5. **sync-dev-from-master の実体を実行（プレフライト判定に従う）**
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: publish-release
+description: Create a git tag on origin/master HEAD and publish a GitHub Release with auto-generated release notes for TrainLCD MobileApp. Use when the user asks to tag a release, publish a GitHub Release, or ship a version after the release PR has been merged to master (e.g., v10.4.2).
+---
+
+# publish-release
+
+`master` ブランチ先端にタグを打って GitHub Release を即公開するスキル。`create-release-pr` でマージされたリリースPRの **後工程** として使う。リリースノートは GitHub の auto-generated release notes（`--generate-notes`）に丸投げする。
+
+## 入力
+
+| 項目 | 必須 | 例 |
+| ---- | ---- | ---- |
+| `version` | 必須 | `10.4.2` または `v10.4.2`（先頭 `v` は任意、内部で剥がす） |
+
+バージョンはセマンティックバージョニング（`MAJOR.MINOR.PATCH`）必須。満たさない場合は中断してユーザーに確認する。
+
+## 前提条件
+
+- カレントディレクトリがリポジトリルート。
+- `gh` CLI 認証済み、`git` が使える。
+- リリースPR（`release/v<version>` → `master`）は既に **master にマージ済み**。未マージなら中断し、ユーザーに確認する。
+- 作業ツリーがクリーン（未コミット変更なし）。残っている場合はユーザーに確認してから退避する。
+
+## 手順
+
+1. **バージョン正規化と検証**
+
+   - 入力の先頭 `v` / `V` を取り除き、`MAJOR.MINOR.PATCH` 形式か検証。満たさなければ中断。
+   - 同名のタグが既に存在するか確認。存在する場合は中断してユーザーに判断を仰ぐ（同じタグを別 SHA に付け直すのは事故のもとなので、このスキルでは勝手に上書きしない）。
+
+     ```bash
+     git fetch --tags origin
+     git tag --list "v<version>"
+     gh release view "v<version>" --json tagName 2>/dev/null || true
+     ```
+
+2. **master 最新化**
+
+   ```bash
+   git fetch origin master --tags
+   ```
+
+   - ローカル `master` は切り替えない（タグは `origin/master` の SHA に対して打つため checkout 不要）。
+   - `origin/master` の HEAD SHA を記録する。
+
+     ```bash
+     git rev-parse origin/master
+     ```
+
+3. **package.json のバージョン照合**
+
+   - `origin/master:package.json` の `version` フィールドを取得し、入力バージョンと一致するか確認する。
+
+     ```bash
+     git show origin/master:package.json | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])"
+     ```
+
+   - 不一致の場合は中断し、ユーザーに原因確認（リリースPR がまだマージされていない／別バージョンがマージされた等）。
+
+4. **タグ作成とプッシュ**
+
+   - `origin/master` の HEAD に **annotated tag** を打つ。タグメッセージは `v<version>` 固定（過去運用と同一）。
+
+     ```bash
+     git tag -a "v<version>" -m "v<version>" <origin/master の SHA>
+     git push origin "v<version>"
+     ```
+
+   - push 前に、タグ名・対象 SHA・master 側の最新コミット件名をユーザーに提示して承認を取る。
+
+5. **GitHub Release 公開**
+
+   - auto-generated release notes で即公開する。`--target` は `master` を明示。直前のタグを基準に差分が生成される。
+
+     ```bash
+     gh release create "v<version>" \
+       --target master \
+       --title "v<version>" \
+       --generate-notes \
+       --latest
+     ```
+
+   - `--latest` によって Latest 扱いになる。プレリリース用途（`vX.Y.Zb` 等の b サフィックス）でこのスキルを流用したい場合は、本スキルの責務外として中断し、ユーザーに確認する。
+
+6. **完了報告**
+
+   - タグ名、対象 SHA、Release URL、Release 本文（冒頭数行）を要約して報告する。
+   - Release 本文は `gh release view v<version> --json url,body -q '.url,.body'` で取得可能。
+
+## 注意事項
+
+- **タグ push と Release 作成は外部に波及する操作**。順序は「タグ push → Release 作成」で固定。Release 作成に失敗した場合でもタグは既に公開済みなので、やり直しは `gh release create` のみで足りる。
+- タグを削除・付け直す操作（`git push --delete` や `git tag -f`）はこのスキルの責務外。事故復旧が必要な場合はユーザーに判断を仰ぐ。
+- `--generate-notes` は **直前のタグ** との差分で自動生成される。想定外のタグ（プレリリース含む）が直前に入っていると本文がブレるので、生成後の本文は必ず目視確認する。ブレていた場合は `gh release edit v<version> --notes-start-tag <基準タグ>` などで再生成をユーザーと相談する。
+- リリースノートの人手調整が必要なら、`gh release edit v<version> --notes "..."` で後追い編集する方針（このスキルでは本文の手編集はしない）。
+- `create-release-pr` の直後に呼ぶのが典型フロー。リリースPR 未マージの状態で呼ばれた場合は、前述のガードで中断する。

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -20,7 +20,7 @@ description: Create a git tag on origin/master HEAD and publish a GitHub Release
 - カレントディレクトリがリポジトリルート。
 - `gh` CLI 認証済み、`git` が使える。
 - リリースPR（`release/v<version>` → `master`）は既に **master にマージ済み**。未マージなら中断し、ユーザーに確認する。
-- 作業ツリーがクリーン（未コミット変更なし）。残っている場合はユーザーに確認してから退避する。
+- 作業ツリーがクリーン（未コミット変更なし）。残っている場合は中断し、ユーザーにクリーンアップを依頼する。
 
 ## 手順
 

--- a/.claude/skills/sync-dev-from-master/SKILL.md
+++ b/.claude/skills/sync-dev-from-master/SKILL.md
@@ -58,7 +58,10 @@ description: Open a dev<-master merge PR that syncs master back into dev after a
    ```
 
    - **ケース A: どこにも存在しない** → そのまま手順 4 へ。
-   - **ケース B: 存在し、直近 PR が `MERGED`** → 削除対象。ブランチ名・直近 PR 番号・PR URL をユーザーに提示し、`git push origin --delete chore/dev-from-master` と `git branch -D chore/dev-from-master`（ローカルに有る場合）の実行可否を承認取り。承認後に削除。
+   - **ケース B: 存在し、直近 PR が `MERGED`** → 削除対象。ブランチ名・直近 PR 番号・PR URL をユーザーに提示し、実行可否を承認取り。承認後の手順は以下の順で行う:
+     1. 現在ブランチを `git rev-parse --abbrev-ref HEAD` で確認。`chore/dev-from-master` に居るとローカル削除が失敗するため、その場合は `git switch dev`（または任意の安全な枝）に退避する。
+     2. `git push origin --delete chore/dev-from-master` でリモートを削除。
+     3. ローカルにも存在する場合は `git branch -D chore/dev-from-master` で削除。
    - **ケース C: 存在するが直近 PR が `MERGED` 以外（`OPEN` は手順 2 で弾かれる。残るのは `CLOSED` または PR 無し）**: 削除しないで中断してユーザーに判断を仰ぐ（未マージ作業の可能性）。
    - **ケース D: ケース B または C（＝リモート `origin/chore/dev-from-master` が存在する）で、かつローカルに未 push コミットが有る**: リモート存在を `git rev-parse --verify origin/chore/dev-from-master` で確認したうえで `git cherry origin/chore/dev-from-master` を実行。出力が空でなければ削除せず中断しユーザーに確認。ケース A（どこにも存在しない）からは分岐しない（リモート非存在時の `git cherry` は fatal になるため実行しない）。
 

--- a/.claude/skills/sync-dev-from-master/SKILL.md
+++ b/.claude/skills/sync-dev-from-master/SKILL.md
@@ -60,7 +60,7 @@ description: Open a dev<-master merge PR that syncs master back into dev after a
    - **ケース A: どこにも存在しない** → そのまま手順 4 へ。
    - **ケース B: 存在し、直近 PR が `MERGED`** → 削除対象。ブランチ名・直近 PR 番号・PR URL をユーザーに提示し、`git push origin --delete chore/dev-from-master` と `git branch -D chore/dev-from-master`（ローカルに有る場合）の実行可否を承認取り。承認後に削除。
    - **ケース C: 存在するが直近 PR が `MERGED` 以外（`OPEN` は手順 2 で弾かれる。残るのは `CLOSED` または PR 無し）**: 削除しないで中断してユーザーに判断を仰ぐ（未マージ作業の可能性）。
-   - **ケース D: ローカルに未 push コミットが有る**: `git cherry origin/chore/dev-from-master` で検知。削除せず中断しユーザーに確認。
+   - **ケース D: ケース B または C（＝リモート `origin/chore/dev-from-master` が存在する）で、かつローカルに未 push コミットが有る**: リモート存在を `git rev-parse --verify origin/chore/dev-from-master` で確認したうえで `git cherry origin/chore/dev-from-master` を実行。出力が空でなければ削除せず中断しユーザーに確認。ケース A（どこにも存在しない）からは分岐しない（リモート非存在時の `git cherry` は fatal になるため実行しない）。
 
 4. **ブランチを origin/master から切り出して push**
 
@@ -117,7 +117,7 @@ description: Open a dev<-master merge PR that syncs master back into dev after a
    ```
 
    **置換ルール**:
-   - `<release_version>`: 入力 `release_version` があればそれ（先頭 `v` は剥がす）。未指定なら `git show origin/master:package.json | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])"` の値。取得失敗時は「概要」節から `**v<release_version>** ` の部分を丸ごと外す（偽情報を書かない）。
+   - `<release_version>`: 入力 `release_version` があればそれ（先頭 `v` は剥がす）。未指定なら `git show origin/master:package.json | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])"` の値。取得失敗時は「概要」節から `**v<release_version>**` の部分を丸ごと外す（偽情報を書かない）。
    - `<N>`: 手順 1 で数えたコミット件数。
    - `<コミット件名の箇条書き>`: `git log --pretty='- %s' origin/dev..origin/master` の出力をそのまま貼る。**50 件を超える場合**は先頭 50 件 + `- ...他 <M> 件` を付けて省略し、省略した旨を「変更内容」節末尾に 1 行書く。
 

--- a/.claude/skills/sync-dev-from-master/SKILL.md
+++ b/.claude/skills/sync-dev-from-master/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: sync-dev-from-master
+description: Open a dev<-master merge PR that syncs master back into dev after a production release for TrainLCD MobileApp. Creates the chore/dev-from-master branch from origin/master, fills the PR template properly (not with empty stubs), and explicitly warns that the PR must be merged as a merge commit (NOT squash). Use after publish-release (or any time master has drifted ahead of dev).
+---
+
+# sync-dev-from-master
+
+本番リリース後に `master` へ積まれた差分を `dev` へ戻すためのマージPRを作るスキル。`publish-release` の後工程として使う（忘れやすいので独立スキル化）。
+
+**最重要: この PR は必ず通常の merge commit でマージする。squash / rebase は禁止。** 過去 PR #5838 で squash merge してしまい、merge commit が潰れて意味が無くなり PR #5840 で再掲する事故があった。スキル実行時と完了報告の両方でこの注意を明示する。
+
+## 入力
+
+| 項目 | 必須 | 既定値 |
+| ---- | ---- | ---- |
+| `release_version` | 任意 | 省略可。指定されれば本文の「概要」に `v<version>` を入れる。未指定なら `origin/master:package.json` の `version` を使う |
+
+ブランチ名は **`chore/dev-from-master` 固定**（過去運用 PR #5838 / #5840 準拠）。入力で変えられない。
+
+## 前提条件
+
+- カレントディレクトリがリポジトリルート。
+- `gh` CLI 認証済み、`git` が使える。
+- 作業ツリーがクリーン（未コミット変更なし）。残っていればユーザーに確認。
+- リモートブランチ `origin/dev` / `origin/master` が存在する。
+
+## 手順
+
+1. **差分確認（無ければ中断）**
+
+   ```bash
+   git fetch origin dev master --tags
+   git log --oneline origin/dev..origin/master
+   ```
+
+   - 0 件なら「master は dev に対して進んでいない。同期 PR 不要」で中断し報告。
+   - 1 件以上あれば続行。コミット件名リストは後で本文に使うので保持。
+
+2. **既存 open PR のガード**
+
+   ```bash
+   gh pr list --base dev --head chore/dev-from-master --state open --json number,url
+   ```
+
+   - 既に open なら新規作成せず、既存 URL を返して中断。
+   - close 済み or merged のみなら続行。
+
+3. **既存 `chore/dev-from-master` の安全な削除・再作成**
+
+   過去リリースの枝が残っている想定で動く。以下の判定で進める。
+
+   ```bash
+   # ローカル・リモートの存在確認
+   git show-ref --verify --quiet refs/heads/chore/dev-from-master && echo LOCAL_EXISTS
+   git ls-remote --heads origin chore/dev-from-master
+   # 直近の dev 宛 PR の状態
+   gh pr list --base dev --head chore/dev-from-master --state all --limit 1 --json number,state,url
+   ```
+
+   - **ケース A: どこにも存在しない** → そのまま手順 4 へ。
+   - **ケース B: 存在し、直近 PR が `MERGED`** → 削除対象。ブランチ名・直近 PR 番号・PR URL をユーザーに提示し、`git push origin --delete chore/dev-from-master` と `git branch -D chore/dev-from-master`（ローカルに有る場合）の実行可否を承認取り。承認後に削除。
+   - **ケース C: 存在するが直近 PR が `MERGED` 以外（`OPEN` は手順 2 で弾かれる。残るのは `CLOSED` または PR 無し）**: 削除しないで中断してユーザーに判断を仰ぐ（未マージ作業の可能性）。
+   - **ケース D: ローカルに未 push コミットが有る**: `git cherry origin/chore/dev-from-master` で検知。削除せず中断しユーザーに確認。
+
+4. **ブランチを origin/master から切り出して push**
+
+   ```bash
+   git fetch origin master
+   git switch -c chore/dev-from-master origin/master
+   git push -u origin chore/dev-from-master
+   ```
+
+   - 何もコミットは積まない（master 先端そのまま）。biome 等のフォーマッタは走らせない（新規コミット無し）。
+   - push 前に、対象 SHA（`git rev-parse origin/master`）・取り込まれるコミット件数・本文に入れる version をユーザーに提示して承認を取る。
+
+5. **PR 本文を組み立て（テンプレ厳守・全節を実内容で埋める）**
+
+   `.github/pull_request_template.md` の節構成をそのまま使う。**全ての節でテンプレの `<!-- ... -->` コメントを残さず実内容に置換する**（過去の雑な埋め方をやめる）。
+
+   本文テンプレ（`<...>` は実値に置換）:
+
+   ```markdown
+   ## 概要
+
+   本番リリース **v<release_version>** 後に `master` ブランチへ積まれた差分を `dev` ブランチへ同期するマージPRです。`master` と `dev` の履歴を揃えることが目的で、コードの新規変更は含みません。
+
+   ## 変更の種類
+
+   - [ ] バグ修正
+   - [ ] 新機能
+   - [ ] リファクタリング
+   - [ ] ドキュメント
+   - [ ] CI/CD
+   - [x] その他
+
+   ## 変更内容
+
+   `master` に積まれていて `dev` に未反映の以下 **<N>** 件のコミットを `dev` に取り込みます。
+
+   <コミット件名の箇条書き>
+
+   ## テスト
+
+   - [ ] `npm run lint` が通ること
+   - [ ] `npm test` が通ること
+   - [ ] `npm run typecheck` が通ること
+
+   本PRはコード変更を含まないマージPRのため、当ブランチ上で lint / test / typecheck は実行していません。取り込まれる各コミットは元の PR 時点および `master` への取り込み時点で検証済みです。
+
+   ## 関連Issue
+
+   なし（リリース後の同期PR）。
+
+   ## スクリーンショット（任意）
+
+   なし（コード変更を含まないマージPR）。
+   ```
+
+   **置換ルール**:
+   - `<release_version>`: 入力 `release_version` があればそれ（先頭 `v` は剥がす）。未指定なら `git show origin/master:package.json | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])"` の値。取得失敗時は「概要」節から `**v<release_version>** ` の部分を丸ごと外す（偽情報を書かない）。
+   - `<N>`: 手順 1 で数えたコミット件数。
+   - `<コミット件名の箇条書き>`: `git log --pretty='- %s' origin/dev..origin/master` の出力をそのまま貼る。**50 件を超える場合**は先頭 50 件 + `- ...他 <M> 件` を付けて省略し、省略した旨を「変更内容」節末尾に 1 行書く。
+
+   **チェックボックスの判定**:
+   - 変更の種類は **`その他` のみ ON**、他は全 OFF。理由: 当PRはアプリ挙動の変更ではなくマージ操作のため（`create-pr` の「大原則: 判定はアプリの挙動に対する変更か」を適用し、コミット件名のトリガ語句に引きずられない）。
+   - テストは **3 項目全 OFF** + 下に実行していない旨の説明文。当ブランチで走らせていない以上、ON にしない（虚偽報告回避）。
+
+6. **PR 作成**
+
+   ```bash
+   gh pr create \
+     --base dev \
+     --head chore/dev-from-master \
+     --title "dev<-master" \
+     --assignee TinyKitten \
+     --body "$(cat <<'EOF'
+   <手順 5 で組み立てた本文>
+   EOF
+   )"
+   ```
+
+   - タイトルは **`dev<-master` 固定**（PR #5467 以降全てこの表記）。
+   - Assignee は `TinyKitten`（CLAUDE.md / メモ）。
+
+7. **完了報告（マージ方法を強調）**
+
+   完了報告の冒頭に、太字で以下を書く:
+
+   > **⚠ このPRは必ず「Create a merge commit」でマージしてください。Squash / Rebase は禁止です。**
+   > Squash すると master 側の merge commit 構造が潰れ、dev と master の履歴分岐が壊れます。過去 PR #5838 で同じミスが起き PR #5840 で再掲した実績あり。
+
+   続けて以下を簡潔に報告:
+   - PR URL
+   - 対象 SHA（`origin/master` の HEAD）
+   - 取り込みコミット件数と、長い場合は省略したか否か
+   - 変更の種類チェック状態（`その他` のみ ON）
+   - テスト欄のチェック状態（全 OFF + 説明文あり）
+   - 使用した `release_version`（どこから取ったか）
+
+## 注意事項
+
+- **Squash merge 禁止**。これがこのスキルの存在理由の半分。実行時と完了報告で二重に明示する。
+- コード変更が無いため `npx biome check --unsafe --fix ./src` は走らせない（メモのルールは「コミット前」に適用されるが当スキルは新規コミットを作らない）。
+- `publish-release` 直後に呼ばれるのが典型だが、master が dev より進んでいるタイミングなら単独でも使える（hotfix を master に直接入れた後など）。
+- PR テンプレの節構成は改変しない（CLAUDE.md ルール）。
+- 既に open な dev<-master PR がある場合は新規作成せず既存 URL を返す（手順 2）。

--- a/.claude/skills/sync-dev-from-master/SKILL.md
+++ b/.claude/skills/sync-dev-from-master/SKILL.md
@@ -21,7 +21,7 @@ description: Open a dev<-master merge PR that syncs master back into dev after a
 
 - カレントディレクトリがリポジトリルート。
 - `gh` CLI 認証済み、`git` が使える。
-- 作業ツリーがクリーン（未コミット変更なし）。残っていればユーザーに確認。
+- 作業ツリーがクリーン（未コミット変更なし）。残っている場合は中断し、ユーザーにクリーンアップを依頼する。
 - リモートブランチ `origin/dev` / `origin/master` が存在する。
 
 ## 手順


### PR DESCRIPTION
## 概要

本番リリース後の手作業（`master` へのタグ付け＋GitHub Release 公開、`dev<-master` の同期PR作成）を自動化する Claude Code スキルを 3 種追加します。過去のリリースで `dev<-master` マージPRの squash merge 事故（PR #5838）や、リリース後の手順ばらつきがあったため、一連の流れを再現可能な手順としてスキル化します。

- **`publish-release`**: 本番リリースPRが `master` にマージされた後、`origin/master` の HEAD に annotated tag（例: `v10.4.2`）を打ち、`gh release create --generate-notes --latest` で GitHub Release を即公開します。入力は `version` のみで、SemVer 検証と `package.json` の `version` との一致確認を行ってから実行します。
- **`sync-dev-from-master`**: 本番リリース後に `master` に積まれた差分を `dev` へ戻すマージPRを作成します。`chore/dev-from-master` ブランチを `origin/master` から切り出し、タイトル `dev<-master` で PR を作成します。**このPRは必ず merge commit でマージする必要**があり（squash 禁止、PR #5838 の教訓）、スキル実行時と完了報告の両方で明示的に警告します。
- **`finalize-release`**: 上記 2 スキルを順番に実行するラッパー。プレフライトで全サブスキルの実行計画を先読みし、**1 回の承認ゲートで両方を通す** のが主目的。`master→dev` 差分が 0 件なら sync 側は自動スキップします。

想定フロー: `create-release-pr` → `master` へマージ → `finalize-release vX.Y.Z`（または `publish-release vX.Y.Z` → `sync-dev-from-master` を個別実行）。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `.claude/skills/publish-release/SKILL.md` を新規追加
  - 入力: `version`（SemVer、先頭 `v` 任意）
  - 処理: 既存タグ・Release 重複チェック → `origin/master` の SHA 記録 → `package.json` との一致確認 → annotated tag 作成・push → `gh release create --target master --generate-notes --latest`
  - 安全装置: 既存タグ/Release 検出時・`package.json` 不一致時・作業ツリー未クリーン時は中断
- `.claude/skills/sync-dev-from-master/SKILL.md` を新規追加
  - 入力: `release_version`（任意、未指定時は `origin/master:package.json` から取得）
  - 処理: `origin/dev..origin/master` の差分確認 → 既存 `chore/dev-from-master` の安全な削除・再作成 → `origin/master` から切り出し・push → PR 作成（base=`dev`, head=`chore/dev-from-master`, title=`dev<-master`, Assignee=`@TinyKitten`）
  - PR 本文: テンプレの全節を実内容で埋める（概要・変更内容の箇条書き・変更の種類は `その他` のみ ON・テスト欄は全 OFF +「master で検証済みのため当ブランチでは実行していない」を明記）
  - 最重要警告: Squash/Rebase merge 禁止を実行時と完了報告で二重明示
- `.claude/skills/finalize-release/SKILL.md` を新規追加
  - 入力: `version`（任意、未指定時は `origin/master:package.json` から取得）
  - 処理: プレフライトで `publish-release` と `sync-dev-from-master` の実行計画を先読み → 1 回の承認ゲート → タグ作成・Release 公開 → sync PR 作成（差分 0 件ならスキップ）→ 完了報告
  - 操作順は「タグ先・PR 後」固定。sync 側が失敗してもタグ/Release は巻き戻さず、`sync-dev-from-master` 単独で追完する方針

## テスト

- [x] \`npm run lint\` が通ること
- [x] \`npm test\` が通ること
- [x] \`npm run typecheck\` が通ること

ローカル実行結果:
- \`npm run lint\`: 494 files checked, 問題なし（biome check）
- \`npm test\`: 148 suites / 1398 tests すべて pass
- \`npm run typecheck\`: \`tsc --noEmit\` 緑

## 関連Issue

なし。

## スクリーンショット（任意）

なし（\`.claude/skills/\` 配下のドキュメント（スキル定義）のみの変更）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リリース作業を一括で完了する対話式ワークフローを追加（公開と開発同期を単一実行で順次実行）
  * 指定バージョンで注釈付きタグ作成とGitHub Releaseの自動公開を実装（バージョン検証・重複チェック・承認ステップ含む）
  * 本番リリース後に開発ブランチへ同期するPRの作成、既存PR再利用、同期不要判定を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->