### PR TITLE
create-canary-pr スキルから skip-version-bump ラベル付与を撤去し canary バージョン bump は auto-trigger に任せる

### DIFF
--- a/.claude/skills/create-canary-pr/SKILL.md
+++ b/.claude/skills/create-canary-pr/SKILL.md
@@ -34,4 +34,4 @@ PR が open された瞬間に `pull_request: opened` トリガでこの workflo
 - タイトルは過去運用（PR #5811〜 #5826）にならい常に `canary` 固定。ユーザーが別タイトルを希望した場合は確認する。
 - `dev` / `canary` 両ブランチとも origin 前提。ローカル `dev` が未 push ならユーザーに push 可否を確認（`create-pr` 側でも同じガードあり）。
 - 変更の種類の自動判定・Assignee・テンプレ節構成の遵守は `create-pr` の手順に従う。このスキルで独自に本文を組み立て直さない。
-- 既に open な dev→canary PR がある場合は新規作成せず、既存 URL を再利用する（`create-pr` 側のガードに任せる）。既存 PR にはすでに `pull_request: opened` 起点で bump PR が作られているはずなので、`gh pr list --search "auto-version-bump-<canary_pr_number>" --state all` で確認しユーザーに状況を報告する。作られていなければ `gh workflow run bump_version_on_canary_pr.yml -f pr_number=<canary_pr_number> -f head_ref=dev` で手動補填する。
+- 既に open な dev→canary PR がある場合は新規作成せず、既存 URL を再利用する（`create-pr` 側のガードに任せる）。既存 PR にはすでに `pull_request: opened` 起点で bump PR が作られているはずなので、`gh pr list --head "auto-version-bump-<canary_pr_number>" --base dev --state all --json number,url,state` で branch 名一致で確認する（`--search` だとタイトル / 本文の曖昧一致になり別 PR を拾う可能性があるため `--head` / `--base` を使う）。マッチが 0 件のときに限り `gh workflow run bump_version_on_canary_pr.yml -f pr_number=<canary_pr_number> -f head_ref=dev` で手動補填する。マッチがあれば結果（PR URL と state）をそのままユーザーに報告するだけで良い。

--- a/.claude/skills/create-canary-pr/SKILL.md
+++ b/.claude/skills/create-canary-pr/SKILL.md
@@ -19,12 +19,19 @@ description: Cut a dev→canary release pull request for TrainLCD MobileApp. Thi
 | `summary` | 省略（テンプレのコメントのみ） |
 | `related_issue` | 省略 |
 | `skip_checks` | `false`（テスト 3 項目は全て ON） |
-| `labels` | `["skip-version-bump"]` |
+| `labels` | 未指定（付与しない） |
+
+## バージョン bump の取り扱い
+
+canary リリースでは semver は据え置きで iOS ビルド番号 / Android `versionCode` のみを上げる。`dev` は protected で直接 push できないため、bump 自体は `.github/workflows/bump_version_on_canary_pr.yml` に任せる。
+
+PR が open された瞬間に `pull_request: opened` トリガでこの workflow が走り、`auto-version-bump-<canary_pr_number> → dev` の bump PR を自動生成する。スキル側で追加でラベルを付けたり `workflow_dispatch` を叩いたりする必要はない（過去にラベル `skip-version-bump` を付与して別途 `workflow_dispatch` を叩く実装にしていた時期があるが、両者を相殺しているだけだったので撤去した）。
+
+完了報告では「`auto-version-bump-<canary_pr_number>` が間もなく自動で作成される。それを `dev` にマージすると canary PR 側にもビルド番号差分が反映される」旨を案内する。
 
 ## リリース特有の注意
 
 - タイトルは過去運用（PR #5811〜 #5826）にならい常に `canary` 固定。ユーザーが別タイトルを希望した場合は確認する。
 - `dev` / `canary` 両ブランチとも origin 前提。ローカル `dev` が未 push ならユーザーに push 可否を確認（`create-pr` 側でも同じガードあり）。
 - 変更の種類の自動判定・Assignee・テンプレ節構成の遵守は `create-pr` の手順に従う。このスキルで独自に本文を組み立て直さない。
-- 既に open な dev→canary PR がある場合は新規作成せず、既存 URL を返す（`create-pr` 側のガードに任せる）。
-- スキル経由で作る canary PR には `skip-version-bump` ラベルを常時付与する。これにより `.github/workflows/bump_version_on_canary_pr.yml` の `bump-version` ジョブがスキップされる（スキル内で独自にバージョンを管理・反映する想定のため、Actions 側の自動バンプを二重起動させない）。手動で開いた canary PR はラベルを付けないので従来どおりバンプ PR が自動作成される。
+- 既に open な dev→canary PR がある場合は新規作成せず、既存 URL を再利用する（`create-pr` 側のガードに任せる）。既存 PR にはすでに `pull_request: opened` 起点で bump PR が作られているはずなので、`gh pr list --search "auto-version-bump-<canary_pr_number>" --state all` で確認しユーザーに状況を報告する。作られていなければ `gh workflow run bump_version_on_canary_pr.yml -f pr_number=<canary_pr_number> -f head_ref=dev` で手動補填する。


### PR DESCRIPTION
## 概要

`create-canary-pr` スキルから `skip-version-bump` ラベル付与を撤去し、canary 用ビルド番号 bump は `bump_version_on_canary_pr.yml` の `pull_request: opened` トリガに任せる構成へ戻す。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `.claude/skills/create-canary-pr/SKILL.md` の `labels` 既定値を `["skip-version-bump"]` から「未指定」に変更。
- 「バージョン bump の取り扱い」節を新設し、bump は `pull_request: opened` の auto-trigger 任せである旨と、過去にラベル + `workflow_dispatch` で二重制御していた経緯を明記。
- 既存 open canary PR があった場合のフォールバック手順を「リリース特有の注意」に追記。bump PR の有無確認は `gh pr list --head "auto-version-bump-<canary_pr_number>" --base dev --state all --json number,url,state` で branch 名一致で行うよう指定（`--search` だと別 PR を曖昧一致で拾う恐れがあるため）。マッチが 0 件のときに限り `gh workflow run bump_version_on_canary_pr.yml` で手動補填する。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * カナリアPRのバージョン更新手順を更新しました。スキル側でラベルを付与しないように変更し、専用ワークフローで自動的にバンプPRが作成されます。
  * 既存のdev→canary PRを再利用する際、対応する自動バンプPRの有無を確認し、欠けている場合のみ手動でワークフローを起動するよう案内を追加しました。
  * 完了メッセージは自動作成されたバンプPRのマージを促す内容に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
