### PR TITLE
Geminiによるフィードバック処理にカテゴリ分類とトリアージレベルを追加

### DIFF
--- a/functions/src/models/ai.ts
+++ b/functions/src/models/ai.ts
@@ -1,6 +1,17 @@
 /**
  * AI生成レポートの型定義
  */
+export const AI_CATEGORIES = [
+  'bug',
+  'feature_request',
+  'improvement',
+  'question',
+] as const;
+export type AICategory = (typeof AI_CATEGORIES)[number];
+
+export const AI_TRIAGE_LEVELS = ['urgent', 'high', 'medium', 'low'] as const;
+export type AITriageLevel = (typeof AI_TRIAGE_LEVELS)[number];
+
 export type AIReport = {
   /** レポートのタイトル */
   title: string;
@@ -14,6 +25,10 @@ export type AIReport = {
   confidence: number;
   /** 分類理由 */
   reason: string;
+  /** 主分類カテゴリ */
+  category: AICategory;
+  /** トリアージ（優先度）レベル */
+  triageLevel: AITriageLevel;
 };
 
 export type FewShotItem = {

--- a/functions/src/workers/__tests__/feedback.test.ts
+++ b/functions/src/workers/__tests__/feedback.test.ts
@@ -1,0 +1,122 @@
+jest.mock('@google-cloud/storage', () => ({
+  Storage: class Storage {
+    bucket() {
+      return {
+        file() {
+          return {
+            async download() {
+              return [Buffer.from('')];
+            },
+          };
+        },
+      };
+    }
+  },
+}));
+
+jest.mock('@google-cloud/vertexai', () => ({
+  VertexAI: class VertexAI {},
+}));
+
+jest.mock('firebase-functions/v2/pubsub', () => ({
+  onMessagePublished: () => () => undefined,
+}));
+
+import { coerceReport } from '../feedback';
+
+describe('coerceReport', () => {
+  it('returns defaults when category and triageLevel are missing', () => {
+    const r = coerceReport({ title: 'タイトル', summary: 'サマリ' });
+    expect(r.category).toBe('question');
+    expect(r.triageLevel).toBe('medium');
+  });
+
+  it('maps canonical category and triageLevel values', () => {
+    const r = coerceReport({
+      title: 't',
+      summary: 's',
+      category: 'bug',
+      triageLevel: 'urgent',
+    });
+    expect(r.category).toBe('bug');
+    expect(r.triageLevel).toBe('urgent');
+  });
+
+  it('maps synonyms to canonical values', () => {
+    const r = coerceReport({
+      title: 't',
+      summary: 's',
+      category: 'feature',
+      triageLevel: 'critical',
+    });
+    expect(r.category).toBe('feature_request');
+    expect(r.triageLevel).toBe('urgent');
+  });
+
+  it('normalizes case, whitespace, and hyphens', () => {
+    const r = coerceReport({
+      title: 't',
+      summary: 's',
+      category: '  Feature-Request  ',
+      triageLevel: '  P0  ',
+    });
+    expect(r.category).toBe('feature_request');
+    expect(r.triageLevel).toBe('urgent');
+  });
+
+  it('maps P-level triage aliases', () => {
+    expect(
+      coerceReport({ category: 'bug', triageLevel: 'P1' }).triageLevel
+    ).toBe('high');
+    expect(
+      coerceReport({ category: 'bug', triageLevel: 'p2' }).triageLevel
+    ).toBe('medium');
+    expect(
+      coerceReport({ category: 'bug', triageLevel: 'P3' }).triageLevel
+    ).toBe('low');
+  });
+
+  it('falls back to defaults for unknown values', () => {
+    const r = coerceReport({
+      title: 't',
+      summary: 's',
+      category: 'nonsense',
+      triageLevel: 'whatever',
+    });
+    expect(r.category).toBe('question');
+    expect(r.triageLevel).toBe('medium');
+  });
+
+  it('accepts case-insensitive key names from Gemini output', () => {
+    const r = coerceReport({
+      Title: 't',
+      Summary: 's',
+      Category: 'Improvement',
+      TriageLevel: 'HIGH',
+    });
+    expect(r.category).toBe('improvement');
+    expect(r.triageLevel).toBe('high');
+  });
+
+  it('still parses existing fields (title truncation, labels, confidence, reason)', () => {
+    const longTitle = 'あ'.repeat(100);
+    const r = coerceReport({
+      title: longTitle,
+      summary: 's',
+      labels: ['ui', 'performance', 42],
+      confidence: 0.8,
+      reason: 'because',
+    });
+    expect(r.title.length).toBeLessThanOrEqual(72);
+    expect(r.labels).toEqual(['ui', 'performance']);
+    expect(r.confidence).toBe(0.8);
+    expect(r.reason).toBe('because');
+  });
+
+  it('supports question and improvement synonyms', () => {
+    expect(coerceReport({ category: 'help' }).category).toBe('question');
+    expect(coerceReport({ category: 'enhancement' }).category).toBe(
+      'improvement'
+    );
+  });
+});

--- a/functions/src/workers/__tests__/feedback.test.ts
+++ b/functions/src/workers/__tests__/feedback.test.ts
@@ -24,6 +24,10 @@ jest.mock('firebase-functions/v2/pubsub', () => ({
 
 import { coerceReport } from '../feedback';
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('coerceReport', () => {
   it('returns defaults when category and triageLevel are missing', () => {
     const r = coerceReport({ title: 'タイトル', summary: 'サマリ' });

--- a/functions/src/workers/feedback.ts
+++ b/functions/src/workers/feedback.ts
@@ -565,14 +565,12 @@ ${reporterUid}
                   name: 'Geminiによる要約',
                   value: aiReport.summary,
                 },
-                {
-                  name: 'カテゴリ',
-                  value: categoryLabel ?? '—',
-                },
-                {
-                  name: 'トリアージ',
-                  value: triageLabel ?? '—',
-                },
+                ...(shouldTagTriage && categoryLabel && triageLabel
+                  ? [
+                      { name: 'カテゴリ', value: categoryLabel },
+                      { name: 'トリアージ', value: triageLabel },
+                    ]
+                  : []),
                 {
                   name: '端末モデル名',
                   value: `${deviceInfo.brand} ${deviceInfo.modelName}(${deviceInfo.modelId})`,
@@ -629,14 +627,12 @@ ${reporterUid}
                   name: 'Geminiによる要約',
                   value: aiReport.summary,
                 },
-                {
-                  name: 'カテゴリ',
-                  value: categoryLabel ?? '—',
-                },
-                {
-                  name: 'トリアージ',
-                  value: triageLabel ?? '—',
-                },
+                ...(shouldTagTriage && categoryLabel && triageLabel
+                  ? [
+                      { name: 'カテゴリ', value: categoryLabel },
+                      { name: 'トリアージ', value: triageLabel },
+                    ]
+                  : []),
                 {
                   name: 'アプリの設定言語',
                   value: language,

--- a/functions/src/workers/feedback.ts
+++ b/functions/src/workers/feedback.ts
@@ -2,7 +2,12 @@ import { Storage } from '@google-cloud/storage';
 import { VertexAI } from '@google-cloud/vertexai';
 import dayjs from 'dayjs';
 import { onMessagePublished } from 'firebase-functions/v2/pubsub';
-import type { AIReport, FewShotItem } from '../models/ai';
+import type {
+  AICategory,
+  AIReport,
+  AITriageLevel,
+  FewShotItem,
+} from '../models/ai';
 import type { DiscordEmbed } from '../models/common';
 import type { FeedbackMessage } from '../models/feedback';
 
@@ -31,7 +36,59 @@ const GITHUB_LABELS = {
   SPAM_TYPE: '💩 Spam',
   UNKNOWN_TYPE: '❓ Unknown Type',
   AUTOMODE_ENABLED: '🤖 Auto Mode',
+  CATEGORY_BUG: '🐛 Bug',
+  CATEGORY_FEATURE_REQUEST: '✨ Feature Request',
+  CATEGORY_IMPROVEMENT: '🛠️ Improvement',
+  CATEGORY_QUESTION: '❓ Question',
+  TRIAGE_URGENT: '🔴 P0 / Urgent',
+  TRIAGE_HIGH: '🟠 P1 / High',
+  TRIAGE_MEDIUM: '🟡 P2 / Medium',
+  TRIAGE_LOW: '🟢 P3 / Low',
 } as const;
+
+const CATEGORY_LABELS: Record<AICategory, string> = {
+  bug: GITHUB_LABELS.CATEGORY_BUG,
+  feature_request: GITHUB_LABELS.CATEGORY_FEATURE_REQUEST,
+  improvement: GITHUB_LABELS.CATEGORY_IMPROVEMENT,
+  question: GITHUB_LABELS.CATEGORY_QUESTION,
+};
+
+const TRIAGE_LABELS: Record<AITriageLevel, string> = {
+  urgent: GITHUB_LABELS.TRIAGE_URGENT,
+  high: GITHUB_LABELS.TRIAGE_HIGH,
+  medium: GITHUB_LABELS.TRIAGE_MEDIUM,
+  low: GITHUB_LABELS.TRIAGE_LOW,
+};
+
+const CATEGORY_SYNONYMS: Record<string, AICategory> = {
+  bug: 'bug',
+  defect: 'bug',
+  crash: 'bug',
+  feature: 'feature_request',
+  feature_request: 'feature_request',
+  featurerequest: 'feature_request',
+  request: 'feature_request',
+  improvement: 'improvement',
+  enhancement: 'improvement',
+  improve: 'improvement',
+  question: 'question',
+  support: 'question',
+  help: 'question',
+};
+
+const TRIAGE_SYNONYMS: Record<string, AITriageLevel> = {
+  urgent: 'urgent',
+  critical: 'urgent',
+  p0: 'urgent',
+  high: 'high',
+  p1: 'high',
+  medium: 'medium',
+  normal: 'medium',
+  p2: 'medium',
+  low: 'low',
+  minor: 'low',
+  p3: 'low',
+};
 
 function looksLikeSpam(text: string) {
   if (!text) return false;
@@ -155,7 +212,7 @@ function extractTextFromVertex(result: VertexResponse): string {
   return typeof txt === 'string' ? txt : '{}';
 }
 
-function coerceReport(raw: unknown, titleMax = 72): AIReport {
+export function coerceReport(raw: unknown, titleMax = 72): AIReport {
   const norm = (k: string) =>
     String(k).toLowerCase().replace(/\s+/g, '').trim();
   const map = new Map<string, unknown>();
@@ -182,12 +239,29 @@ function coerceReport(raw: unknown, titleMax = 72): AIReport {
     : [];
   const confidence = getNum('confidence', 0.5);
   const reason = getStr('reason');
+  const categoryKey = getStr('category')
+    .toLowerCase()
+    .replaceAll(/[\s-]+/g, '');
+  const category: AICategory = CATEGORY_SYNONYMS[categoryKey] ?? 'question';
+  const triageKey = getStr('triagelevel')
+    .toLowerCase()
+    .replaceAll(/[\s-]+/g, '');
+  const triageLevel: AITriageLevel = TRIAGE_SYNONYMS[triageKey] ?? 'medium';
 
   if (!title) title = '要約未取得';
   if (title.length > titleMax) title = `${title.slice(0, titleMax - 1)}…`;
   if (!summary) summary = '';
 
-  return { title, summary, isSpam, labels, confidence, reason };
+  return {
+    title,
+    summary,
+    isSpam,
+    labels,
+    confidence,
+    reason,
+    category,
+    triageLevel,
+  };
 }
 
 // ---- Few-shot loader ----
@@ -203,10 +277,21 @@ const FEW_SHOT_PER_EX_MAX = Number(process.env.FEW_SHOT_PER_EX_MAX ?? 800); // c
 
 const SYSTEM_PROMPT = `
 You are a precise issue triager for TrainLCD.
-Task: 
+Task:
 1. Summarize the user's message into a ONE-LINE issue title in Japanese (≤72 chars).
 2. Also create a 1–3 sentence summary in Japanese that concisely describes the feedback content.
 3. Classify spam.
+4. If NOT spam, pick ONE primary "category" from ["bug","feature_request","improvement","question"]:
+   - bug: 不具合・誤動作・クラッシュ・表示崩れ
+   - feature_request: まだ存在しない機能の新規要望
+   - improvement: 既存機能の改善・調整
+   - question: 質問・使い方の確認・情報要求
+5. If NOT spam, pick ONE "triageLevel" from ["urgent","high","medium","low"]:
+   - urgent: クラッシュ・データ消失・広範な実用不能
+   - high: 特定機能が使えない／重要機能要望
+   - medium: 通常の改善・軽微なバグ
+   - low: 体裁の問題・質問・軽い要望
+   If spam, omit "category" and "triageLevel" entirely.
 
 Rules:
 - Newspaper-style headline: [症状/論点]+[対象]（助詞は最小限）
@@ -217,7 +302,7 @@ Rules:
   ["bug","improvement","feature","localization","location","ui","performance","network","settings"]
 
 Output JSON only:
-{"title": "...", "summary": "...", "isSpam": true|false, "labels": [], "confidence": 0..1, "reason": "..."}
+{"title": "...", "summary": "...", "isSpam": true|false, "labels": [], "category": "...", "triageLevel": "...", "confidence": 0..1, "reason": "..."}
 
 Return ONLY that JSON. No prose, no markdown.
 `.trim();
@@ -372,6 +457,14 @@ export const feedbackTriageWorker = onMessagePublished(
       return undefined;
     })();
 
+    const shouldTagTriage = reportType === 'feedback' && !aiReport.isSpam;
+    const categoryLabel = shouldTagTriage
+      ? CATEGORY_LABELS[aiReport.category]
+      : undefined;
+    const triageLabel = shouldTagTriage
+      ? TRIAGE_LABELS[aiReport.triageLevel]
+      : undefined;
+
     try {
       const res = await fetch(
         'https://api.github.com/repos/TrainLCD/Issues/issues',
@@ -440,6 +533,8 @@ ${reporterUid}
               aiReport.isSpam && GITHUB_LABELS.SPAM_TYPE,
               osNameLabel,
               autoModeLabel,
+              categoryLabel,
+              triageLabel,
             ].filter(Boolean),
           }),
         }
@@ -469,6 +564,14 @@ ${reporterUid}
                 {
                   name: 'Geminiによる要約',
                   value: aiReport.summary,
+                },
+                {
+                  name: 'カテゴリ',
+                  value: categoryLabel ?? '—',
+                },
+                {
+                  name: 'トリアージ',
+                  value: triageLabel ?? '—',
                 },
                 {
                   name: '端末モデル名',
@@ -525,6 +628,14 @@ ${reporterUid}
                 {
                   name: 'Geminiによる要約',
                   value: aiReport.summary,
+                },
+                {
+                  name: 'カテゴリ',
+                  value: categoryLabel ?? '—',
+                },
+                {
+                  name: 'トリアージ',
+                  value: triageLabel ?? '—',
                 },
                 {
                   name: 'アプリの設定言語',


### PR DESCRIPTION
## 概要

Gemini によるフィードバック処理（`functions/src/workers/feedback.ts`）に、タイトル・要約・スパム判定に加えて **カテゴリ分類** と **トリアージレベル** を追加する。生成結果は GitHub Issue ラベルと Discord 埋め込みに反映される。

- カテゴリ: `bug` / `feature_request` / `improvement` / `question`
- トリアージ: `urgent` / `high` / `medium` / `low`

スパム判定済みの feedback には category / triageLevel を付けない（`shouldTagTriage = reportType === 'feedback' && !aiReport.isSpam`）。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `functions/src/models/ai.ts`: `AI_CATEGORIES` / `AI_TRIAGE_LEVELS` 定数と `AICategory` / `AITriageLevel` 型を追加。`AIReport` に `category` / `triageLevel` を追加。
- `functions/src/workers/feedback.ts`:
  - `GITHUB_LABELS` に 4 カテゴリ × 4 トリアージ計 8 個の絵文字付きラベルを追加（例: `🐛 Bug`, `🔴 P0 / Urgent`）。
  - `CATEGORY_SYNONYMS` / `TRIAGE_SYNONYMS` でシノニムを吸収（`feature` → `feature_request`、`critical` / `P0` → `urgent` など）。
  - `SYSTEM_PROMPT` に category / triageLevel の選定ルールを追記。spam 時は両フィールドを出力しないよう明示。
  - `coerceReport()` を export 化し、category / triageLevel を防御的にパース（未指定・不正値は `question` / `medium` にフォールバック）。
  - GitHub Issue labels と Discord embed（feedback 側の deviceInfo あり/なし両方）にカテゴリ / トリアージを反映。crash 側の embed と本文テンプレートは変更なし。
- `functions/src/workers/__tests__/feedback.test.ts`: `coerceReport` の単体テストを新規追加（デフォルト・シノニム・正規化・不正値・大文字キー・既存フィールド整合）。

## テスト

`functions/` ディレクトリで以下を実行済み。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は既存スイートを含め **23/23 pass**。新規 `feedback.test.ts` のみだと **9/9 pass**。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---

### フォローアップ（本PRでは対応せず）

- GCS の few-shot JSONL (`FEW_SHOT_GCS_URI`) を `category` / `triageLevel` を含む形式で再生成すると Gemini の精度が向上する。コード側は欠落時のデフォルトで動作するため、別作業で対応予定。
- `coerceReport` の `getBool('isSpam')` はキー正規化との大文字小文字不一致による既存バグあり。本PRのスコープ外のため別PRで修正を推奨。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AI報告に「カテゴリー」と「優先度（トリアージ）」を追加。バグ／機能要望／改善／質問と、緊急／高／中／低の分類で自動割り当てされ、通知やラベル表示に反映されます。
  * 入力の表記ゆれや同義語を正規化して適切なカテゴリー／優先度にマッピングします。

* **テスト**
  * カテゴリー・優先度の割当てと正規化ロジックを網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->