### PR TITLE
主要ホットパスのレンダリング・状態更新を見直してパフォーマンスを改善

### DIFF
--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -39,17 +39,20 @@ const LineBoard: React.FC<Props> = ({ hasTerminus = false }: Props) => {
   const station = useCurrentStation();
   const isBus = isBusLine(station?.line);
 
-  const slicedLeftStations = useMemo(
-    () =>
-      leftStations.slice(0, 8).map((sta) => ({
-        ...sta,
-        name: isBus ? sta.name?.replace(parenthesisRegexp, '') : sta.name,
-        nameRoman: isBus
-          ? sta.nameRoman?.replace(parenthesisRegexp, '')
-          : sta.nameRoman,
-      })),
-    [leftStations, isBus]
-  );
+  const slicedLeftStations = useMemo(() => {
+    // 8 件だけ取り出す。bus 路線の場合は親括弧を駅名から除去する加工が必要。
+    // 鉄道路線では加工が不要 = 元の配列をそのまま返してオブジェクト生成 / 子コンポーネント
+    // の再 memoize を抑える（とくに山手線iPad テーマでアニメーションが何度も走る原因になる）。
+    if (!isBus) {
+      // sliceは新しい配列を返すが要素は同一参照なので、子コンポーネントは memo 効きやすい。
+      return leftStations.length <= 8 ? leftStations : leftStations.slice(0, 8);
+    }
+    return leftStations.slice(0, 8).map((sta) => ({
+      ...sta,
+      name: sta.name?.replace(parenthesisRegexp, ''),
+      nameRoman: sta.nameRoman?.replace(parenthesisRegexp, ''),
+    }));
+  }, [leftStations, isBus]);
 
   const currentStationIndex = useMemo(
     () =>

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -198,7 +198,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             station={station}
             en={isEn}
             horizontal={includesLongStationName}
-            passed={getIsPass(station) || shouldGrayscale}
+            passed={shouldGrayscale}
           />
         </View>
         {/* バー（常に路線色） */}

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -375,7 +375,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             station={station}
             en={isEn}
             horizontal={includesLongStationName}
-            passed={getIsPass(station) || shouldGrayscale}
+            passed={shouldGrayscale}
           />
         </View>
         {isOdakyu ? (
@@ -510,12 +510,19 @@ const LineBoardEast: React.FC<Props> = ({
 
   useInterval(intervalStep, 1000);
 
+  const stationsWithEmpty = useMemo(() => {
+    const filled = stations.length >= 8 ? stations : [...stations];
+    while (filled.length < 8) {
+      // 残りスロットは undefined のまま埋め切る (型上は Station[] にキャスト)
+      filled.push(undefined as unknown as Station);
+    }
+    return filled;
+  }, [stations]);
+
   const stationNameCellForMap = useCallback(
     (s: Station, i: number): React.ReactNode | null => {
-      const isLast =
-        [...stations, ...Array.from({ length: 8 - stations.length })].length -
-          1 ===
-        i;
+      // padded 後の長さは常に 8 なので最後尾は i === 7
+      const isLast = i === 7;
 
       if (!s) {
         return (
@@ -548,15 +555,6 @@ const LineBoardEast: React.FC<Props> = ({
       );
     },
     [chevronColor, hasTerminus, line, lineColors, stations, isOdakyu]
-  );
-
-  const stationsWithEmpty = useMemo(
-    () =>
-      [
-        ...stations,
-        ...Array.from({ length: 8 - stations.length }),
-      ] as Station[],
-    [stations]
   );
 
   return (

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -323,7 +323,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             station={station}
             en={isEn}
             horizontal={includesLongStationName}
-            passed={getIsPass(station) || shouldGrayscale}
+            passed={shouldGrayscale}
           />
         </View>
 

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -241,7 +241,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             station={station}
             en={isEn}
             horizontal={includesLongStationName}
-            passed={getIsPass(station) || shouldGrayscale}
+            passed={shouldGrayscale}
           />
         </View>
         <BarGradients

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -394,7 +394,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             station={station}
             en={isEn}
             horizontal={includesLongStationName}
-            passed={getIsPass(station) || shouldGrayscale}
+            passed={shouldGrayscale}
             isKoEnabled={isKoEnabled}
             isZhEnabled={isZhEnabled}
             hasNumbering={!!numberingObj?.stationNumber}
@@ -404,7 +404,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
           <Typography
             style={[
               styles.stationNumber,
-              getIsPass(station) || shouldGrayscale ? styles.grayColor : null,
+              shouldGrayscale ? styles.grayColor : null,
             ]}
             adjustsFontSizeToFit
             numberOfLines={1}

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -727,16 +727,19 @@ const PadArch: React.FC<Props> = ({
       </Animated.View>
 
       <View style={styles.stationNames}>
-        {stations.map((s, i) =>
-          s ? (
+        {stations.map((s, i) => {
+          if (!s) return null;
+          // 同一駅 s に対して getIsPass を複数回呼ばないように1回だけ計算してreuseする。
+          const isPass = getIsPass(s);
+          return (
             <React.Fragment key={s.id}>
               <View
                 style={[
                   styles.circle,
-                  (arrived && i === stations.length - 2) || getIsPass(s)
+                  (arrived && i === stations.length - 2) || isPass
                     ? styles.arrivedCircle
                     : undefined,
-                  getCustomDotStyle(i, stations, arrived, getIsPass(s)),
+                  getCustomDotStyle(i, stations, arrived, isPass),
                 ]}
               />
               <View
@@ -753,7 +756,7 @@ const PadArch: React.FC<Props> = ({
                         .signShape === MARK_SHAPE.SQUARE
                         ? styles.numberingSquareIconContainer
                         : styles.numberingIconContainer,
-                      getIsPass(s) ? styles.halfOpacity : null,
+                      isPass ? styles.halfOpacity : null,
                     ]}
                   >
                     <NumberingIcon
@@ -775,15 +778,15 @@ const PadArch: React.FC<Props> = ({
                   style={[
                     styles.stationName,
                     dynamicStyles.stationName,
-                    getIsPass(s) ? styles.halfOpacity : null,
+                    isPass ? styles.halfOpacity : null,
                   ]}
                 >
                   {isEn ? s.nameRoman : s.name}
                 </Typography>
               </View>
             </React.Fragment>
-          ) : null
-        )}
+          );
+        })}
       </View>
     </>
   );

--- a/src/hooks/useAfterNextStation.ts
+++ b/src/hooks/useAfterNextStation.ts
@@ -11,13 +11,19 @@ export const useAfterNextStation = () => {
   const slicedStationsOrigin = useSlicedStations();
 
   // 直通時、同じGroupIDの駅が違う駅として扱われるのを防ぐ(ex. 渋谷の次は、渋谷に止まります)
-  const slicedStations = useMemo(
-    () =>
-      Array.from(new Set(slicedStationsOrigin.map((s) => s.groupId)))
-        .map((gid) => slicedStationsOrigin.find((s) => s.groupId === gid))
-        .filter((s): s is Station => !!s),
-    [slicedStationsOrigin]
-  );
+  // 以前は new Set + find のチェーンで O(n²) だった。Map + 単一スキャンで O(n) に。
+  const slicedStations = useMemo(() => {
+    const seen = new Map<number, Station>();
+    const result: Station[] = [];
+    for (const s of slicedStationsOrigin) {
+      if (s.groupId == null) continue;
+      if (!seen.has(s.groupId)) {
+        seen.set(s.groupId, s);
+        result.push(s);
+      }
+    }
+    return result;
+  }, [slicedStationsOrigin]);
 
   const afterNextStation = useMemo(
     () =>

--- a/src/hooks/useConnectedLines.ts
+++ b/src/hooks/useConnectedLines.ts
@@ -44,16 +44,20 @@ export const useConnectedLines = (excludePassed = true): Line[] => {
       (lid) => lid === currentLine?.id
     );
 
+    // 以前は belongLines.slice().reverse()[i] を要素ごとに呼んでおり O(n²)。
+    // reverse は1度だけキャッシュする。
+    const reversedBelongLines =
+      selectedDirection === 'INBOUND' ? belongLines.slice().reverse() : null;
+
     const notGroupedJoinedLines: Line[] =
       selectedDirection === 'INBOUND'
         ? joinedLineIds
             .slice(currentLineIndex + 1, joinedLineIds.length)
-            .map((_, i) => belongLines.slice().reverse()[i])
+            .map((_, i) => (reversedBelongLines as Line[])[i])
             .map((l) => ({
               ...l,
               name: l.nameShort?.replace(parenthesisRegexp, ''),
             }))
-            .map((l) => l)
             .reverse()
         : joinedLineIds
             .slice(0, currentLineIndex)
@@ -62,7 +66,6 @@ export const useConnectedLines = (excludePassed = true): Line[] => {
               ...l,
               name: l.nameShort?.replace(parenthesisRegexp, ''),
             }))
-            .map((l) => l)
             .reverse();
     const companyDuplicatedLines = notGroupedJoinedLines
       .filter((l, i, arr) => l.company?.id === arr[i - 1]?.company?.id)

--- a/src/hooks/useCurrentLine.ts
+++ b/src/hooks/useCurrentLine.ts
@@ -10,14 +10,30 @@ export const useCurrentLine = (): Line | null => {
   const { selectedLine } = useAtomValue(lineState);
   const currentStation = useCurrentStation();
 
-  const actualCurrentStation = useMemo(
-    () =>
-      (selectedDirection === 'INBOUND'
-        ? stations.slice().reverse()
-        : stations
-      ).find((rs) => rs.groupId === currentStation?.groupId),
-    [currentStation?.groupId, selectedDirection, stations]
-  );
+  const actualCurrentStation = useMemo(() => {
+    if (!currentStation?.groupId) {
+      return undefined;
+    }
+    // 複数候補がある場合に INBOUND は末尾優先 (= reverse して最初に当たるもの)、
+    // OUTBOUND は先頭優先という従来仕様を維持しつつ、フル配列の slice().reverse()
+    // を回避するため逆方向ループで探索する。
+    if (selectedDirection === 'INBOUND') {
+      for (let i = stations.length - 1; i >= 0; i--) {
+        const s = stations[i];
+        if (s?.groupId === currentStation.groupId) {
+          return s;
+        }
+      }
+      return undefined;
+    }
+    for (let i = 0; i < stations.length; i++) {
+      const s = stations[i];
+      if (s?.groupId === currentStation.groupId) {
+        return s;
+      }
+    }
+    return undefined;
+  }, [currentStation?.groupId, selectedDirection, stations]);
 
   // NOTE: selectedLineがnullishの時はcurrentLineもnullishであってほしい
   return (selectedLine && actualCurrentStation?.line) ?? null;

--- a/src/hooks/useCurrentStation.ts
+++ b/src/hooks/useCurrentStation.ts
@@ -15,40 +15,66 @@ export const useCurrentStation = (
   } = useAtomValue(stationState);
 
   // NOTE: 選択した路線と現在の駅の路線を一致させる
-  const station = useMemo(
-    () =>
-      stations.find((s) => s.id === stationFromState?.id) ??
-      stations.find((s) => s.groupId === stationFromState?.groupId),
-    [stationFromState?.id, stationFromState?.groupId, stations]
-  );
+  // 元は find を 2 回チェーンしていたが 1 パスに集約。
+  const station = useMemo(() => {
+    if (!stationFromState?.id && !stationFromState?.groupId) return undefined;
+    let groupMatch: Station | undefined;
+    for (const s of stations) {
+      if (s.id === stationFromState.id) return s;
+      if (!groupMatch && s.groupId === stationFromState.groupId) {
+        groupMatch = s;
+      }
+    }
+    return groupMatch;
+  }, [stationFromState?.id, stationFromState?.groupId, stations]);
 
+  const needsTrainTypeStation = skipPassStation || withTrainTypes;
+
+  // skipPass / withTrainTypes が必要な呼び出しでのみ算出する。
+  // 以前は常時計算しており stations.slice().reverse() のコストが必ず発生していた。
   const withTrainTypeStation = useMemo(() => {
-    const foundStation = stations
-      .filter((s) => (skipPassStation ? !getIsPass(s) : true))
-      .find((rs) => rs.id === station?.id);
-    if (foundStation) {
-      return foundStation;
+    if (!needsTrainTypeStation) return undefined;
+    // 直接マッチを 1 パスで探す
+    for (const rs of stations) {
+      if (skipPassStation && getIsPass(rs)) continue;
+      if (rs.id === station?.id) return rs;
     }
 
-    const reversedStations =
-      selectedDirection === 'INBOUND' ? stations : stations.slice().reverse();
-
-    const curIndex = reversedStations.findIndex((s) => s.id === station?.id);
-    if (curIndex === -1) {
-      return;
+    // INBOUND 時は元配列、OUTBOUND 時は逆順で curIndex を求める。
+    // ただしフル配列を slice().reverse() しなくても、逆方向ループで等価に処理できる。
+    const isInbound = selectedDirection === 'INBOUND';
+    const len = stations.length;
+    let curIndex = -1;
+    for (let i = 0; i < len; i++) {
+      const idx = isInbound ? i : len - 1 - i;
+      if (stations[idx]?.id === station?.id) {
+        curIndex = i;
+        break;
+      }
     }
+    if (curIndex === -1) return undefined;
 
-    const stationsFromRange = reversedStations
-      .slice(0, curIndex)
-      .filter((s) => (skipPassStation ? !getIsPass(s) : true));
-    return stationsFromRange[stationsFromRange.length - 1];
-  }, [selectedDirection, skipPassStation, station?.id, stations]);
+    // reversed[0..curIndex) を後ろから前へ走査して直近停車駅を返す
+    for (let j = curIndex - 1; j >= 0; j--) {
+      const idx = isInbound ? j : len - 1 - j;
+      const s = stations[idx];
+      if (!s) continue;
+      if (skipPassStation && getIsPass(s)) continue;
+      return s;
+    }
+    return undefined;
+  }, [
+    needsTrainTypeStation,
+    selectedDirection,
+    skipPassStation,
+    station?.id,
+    stations,
+  ]);
 
-  if (skipPassStation || withTrainTypes) {
+  if (needsTrainTypeStation) {
     return withTrainTypeStation;
   }
 
   // NOTE: 路線が選択されていない場合stationはnullishになる
-  const result = station ?? stationFromState;
-  return result ?? undefined;
+  return station ?? stationFromState ?? undefined;
 };

--- a/src/hooks/useLoopLine.ts
+++ b/src/hooks/useLoopLine.ts
@@ -95,12 +95,17 @@ export const useLoopLine = (
     [line, stations]
   );
 
+  // OUTBOUND/INBOUND どちらでも参照されうる reverse 結果をメモ化。
+  // 以前は inboundStationsForLoopLine が呼ばれる度にフル配列を slice().reverse() していた。
+  const reversedStations = useMemo(
+    () => stations.slice().reverse(),
+    [stations]
+  );
+
   const inboundStationsForLoopLine = useMemo((): Station[] => {
     if (!station || !isLoopLine) {
       return [];
     }
-
-    const reversedStations = stations.slice().reverse();
 
     const currentStationIndex = reversedStations.findIndex(
       (s) => s.groupId === station.groupId
@@ -108,27 +113,22 @@ export const useLoopLine = (
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const seenGroupIds = new Set<number>();
-    const majorStations = [
-      ...reversedStations.slice(currentStationIndex),
-      ...reversedStations.slice(0, currentStationIndex),
-    ].filter((s) => {
-      if (s.id === undefined || s.id === null || !majorStationIdSet.has(s.id)) {
-        return false;
-      }
-      if (s.groupId === station.groupId) {
-        return false;
-      }
-      if (s.groupId != null && seenGroupIds.has(s.groupId)) {
-        return false;
-      }
+    const majorStations: Station[] = [];
+    // 連結配列を物理生成せず 2 段スキャンで集める
+    const total = reversedStations.length;
+    for (let step = 0; step < total && majorStations.length < 2; step++) {
+      const idx = (currentStationIndex + step) % total;
+      const s = reversedStations[idx];
+      if (!s || s.id == null || !majorStationIdSet.has(s.id)) continue;
+      if (s.groupId === station.groupId) continue;
       if (s.groupId != null) {
+        if (seenGroupIds.has(s.groupId)) continue;
         seenGroupIds.add(s.groupId);
       }
-      return true;
-    });
-
-    return majorStations.slice(0, 2);
-  }, [isLoopLine, majorStationIdSet, station, stations]);
+      majorStations.push(s);
+    }
+    return majorStations;
+  }, [isLoopLine, majorStationIdSet, station, reversedStations]);
 
   const outboundStationsForLoopLine = useMemo((): Station[] => {
     if (!station || !isLoopLine) {
@@ -141,26 +141,20 @@ export const useLoopLine = (
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const seenGroupIds = new Set<number>();
-    const majorStations = [
-      ...stations.slice(currentStationIndex),
-      ...stations.slice(0, currentStationIndex),
-    ].filter((s) => {
-      if (s.id === undefined || s.id === null || !majorStationIdSet.has(s.id)) {
-        return false;
-      }
-      if (s.groupId === station.groupId) {
-        return false;
-      }
-      if (s.groupId != null && seenGroupIds.has(s.groupId)) {
-        return false;
-      }
+    const majorStations: Station[] = [];
+    const total = stations.length;
+    for (let step = 0; step < total && majorStations.length < 2; step++) {
+      const idx = (currentStationIndex + step) % total;
+      const s = stations[idx];
+      if (!s || s.id == null || !majorStationIdSet.has(s.id)) continue;
+      if (s.groupId === station.groupId) continue;
       if (s.groupId != null) {
+        if (seenGroupIds.has(s.groupId)) continue;
         seenGroupIds.add(s.groupId);
       }
-      return true;
-    });
-
-    return majorStations.slice(0, 2);
+      majorStations.push(s);
+    }
+    return majorStations;
   }, [isLoopLine, majorStationIdSet, station, stations]);
 
   return {

--- a/src/hooks/useLoopLine.ts
+++ b/src/hooks/useLoopLine.ts
@@ -110,6 +110,11 @@ export const useLoopLine = (
     const currentStationIndex = reversedStations.findIndex(
       (s) => s.groupId === station.groupId
     );
+    // findIndex が -1 の場合、(-1 + step) % total は負値起点になり末尾要素を取りこぼす。
+    // overrideStations 等で current station が配列に居ないケースを安全に扱うため早期 return。
+    if (currentStationIndex === -1) {
+      return [];
+    }
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const seenGroupIds = new Set<number>();
@@ -138,6 +143,9 @@ export const useLoopLine = (
     const currentStationIndex = stations.findIndex(
       (s) => s.groupId === station.groupId
     );
+    if (currentStationIndex === -1) {
+      return [];
+    }
 
     // 配列の途中から走査しているので端っこだと表示されるべき駅が存在しないものとされるので、環状させる
     const seenGroupIds = new Set<number>();

--- a/src/hooks/useNextStation.ts
+++ b/src/hooks/useNextStation.ts
@@ -16,92 +16,89 @@ export const useNextStation = (
   const currentStation = useCurrentStation();
   const { isLoopLine } = useLoopLine();
 
-  const station = useMemo(
-    () => originStation ?? currentStation,
-    [originStation, currentStation]
-  );
+  const station = originStation ?? currentStation;
 
   const stations = useMemo(
     () => dropEitherJunctionStation(stationsFromState, selectedDirection),
     [selectedDirection, stationsFromState]
   );
 
-  const stationIndex = useMemo(() => {
-    const index = stations.findIndex((s) => s.id === station?.id);
-    if (index !== -1) {
-      return index;
-    }
+  const isInbound = selectedDirection === 'INBOUND';
 
-    return stations.findIndex((s) => s.groupId === station?.groupId);
-  }, [station?.id, station?.groupId, stations]);
+  // OUTBOUND 用に reverse した配列をメモ化（必要なときだけ作る）。
+  // 以前は useMemo を 2 つに分けて毎回 stations.slice().reverse() を 2 回計算していた。
+  const reversedStations = useMemo(
+    () => (isInbound ? null : stations.slice().reverse()),
+    [isInbound, stations]
+  );
 
-  const outboundStationIndex = useMemo(() => {
-    const index = stations
-      .slice()
-      .reverse()
-      .findIndex((s) => s.id === station?.id);
+  const result = useMemo(() => {
+    const orderedStations = isInbound
+      ? stations
+      : (reversedStations ?? stations);
+    const idMatchIndex = orderedStations.findIndex((s) => s.id === station?.id);
+    const stationIndex =
+      idMatchIndex !== -1
+        ? idMatchIndex
+        : orderedStations.findIndex((s) => s.groupId === station?.groupId);
 
-    if (index !== -1) {
-      return index;
-    }
-
-    return stations
-      .slice()
-      .reverse()
-      .findIndex((s) => s.groupId === station?.groupId);
-  }, [station?.id, station?.groupId, stations]);
-
-  const actualNextStation = useMemo(() => {
     if (stationIndex === -1) {
-      return;
+      return undefined;
     }
 
-    if (isLoopLine) {
-      const loopLineStationIndex =
-        selectedDirection === 'INBOUND' ? stationIndex - 1 : stationIndex + 1;
-
-      if (!stations[loopLineStationIndex]) {
-        return stations[
-          selectedDirection === 'INBOUND' ? stations.length - 1 : 0
-        ];
+    // ループ線とそれ以外で進行方向の取り方が違う。
+    // INBOUND→reversedで stationIndex+1、OUTBOUND→reversedで stationIndex+1（共通）。
+    const actualNextStation = (() => {
+      if (isLoopLine) {
+        // 元配列基準で INBOUND は -1, OUTBOUND は +1 だったが、
+        // ここでは orderedStations が常に進行方向順なので +1 で揃えられる場合とそうでない場合がある。
+        // 既存仕様を保つため元の挙動を再現する。
+        const flatIndex = stations.findIndex((s) => s.id === station?.id);
+        const groupIndex =
+          flatIndex !== -1
+            ? flatIndex
+            : stations.findIndex((s) => s.groupId === station?.groupId);
+        if (groupIndex === -1) {
+          return undefined;
+        }
+        const loopLineStationIndex = isInbound
+          ? groupIndex - 1
+          : groupIndex + 1;
+        if (!stations[loopLineStationIndex]) {
+          return stations[isInbound ? stations.length - 1 : 0];
+        }
+        return stations[loopLineStationIndex];
       }
 
-      return stations[loopLineStationIndex];
+      // 非ループ線: orderedStations は進行方向順なので次は +1
+      return orderedStations[stationIndex + 1];
+    })();
+
+    if (!actualNextStation) {
+      return undefined;
     }
 
-    const notLoopLineStationIndex =
-      selectedDirection === 'INBOUND' ? stationIndex + 1 : stationIndex - 1;
-
-    return stations[notLoopLineStationIndex];
-  }, [isLoopLine, selectedDirection, stationIndex, stations]);
-
-  const nextInboundStopStation = useMemo(() => {
-    if (stationIndex === -1) {
-      return;
+    if (!ignorePass || !getIsPass(actualNextStation)) {
+      return actualNextStation;
     }
 
-    return actualNextStation && getIsPass(actualNextStation) && ignorePass
-      ? stations
-          .slice(stationIndex - stations.length + 1)
-          .find((s) => !getIsPass(s))
-      : actualNextStation;
-  }, [actualNextStation, ignorePass, stationIndex, stations]);
-
-  const nextOutboundStopStation = useMemo(() => {
-    if (outboundStationIndex === -1) {
-      return;
+    // 通過駅をスキップして次の停車駅を探す
+    for (let i = stationIndex + 1; i < orderedStations.length; i++) {
+      const s = orderedStations[i];
+      if (s && !getIsPass(s)) {
+        return s;
+      }
     }
+    return undefined;
+  }, [
+    ignorePass,
+    isInbound,
+    isLoopLine,
+    reversedStations,
+    station?.groupId,
+    station?.id,
+    stations,
+  ]);
 
-    return actualNextStation && getIsPass(actualNextStation) && ignorePass
-      ? stations
-          .slice()
-          .reverse()
-          .slice(outboundStationIndex - stations.length + 1)
-          .find((s) => !getIsPass(s))
-      : actualNextStation;
-  }, [actualNextStation, ignorePass, outboundStationIndex, stations]);
-
-  return selectedDirection === 'INBOUND'
-    ? nextInboundStopStation
-    : nextOutboundStopStation;
+  return result;
 };

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -1,7 +1,5 @@
 import * as Location from 'expo-location';
 import getDistance from 'geolib/es/getDistance';
-import getPathLength from 'geolib/es/getPathLength';
-import type { GeolibInputCoordinates } from 'geolib/es/types';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { LineType } from '~/@types/graphql';
@@ -47,6 +45,15 @@ export const useSimulationMode = (): void => {
   const speedProfilesRef = useRef<number[][]>([]);
   const segmentProgressDistanceRef = useRef(0);
   const dwellPendingRef = useRef(false);
+  // 区間ごとの (waypoints, cumulativeDistances) キャッシュ。
+  // step() は毎秒呼ばれる。区間が変わらない限り cumulativeDistances は同じなので、
+  // waypoints 毎の getDistance / reduce を毎ティック走らせる必要は無い。
+  type SegmentGeometry = {
+    waypoints: { latitude: number; longitude: number }[];
+    cumulativeDistances: number[];
+    totalDistance: number;
+  };
+  const segmentGeometryCacheRef = useRef<SegmentGeometry[]>([]);
 
   const stations = useMemo(
     () => dropEitherJunctionStation(rawStations, selectedDirection),
@@ -152,83 +159,132 @@ export const useSimulationMode = (): void => {
   }, [enabled]);
 
   useEffect(() => {
-    const speedProfiles = maybeRevsersedStations.map(
-      (cur, curMapIndex, arr) => {
-        if (getIsPass(cur)) {
-          // 通過駅は速度プロファイル生成対象外
-          return [];
-        }
-
-        const nextStationIndex = arr.findIndex(
-          (station, idx) => idx > curMapIndex && !getIsPass(station)
-        );
-        if (nextStationIndex === -1) {
-          return [];
-        }
-        const next = arr[nextStationIndex];
-        if (!next) {
-          return [];
-        }
-
-        const betweenNextStation = arr.slice(curMapIndex + 1, nextStationIndex);
-
-        if (
-          cur.latitude == null ||
-          cur.longitude == null ||
-          next.latitude == null ||
-          next.longitude == null
-        ) {
-          return [];
-        }
-
-        const points: GeolibInputCoordinates[] = [
-          {
-            latitude: cur.latitude as number,
-            longitude: cur.longitude as number,
-          },
-          ...betweenNextStation
-            .filter((s) => s.latitude != null && s.longitude != null)
-            .map((s) => ({
-              latitude: s.latitude as number,
-              longitude: s.longitude as number,
-            })),
-          {
-            latitude: next.latitude as number,
-            longitude: next.longitude as number,
-          },
-        ];
-
-        const distanceForNextStation = getPathLength(points);
-
-        const accel = isBus
-          ? BUS_MAX_ACCEL_IN_M_S
-          : LINE_TYPE_MAX_ACCEL_IN_M_S[currentLineType];
-        const decel = isBus
-          ? BUS_MAX_DECEL_IN_M_S
-          : LINE_TYPE_MAX_DECEL_IN_M_S[currentLineType];
-
-        const speedProfile = generateTrainSpeedProfile({
-          distance: distanceForNextStation,
-          maxSpeed,
-          accel,
-          decel,
-          interval: 1,
-        });
-
-        const profileDistance = speedProfile.reduce((sum, v) => sum + v, 0);
-        const correctedProfile =
-          profileDistance === 0
-            ? speedProfile.map(() => 0)
-            : speedProfile.map(
-                (v) => v * (distanceForNextStation / profileDistance)
-              );
-
-        return correctedProfile;
-      }
+    const speedProfiles: number[][] = new Array(maybeRevsersedStations.length);
+    const segmentGeometry: SegmentGeometry[] = new Array(
+      maybeRevsersedStations.length
     );
+
+    const accel = isBus
+      ? BUS_MAX_ACCEL_IN_M_S
+      : LINE_TYPE_MAX_ACCEL_IN_M_S[currentLineType];
+    const decel = isBus
+      ? BUS_MAX_DECEL_IN_M_S
+      : LINE_TYPE_MAX_DECEL_IN_M_S[currentLineType];
+    const emptyGeometry: SegmentGeometry = {
+      waypoints: [],
+      cumulativeDistances: [],
+      totalDistance: 0,
+    };
+
+    for (
+      let curMapIndex = 0;
+      curMapIndex < maybeRevsersedStations.length;
+      curMapIndex++
+    ) {
+      const cur = maybeRevsersedStations[curMapIndex];
+      if (!cur || getIsPass(cur)) {
+        // 通過駅は速度プロファイル生成対象外
+        speedProfiles[curMapIndex] = [];
+        segmentGeometry[curMapIndex] = emptyGeometry;
+        continue;
+      }
+
+      // 次の停車駅インデックスを線形探索
+      let nextStationIndex = -1;
+      for (let i = curMapIndex + 1; i < maybeRevsersedStations.length; i++) {
+        const s = maybeRevsersedStations[i];
+        if (s && !getIsPass(s)) {
+          nextStationIndex = i;
+          break;
+        }
+      }
+      if (nextStationIndex === -1) {
+        speedProfiles[curMapIndex] = [];
+        segmentGeometry[curMapIndex] = emptyGeometry;
+        continue;
+      }
+      const next = maybeRevsersedStations[nextStationIndex];
+      if (
+        !next ||
+        cur.latitude == null ||
+        cur.longitude == null ||
+        next.latitude == null ||
+        next.longitude == null
+      ) {
+        speedProfiles[curMapIndex] = [];
+        segmentGeometry[curMapIndex] = emptyGeometry;
+        continue;
+      }
+
+      // step() で参照する waypoints と累積距離を一度だけ計算してキャッシュする。
+      // step() は毎秒呼ばれるため、ここで先払いすればその分のCPU負荷が減る。
+      const waypoints: { latitude: number; longitude: number }[] = [
+        {
+          latitude: cur.latitude as number,
+          longitude: cur.longitude as number,
+        },
+      ];
+      for (let idx = curMapIndex + 1; idx < nextStationIndex; idx++) {
+        const wp = maybeRevsersedStations[idx];
+        if (!wp || wp.latitude == null || wp.longitude == null) {
+          continue;
+        }
+        waypoints.push({
+          latitude: wp.latitude as number,
+          longitude: wp.longitude as number,
+        });
+      }
+      waypoints.push({
+        latitude: next.latitude as number,
+        longitude: next.longitude as number,
+      });
+
+      const cumulative = new Array<number>(waypoints.length);
+      cumulative[0] = 0;
+      for (let i = 1; i < waypoints.length; i++) {
+        const prev = waypoints[i - 1];
+        const cur = waypoints[i];
+        const d = getDistance(
+          { latitude: prev.latitude, longitude: prev.longitude },
+          { latitude: cur.latitude, longitude: cur.longitude }
+        );
+        cumulative[i] = (cumulative[i - 1] ?? 0) + d;
+      }
+      const distanceForNextStation = cumulative[cumulative.length - 1] ?? 0;
+
+      segmentGeometry[curMapIndex] = {
+        waypoints,
+        cumulativeDistances: cumulative,
+        totalDistance: distanceForNextStation,
+      };
+
+      const speedProfile = generateTrainSpeedProfile({
+        distance: distanceForNextStation,
+        maxSpeed,
+        accel,
+        decel,
+        interval: 1,
+      });
+
+      let profileDistance = 0;
+      for (let i = 0; i < speedProfile.length; i++) {
+        profileDistance += speedProfile[i] ?? 0;
+      }
+      if (profileDistance === 0) {
+        speedProfiles[curMapIndex] = speedProfile.map(() => 0);
+      } else {
+        const ratio = distanceForNextStation / profileDistance;
+        const corrected = new Array<number>(speedProfile.length);
+        for (let i = 0; i < speedProfile.length; i++) {
+          corrected[i] = (speedProfile[i] ?? 0) * ratio;
+        }
+        speedProfiles[curMapIndex] = corrected;
+      }
+    }
 
     segmentIndexRef.current = resolveStartIndex();
     speedProfilesRef.current = speedProfiles;
+    segmentGeometryCacheRef.current = segmentGeometry;
     childIndexRef.current = 0;
     segmentProgressDistanceRef.current = 0;
     dwellPendingRef.current = false;
@@ -257,11 +313,9 @@ export const useSimulationMode = (): void => {
         segmentProgressDistanceRef.current = 0;
       }
 
-      // segmentIndexRefに基づいて目的地を決定（nextStationフックに依存しない）
-      const nextStopStationIndex = maybeRevsersedStations.findIndex(
-        (station, idx) => idx > normalizedSegmentIndex && !getIsPass(station)
-      );
-      if (nextStopStationIndex === -1) {
+      const geometry = segmentGeometryCacheRef.current[normalizedSegmentIndex];
+      // geometry が空 (= 当該駅から先に停車駅が無い / 通過駅) の場合は終端扱い
+      if (!geometry || geometry.waypoints.length === 0) {
         segmentIndexRef.current = 0;
         childIndexRef.current = 0;
         segmentProgressDistanceRef.current = 0;
@@ -283,103 +337,35 @@ export const useSimulationMode = (): void => {
         return;
       }
 
-      const currentSegmentStation =
-        maybeRevsersedStations[normalizedSegmentIndex];
-      if (!currentSegmentStation) {
-        return;
-      }
-      const currentSegmentStationIndex = normalizedSegmentIndex;
-
-      const nextStopStation = maybeRevsersedStations[nextStopStationIndex];
-      if (!nextStopStation) {
-        return;
-      }
-
-      if (
-        nextStopStation.latitude == null ||
-        nextStopStation.longitude == null
-      ) {
-        return;
-      }
-
-      if (
-        nextStopStationIndex < 0 ||
-        nextStopStationIndex < currentSegmentStationIndex
-      ) {
-        segmentIndexRef.current = 0;
-        childIndexRef.current = 0;
-        segmentProgressDistanceRef.current = 0;
-        return;
-      }
-
-      const waypoints = maybeRevsersedStations
-        .slice(currentSegmentStationIndex, nextStopStationIndex + 1)
-        .filter((s) => s.latitude != null && s.longitude != null);
-
-      if (waypoints.length === 0) {
-        return;
-      }
-
+      const { waypoints, cumulativeDistances, totalDistance } = geometry;
       const progressedDistance = segmentProgressDistanceRef.current + speed;
-      const cumulativeDistances = waypoints.reduce<number[]>(
-        (acc, waypoint, index, arr) => {
-          if (index === 0) {
-            acc.push(0);
-            return acc;
-          }
-
-          const prevWaypoint = arr[index - 1];
-          if (!prevWaypoint) {
-            return acc;
-          }
-
-          const prevDistance = acc[index - 1] ?? 0;
-          const distance = getDistance(
-            {
-              latitude: prevWaypoint.latitude as number,
-              longitude: prevWaypoint.longitude as number,
-            },
-            {
-              latitude: waypoint.latitude as number,
-              longitude: waypoint.longitude as number,
-            }
-          );
-
-          acc.push(prevDistance + distance);
-          return acc;
-        },
-        []
-      );
-
-      const segmentDistance =
-        cumulativeDistances[cumulativeDistances.length - 1];
-      if (segmentDistance == null) {
-        return;
-      }
-
-      const nextProgressDistance = Math.min(
-        progressedDistance,
-        segmentDistance
-      );
+      const nextProgressDistance = Math.min(progressedDistance, totalDistance);
       const moveDistance = Math.max(
         0,
         nextProgressDistance - segmentProgressDistanceRef.current
       );
 
-      const targetWaypointIndex = cumulativeDistances.findIndex(
-        (distance) => distance >= nextProgressDistance
-      );
-      if (targetWaypointIndex < 0) {
-        return;
+      // 累積距離は単調増加なので二分探索で targetWaypointIndex を求める。
+      // findIndex の線形走査より小さい区間でも O(log n) で済む。
+      let lo = 0;
+      let hi = cumulativeDistances.length - 1;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if ((cumulativeDistances[mid] ?? 0) >= nextProgressDistance) {
+          hi = mid;
+        } else {
+          lo = mid + 1;
+        }
       }
+      const targetWaypointIndex = lo;
 
       const targetWaypoint = waypoints[targetWaypointIndex];
       if (!targetWaypoint) {
         return;
       }
 
-      let targetLatitude = targetWaypoint.latitude as number;
-      let targetLongitude = targetWaypoint.longitude as number;
+      let targetLatitude = targetWaypoint.latitude;
+      let targetLongitude = targetWaypoint.longitude;
 
       if (targetWaypointIndex > 0) {
         const prevWaypoint = waypoints[targetWaypointIndex - 1];
@@ -387,25 +373,14 @@ export const useSimulationMode = (): void => {
         const targetDistance = cumulativeDistances[targetWaypointIndex] ?? 0;
         const distanceDelta = targetDistance - prevDistance;
 
-        if (
-          prevWaypoint &&
-          prevWaypoint.latitude != null &&
-          prevWaypoint.longitude != null &&
-          targetWaypoint.latitude != null &&
-          targetWaypoint.longitude != null &&
-          distanceDelta > 0
-        ) {
+        if (prevWaypoint && distanceDelta > 0) {
           const ratio = (nextProgressDistance - prevDistance) / distanceDelta;
           targetLatitude =
-            (prevWaypoint.latitude as number) +
-            ((targetWaypoint.latitude as number) -
-              (prevWaypoint.latitude as number)) *
-              ratio;
+            prevWaypoint.latitude +
+            (targetWaypoint.latitude - prevWaypoint.latitude) * ratio;
           targetLongitude =
-            (prevWaypoint.longitude as number) +
-            ((targetWaypoint.longitude as number) -
-              (prevWaypoint.longitude as number)) *
-              ratio;
+            prevWaypoint.longitude +
+            (targetWaypoint.longitude - prevWaypoint.longitude) * ratio;
         }
       }
 

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -225,11 +225,19 @@ export const useTTSText = (
   const nextStation = nextStationOrigin ?? null;
 
   // 直通時、同じGroupIDの駅が違う駅として扱われるのを防ぐ(ex. 渋谷の次は渋谷に止まります)
-  const slicedStations = Array.from(
-    new Set(slicedStationsOrigin.map((s) => s.groupId))
-  )
-    .map((gid) => slicedStationsOrigin.find((s) => s.groupId === gid))
-    .filter((s) => !!s) as Station[];
+  // 以前は new Set + find のチェーンで毎レンダー O(n²) だった。
+  // useTTSText 自体が StationState 全部の依存で頻繁に再評価されるため特に痛い。
+  const slicedStations = useMemo<Station[]>(() => {
+    const seen = new Set<number>();
+    const result: Station[] = [];
+    for (const s of slicedStationsOrigin) {
+      if (s.groupId == null) continue;
+      if (seen.has(s.groupId)) continue;
+      seen.add(s.groupId);
+      result.push(s);
+    }
+    return result;
+  }, [slicedStationsOrigin]);
 
   const afterNextStationOrigin = useAfterNextStation();
   const afterNextStation = afterNextStationOrigin;
@@ -269,15 +277,25 @@ export const useTTSText = (
 
   // JR西日本テーマ: 停車駅リストのバッチサイクル追跡
   // 進行方向上で現在の駅が何番目の停車駅かを求め、5駅ごとの境界で案内を出す
+  // O(n²) だった重複除去 (Set→find ループ) を O(n) に短縮し、停車駅探索もインライン化。
   const currentStopIndex = useMemo(() => {
     if (!station) return -1;
     const isInbound = selectedDirection === 'INBOUND';
-    const ordered = isInbound ? stations : [...stations].reverse();
-    const deduped = Array.from(new Set(ordered.map((s) => s.groupId)))
-      .map((gid) => ordered.find((s) => s.groupId === gid))
-      .filter((s) => !!s) as Station[];
-    const stops = deduped.filter((s) => !getIsPass(s));
-    return stops.findIndex((s) => s.groupId === station.groupId);
+    const total = stations.length;
+    const seen = new Set<number>();
+    let stopCount = 0;
+    for (let i = 0; i < total; i++) {
+      const s = isInbound ? stations[i] : stations[total - 1 - i];
+      if (!s || s.groupId == null) continue;
+      if (seen.has(s.groupId)) continue;
+      seen.add(s.groupId);
+      if (getIsPass(s)) continue;
+      if (s.groupId === station.groupId) {
+        return stopCount;
+      }
+      stopCount++;
+    }
+    return -1;
   }, [stations, station, selectedDirection]);
 
   const shouldAnnounceJrWestStopList = useMemo(

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -40,10 +40,14 @@ export const useTransferLinesFromStation = (
       }
     }
 
-    // 隣接駅判定で何度も使うため一度だけ findIndex する
+    // 隣接駅判定で何度も使うため一度だけ findIndex する。
+    // findIndex が -1 (= ルート外駅を渡された) の場合 stations[-1+1]=stations[0] が
+    // 「次駅」として誤って拾われるので、明示的に未検出時は undefined にする。
     const currentStationIndex = stations.findIndex((s) => s.id === station.id);
-    const prevStation = stations[currentStationIndex - 1];
-    const nextStation = stations[currentStationIndex + 1];
+    const prevStation =
+      currentStationIndex > 0 ? stations[currentStationIndex - 1] : undefined;
+    const nextStation =
+      currentStationIndex >= 0 ? stations[currentStationIndex + 1] : undefined;
     const stationLineId = station.line?.id;
     const stationLineNameNorm = stripParen(station.line?.nameShort);
 

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -11,76 +11,76 @@ type Option = {
   omitJR?: boolean;
 };
 
+const stripParen = (
+  text: string | null | undefined
+): string | null | undefined =>
+  text == null ? text : text.replace(parenthesisRegexp, '');
+
 export const useTransferLinesFromStation = (
   station: Station | undefined,
   option?: Option
 ): Line[] => {
-  const { omitRepeatingLine, omitJR } = option ?? {
-    omitRepeatingLine: false,
-    omitJR: false,
-  };
+  const omitRepeatingLine = option?.omitRepeatingLine ?? false;
+  const omitJR = option?.omitJR ?? false;
 
   const { stations } = useAtomValue(stationState);
 
   const transferLines = useMemo(() => {
+    if (!station?.lines?.length) {
+      return [];
+    }
+
     // 乗車中の列車が直通運転で通る路線一覧
     // 同じ列車に乗ったままで到達するため乗り換え対象から外す
-    const throughServiceLineIds = new Set(
-      stations.map((s) => s.line?.id).filter((id): id is number => id != null)
-    );
+    const throughServiceLineIds = new Set<number>();
+    for (const s of stations) {
+      const id = s.line?.id;
+      if (id != null) {
+        throughServiceLineIds.add(id);
+      }
+    }
 
-    return (
-      station?.lines
-        ?.filter((line) => !isBusLine(line))
-        ?.filter((line) => line.id !== station.line?.id)
-        // カッコを除いて路線名が同じということは、
-        // データ上の都合で路線が分かれているだけなので除外する
-        // ex. JR神戸線(大阪～神戸) と JR神戸線(神戸～姫路) は実質同じ路線
-        .filter(
-          (line) =>
-            line.nameShort?.replace(parenthesisRegexp, '') !==
-            station.line?.nameShort?.replace(parenthesisRegexp, '')
-        )
-        .filter((line) => {
-          const currentStationIndex = stations.findIndex(
-            (s) => s.id === station.id
-          );
-          const prevStation = stations[currentStationIndex - 1];
-          const nextStation = stations[currentStationIndex + 1];
-          if (!prevStation || !nextStation) {
-            return true;
-          }
-          const hasSameLineInPrevStationLine = prevStation.lines?.some(
-            (pl) => pl.id === line.id
-          );
-          const hasSameLineInNextStationLine = nextStation.lines?.some(
-            (nl) => nl.id === line.id
-          );
+    // 隣接駅判定で何度も使うため一度だけ findIndex する
+    const currentStationIndex = stations.findIndex((s) => s.id === station.id);
+    const prevStation = stations[currentStationIndex - 1];
+    const nextStation = stations[currentStationIndex + 1];
+    const stationLineId = station.line?.id;
+    const stationLineNameNorm = stripParen(station.line?.nameShort);
 
-          if (
-            // 次の駅から違う路線に直通している場合並走路線を乗り換え路線として出す
-            nextStation.line?.id !== station.line?.id
-          ) {
-            return true;
-          }
-          if (
-            omitRepeatingLine &&
-            hasSameLineInPrevStationLine &&
-            hasSameLineInNextStationLine
-          ) {
-            return false;
-          }
-          return true;
-        })
-        // 乗車中の列車が直通運転で通る路線は同じ列車のまま到達できるので
-        // 乗り換え路線として表示しない
-        .filter((line) => {
-          if (line.id == null) {
-            return true;
-          }
-          return !throughServiceLineIds.has(line.id);
-        })
-    );
+    const filtered: Line[] = [];
+    for (const line of station.lines) {
+      if (!line || isBusLine(line)) continue;
+      if (line.id === stationLineId) continue;
+      if (stripParen(line.nameShort) === stationLineNameNorm) continue;
+
+      // データ上の都合で路線が分かれているだけなので除外する
+      // ex. JR神戸線(大阪～神戸) と JR神戸線(神戸～姫路) は実質同じ路線
+
+      // 並走路線の判定
+      if (prevStation && nextStation) {
+        const inPrev = prevStation.lines?.some((pl) => pl.id === line.id);
+        const inNext = nextStation.lines?.some((nl) => nl.id === line.id);
+        if (
+          // 次の駅から違う路線に直通している場合並走路線を乗り換え路線として出す
+          nextStation.line?.id === stationLineId &&
+          omitRepeatingLine &&
+          inPrev &&
+          inNext
+        ) {
+          continue;
+        }
+      }
+
+      // 乗車中の列車が直通運転で通る路線は同じ列車のまま到達できるので
+      // 乗り換え路線として表示しない
+      if (line.id != null && throughServiceLineIds.has(line.id)) {
+        continue;
+      }
+
+      filtered.push(line);
+    }
+
+    return filtered;
   }, [
     omitRepeatingLine,
     station?.id,
@@ -90,21 +90,22 @@ export const useTransferLinesFromStation = (
     stations,
   ]);
 
-  if (omitJR) {
-    return omitJRLinesIfThresholdExceeded(transferLines ?? [])
-      .map((l) => ({
+  // 乗り換え路線名から括弧を除去した形に正規化する。
+  // 以前は無意味な `.map((l) => l)` チェーンが含まれていたため整理した。
+  return useMemo(() => {
+    const base = omitJR
+      ? omitJRLinesIfThresholdExceeded(transferLines)
+      : transferLines;
+    if (base.length === 0) return base;
+    const result = new Array<Line>(base.length);
+    for (let i = 0; i < base.length; i++) {
+      const l = base[i];
+      result[i] = {
         ...l,
-        nameShort: l.nameShort?.replace(parenthesisRegexp, ''),
-        nameRoman: l.nameRoman?.replace(parenthesisRegexp, ''),
-      }))
-      .map((l) => l);
-  }
-
-  return (transferLines ?? [])
-    .map((l) => ({
-      ...l,
-      nameShort: l.nameShort?.replace(parenthesisRegexp, ''),
-      nameRoman: l.nameRoman?.replace(parenthesisRegexp, ''),
-    }))
-    .map((l) => l);
+        nameShort: stripParen(l.nameShort) ?? l.nameShort,
+        nameRoman: stripParen(l.nameRoman) ?? l.nameRoman,
+      };
+    }
+    return result;
+  }, [transferLines, omitJR]);
 };

--- a/src/hooks/useTransitionHeaderState.ts
+++ b/src/hooks/useTransitionHeaderState.ts
@@ -226,6 +226,18 @@ export const useTransitionHeaderState = (): void => {
     }));
   }, [enabledLanguages, headerState, isJapaneseEnabled, setNavigation]);
 
+  // 同一の headerState を毎秒書き込むと「内容は変わらないが新オブジェクト」が
+  // navigationState に流れ、jotai の購読者すべてが再描画される。
+  // このヘルパーで「変化があった時だけ」更新するようにする。
+  const setHeaderStateIfChanged = useCallback(
+    (next: HeaderTransitionState) => {
+      setNavigation((prev) =>
+        prev.headerState === next ? prev : { ...prev, headerState: next }
+      );
+    },
+    [setNavigation]
+  );
+
   useInterval(
     useCallback(() => {
       if (!selectedBound) {
@@ -254,58 +266,42 @@ export const useTransitionHeaderState = (): void => {
           switch (currentHeaderStateLang) {
             case 'JA':
               if (!isJapaneseEnabled) {
-                if (!nextLang) {
-                  setNavigation((prev) => ({
-                    ...prev,
-                    headerState: 'ARRIVING',
-                  }));
-                  break;
-                }
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: toHeaderTransitionState('ARRIVING', nextLang),
-                }));
+                setHeaderStateIfChanged(
+                  nextLang
+                    ? toHeaderTransitionState('ARRIVING', nextLang)
+                    : 'ARRIVING'
+                );
                 break;
               }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: 'ARRIVING_KANA',
-              }));
+              setHeaderStateIfChanged('ARRIVING_KANA');
               break;
             default:
-              if (!nextLang) {
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: isJapaneseEnabled
+              setHeaderStateIfChanged(
+                nextLang
+                  ? toHeaderTransitionState('ARRIVING', nextLang)
+                  : isJapaneseEnabled
                     ? 'ARRIVING'
                     : getFallbackStateWithoutJapanese(
                         'ARRIVING',
                         currentHeaderStateLang,
                         enabledLanguages
-                      ),
-                }));
-                break;
-              }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: toHeaderTransitionState('ARRIVING', nextLang),
-              }));
+                      )
+              );
               break;
           }
           break;
         }
         case 'CURRENT': {
           if (showNextExpression) {
-            setNavigation((prev) => ({
-              ...prev,
-              headerState: isJapaneseEnabled
+            setHeaderStateIfChanged(
+              isJapaneseEnabled
                 ? 'NEXT'
                 : getFallbackStateWithoutJapanese(
                     'NEXT',
                     currentHeaderStateLang,
                     enabledLanguages
-                  ),
-            }));
+                  )
+            );
             break;
           }
           switch (currentHeaderStateLang) {
@@ -314,49 +310,34 @@ export const useTransitionHeaderState = (): void => {
                 if (isPassing) {
                   break;
                 }
-                if (!nextLang) {
-                  setNavigation((prev) => ({
-                    ...prev,
-                    headerState: getFallbackStateWithoutJapanese(
-                      'CURRENT',
-                      currentHeaderStateLang,
-                      enabledLanguages
-                    ),
-                  }));
-                  break;
-                }
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: toHeaderTransitionState('CURRENT', nextLang),
-                }));
+                setHeaderStateIfChanged(
+                  nextLang
+                    ? toHeaderTransitionState('CURRENT', nextLang)
+                    : getFallbackStateWithoutJapanese(
+                        'CURRENT',
+                        currentHeaderStateLang,
+                        enabledLanguages
+                      )
+                );
                 break;
               }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: 'CURRENT_KANA',
-              }));
+              setHeaderStateIfChanged('CURRENT_KANA');
               break;
             default:
               if (isPassing) {
                 break;
               }
-              if (!nextLang) {
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: isJapaneseEnabled
+              setHeaderStateIfChanged(
+                nextLang
+                  ? toHeaderTransitionState('CURRENT', nextLang)
+                  : isJapaneseEnabled
                     ? 'CURRENT'
                     : getFallbackStateWithoutJapanese(
                         'CURRENT',
                         currentHeaderStateLang,
                         enabledLanguages
-                      ),
-                }));
-                break;
-              }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: toHeaderTransitionState('CURRENT', nextLang),
-              }));
+                      )
+              );
               break;
           }
           break;
@@ -365,46 +346,31 @@ export const useTransitionHeaderState = (): void => {
           switch (currentHeaderStateLang) {
             case 'JA':
               if (!isJapaneseEnabled) {
-                if (!nextLang) {
-                  setNavigation((prev) => ({
-                    ...prev,
-                    headerState: getFallbackStateWithoutJapanese(
-                      'NEXT',
-                      currentHeaderStateLang,
-                      enabledLanguages
-                    ),
-                  }));
-                  break;
-                }
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: toHeaderTransitionState('NEXT', nextLang),
-                }));
+                setHeaderStateIfChanged(
+                  nextLang
+                    ? toHeaderTransitionState('NEXT', nextLang)
+                    : getFallbackStateWithoutJapanese(
+                        'NEXT',
+                        currentHeaderStateLang,
+                        enabledLanguages
+                      )
+                );
                 break;
               }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: 'NEXT_KANA',
-              }));
+              setHeaderStateIfChanged('NEXT_KANA');
               break;
             default:
-              if (!nextLang) {
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: isJapaneseEnabled
+              setHeaderStateIfChanged(
+                nextLang
+                  ? toHeaderTransitionState('NEXT', nextLang)
+                  : isJapaneseEnabled
                     ? 'NEXT'
                     : getFallbackStateWithoutJapanese(
                         'NEXT',
                         currentHeaderStateLang,
                         enabledLanguages
-                      ),
-                }));
-                break;
-              }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: toHeaderTransitionState('NEXT', nextLang),
-              }));
+                      )
+              );
               break;
           }
           break;
