### PR TITLE
Transfers画面と乗換案内TTSで直通運転路線を一覧から除外

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
 });
 
 const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
-  const lines = useTransferLines();
+  const lines = useTransferLines({ omitThroughService: true });
   const getLineMarkFunc = useGetLineMark();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 

--- a/src/components/TransfersYamanote.tsx
+++ b/src/components/TransfersYamanote.tsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
 
 const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
   const getLineMarkFunc = useGetLineMark();
-  const lines = useTransferLines();
+  const lines = useTransferLines({ omitThroughService: true });
   const dim = useWindowDimensions();
 
   const flexBasis = useMemo(() => dim.width / 3, [dim.width]);

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -70,7 +70,8 @@ export const useTTSText = (
   const currentLineOrigin = useCurrentLine();
 
   const connectedLinesOrigin = useConnectedLines();
-  const transferLinesOrigin = useTransferLines();
+  // 直通運転で同じ列車が通る路線は乗り換え案内に含めない
+  const transferLinesOrigin = useTransferLines({ omitThroughService: true });
 
   const connectedLines = connectedLinesOrigin;
   const transferLines = transferLinesOrigin;

--- a/src/hooks/useTransferLines.test.tsx
+++ b/src/hooks/useTransferLines.test.tsx
@@ -31,7 +31,7 @@ jest.mock('../utils/isPass', () => ({
 }));
 
 const TestComponent: React.FC<{
-  options?: { omitJR?: boolean };
+  options?: { omitJR?: boolean; omitThroughService?: boolean };
 }> = ({ options }) => {
   const lines = useTransferLines(options);
   return <Text testID="transferLines">{JSON.stringify(lines)}</Text>;
@@ -95,6 +95,7 @@ describe('useTransferLines', () => {
       {
         omitRepeatingLine: false,
         omitJR: false,
+        omitThroughService: false,
       }
     );
     expect(getByTestId('transferLines').props.children).toContain('metro');
@@ -115,6 +116,7 @@ describe('useTransferLines', () => {
       {
         omitRepeatingLine: undefined,
         omitJR: true,
+        omitThroughService: undefined,
       }
     );
   });
@@ -129,6 +131,21 @@ describe('useTransferLines', () => {
     expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
       omitRepeatingLine: false,
       omitJR: false,
+      omitThroughService: false,
+    });
+  });
+
+  it('omitThroughService オプションを useTransferLinesFromStation に伝搬する', () => {
+    const nextStation = createStation(30);
+    stationAtomValue.arrived = false;
+    nextStationValue = nextStation;
+
+    render(<TestComponent options={{ omitThroughService: true }} />);
+
+    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
+      omitRepeatingLine: undefined,
+      omitJR: undefined,
+      omitThroughService: true,
     });
   });
 });

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -10,6 +10,7 @@ import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
+  omitThroughService?: boolean;
 };
 
 export const useTransferLines = (options?: Option): Line[] => {
@@ -24,14 +25,16 @@ export const useTransferLines = (options?: Option): Line[] => {
     [arrived, currentStation, nextStation]
   );
 
-  const { omitRepeatingLine, omitJR } = options ?? {
+  const { omitRepeatingLine, omitJR, omitThroughService } = options ?? {
     omitRepeatingLine: false,
     omitJR: false,
+    omitThroughService: false,
   };
 
   const transferLines = useTransferLinesFromStation(targetStation, {
     omitRepeatingLine,
     omitJR,
+    omitThroughService,
   });
 
   return transferLines;

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -19,6 +19,7 @@ type TestComponentProps = {
   options?: {
     omitRepeatingLine?: boolean;
     omitJR?: boolean;
+    omitThroughService?: boolean;
   };
 };
 
@@ -212,6 +213,73 @@ describe('useTransferLinesFromStation', () => {
     );
 
     expect(lines.map((l: Line) => l.id)).toContain(2);
+  });
+
+  it('omitThroughService が true の場合、列車が直通運転で通る路線を除外する', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '東急東横線' });
+    const throughServiceLine = createLineNested({
+      id: 2,
+      nameShort: '東京メトロ副都心線',
+    });
+    const independentLine = createLineNested({ id: 3, nameShort: '銀座線' });
+
+    const currentStation = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, throughServiceLine, independentLine],
+    });
+    const transitionStation = createStation(101, {
+      line: throughServiceLine,
+      lines: [currentLine, throughServiceLine],
+    });
+    const futureStation = createStation(102, {
+      line: throughServiceLine,
+      lines: [throughServiceLine],
+    });
+
+    stationAtomValue.stations = [
+      currentStation,
+      transitionStation,
+      futureStation,
+    ];
+
+    const { getByTestId } = render(
+      <TestComponent
+        station={currentStation}
+        options={{ omitThroughService: true }}
+      />
+    );
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
+    expect(lines.find((l: Line) => l.id === 3)).toBeDefined();
+  });
+
+  it('omitThroughService が false の場合、直通運転で通る路線も乗り換え路線として残る', () => {
+    const currentLine = createLineNested({ id: 1, nameShort: '東急東横線' });
+    const throughServiceLine = createLineNested({
+      id: 2,
+      nameShort: '東京メトロ副都心線',
+    });
+
+    const currentStation = createStation(100, {
+      line: currentLine,
+      lines: [currentLine, throughServiceLine],
+    });
+    const transitionStation = createStation(101, {
+      line: throughServiceLine,
+      lines: [currentLine, throughServiceLine],
+    });
+
+    stationAtomValue.stations = [currentStation, transitionStation];
+
+    const { getByTestId } = render(<TestComponent station={currentStation} />);
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.find((l: Line) => l.id === 2)).toBeDefined();
   });
 
   it('omitJR が true で JR路線が閾値以上の場合、JR線として集約される', () => {

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -9,21 +9,29 @@ import omitJRLinesIfThresholdExceeded from '../utils/jr';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
+  omitThroughService?: boolean;
 };
 
 export const useTransferLinesFromStation = (
   station: Station | undefined,
   option?: Option
 ): Line[] => {
-  const { omitRepeatingLine, omitJR } = option ?? {
+  const { omitRepeatingLine, omitJR, omitThroughService } = option ?? {
     omitRepeatingLine: false,
     omitJR: false,
+    omitThroughService: false,
   };
 
   const { stations } = useAtomValue(stationState);
 
-  const transferLines = useMemo(
-    () =>
+  const transferLines = useMemo(() => {
+    // 乗車中の列車が直通運転で通る路線一覧
+    // 同じ列車に乗ったままで到達するため乗り換え対象から外す用途で使う
+    const throughServiceLineIds = new Set(
+      stations.map((s) => s.line?.id).filter((id): id is number => id != null)
+    );
+
+    return (
       station?.lines
         ?.filter((line) => !isBusLine(line))
         ?.filter((line) => line.id !== station.line?.id)
@@ -65,16 +73,25 @@ export const useTransferLinesFromStation = (
             return false;
           }
           return true;
-        }),
-    [
-      omitRepeatingLine,
-      station?.id,
-      station?.line?.id,
-      station?.line?.nameShort,
-      station?.lines,
-      stations,
-    ]
-  );
+        })
+        // 乗車中の列車が直通運転で通る路線は同じ列車のまま到達できるので
+        // 乗り換え路線として表示しない
+        .filter((line) => {
+          if (!omitThroughService || line.id == null) {
+            return true;
+          }
+          return !throughServiceLineIds.has(line.id);
+        })
+    );
+  }, [
+    omitRepeatingLine,
+    omitThroughService,
+    station?.id,
+    station?.line?.id,
+    station?.line?.nameShort,
+    station?.lines,
+    stations,
+  ]);
 
   if (omitJR) {
     return omitJRLinesIfThresholdExceeded(transferLines ?? [])

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -17,7 +17,9 @@ export const useUpdateBottomState = () => {
 
   const isTypeWillChange = useTypeWillChange();
   const isTypeWillChangeRef = useValueRef(isTypeWillChange);
-  const transferLines = useTransferLines();
+  // Transfers 画面と同じ条件で件数を見る必要があるため
+  // 直通運転で到達できる路線は除外する
+  const transferLines = useTransferLines({ omitThroughService: true });
   const isLEDThemeRef = useValueRef(isLEDTheme);
   const shouldHideTypeChange = useShouldHideTypeChange();
   const shouldHideTypeChangeRef = useValueRef(shouldHideTypeChange);


### PR DESCRIPTION
## 概要

Transfers画面と乗換案内TTSで、乗車中の列車が直通運転で通る路線を「乗り換え路線」として一覧に出していた挙動を修正します。同じ列車に乗ったまま到達できる路線は乗り換え対象ではないため、表示・読み上げから除外します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTransferLinesFromStation` に `omitThroughService` オプションを追加し、有効時は journey 上の `stations[i].line.id` 集合に一致する路線を除外するフィルタを追加。
- `useTransferLines` でも同オプションを受け取り、`useTransferLinesFromStation` へ伝搬。
- `Transfers.tsx` / `TransfersYamanote.tsx` から `useTransferLines({ omitThroughService: true })` で呼び出し、Transfers 画面に直通路線が出ないようにする。
- `useUpdateBottomState` も同オプションを有効化し、直通路線しか残らない場合に Transfers タブが空のまま表示されないようにする。
- `useTTSText` も同オプションを有効化し、TTS の乗り換え案内で直通路線を読み上げないようにする。
- 既存テスト（オプション伝搬の期待値）を更新し、`omitThroughService` の on/off / 伝搬を検証するテストを追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* 乗り換え情報から通過列車を除外する機能を追加しました。乗り換え表示、音声ガイダンス、および関連する表示ロジック全体に適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->