### PR TITLE
NowHeaderの都営バスバッジがスクロール後に下ぞろえになる不具合を修正

### DIFF
--- a/src/components/NowHeader.tsx
+++ b/src/components/NowHeader.tsx
@@ -81,6 +81,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   busBadge: {
+    alignSelf: 'center',
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 6,


### PR DESCRIPTION
## 概要

NowHeader の都営バスバッジが、初期表示では駅名と上下中央揃えだったのに対し、スクロール後（インライン表示）では下ぞろえになっていた不具合を修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `busBadge` スタイルに `alignSelf: 'center'` を追加し、親側の `alignItems` に依存せずに常時上下中央揃えになるようにした。
  - 初期表示（スタックレイアウト）の親 `busStationRow` は元から `alignItems: 'center'` のため見た目に変化なし。
  - スクロール後（インラインレイアウト）の親 `nowHeaderInline` は `alignItems: 'flex-end'` だが、`alignSelf` で上書きされて中央揃えになる。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ヘッダー内のバスバッジの配置を調整し、より適切なアライメントを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->