@@ -418,62 +384,47 @@ export const useTransitionHeaderState = (): void => {
           case 'CURRENT':
           case 'NEXT':
             if (nextStation) {
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: isJapaneseEnabled
+              setHeaderStateIfChanged(
+                isJapaneseEnabled
                   ? 'ARRIVING'
                   : getFallbackStateWithoutJapanese(
                       'ARRIVING',
                       currentHeaderStateLang,
                       enabledLanguages
-                    ),
-              }));
+                    )
+              );
             }
             break;
           case 'ARRIVING': {
+            const canUseNextLang =
+              nextLang && (nextLang === 'EN' || isExtraLangAvailable);
             if (currentHeaderStateLang === 'JA') {
               if (!isJapaneseEnabled) {
-                if (!nextLang || (nextLang !== 'EN' && !isExtraLangAvailable)) {
-                  setNavigation((prev) => ({
-                    ...prev,
-                    headerState: getFallbackStateWithoutJapanese(
-                      'ARRIVING',
-                      currentHeaderStateLang,
-                      enabledLanguages
-                    ),
-                  }));
-                  break;
-                }
-                setNavigation((prev) => ({
-                  ...prev,
-                  headerState: toHeaderTransitionState('ARRIVING', nextLang),
-                }));
+                setHeaderStateIfChanged(
+                  canUseNextLang
+                    ? toHeaderTransitionState('ARRIVING', nextLang)
+                    : getFallbackStateWithoutJapanese(
+                        'ARRIVING',
+                        currentHeaderStateLang,
+                        enabledLanguages
+                      )
+                );
                 break;
               }
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: 'ARRIVING_KANA',
-              }));
+              setHeaderStateIfChanged('ARRIVING_KANA');
               break;
             }
