### PR TITLE
create-pr スキルのPR本文渡しを --body-file ベースに変更してバッククォート escape 事故を防ぐ

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -158,19 +158,23 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
    実装手順:
 
    1. Write ツールで本文を一時ファイルに書き出す（例: `/tmp/pr-body-<pr-or-branch>.md`）。バッククォートは **素のまま** 書く。escape しない。
-   2. 下の `gh` コマンドを実行する。
-   3. 完了後、一時ファイルを削除する。
+   2. 下の `gh` コマンドをサブシェル内で `trap` と一緒に実行する。`gh` の成功・失敗に関わらず `EXIT` / `INT` / `TERM` のどれでも一時ファイルを確実に削除されるようにする（`&&` で `rm` を繋ぐだけだと失敗時に `/tmp` にゴミが残る）。
+   3. `gh` 呼び出しと `rm`（を含む `trap`）は Bash tool の 1 呼び出し内で完結させる。別呼び出しで後片付けすると、前段の呼び出しがエラー／中断で終わった場合にクリーンアップが実行されない。
 
    **新規作成モード**
 
    ```bash
-   gh pr create \
-     --base "<base>" \
-     --head "<head>" \
-     --title "<title>" \
-     --assignee TinyKitten \
-     [--label "<label1>" --label "<label2>" ...] \
-     --body-file "<tmp-body-path>"
+   BODY_FILE=/tmp/pr-body-<pr-or-branch>.md
+   (
+     trap 'rm -f "$BODY_FILE"' EXIT INT TERM
+     gh pr create \
+       --base "<base>" \
+       --head "<head>" \
+       --title "<title>" \
+       --assignee TinyKitten \
+       [--label "<label1>" --label "<label2>" ...] \
+       --body-file "$BODY_FILE"
+   )
    ```
 
    - Assignee は常に `TinyKitten`（CLAUDE.md ルール）。
@@ -180,9 +184,13 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
    **更新モード**
 
    ```bash
-   gh pr edit <pr-number> \
-     [--title "<更新後タイトル>"] \
-     --body-file "<tmp-body-path>"
+   BODY_FILE=/tmp/pr-body-<pr-number>.md
+   (
+     trap 'rm -f "$BODY_FILE"' EXIT INT TERM
+     gh pr edit <pr-number> \
+       [--title "<更新後タイトル>"] \
+       --body-file "$BODY_FILE"
+   )
    ```
 
    - **タイトルは毎回スコープ整合性を再評価する**（AGENTS.md「Keep PR metadata in sync with the branch state」より）。手順 1 のタイトル推論ルールと最新のコミット群を照合し、現タイトルが新しい主題（追加スキル・大きな機能変更など）を拾えていなければ更新案を提示してユーザー承認を取り、`--title` に含めて反映する。タイトルが最新差分と整合している場合は `--title` を付けない。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -153,6 +153,14 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
 
 5. **PR 作成 / 更新**
 
+   本文は **必ず一時ファイル経由で渡す**（`gh pr create --body-file` / `gh pr edit --body-file`）。理由: `--body "$(cat <<'EOF' ... EOF)"` のようにヒアドキュメントをシェル経由で渡すと、エディタ側の癖や Claude Code 側の生成で本文中のバッククォートが `\`` のように誤って escape されてしまい、PR 画面でコードスパン／フェンスがレンダリングされない事故が起きる（実例: PR #5857 の初稿で Markdown が崩れた）。`--body-file` ならシェルの引用符を一切介さないので構造的に起きない。
+
+   実装手順:
+
+   1. Write ツールで本文を一時ファイルに書き出す（例: `/tmp/pr-body-<pr-or-branch>.md`）。バッククォートは **素のまま** 書く。escape しない。
+   2. 下の `gh` コマンドを実行する。
+   3. 完了後、一時ファイルを削除する。
+
    **新規作成モード**
 
    ```bash
@@ -162,10 +170,7 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
      --title "<title>" \
      --assignee TinyKitten \
      [--label "<label1>" --label "<label2>" ...] \
-     --body "$(cat <<'EOF'
-   <本文>
-   EOF
-   )"
+     --body-file "<tmp-body-path>"
    ```
 
    - Assignee は常に `TinyKitten`（CLAUDE.md ルール）。
