### PR TITLE
行先選択モーダルの「方面」「for 」を小さく表示

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -7,6 +7,7 @@ import { Path, Svg } from 'react-native-svg';
 import type { Line, Station } from '~/@types/graphql';
 import isTablet from '~/utils/isTablet';
 import { getLocalizedLineName, isBusLine } from '~/utils/line';
+import { RFValue } from '~/utils/rfValue';
 import { MARK_SHAPE, NUMBERING_ICON_SIZE } from '../constants';
 import { useBounds, useGetLineMark } from '../hooks';
 import { isLEDThemeAtom } from '../store/atoms/theme';
@@ -22,6 +23,8 @@ type Props = {
   title?: string;
   /** カッコ内の文字を小さく表示する際、カッコ自体を非表示にする */
   hideParens?: boolean;
+  /** 方面を表す接辞（日本語の末尾「方面」/英語の先頭「for 」）を小さいフォントで表示する */
+  shrinkBoundAffix?: boolean;
   subtitle?: string;
   subtitleNumberOfLines?: number;
   /** 右端のシェブロンを非表示にする */
@@ -95,7 +98,12 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
   titleParens: {
-    fontSize: 14,
+    fontSize: RFValue(13),
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  titleAffix: {
+    fontSize: RFValue(13),
     fontWeight: 'bold',
     color: '#fff',
   },
@@ -200,6 +208,7 @@ export const CommonCard: React.FC<Props> = ({
   stations = [],
   title,
   hideParens,
+  shrinkBoundAffix,
   subtitle,
   subtitleNumberOfLines,
   hideChevron,
@@ -302,10 +311,33 @@ export const CommonCard: React.FC<Props> = ({
     return { transform: [{ scale: 0.5 }] } as const;
   }, [mark?.signPath, targetStationNumber, targetStationThreeLetterCode]);
 
-  const titleParts = useMemo(
-    () => titleOrLineName.split(/(\([^)]*\))/),
-    [titleOrLineName]
-  );
+  const { titlePrefix, titleParts, titleSuffix } = useMemo(() => {
+    let main = titleOrLineName;
+    let prefix: string | null = null;
+    let suffix: string | null = null;
+    if (shrinkBoundAffix) {
+      if (isJapanese) {
+        // 「○○方面」末尾の「方面」を分離（カッコ内の「方面」は対象外）
+        const match = /^(.+?)方面$/.exec(main);
+        if (match && !match[1].endsWith(')')) {
+          main = match[1];
+          suffix = '方面';
+        }
+      } else {
+        // 「for ○○」先頭の「for 」を分離
+        const match = /^(for )(.+)$/.exec(main);
+        if (match) {
+          prefix = match[1];
+          main = match[2];
+        }
+      }
+    }
+    return {
+      titlePrefix: prefix,
+      titleParts: main.split(/(\([^)]*\))/),
+      titleSuffix: suffix,
+    };
+  }, [titleOrLineName, shrinkBoundAffix]);
 
   const additionalRootStyle = useMemo(
     () => ({
@@ -411,6 +443,9 @@ export const CommonCard: React.FC<Props> = ({
         )}
         <View style={styles.texts}>
           <Typography style={styles.title} numberOfLines={1}>
+            {titlePrefix ? (
+              <Typography style={styles.titleAffix}>{titlePrefix}</Typography>
+            ) : null}
             {titleParts.map((part, index) =>
               /^\(.*\)$/.test(part) ? (
                 <Typography key={`${index}-${part}`} style={styles.titleParens}>
@@ -423,6 +458,9 @@ export const CommonCard: React.FC<Props> = ({
                 part
               )
             )}
+            {titleSuffix ? (
+              <Typography style={styles.titleAffix}>{titleSuffix}</Typography>
+            ) : null}
           </Typography>
           {subtitle && (
             <Subtitle

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -494,6 +494,7 @@ export const SelectBoundModal: React.FC<Props> = ({
               disabled={isTransitioning}
               loading={isTransitioning}
               title={title}
+              shrinkBoundAffix
               subtitle={subtitle}
               targetStation={finalStop}
             />
@@ -533,6 +534,7 @@ export const SelectBoundModal: React.FC<Props> = ({
                   ? `${presetOrigin.name}方面`
                   : `for ${presetOrigin.nameRoman ?? ''}`
               }
+              shrinkBoundAffix
               subtitle={reverseSubtitle}
               targetStation={presetOrigin}
             />
@@ -566,6 +568,7 @@ export const SelectBoundModal: React.FC<Props> = ({
           loading={isTransitioning}
           line={lineForCard}
           title={title}
+          shrinkBoundAffix
           subtitle={subtitle}
           targetStation={boundStations[0]}
         />


### PR DESCRIPTION
## 概要

行先選択モーダル（SelectBoundModal）の方面表示において、「方面」（日本語）および「for 」（英語）の接辞部分を駅名より小さなフォントサイズで描画し、駅名を視覚的に強調する。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `CommonCard` に `shrinkBoundAffix` prop を追加し、有効時にタイトル末尾の「方面」（日本語）/ 先頭の「for 」（英語）を `RFValue(13)` の小さなフォントで表示するようにした
- `titleParens` のフォントサイズを `RFValue(13)` に変更し、`titleAffix` と統一して見た目を揃えた
- `SelectBoundModal` の 3 箇所の `CommonCard` で `shrinkBoundAffix` を有効化（通常方面カード、wantedDestination 方向カード、逆方向プリセットカード）

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 乗車方面などの補足情報の表示方法をより柔軟に調整できるようになりました。

* **改善**
  * タイトル周辺のテキストサイズを統一し、表示品質を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->