### PR TITLE
NowHeaderの駅名が一行に収まらない場合に末尾を…で省略表示

### DIFF
--- a/src/components/NowHeader.tsx
+++ b/src/components/NowHeader.tsx
@@ -72,8 +72,12 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   nowStationScaleWrap: {
-    alignSelf: 'flex-start',
+    alignSelf: 'stretch',
     transformOrigin: 'left bottom',
+  },
+  nowStationFlexible: {
+    flexShrink: 1,
+    minWidth: 0,
   },
   busStationRow: {
     flexDirection: 'row',
@@ -86,6 +90,7 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     borderRadius: 6,
     borderWidth: 1,
+    flexShrink: 0,
   },
   busBadgeText: {
     fontSize: isTablet ? 16 : 12,
@@ -255,9 +260,9 @@ export const NowHeader = ({
                 >
                   <View style={styles.busStationRow}>
                     <Typography
-                      style={styles.nowStation}
+                      style={[styles.nowStation, styles.nowStationFlexible]}
                       numberOfLines={1}
-                      adjustsFontSizeToFit
+                      ellipsizeMode="tail"
                     >
                       {nowHeader.name ?? ''}
                     </Typography>
@@ -288,9 +293,9 @@ export const NowHeader = ({
                 {nowHeader.label ?? ''}
               </Typography>
               <Typography
-                style={styles.nowStation}
+                style={[styles.nowStation, styles.nowStationFlexible]}
                 numberOfLines={1}
-                adjustsFontSizeToFit
+                ellipsizeMode="tail"
               >
                 {station
                   ? (nowHeader.name ?? '')


### PR DESCRIPTION
## 概要

NowHeader の駅名が長くて1行に収まらない場合、フォント縮小ではなく末尾を「…」で省略表示するように変更しました。都営バス時はバッジを正サイズに保ったまま駅名側のみ省略します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `nowStationScaleWrap` の `alignSelf` を `flex-start` から `stretch` に変更し、駅名コンテナがヘッダー幅いっぱいに広がるようにした
- 駅名 Typography に `flexShrink: 1, minWidth: 0` を当て、`adjustsFontSizeToFit` を外して `numberOfLines={1}` + `ellipsizeMode="tail"` による「…」省略に統一
- 都営バスバッジに `flexShrink: 0` を付与し、駅名が縮小してもバッジは正サイズを保つようにした

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 駅名表示が制約されたレイアウトでより適切に動作するよう改善しました。テキストの省略表示方法を最適化し、限られたスペース内でのレイアウト対応性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->