### PR TITLE
canary 向けバージョン bump ワークフローを workflow_dispatch で手動実行できるようにする

### DIFF
--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-22.04
     if: |
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == "pull_request" &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
-      ) || github.event_name == 'workflow_dispatch'
+        !contains(github.event.pull_request.labels.*.name, "skip-version-bump")
+      ) || github.event_name == "workflow_dispatch"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-22.04
     if: |
       (
-        github.event_name == "pull_request" &&
+        github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        !contains(github.event.pull_request.labels.*.name, "skip-version-bump")
-      ) || github.event_name == "workflow_dispatch"
+        !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+      ) || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -5,6 +5,7 @@ on:
     types: opened
     branches:
       - canary
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/bump_version_on_canary_pr.yml
+++ b/.github/workflows/bump_version_on_canary_pr.yml
@@ -6,6 +6,15 @@ on:
     branches:
       - canary
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Target PR number"
+        required: true
+        type: string
+      head_ref:
+        description: "Source branch name of target PR"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,12 +27,15 @@ jobs:
   bump-version:
     runs-on: ubuntu-22.04
     if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+      ) || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.ref || inputs.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
@@ -44,17 +56,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Bump version for canary release"
-          title: "chore: Bump version for PR #${{ github.event.pull_request.number }}"
+          title: "chore: Bump version for PR #${{ github.event.pull_request.number || inputs.pr_number }}"
           body: |
             This PR was automatically created by the bump version workflow.
 
             It bumps the version number for the canary release.
 
-            **Related PR:** #${{ github.event.pull_request.number }}
+            **Related PR:** #${{ github.event.pull_request.number || inputs.pr_number }}
 
-            Please merge this PR into the source branch of PR #${{ github.event.pull_request.number }} to update its version numbers.
-          branch: "auto-version-bump-${{ github.event.pull_request.number }}"
-          base: ${{ github.event.pull_request.head.ref }}
+            Please merge this PR into the source branch of PR #${{ github.event.pull_request.number || inputs.pr_number }} to update its version numbers.
+          branch: "auto-version-bump-${{ github.event.pull_request.number || inputs.pr_number }}"
+          base: ${{ github.event.pull_request.head.ref || inputs.head_ref }}
           delete-branch: true
           labels: |
             automated


### PR DESCRIPTION
## 概要

canary 向けバージョン bump ワークフロー (`bump_version_on_canary_pr.yml`) に `workflow_dispatch` トリガーを追加し、GitHub Actions の UI から手動で実行できるようにする。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.github/workflows/bump_version_on_canary_pr.yml` の `on:` に `workflow_dispatch:` を追加。canary 向け PR が opened された時の自動実行に加えて、Actions タブから任意のタイミングで手動実行できる。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **メンテナンス**
  * バージョン管理ワークフローが手動実行に対応しました。canary ブランチへのプルリクエストに加え、手動トリガーでも実行可能です。
  * 手動実行時にプルリクエスト番号やヘッドブランチを入力でき、実行時に適切な PR 情報を参照して処理されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->