### PR TITLE
LineBoardToei下部の空きを詰めて都営バスのフォールバック判定を撤去

### DIFF
--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -76,6 +76,7 @@ interface StationNameToeiProps {
   passed?: boolean;
   isKoEnabled?: boolean;
   isZhEnabled?: boolean;
+  hasNumbering?: boolean;
 }
 
 const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
@@ -85,26 +86,23 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
   passed,
   isKoEnabled,
   isZhEnabled,
+  hasNumbering,
 }) => {
   const stationNameR = useMemo(() => getStationNameR(station), [station]);
   const dim = useWindowDimensions();
 
   const horizontalAdditionalStyle = useMemo(() => {
-    const commonStyle = {
-      marginBottom: isTablet ? dim.height / 10 : dim.height / 6,
-    };
-
-    if (!station.stationNumbers?.length) {
+    if (!hasNumbering) {
       return {
-        ...commonStyle,
+        marginBottom: isTablet ? dim.height / 14 : dim.height / 10,
         width: isTablet ? dim.height / 3 : dim.height / 2.5,
       };
     }
     return {
-      ...commonStyle,
+      marginBottom: isTablet ? dim.height / 10 : dim.height / 6,
       width: isTablet ? dim.height / 3.5 : dim.height / 2,
     };
-  }, [dim.height, station.stationNumbers]);
+  }, [dim.height, hasNumbering]);
 
   if (en) {
     return (
@@ -116,7 +114,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
         ]}
       >
         {stationNameR}
-        {isZhEnabled ? (
+        {isZhEnabled && station.nameChinese ? (
           <>
             {'\n'}
             <Typography
@@ -125,7 +123,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
                 passed ? styles.grayColor : null,
               ]}
             >
-              {station.nameChinese ?? ''}
+              {station.nameChinese}
             </Typography>
           </>
         ) : null}
@@ -143,7 +141,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
         ]}
       >
         {station.name}
-        {isKoEnabled ? (
+        {isKoEnabled && station.nameKorean ? (
           <>
             {'\n'}
             <Typography
@@ -152,7 +150,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
                 passed ? styles.grayColor : null,
               ]}
             >
-              {station.nameKorean ?? ''}
+              {station.nameKorean}
             </Typography>
           </>
         ) : null}
@@ -399,18 +397,21 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             passed={getIsPass(station) || shouldGrayscale}
             isKoEnabled={isKoEnabled}
             isZhEnabled={isZhEnabled}
+            hasNumbering={!!numberingObj?.stationNumber}
           />
         </View>
-        <Typography
-          style={[
-            styles.stationNumber,
-            getIsPass(station) || shouldGrayscale ? styles.grayColor : null,
-          ]}
-          adjustsFontSizeToFit
-          numberOfLines={1}
-        >
-          {numberingObj?.stationNumber ?? ''}
-        </Typography>
+        {numberingObj?.stationNumber ? (
+          <Typography
+            style={[
+              styles.stationNumber,
+              getIsPass(station) || shouldGrayscale ? styles.grayColor : null,
+            ]}
+            adjustsFontSizeToFit
+            numberOfLines={1}
+          >
+            {numberingObj.stationNumber}
+          </Typography>
+        ) : null}
         <BackgroundBars line={line} barLeft={barLeft} barWidth={barWidth} />
         <FutureBars
           arrived={arrived}

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -170,9 +170,9 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
           </Typography>
         ))}
       </View>
-      {isKoEnabled ? (
+      {isKoEnabled && station.nameKorean ? (
         <View style={styles.splittedStationName}>
-          {(station.nameKorean ?? '').split('').map((c, j) => (
+          {station.nameKorean.split('').map((c, j) => (
             <Typography
               style={[
                 styles.stationNameExtra,

--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -1,4 +1,4 @@
-import { type Line, TransportType } from '~/@types/graphql';
+import type { Line } from '~/@types/graphql';
 import { YAMANOTE_LINE_ID } from '~/constants/line';
 import { APP_THEME } from '~/models/Theme';
 import { resolveThemeForLine } from './resolveThemeForLine';
@@ -91,18 +91,6 @@ describe('resolveThemeForLine', () => {
         makeLine({ id: 99302, company: makeCompany('東京都交通局地下鉄') })
       )
     ).toBe(APP_THEME.TOEI);
-  });
-
-  it('都営バス（東京都交通局のバス路線）はTOKYO_METROにフォールバックする', () => {
-    expect(
-      resolveThemeForLine(
-        makeLine({
-          id: 99303,
-          company: makeCompany('東京都交通局'),
-          transportType: TransportType.Bus,
-        })
-      )
-    ).toBe(APP_THEME.TOKYO_METRO);
   });
 
   it('JR西日本の路線はJR_WESTを返す', () => {

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -1,4 +1,4 @@
-import { type Line, TransportType } from '~/@types/graphql';
+import type { Line } from '~/@types/graphql';
 import { YAMANOTE_LINE_ID } from '~/constants/line';
 import { APP_THEME, type AppTheme } from '~/models/Theme';
 
@@ -28,11 +28,6 @@ const DEFAULT_THEME = APP_THEME.TOKYO_METRO;
 
 export const resolveThemeForLine = (line: Line | null): AppTheme => {
   if (!line) {
-    return DEFAULT_THEME;
-  }
-
-  // バス路線は鉄道向けの社別テーマ（都営地下鉄風など）を流用しない
-  if (line.transportType === TransportType.Bus) {
     return DEFAULT_THEME;
   }
 


### PR DESCRIPTION
## 概要

`LineBoardToei` で駅ナンバリングや多言語駅名のデータが無いときに発生していた、下部の不要な空きスペースを詰めるように調整しました。

これにより都営テーマがナンバリング・中韓表示を持たない駅（バス停など）でもレイアウト崩れを起こさなくなったため、回避策として導入していた #5888 の「都営バス路線を東京メトロ風テーマへフォールバックする」判定も撤去します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `numberingObj?.stationNumber` が無い駅ではナンバリング `Typography` 自体をレンダリングしないように変更（タブレットの `position: 'relative'` で出ていた空白を解消）。
- `StationNameToei` に `hasNumbering` プロップを追加し、英語/中国語表示時の `horizontalAdditionalStyle.marginBottom` をナンバリングが無いときだけ控えめな値に切り替え（バーへの食い込みを避けつつ余白を圧縮）。
- 中国語データ／韓国語データが空のときは、改行と空の `Typography` を出さずブロックごと描画しないように変更（多言語表示時の浮き上がりを解消）。
- `resolveThemeForLine` から `TransportType.Bus` の早期リターンを撤去し、対応するテストケースも削除（#5888 の回避策が不要になったため）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 駅番号が存在する場合のみ駅番号ラベルを表示するよう修正しました。
  * 中国語・韓国語の副名は対応言語が有効かつ該当名が存在する場合のみ表示するよう改善しました。
  * 表示レイアウトの幅・余白計算を駅番号の有無に基づいて調整しました。

* **Chores**
  * 路線テーマ判定から一部交通種別の特別扱いを削除し判定処理を簡素化しました。

* **Tests**
  * 不要なテストケースを削除しテストを整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->