### PR TITLE
AGENTS.md にmarkdownlint準拠のMarkdown執筆ルールを明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,16 @@ This handbook defines how automation agents collaborate safely and effectively o
 - Co-locate style modules or constants near their consumers; share cross-cutting utilities through `src/utils/`.
 - Keep comments purposeful: explain intent or non-obvious constraints, not obvious mechanics.
 
+### Markdown documentation (docs/, README, .claude/skills/\*\*/SKILL.md)
+
+`markdownlint-cli2` 準拠。CodeRabbit も同ルールで指摘するため、執筆時点で以下を守る:
+
+- **MD040 (fenced code language)**: フェンスコードブロックには必ず言語指定を付ける。用途別の既定: 平文の図示・実行計画サマリは `text`、シェル例は `bash`、差分は `diff`、埋め込みテンプレ本文は `markdown`、構造化データは `json` / `yaml`。
+- **MD038 (no spaces in code spans)**: インラインコード（バッククォート）の内側先頭・末尾に空白を入れない。`` `**v<release_version>**` `` は OK、`` `**v<release_version>** ` `` は NG。
+- **MD031 / MD032 (blanks around fences / lists)**: フェンスコードブロック・リストブロックの前後に空行を 1 行入れる。
+- **MD029 (ordered list numbering)**: 順序リストの番号付けは単一ファイル内で統一する（全て `1.` で書くか、`1.` `2.` `3.` と逐次番号を振るか）。
+- **MD033 (inline HTML)**: Markdown で表現できる構造は HTML タグに落とさない。例外として `<details><summary>…</summary>` と表セル内の `<br>` は許可。
+
 ## Testing Strategy
 
 - Jest global setup lives in `jest.setup.js` and `src/setupTests.ts`.


### PR DESCRIPTION
## 概要

PR #5842 のレビューで CodeRabbit から markdownlint 違反（MD040 フェンス言語指定なし、MD038 インラインコード末尾スペース）を複数件指摘されたため、同種の違反を執筆時点で回避できるよう `AGENTS.md` に Markdown 執筆ルールを明文化します。`CLAUDE.md` は `AGENTS.md` へのシンボリックリンクのため、1 ファイルの編集で両方が更新されます。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AGENTS.md` の `## Coding Style & Naming Conventions` 節の末尾に `### Markdown documentation (docs/, README, .claude/skills/**/SKILL.md)` サブセクションを追加
- 対象ルール（`markdownlint-cli2` 準拠、CodeRabbit の指摘と一致）:
  - **MD040** フェンスコードブロックに言語指定必須（平文は `text`、シェルは `bash`、差分は `diff`、埋め込みテンプレは `markdown`、構造化データは `json` / `yaml`）
  - **MD038** インラインコード（バッククォート）内の先頭・末尾空白禁止
  - **MD031 / MD032** フェンスコードブロック・リストブロック前後の空行必須
  - **MD029** 順序リスト番号付けのファイル内統一
  - **MD033** Markdown で表現可能な構造の HTML タグ化を避ける（例外: `<details><summary>` と表セル内の `<br>`）
- `.claude/skills/**/SKILL.md` も対象範囲として明記

## テスト

- [x] \`npm run lint\` が通ること
- [x] \`npm test\` が通ること
- [x] \`npm run typecheck\` が通ること

ドキュメントのみの変更（`AGENTS.md` のみ、`CLAUDE.md` は symlink）のため、`src/` 配下には一切影響なし。コードベースに対する lint / test / typecheck は前回 PR #5842 での実行結果と同等（494 files lint clean, 148 suites / 1398 tests pass, typecheck 緑）。

## 関連Issue

- 元となった CodeRabbit 指摘: PR #5842 の 2 巡目レビュー（MD040 on `finalize-release/SKILL.md:71`, MD038 on `sync-dev-from-master/SKILL.md:120`）

## スクリーンショット（任意）

なし（ドキュメントのみの変更）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* マークダウンドキュメント標準の強化：コードブロックの言語識別子、インラインコードの空白制限、フェンス周辺の行間隔、順序リストの一貫性、およびHTMLタグ使用規則に関する統一的なフォーマット基準を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->