### PR TITLE
自動テーマでバス路線をデフォルトの東京メトロ風テーマにフォールバック

### DIFF
--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -1,4 +1,4 @@
-import type { Line } from '~/@types/graphql';
+import { type Line, TransportType } from '~/@types/graphql';
 import { YAMANOTE_LINE_ID } from '~/constants/line';
 import { APP_THEME } from '~/models/Theme';
 import { resolveThemeForLine } from './resolveThemeForLine';
@@ -91,6 +91,18 @@ describe('resolveThemeForLine', () => {
         makeLine({ id: 99302, company: makeCompany('東京都交通局地下鉄') })
       )
     ).toBe(APP_THEME.TOEI);
+  });
+
+  it('都営バス（東京都交通局のバス路線）はTOKYO_METROにフォールバックする', () => {
+    expect(
+      resolveThemeForLine(
+        makeLine({
+          id: 99303,
+          company: makeCompany('東京都交通局'),
+          transportType: TransportType.Bus,
+        })
+      )
+    ).toBe(APP_THEME.TOKYO_METRO);
   });
 
   it('JR西日本の路線はJR_WESTを返す', () => {

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -1,4 +1,4 @@
-import type { Line } from '~/@types/graphql';
+import { type Line, TransportType } from '~/@types/graphql';
 import { YAMANOTE_LINE_ID } from '~/constants/line';
 import { APP_THEME, type AppTheme } from '~/models/Theme';
 
@@ -28,6 +28,11 @@ const DEFAULT_THEME = APP_THEME.TOKYO_METRO;
 
 export const resolveThemeForLine = (line: Line | null): AppTheme => {
   if (!line) {
+    return DEFAULT_THEME;
+  }
+
+  // バス路線は鉄道向けの社別テーマ（都営地下鉄風など）を流用しない
+  if (line.transportType === TransportType.Bus) {
     return DEFAULT_THEME;
   }
 


### PR DESCRIPTION
## 概要

自動テーマ有効時、`東京都交通局` を会社名プレフィックスで一律 `TOEI`（都営地下鉄風）テーマに割り当てていたため、`都営バス` まで都営地下鉄風テーマが適用されていた。バス路線はデフォルトの `TOKYO_METRO`（東京メトロ風）テーマにフォールバックさせる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `resolveThemeForLine` で `transportType === TransportType.Bus` の場合に早期に `DEFAULT_THEME`（`TOKYO_METRO`）を返すように変更（`src/utils/resolveThemeForLine.ts`）。
- 都営バス（`東京都交通局` × `TransportType.Bus`）が `TOKYO_METRO` にフォールバックすることを検証するテストを追加（`src/utils/resolveThemeForLine.test.ts`）。

なぜ「都営地下鉄風テーマをバスに流用」ではなく「東京メトロ風テーマへのフォールバック」を選んだかは、都営テーマが持つ中韓表記対応・ナンバリング表示対応がバス路線では逆にノイズになるため。これらの装飾を出さない東京メトロ風テーマのほうがバス停表示として都合がよい、という判断。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * バス路線のテーマ表示を改善しました。バス路線が正しいテーマフォールバックロジックに従うようになり、表示の一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->