### PR TITLE
位置情報・タイマー・JS再レンダリングを抑制してバッテリー消費を低減

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,9 +1,18 @@
-import React, { useCallback, useState } from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, type TextStyle, View, type ViewStyle } from 'react-native';
-import { useClock, useInterval } from '~/hooks';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import { useClock } from '~/hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
 import Typography from './Typography';
+
+const AnimatedTypography = Animated.createAnimatedComponent(Typography);
 
 const styles = StyleSheet.create({
   clockContainer: {
@@ -25,14 +34,22 @@ type Props = {
 
 const Clock = ({ style, white, bold }: Props): React.ReactElement => {
   const [hours, minutes] = useClock();
-  const [colonOpacity, setColonOpacity] = useState(0);
+  // コロン点滅は LCD らしさを保つため必須。
+  // JS スレッドで毎 500ms に setState すると Header 配下を再レンダリングしてしまうため、
+  // Reanimated で UI スレッドだけで完結させる。
+  const colonOpacity = useSharedValue(0);
 
-  useInterval(
-    useCallback(() => {
-      setColonOpacity((prev) => (prev === 0 ? 1 : 0));
-    }, []),
-    500
-  );
+  useEffect(() => {
+    colonOpacity.value = withRepeat(
+      withTiming(1, { duration: 500, easing: Easing.linear }),
+      -1,
+      true
+    );
+  }, [colonOpacity]);
+
+  const colonAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: colonOpacity.value,
+  }));
 
   const textCustomStyle: TextStyle = {
     color: white ? 'white' : '#3a3a3a',
@@ -44,11 +61,11 @@ const Clock = ({ style, white, bold }: Props): React.ReactElement => {
       <Typography style={[styles.clockItem, textCustomStyle]}>
         {hours}
       </Typography>
-      <Typography
-        style={[styles.clockItem, textCustomStyle, { opacity: colonOpacity }]}
+      <AnimatedTypography
+        style={[styles.clockItem, textCustomStyle, colonAnimatedStyle]}
       >
         :
-      </Typography>
+      </AnimatedTypography>
       <Typography style={[styles.clockItem, textCustomStyle]}>
         {minutes}
       </Typography>

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -2,8 +2,8 @@ import * as Location from 'expo-location';
 
 export const LOCATION_TASK_NAME = 'trainlcd-background-location-task';
 export const LOCATION_ACCURACY = Location.Accuracy.Highest;
-export const LOCATION_DISTANCE_INTERVAL = 5;
-export const LOCATION_TIME_INTERVAL = 3000;
+export const LOCATION_DISTANCE_INTERVAL = 10;
+export const LOCATION_TIME_INTERVAL = 5000;
 
 export const MAX_PERMIT_ACCURACY = 4000;
 

--- a/src/hooks/useClock.ts
+++ b/src/hooks/useClock.ts
@@ -1,23 +1,68 @@
-import { useCallback, useState } from 'react';
-import { useInterval } from './useInterval';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+const formatTwoDigits = (n: number): string =>
+  n < 10 ? `0${n}` : n.toString();
 
 export const useClock = (): [string, string] => {
   const [hours, setHours] = useState('00');
   const [minutes, setMinutes] = useState('00');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const updateTime = useCallback((): void => {
     const date = new Date();
-    const h =
-      date.getHours() < 10 ? `0${date.getHours()}` : date.getHours().toString();
-    const m =
-      date.getMinutes() < 10
-        ? `0${date.getMinutes()}`
-        : date.getMinutes().toString();
-    setHours(h);
-    setMinutes(m);
+    setHours(formatTwoDigits(date.getHours()));
+    setMinutes(formatTwoDigits(date.getMinutes()));
   }, []);
 
-  useInterval(updateTime, 1000);
+  useEffect(() => {
+    const clearTimers = (): void => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    // 次の正分まで待ってから60秒間隔で更新する
+    // 1秒ごとにJSスレッドを起こさないことで電池消費とCPUコストを下げる
+    const scheduleNextTick = (): void => {
+      const now = new Date();
+      const msUntilNextMinute =
+        (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+
+      timeoutRef.current = setTimeout(() => {
+        updateTime();
+        intervalRef.current = setInterval(updateTime, 60_000);
+      }, msUntilNextMinute);
+    };
+
+    updateTime();
+    scheduleNextTick();
+
+    // バックグラウンドから復帰した直後は分が古いままになりうるので即同期する
+    const handleAppStateChange = (state: AppStateStatus): void => {
+      if (state === 'active') {
+        clearTimers();
+        updateTime();
+        scheduleNextTick();
+      }
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange
+    );
+
+    return () => {
+      clearTimers();
+      subscription.remove();
+    };
+  }, [updateTime]);
 
   return [hours, minutes];
 };

--- a/src/hooks/useConsoleTelemetry.enabled.test.tsx
+++ b/src/hooks/useConsoleTelemetry.enabled.test.tsx
@@ -56,7 +56,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.log('test message');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -80,7 +80,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.error('something failed');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -102,7 +102,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.warn('a warning');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -123,7 +123,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.debug('debug info');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -144,7 +144,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.log('data:', { key: 'value' }, 42);
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -165,7 +165,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.error(new TypeError('invalid type'));
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -186,7 +186,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.error('Authorization: Bearer my-super-secret-token');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -208,7 +208,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.log('auth test');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -231,7 +231,7 @@ describe('useConsoleTelemetry (enabled)', () => {
       console.log(`message-${i}`);
     }
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -275,7 +275,7 @@ describe('useConsoleTelemetry (enabled)', () => {
 
     console.log('will fail to send');
 
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
     await Promise.resolve();
     await Promise.resolve();
 

--- a/src/hooks/useConsoleTelemetry.ts
+++ b/src/hooks/useConsoleTelemetry.ts
@@ -138,7 +138,8 @@ export const useConsoleTelemetry = (
       isFlushingRef.current = false;
     };
 
-    const intervalId = setInterval(flush, 1000);
+    // 毎秒fetchするとログ量が少ない通常時に無線通信を起こしすぎるため5秒間隔に伸ばす
+    const intervalId = setInterval(flush, 5000);
 
     return () => {
       console.log = originalConsole.log;

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -10,16 +10,25 @@ export const useInterval = (
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
   const [isPausing, setIsPausing] = useState(false);
 
+  // handlerをrefに保持することで、呼び出し元のuseCallback依存変化による
+  // setInterval / clearInterval の再生成を抑制する
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
   useEffect(() => {
     if (isPausing) {
       return () => undefined;
     }
 
-    const id = setInterval(handler, timeout);
+    const id = setInterval(() => {
+      handlerRef.current();
+    }, timeout);
     intervalId.current = id;
 
     return () => clearInterval(id);
-  }, [handler, isPausing, timeout]);
+  }, [isPausing, timeout]);
 
   const pause = useCallback(() => {
     setIsPausing(true);

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -21,41 +21,63 @@ export const useNearestStation = (): Station | undefined => {
     [stations]
   );
 
+  // findNearestへ毎回渡す座標タプルは駅リスト変更時にだけ作り直す
+  const stationCoordinates = useMemo(
+    () =>
+      validStations.map((sta) => ({
+        latitude: sta.latitude as number,
+        longitude: sta.longitude as number,
+      })),
+    [validStations]
+  );
+
   const nearestStation = useMemo<Station | undefined>(() => {
-    if (latitude == null || longitude == null) {
+    if (
+      latitude == null ||
+      longitude == null ||
+      stationCoordinates.length === 0
+    ) {
       return undefined;
     }
 
-    const nearestCoordinates = validStations.length
-      ? (findNearest(
-          {
-            latitude,
-            longitude,
-          },
-          validStations.map((sta) => ({
-            latitude: sta.latitude as number,
-            longitude: sta.longitude as number,
-          }))
-        ) as { latitude: number; longitude: number })
-      : undefined;
+    const nearestCoordinates = findNearest(
+      { latitude, longitude },
+      stationCoordinates
+    ) as { latitude: number; longitude: number } | undefined;
 
     if (!nearestCoordinates) {
       return undefined;
     }
 
-    const nearestStations = validStations.filter(
+    // currentStation / nextStation は到着判定で頻繁に最寄りになるため
+    // validStations全体の走査前にショートサーキットして O(1) で返す
+    if (
+      currentStation?.latitude === nearestCoordinates.latitude &&
+      currentStation?.longitude === nearestCoordinates.longitude
+    ) {
+      return currentStation;
+    }
+    if (
+      nextStation?.latitude === nearestCoordinates.latitude &&
+      nextStation?.longitude === nearestCoordinates.longitude
+    ) {
+      return nextStation;
+    }
+
+    // 同座標の駅が複数あるケースに備えて先頭一致を返す
+    return validStations.find(
       (sta) =>
         sta.latitude === nearestCoordinates.latitude &&
         sta.longitude === nearestCoordinates.longitude
     );
-
-    // currentStationを優先して返すことで、到着直後にnextStationへ誤って進むのを防ぐ
-    return (
-      nearestStations.find((s) => s.id === currentStation?.id) ??
-      nearestStations.find((s) => s.id === nextStation?.id) ??
-      nearestStations[0]
-    );
-  }, [latitude, longitude, validStations, currentStation, nextStation]);
+  }, [
+    latitude,
+    longitude,
+    validStations,
+    stationCoordinates,
+    currentStation,
+    nextStation,
+  ]);
 
   return nearestStation;
 };


### PR DESCRIPTION
## 概要

スマホ・タブレットでの電池消費が著しいという報告を受けた調査結果に基づき、ユーザー体験（GPS の精度・常時画面オン・LCD らしいコロン点滅など）を維持したまま、位置情報の更新頻度・JS スレッドのタイマー駆動・無駄な再レンダリングを抑制してバッテリー消費を低減する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/constants/location.ts`: `LOCATION_TIME_INTERVAL` を 3000ms → 5000ms、`LOCATION_DISTANCE_INTERVAL` を 5m → 10m に緩めて GNSS チップのウェイクアップ頻度を削減。`LOCATION_ACCURACY = Highest` と `pausesUpdatesAutomatically: false` は田舎路線での測位フォールバック不可・優等待ち合わせ後の再開不能というバグ回避のため維持。Android 16 の二重取得経路（`watchPositionAsync` 併用）にも `LOCATION_WATCH_OPTIONS` 経由で同じ緩和が反映される。
- `src/hooks/useNearestStation.ts`: `findNearest` 用の座標タプルを `validStations` 単位でメモ化し、位置更新ごとの `.map()` アロケーションを排除。現在駅／次駅と最寄り座標が一致する場合は `validStations` の再走査をスキップする O(1) ショートサーキットを追加。
- `src/hooks/useClock.ts`: 1秒 `setInterval` を「次の正分まで `setTimeout` → 60秒間隔」に置き換え、JS スレッドの毎秒ウェイクを廃止。`AppState` 復帰時に即同期して古い分が残らないようにした。
- `src/components/Clock.tsx`: 500ms ごとに JS スレッドで `setState` していたコロン点滅を `react-native-reanimated` の `withRepeat(withTiming)` に置き換え、UI スレッドだけで往復させるよう変更。LCD らしさのコロン点滅は維持。
- `src/hooks/useInterval.ts`: `handler` を `ref` に保持して、呼び出し元の `useCallback` 依存変化による `setInterval` / `clearInterval` の再生成を抑制。
- `src/hooks/useConsoleTelemetry.ts`: ログ flush 間隔を 1秒 → 5秒に延長。テスト側も同じ 5秒で `advanceTimersByTime` するよう更新。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01NkD9g3MnLA1rNBKbv3pcNF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 時刻表示を分単位での更新に最適化し、リソース消費を削減
  * クロック秒間表示のアニメーション処理を改善
  * 位置情報追跡の更新間隔を調整してバッテリー消費を低減
  * ログ送信機能の更新間隔を延長してネットワーク負荷を軽減

* **Tests**
  * テスト設定を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->