@@ -173,13 +178,11 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
    - 作成後の URL と、ON にしたチェック項目・判定根拠（例: コミット `fix: ...` により「バグ修正」を ON）、付与したラベルがあればその名前を報告する。
 
    **更新モード**
+
    ```bash
    gh pr edit <pr-number> \
      [--title "<更新後タイトル>"] \
-     --body "$(cat <<'EOF'
-   <再生成した本文>
-   EOF
-   )"
+     --body-file "<tmp-body-path>"
    ```
 
    - **タイトルは毎回スコープ整合性を再評価する**（AGENTS.md「Keep PR metadata in sync with the branch state」より）。手順 1 のタイトル推論ルールと最新のコミット群を照合し、現タイトルが新しい主題（追加スキル・大きな機能変更など）を拾えていなければ更新案を提示してユーザー承認を取り、`--title` に含めて反映する。タイトルが最新差分と整合している場合は `--title` を付けない。
@@ -192,3 +195,4 @@ Hot fix の文脈（`head` が `hotfix/` で始まる、または件名に `Hotf
 - `git push --no-verify` や force push はしない。push が必要ならユーザーに確認。
 - 既存 open PR を上書きしない（重複作成禁止）。
 - Hot fix の場合はタイトルに `Hotfix:` プレフィックスを付けるようユーザーに確認する（CLAUDE.md）。
+- 本文は `gh pr create --body` / `gh pr edit --body` のようにインラインで渡さない。必ず `--body-file` で一時ファイル経由で渡す（バッククォートなど特殊文字の escape 事故を構造的に防ぐため）。


### PR DESCRIPTION
## 概要

`create-pr` スキルの PR 本文の渡し方を `--body "$(cat <<'EOF' ... EOF)"` のヒアドキュメント方式から、一時ファイルに書き出して `--body-file` で渡す方式に変更する。

バッククォート等の特殊文字の escape 事故を構造的に防ぐため。実例として #5857 の初稿で、本文内のバッククォートが `\`` として PR に書き込まれ、コードスパン／フェンスがレンダリングされない不具合が発生した。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `.claude/skills/create-pr/SKILL.md` の手順 5（PR 作成 / 更新）を `--body-file` ベースに書き換え。Write ツールで本文を一時ファイルに書き出してから `gh pr create --body-file` / `gh pr edit --body-file` で渡す手順に統一。
- 失敗事例（#5857 初稿の Markdown 崩れ）を inline で記載し、なぜこの運用なのかの根拠を残す。
- 「注意事項」セクションにも `--body` のインライン渡し禁止を明記。
- `gh` 呼び出しを `trap 'rm -f "$BODY_FILE"' EXIT INT TERM` 付きのサブシェルで包む形に強化。`&&` で `rm` を繋ぐパターンだと `gh` が失敗したときに `/tmp` にゴミが残るので、成功・失敗・中断いずれのケースでもクリーンアップされるようにした。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

スキル（Markdown ドキュメント）のみの変更でアプリ本体やビルド対象に影響しないため、`lint` / `test` / `typecheck` の実行は省略。

## 関連Issue

#5857 初稿で発生した PR 本文 Markdown 崩れの再発防止。

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * PR作成・更新手順を見直しました。
  * 本文の渡し方をヒアドキュメントから一時ファイル経由（--body-file）へ変更し、特殊文字やレンダリング崩れを防ぎます。
  * 一時ファイルの作成・削除を確実に行うフロー（失敗・中断時の削除を含む）に更新しました。
  * 更新モードでも同一の本文渡し方式を採用するよう統一し、運用注意を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->