### PR TITLE
eas.json の node 固定と engines.node を撤廃して EAS Submit の npm ci 失敗を解消

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -5,7 +5,6 @@
   "build": {
     "development": {
       "distribution": "store",
-      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },
@@ -25,7 +24,6 @@
     },
     "preview": {
       "distribution": "store",
-      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },
@@ -38,7 +36,6 @@
     },
     "production": {
       "distribution": "store",
-      "node": "22.17.0",
       "env": {
         "EAS_USE_CACHE": "1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "typescript": "~5.9.2"
       },
       "engines": {
-        "node": "22.x",
+        "node": "22.x || 20.x",
         "npm": "10.x"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
         "typescript": "~5.9.2"
       },
       "engines": {
-        "node": "22.x || 20.x",
         "npm": "10.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   },
   "private": true,
   "engines": {
-    "node": "22.x",
+    "node": "22.x || 20.x",
     "npm": "10.x"
   },
   "expo": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
   },
   "private": true,
   "engines": {
-    "node": "22.x || 20.x",
     "npm": "10.x"
   },
   "expo": {


### PR DESCRIPTION
## 概要

`Create Production Builds` ワークフローの `Submit to Google Play Store` ジョブ（`type: submit`）が、EAS 内部で実行する `npm ci --include=dev` で `EBADENGINE` 失敗する問題を修正する。

```text
npm error notsup Not compatible with your version of node/npm: trainlcd@10.4.2
npm error notsup Required: {"node":"22.x","npm":"10.x"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.4"}
```

`eas.json` の Build プロファイルだけ Node を `22.17.0` に固定できていたが、Submit プロファイル側には Node を固定する手段が無い。この非対称を Build 側の node 固定も撤廃する形で解消する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `eas.json` の `build.development` / `build.preview` / `build.production` の `"node": "22.17.0"` を削除（#5852 の事実上の revert）。
- `package.json` の `engines.node` を撤廃。`engines.npm: "10.x"` はそのまま残す。
- `package-lock.json` は root の engines を同じ内容にミラー更新するだけ。

### 背景 / 経緯

- #5849 で `engines: {node: 22.x, npm: 10.x}` と `.npmrc` の `engine-strict=true` を追加。
- #5852 で EAS **Build** 側は `eas.json` の `build.*.node: "22.17.0"` で対応済み。
- しかし EAS **Submit** は Android の `app.config.ts` を評価するため EAS 内部で `npm ci --include=dev` を走らせる仕様で、Submit プロファイルには Node バージョンを固定するフィールドが無い（EAS CLI 18.7.0 の `@expo/eas-json` の `UnresolvedSubmitProfileSchema` に `node` / `env` / `image` のいずれも存在しない）。
- そのため EAS 既定の Node 20.19.4 で `npm ci` が走り、`engine-strict=true` + `engines.node: 22.x` により EBADENGINE で弾かれていた。

### なぜ「Build の node 固定も外す」方を選んだか

- `engine-strict=true` を維持する限り、`engines.node` で指定した範囲と実際に使われる Node を完全一致させる必要がある。EAS は Build / Submit で Node の制御手段が非対称（Build は指定可、Submit は不可）なので、「Node を 22 に強制する」ポリシーと「EAS で安定に動かす」ポリシーは原理的に両立しない。
- メモでも明示されているように、本当に守りたいガードは **npm 10.x**（npm 11 の `npm install` が CI 互換 lockfile を壊す問題の防止）。これは `engines.npm: 10.x` + `engine-strict=true` で今後も継続して効く。
- ローカル開発者向けには `.nvmrc` と `mise.toml` が引き続き `22` を指すので、通常の開発フローは Node 22 のまま。engines から node を外しても実運用上はほぼ変わらない。
- eas.json の node 固定だけ残すと Build と Submit で非対称なまま（Build は Node 22、Submit は Node 20）になるので、どちらも EAS 既定に任せる形に揃える。

### 採用しなかった代替案

- `engine-strict=false` に緩める: npm 11 のインストールもスルーしてしまうため不可
- `engines.node` を `20.x || 22.x` 等に列挙: EAS 既定の Node が上がるたびに追随が必要で、ポリシーとしての意味が薄い
- `app.config.ts` → `app.json` 静的化: 影響範囲が広く、動的 config を失う
- EAS Submit プロファイルへの `node` フィールド追加を Expo にリクエスト: 別途フィードバック予定だが即時解決にならない

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（148 suites / 1398 tests）
- [x] `npm run typecheck` が通ること

Submit 自体の通過確認はマージ後の production リリースで検証する。

## 関連Issue

#5849 で導入した engines 制約の fallout の仕上げ。#5852 の対応（Build 側の node 固定）も本 PR で事実上 revert する。

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
