### PR TITLE
Firebase Functions SDK を 7.2.5 へ更新

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,7 @@
         "@googleapis/androidpublisher": "^15.0.0",
         "dayjs": "^1.11.9",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^6.3.1",
+        "firebase-functions": "^7.2.5",
         "google-auth-library": "^9.14.2"
       },
       "devDependencies": {
@@ -3510,9 +3510,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.1.tgz",
-      "integrity": "sha512-LTbmsEkSgaOhzTzGUoF7dv906JJJW89o0/spXgnU8gASyR8JLMrCqwV7FnWLso5hyF0fUqNPaEEw/TzLdZMVXw==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -3525,10 +3525,24 @@
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/firebase-functions-test": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -30,7 +30,7 @@
     "@googleapis/androidpublisher": "^15.0.0",
     "dayjs": "^1.11.9",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^6.3.1",
+    "firebase-functions": "^7.2.5",
     "google-auth-library": "^9.14.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概要

Firebase Functions SDK を `^6.3.1` から `^7.2.5` へ更新する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `functions/package.json` の `firebase-functions` を `^6.3.1` → `^7.2.5` に更新
- `functions/package-lock.json` を再生成

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Firebase Functionsライブラリの依存関係をバージョン6.3.1からバージョン7.2.5にアップデートしました。プロジェクトで使用されるランタイムライブラリのバージョンが更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->