### PR TITLE
EASビルド環境のNodeを22.17.0に明示指定

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -5,6 +5,7 @@
   "build": {
     "development": {
       "distribution": "store",
+      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },
@@ -24,6 +25,7 @@
     },
     "preview": {
       "distribution": "store",
+      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },
@@ -36,6 +38,7 @@
     },
     "production": {
       "distribution": "store",
+      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },


### PR DESCRIPTION
## 概要

#5849 で `package.json` の `engines` に `node: 22.x / npm: 10.x` と `.npmrc` の `engine-strict=true` を追加したところ、EAS のデフォルトビルドイメージ (Node 20.19.4 / npm 10.8.2) で `npm ci --include=dev` が `EBADENGINE` で失敗するようになった。EAS 側に Node バージョンを明示指定して整合させる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `eas.json` の `build.development` / `build.preview` / `build.production` 3 プロファイルに `"node": "22.17.0"` を追加
- これにより EAS ビルド環境も Node 22 LTS で揃い、`engines` 制約と矛盾しなくなる

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

※ 実際の EAS ビルドはマージ後に canary 側で検証。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

#5849 で導入した engines 制約の fallout。

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューア（Chore）**
  * ビルド構成をNode.js バージョン 22.17.0に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->