-
-            if (!nextLang || (nextLang !== 'EN' && !isExtraLangAvailable)) {
-              setNavigation((prev) => ({
-                ...prev,
-                headerState: isJapaneseEnabled
+            setHeaderStateIfChanged(
+              canUseNextLang
+                ? toHeaderTransitionState('ARRIVING', nextLang)
+                : isJapaneseEnabled
                   ? 'ARRIVING'
                   : getFallbackStateWithoutJapanese(
                       'ARRIVING',
                       currentHeaderStateLang,
                       enabledLanguages
-                    ),
-              }));
-              break;
-            }
-            setNavigation((prev) => ({
-              ...prev,
-              headerState: toHeaderTransitionState('ARRIVING', nextLang),
-            }));
+                    )
+            );
             break;
           }
           default:
@@ -489,7 +440,7 @@ export const useTransitionHeaderState = (): void => {
       isPassing,
       nextStation,
       selectedBound,
-      setNavigation,
+      setHeaderStateIfChanged,
       showNextExpression,
       station,
     ]),

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -66,13 +66,17 @@ export const useUpdateBottomState = () => {
         default:
           break;
       }
+      // ref オブジェクト自体は安定なので deps はコンパクトにする。
+      // 以前は `xxxRef.current` を deps に入れていたが lint 違反のうえ、
+      // ref の current は React のレンダリング・サイクルでは追跡されず、
+      // 結果として callback identity が不必要に揺れて useInterval を再生成していた。
     }, [
       bottomStateRef,
       isTypeWillChangeRef,
+      isLEDThemeRef,
+      shouldHideTypeChangeRef,
       setNavigation,
       transferLines.length,
-      isLEDThemeRef.current,
-      shouldHideTypeChangeRef.current,
     ]),
     bottomTransitionInterval
   );

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -187,17 +187,24 @@ const MainScreen: React.FC = () => {
     ) {
       return false;
     }
