### PR TITLE
直通運転路線を乗り換え一覧から除外する処理をオプションからデフォルト動作に変更

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
 });
 
 const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
-  const lines = useTransferLines({ omitThroughService: true });
+  const lines = useTransferLines();
   const getLineMarkFunc = useGetLineMark();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 

--- a/src/components/TransfersYamanote.tsx
+++ b/src/components/TransfersYamanote.tsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
 
 const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
   const getLineMarkFunc = useGetLineMark();
-  const lines = useTransferLines({ omitThroughService: true });
+  const lines = useTransferLines();
   const dim = useWindowDimensions();
 
   const flexBasis = useMemo(() => dim.width / 3, [dim.width]);

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -70,8 +70,7 @@ export const useTTSText = (
   const currentLineOrigin = useCurrentLine();
 
   const connectedLinesOrigin = useConnectedLines();
-  // 直通運転で同じ列車が通る路線は乗り換え案内に含めない
-  const transferLinesOrigin = useTransferLines({ omitThroughService: true });
+  const transferLinesOrigin = useTransferLines();
 
   const connectedLines = connectedLinesOrigin;
   const transferLines = transferLinesOrigin;

--- a/src/hooks/useTransferLines.test.tsx
+++ b/src/hooks/useTransferLines.test.tsx
@@ -31,7 +31,7 @@ jest.mock('../utils/isPass', () => ({
 }));
 
 const TestComponent: React.FC<{
-  options?: { omitJR?: boolean; omitThroughService?: boolean };
+  options?: { omitJR?: boolean };
 }> = ({ options }) => {
   const lines = useTransferLines(options);
   return <Text testID="transferLines">{JSON.stringify(lines)}</Text>;
@@ -95,7 +95,6 @@ describe('useTransferLines', () => {
       {
         omitRepeatingLine: false,
         omitJR: false,
-        omitThroughService: false,
       }
     );
     expect(getByTestId('transferLines').props.children).toContain('metro');
@@ -116,7 +115,6 @@ describe('useTransferLines', () => {
       {
         omitRepeatingLine: undefined,
         omitJR: true,
-        omitThroughService: undefined,
       }
     );
   });
@@ -131,21 +129,6 @@ describe('useTransferLines', () => {
     expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
       omitRepeatingLine: false,
       omitJR: false,
-      omitThroughService: false,
-    });
-  });
-
-  it('omitThroughService オプションを useTransferLinesFromStation に伝搬する', () => {
-    const nextStation = createStation(30);
-    stationAtomValue.arrived = false;
-    nextStationValue = nextStation;
-
-    render(<TestComponent options={{ omitThroughService: true }} />);
-
-    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
-      omitRepeatingLine: undefined,
-      omitJR: undefined,
-      omitThroughService: true,
     });
   });
 });

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -10,7 +10,6 @@ import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
-  omitThroughService?: boolean;
 };
 
 export const useTransferLines = (options?: Option): Line[] => {
@@ -25,16 +24,14 @@ export const useTransferLines = (options?: Option): Line[] => {
     [arrived, currentStation, nextStation]
   );
 
-  const { omitRepeatingLine, omitJR, omitThroughService } = options ?? {
+  const { omitRepeatingLine, omitJR } = options ?? {
     omitRepeatingLine: false,
     omitJR: false,
-    omitThroughService: false,
   };
 
   const transferLines = useTransferLinesFromStation(targetStation, {
     omitRepeatingLine,
     omitJR,
-    omitThroughService,
   });
 
   return transferLines;

--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -19,7 +19,6 @@ type TestComponentProps = {
   options?: {
     omitRepeatingLine?: boolean;
     omitJR?: boolean;
-    omitThroughService?: boolean;
   };
 };
 
@@ -215,7 +214,7 @@ describe('useTransferLinesFromStation', () => {
     expect(lines.map((l: Line) => l.id)).toContain(2);
   });
 
-  it('omitThroughService が true の場合、列車が直通運転で通る路線を除外する', () => {
+  it('列車が直通運転で通る路線は乗り換え路線として除外する', () => {
     const currentLine = createLineNested({ id: 1, nameShort: '東急東横線' });
     const throughServiceLine = createLineNested({
       id: 2,
@@ -242,44 +241,13 @@ describe('useTransferLinesFromStation', () => {
       futureStation,
     ];
 
-    const { getByTestId } = render(
-      <TestComponent
-        station={currentStation}
-        options={{ omitThroughService: true }}
-      />
-    );
+    const { getByTestId } = render(<TestComponent station={currentStation} />);
     const lines = JSON.parse(
       getByTestId('transferLines').props.children as string
     );
 
     expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
     expect(lines.find((l: Line) => l.id === 3)).toBeDefined();
-  });
-
-  it('omitThroughService が false の場合、直通運転で通る路線も乗り換え路線として残る', () => {
-    const currentLine = createLineNested({ id: 1, nameShort: '東急東横線' });
-    const throughServiceLine = createLineNested({
-      id: 2,
-      nameShort: '東京メトロ副都心線',
-    });
-
-    const currentStation = createStation(100, {
-      line: currentLine,
-      lines: [currentLine, throughServiceLine],
-    });
-    const transitionStation = createStation(101, {
-      line: throughServiceLine,
-      lines: [currentLine, throughServiceLine],
-    });
-
-    stationAtomValue.stations = [currentStation, transitionStation];
-
-    const { getByTestId } = render(<TestComponent station={currentStation} />);
-    const lines = JSON.parse(
-      getByTestId('transferLines').props.children as string
-    );
-
-    expect(lines.find((l: Line) => l.id === 2)).toBeDefined();
   });
 
   it('omitJR が true で JR路線が閾値以上の場合、JR線として集約される', () => {

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -9,24 +9,22 @@ import omitJRLinesIfThresholdExceeded from '../utils/jr';
 type Option = {
   omitRepeatingLine?: boolean;
   omitJR?: boolean;
-  omitThroughService?: boolean;
 };
 
 export const useTransferLinesFromStation = (
   station: Station | undefined,
   option?: Option
 ): Line[] => {
-  const { omitRepeatingLine, omitJR, omitThroughService } = option ?? {
+  const { omitRepeatingLine, omitJR } = option ?? {
     omitRepeatingLine: false,
     omitJR: false,
-    omitThroughService: false,
   };
 
   const { stations } = useAtomValue(stationState);
 
   const transferLines = useMemo(() => {
     // 乗車中の列車が直通運転で通る路線一覧
-    // 同じ列車に乗ったままで到達するため乗り換え対象から外す用途で使う
+    // 同じ列車に乗ったままで到達するため乗り換え対象から外す
     const throughServiceLineIds = new Set(
       stations.map((s) => s.line?.id).filter((id): id is number => id != null)
     );
@@ -77,7 +75,7 @@ export const useTransferLinesFromStation = (
         // 乗車中の列車が直通運転で通る路線は同じ列車のまま到達できるので
         // 乗り換え路線として表示しない
         .filter((line) => {
-          if (!omitThroughService || line.id == null) {
+          if (line.id == null) {
             return true;
           }
           return !throughServiceLineIds.has(line.id);
@@ -85,7 +83,6 @@ export const useTransferLinesFromStation = (
     );
   }, [
     omitRepeatingLine,
-    omitThroughService,
     station?.id,
     station?.line?.id,
     station?.line?.nameShort,

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -17,9 +17,7 @@ export const useUpdateBottomState = () => {
 
   const isTypeWillChange = useTypeWillChange();
   const isTypeWillChangeRef = useValueRef(isTypeWillChange);
-  // Transfers 画面と同じ条件で件数を見る必要があるため
-  // 直通運転で到達できる路線は除外する
-  const transferLines = useTransferLines({ omitThroughService: true });
+  const transferLines = useTransferLines();
   const isLEDThemeRef = useValueRef(isLEDTheme);
   const shouldHideTypeChange = useShouldHideTypeChange();
   const shouldHideTypeChangeRef = useValueRef(shouldHideTypeChange);


### PR DESCRIPTION
## 概要

PR #5883 で導入した `omitThroughService` オプションを撤去し、`useTransferLinesFromStation` で常に直通運転路線を乗り換え一覧から除外する**デフォルト動作**に変更します。

直通運転で同じ列車が通る路線は本質的に乗り換え対象ではないため、特定の呼び出しでだけ on にする扱い（オプション）は不要と判断したためです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTransferLinesFromStation` から `omitThroughService` オプションを削除し、直通運転路線を除外する filter を常時適用するように変更。
- `useTransferLines` も `omitThroughService` を伝搬する分岐を撤去（オプション型からも削除）。
- 既存の呼び出し箇所（`Transfers.tsx` / `TransfersYamanote.tsx` / `useUpdateBottomState` / `useTTSText`）から `{ omitThroughService: true }` を撤去し、引数なしの素の `useTransferLines()` 呼び出しに戻した。
- テストを更新: オプション伝搬の期待値から `omitThroughService` を削除し、`omitThroughService` の on/off テスト 2 本を「直通運転路線を除外する」デフォルト動作テスト 1 本に統合。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #5883

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更**
  * 乗換案内に経由便を含めて表示するようになりました。これまで除外されていた経由サービスの乗換情報が利用可能になります。
  * 乗換情報の音声案内にも経由便が追加されました。
  * アプリ全体で乗換情報表示の統一性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->