### PR TITLE
canary PR作成スキル経由のPRには skip-version-bump ラベルを付与して自動バンプを抑止

### DIFF
--- a/.claude/skills/create-canary-pr/SKILL.md
+++ b/.claude/skills/create-canary-pr/SKILL.md
@@ -19,6 +19,7 @@ description: Cut a dev→canary release pull request for TrainLCD MobileApp. Thi
 | `summary` | 省略（テンプレのコメントのみ） |
 | `related_issue` | 省略 |
 | `skip_checks` | `false`（テスト 3 項目は全て ON） |
+| `labels` | `["skip-version-bump"]` |
 
 ## リリース特有の注意
 
@@ -26,3 +27,4 @@ description: Cut a dev→canary release pull request for TrainLCD MobileApp. Thi
 - `dev` / `canary` 両ブランチとも origin 前提。ローカル `dev` が未 push ならユーザーに push 可否を確認（`create-pr` 側でも同じガードあり）。
 - 変更の種類の自動判定・Assignee・テンプレ節構成の遵守は `create-pr` の手順に従う。このスキルで独自に本文を組み立て直さない。
 - 既に open な dev→canary PR がある場合は新規作成せず、既存 URL を返す（`create-pr` 側のガードに任せる）。
+- スキル経由で作る canary PR には `skip-version-bump` ラベルを常時付与する。これにより `.github/workflows/bump_version_on_canary_pr.yml` の `bump-version` ジョブがスキップされる（スキル内で独自にバージョンを管理・反映する想定のため、Actions 側の自動バンプを二重起動させない）。手動で開いた canary PR はラベルを付けないので従来どおりバンプ PR が自動作成される。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -19,6 +19,7 @@ description: Create a GitHub pull request for TrainLCD MobileApp that conforms t
 | `summary` | 空なら「概要」「変更内容」本文はテンプレのコメントのみ残す |
 | `related_issue` | 空なら節のコメントのみ。コミット件名に `Closes #N` / `Fixes #N` / `Refs #N` があれば拾う |
 | `skip_checks` | `false`（テスト 3 項目を ON）。`true` なら全 OFF |
+| `labels` | 文字列配列、または未指定。未指定なら付与しない。指定した場合は `gh pr create --label <name>` でアトミックに付与する（作成後に `gh pr edit --add-label` すると `pull_request: opened` トリガのワークフローに間に合わないため、必ず `gh pr create` 時に渡す） |
 
 ### タイトル推論ルール
 
@@ -153,12 +154,14 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
 5. **PR 作成 / 更新**
 
    **新規作成モード**
+
    ```bash
    gh pr create \
      --base "<base>" \
      --head "<head>" \
      --title "<title>" \
      --assignee TinyKitten \
+     [--label "<label1>" --label "<label2>" ...] \
      --body "$(cat <<'EOF'
    <本文>
    EOF
@@ -166,7 +169,8 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
    ```
 
    - Assignee は常に `TinyKitten`（CLAUDE.md ルール）。
-   - 作成後の URL と、ON にしたチェック項目・判定根拠（例: コミット `fix: ...` により「バグ修正」を ON）を報告する。
+   - `labels` 入力があれば、その要素数だけ `--label` を繰り返して渡す。未指定なら `--label` 自体を書かない。
+   - 作成後の URL と、ON にしたチェック項目・判定根拠（例: コミット `fix: ...` により「バグ修正」を ON）、付与したラベルがあればその名前を報告する。
 
    **更新モード**
    ```bash

--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -16,7 +16,9 @@ env:
 jobs:
   bump-version:
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 概要

`create-canary-pr` スキル経由で開いた dev→canary PR では、スキル側で変更内容やリリース手順を制御している前提のため、`bump_version_on_canary_pr.yml` による自動バージョンバンプ PR の作成を走らせたくない。スキル生成 PR だけを識別して当該ワークフローをスキップできるよう、ラベルによるオプトアウト機構を導入する。手動で開いた canary PR はラベルを付けないので従来どおり自動バンプ PR が作られる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.github/workflows/bump_version_on_canary_pr.yml`: `bump-version` ジョブの `if:` に `!contains(github.event.pull_request.labels.*.name, 'skip-version-bump')` を追加。同名ラベルが付いている PR ではジョブをスキップする
- `.claude/skills/create-pr/SKILL.md`: 任意入力 `labels` を追加。指定があれば `gh pr create --label ...` でアトミックに付与（`gh pr edit --add-label` で後付けすると `pull_request: opened` トリガに間に合わず競合するため）
- `.claude/skills/create-canary-pr/SKILL.md`: プリセットに `labels: ["skip-version-bump"]` を追加し、スキル経由の canary PR には常時当該ラベルを付ける旨を明記
- ラベル `skip-version-bump` はリポジトリに作成済み（本 PR に先行して `gh label create` で追加）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

※ ワークフローの実挙動（ラベルでスキップされること）は、本 PR マージ後に次回のスキル経由 canary PR で検証する。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プルリクエスト作成時にラベルを指定できるようになりました。

* **改善**
  * 自動で作成されるキャナリープルリクエストにバージョンバンプをスキップするラベルが付与されるようになりました。
  * 手動で作成されたキャナリープルリクエストは従来通りバージョンが自動バンプされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->