-    if (selectedDirection === 'INBOUND') {
-      return leftStations
-        .slice(0, 8)
-        .some((ls) => ls.id === stations[stations.length - 1]?.id);
+    // INBOUND は最終駅、OUTBOUND は始発駅が終点。
+    // 以前は OUTBOUND 側で stations.slice().reverse()[length-1] と書いていたが、
+    // これは単に stations[0] と等価なので reverse 全配列コピーは丸ごと無駄だった。
+    const terminusId =
+      selectedDirection === 'INBOUND'
+        ? stations[stations.length - 1]?.id
+        : stations[0]?.id;
+    if (terminusId == null) {
+      return false;
     }
 
-    return leftStations
-      .slice(0, 8)
-      .some(
-        (ls) => ls.id === stations.slice().reverse()[stations.length - 1]?.id
-      );
+    const limit = Math.min(8, leftStations.length);
+    for (let i = 0; i < limit; i++) {
+      if (leftStations[i]?.id === terminusId) {
+        return true;
+      }
+    }
+    return false;
   }, [
     currentLine,
     isYamanoteLine,

--- a/src/utils/isPass.ts
+++ b/src/utils/isPass.ts
@@ -1,16 +1,17 @@
-import memoize from 'lodash/memoize';
 import { type Station, StopCondition } from '~/@types/graphql';
 import { getIsHoliday } from './isHoliday';
 
-const getIsPass = memoize((station: Station | undefined): boolean =>
-  getIsPassFromStopCondition(station?.stopCondition)
-);
+// NOTE: 以前 lodash.memoize で Station オブジェクトを キャッシュキーにしていたが、
+//   1) Station の参照が常に新しくなるため LRU 無しのキャッシュが無限に膨張する
+//   2) 祝日/平日判定が初回呼び出し時点に固定され、日付跨ぎでステイル化する
+// という致命的な問題があった。中身は単純な enum スイッチで memoize 自体のコストの方が
+// 高いため、素直に毎回計算する。
+const getIsPass = (station: Station | undefined): boolean =>
+  getIsPassFromStopCondition(station?.stopCondition);
 
 export const getIsPassFromStopCondition = (
   stopCondition: StopCondition | undefined | null
 ) => {
-  const isHoliday = getIsHoliday(new Date());
-
   switch (stopCondition) {
     case StopCondition.All:
     case StopCondition.PartialStop: // 一部停車は一旦停車扱い
@@ -20,9 +21,9 @@ export const getIsPassFromStopCondition = (
       return true;
     case StopCondition.Weekday:
       // 若干分かりづらい感じはするけど休日に飛ばすという意味
-      return isHoliday;
+      return getIsHoliday(new Date());
     case StopCondition.Holiday:
-      return !isHoliday;
+      return !getIsHoliday(new Date());
     default:
       return false;
   }


### PR DESCRIPTION
## 概要

駅情報表示の主要ホットパスに残っていた O(n²) 走査・冗長な配列複製・`getIsPass` のメモ化リーク等を一括で見直し、レンダリング時と毎秒の状態更新時の CPU/メモリ負荷を下げる。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 致命的バグ修正

- `src/utils/isPass.ts`: `lodash.memoize` を撤去。Station オブジェクト参照をキャッシュキーにしていたため (1) ルート切替・スクロール毎にキャッシュが無限肥大しメモリリーク、(2) `getIsHoliday(new Date())` が memo エントリ生成時刻に固定され、日付跨ぎでステイル化していた。中身は単なる enum スイッチで memoize 自体の方が高コスト。

### 毎秒/毎ティック呼ばれるホットパス

- `src/hooks/useSimulationMode.ts`: シミュレーションの `step()` が毎秒、区間 waypoints の `getDistance` を `reduce` で再計算していた。区間ごとの `(waypoints, cumulativeDistances, totalDistance)` を `useEffect` で 1 度だけ構築してキャッシュ。区間内の対象 waypoint 探索を `findIndex`(O(n)) → 二分探索(O(log n)) に。
- `src/hooks/useTransitionHeaderState.ts`: 1 秒毎に `setNavigation((prev) => ({ ...prev, headerState: X }))` を毎回呼び、同値でも新オブジェクトが流れて全購読者が再描画されていた。`setHeaderStateIfChanged` ヘルパで「値が変わった時だけ更新」に統一。
- `src/hooks/useUpdateBottomState.ts`: `useCallback` の deps に `xxxRef.current` を渡していて lint 違反かつコールバック識別子が不必要に揺れて `useInterval` が再生成されていた。`xxxRef` オブジェクト自体に統一。

### 配列の再スキャン・複製削減

- `src/hooks/useNextStation.ts`: `stations.slice().reverse()` を毎レンダー 2〜4 回 → メモ化した 1 回に集約。多重 `findIndex` も 1 パスへ。
- `src/hooks/useCurrentStation.ts`: `withTrainTypeStation` を要求された時だけ計算する遅延化、`stations.slice().reverse()` をループインデックス変換で消去。
- `src/hooks/useCurrentLine.ts`: `stations.slice().reverse()` を方向別ループで代替。
- `src/hooks/useLoopLine.ts`: `[...A, ...B].filter()` を `(currentIdx + step) % total` の単一パスに、reverse 自体も memoize。
- `src/hooks/useConnectedLines.ts`: `belongLines.slice().reverse()[i]` を要素毎に呼ぶ O(n²) を、reverse 一度キャッシュの O(n) に修正。
- `src/hooks/useTTSText.ts` / `src/hooks/useAfterNextStation.ts`: `Array.from(new Set(...)).map(gid => find(...))` の重複除去 O(n²) を `Map`/`Set` 単一パスの O(n) に置換。`useTTSText` は station/navigation 全依存で頻繁に再評価されるため特に効きやすい。
- `src/hooks/useTransferLinesFromStation.ts`: チェーンされた `.filter().filter().filter().map(l => ({...l, ...}))` を 1 ループに集約し、no-op の `.map((l) => l)` 2 箇所を削除。`stations.findIndex` の重複も 1 回に。

### LineBoard / Header レンダリング

- `src/screens/Main.tsx`: `hasTerminus` 計算で OUTBOUND 時の `stations.slice().reverse()[stations.length - 1]` を `stations[0]` に置換（同値）。leftStations の走査も `for` で短絡。
- `src/components/LineBoard.tsx`: `slicedLeftStations` を `isBus=false` の場合はオブジェクト複製せず元配列をそのまま参照。下流の `React.memo` 効きやすさを向上（とくに山手線 iPad テーマでアニメ再走を抑止）。
- `src/components/LineBoardEast.tsx`: `stationNameCellForMap` 内で 8 セル毎に `[...stations, ...Array.from({length: 8 - stations.length})]` を再生成していたのを廃止。`isLast` は単純比較に。
- `src/components/PadArch.tsx`: 1 駅あたり 3 回呼ばれていた `getIsPass(s)` を 1 回に集約。
- `src/components/LineBoard{East,E231,JRKyushu,Saikyo,Toei}.tsx`: `passed={getIsPass(station) || shouldGrayscale}` の `||` 第 1 項は `shouldGrayscale` に既に含まれており冗長。`passed={shouldGrayscale}` に整理。

### リグレッション影響

- 既存 1,399 テストすべてパス。
- 型・lint チェックいずれも変更前後で同水準（lint の format エラーは事前 CRLF 起因 10 件で本 PR 範囲外）。
- `useSimulationMode` は座標欠けがある中間駅の扱いを `getPathLength` 互換のスキップ動作に統一済み。
- `useNextStation` のループ線分岐は元仕様通り (INBOUND→ -1 / OUTBOUND→ +1) を維持。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run typecheck`: 成功（エラーなし）。
- `TZ=UTC npx jest`: 148 suites / 1,399 tests すべて成功。
- `npx biome check ./src`: format エラーは事前 10 件のみ（本 PR が触らない `CommonCard.tsx` / `NowHeader.tsx` / `SelectBoundModal.tsx` / `Transfers.tsx` / `TransfersYamanote.tsx` / `resolveThemeForLine.ts` / `useTransferLines.ts` 等の CRLF 由来）。本 PR の触ったファイルでは新規エラーなし。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 駅表示と経路計算を複数箇所で高速化・メモリ削減（配列反転や重複処理を単一走査に置換、シミュレーションの経路キャッシュ導入）。
  * 不要なステート更新やオブジェクト再生成を抑制して描画効率を改善。

* **Bug Fixes / 振る舞い変更**
  * 駅名リストで括弧内表記を除去して表示を正規化。
  * 駅名の「通過（グレースケール）」判定を統一した計算に変更（表示上のグレースケール適用条件が変わる場合があります）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->