### PR TITLE
Clockのコロン点滅をRN標準Animatedに戻して_getAnimationTimestamp未定義クラッシュを解消

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect } from 'react';
-import { StyleSheet, type TextStyle, View, type ViewStyle } from 'react-native';
-import Animated, {
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
   Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
+  StyleSheet,
+  type TextStyle,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import { useClock } from '~/hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
@@ -36,20 +36,29 @@ const Clock = ({ style, white, bold }: Props): React.ReactElement => {
   const [hours, minutes] = useClock();
   // コロン点滅は LCD らしさを保つため必須。
   // JS スレッドで毎 500ms に setState すると Header 配下を再レンダリングしてしまうため、
-  // Reanimated で UI スレッドだけで完結させる。
-  const colonOpacity = useSharedValue(0);
+  // useNativeDriver でネイティブスレッドだけで完結させる。
+  const colonOpacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    colonOpacity.value = withRepeat(
-      withTiming(1, { duration: 500, easing: Easing.linear }),
-      -1,
-      true
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(colonOpacity, {
+          toValue: 1,
+          duration: 500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(colonOpacity, {
+          toValue: 0,
+          duration: 500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      ])
     );
+    loop.start();
+    return () => loop.stop();
   }, [colonOpacity]);
-
-  const colonAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: colonOpacity.value,
-  }));
 
   const textCustomStyle: TextStyle = {
     color: white ? 'white' : '#3a3a3a',
@@ -62,7 +71,7 @@ const Clock = ({ style, white, bold }: Props): React.ReactElement => {
         {hours}
       </Typography>
       <AnimatedTypography
-        style={[styles.clockItem, textCustomStyle, colonAnimatedStyle]}
+        style={[styles.clockItem, textCustomStyle, { opacity: colonOpacity }]}
       >
         :
       </AnimatedTypography>

--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import {
   Animated,
-  Easing,
   StyleSheet,
   type TextStyle,
   View,
@@ -37,21 +36,21 @@ const Clock = ({ style, white, bold }: Props): React.ReactElement => {
   // コロン点滅は LCD らしさを保つため必須。
   // JS スレッドで毎 500ms に setState すると Header 配下を再レンダリングしてしまうため、
   // useNativeDriver でネイティブスレッドだけで完結させる。
-  const colonOpacity = useRef(new Animated.Value(0)).current;
+  const colonOpacity = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
     const loop = Animated.loop(
       Animated.sequence([
         Animated.timing(colonOpacity, {
-          toValue: 1,
-          duration: 500,
-          easing: Easing.linear,
+          toValue: 0,
+          duration: 0,
+          delay: 500,
           useNativeDriver: true,
         }),
         Animated.timing(colonOpacity, {
-          toValue: 0,
-          duration: 500,
-          easing: Easing.linear,
+          toValue: 1,
+          duration: 0,
+          delay: 500,
           useNativeDriver: true,
         }),
       ])


### PR DESCRIPTION
## 概要

埼京線テーマ・山手線テーマ・JOテーマ・JLテーマで `[TypeError: global._getAnimationTimestamp is not a function (it is undefined)]` が発生してクラッシュしていた問題を、`Clock` のコロン点滅アニメーションを React Native 標準の `Animated` に戻すことで解消する。あわせて、コロンの点滅を LCD 風のステップ点滅（duration 0 + delay 500ms）に変更してフェードを廃止する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/Clock.tsx` のコロン点滅を `react-native-reanimated` の `withRepeat(withTiming(...))` から RN 標準 `Animated.loop(Animated.sequence([...]))` + `useNativeDriver: true` に置き換え
- `useSharedValue` / `useAnimatedStyle` を撤去し、`useRef(new Animated.Value(1))` と通常の `style={{ opacity: ... }}` に戻す
- `Animated.createAnimatedComponent(Typography)` のラッパー名 `AnimatedTypography` は維持し、ベース実装のみ Reanimated → RN に切り替え
- 点滅を 1 秒周期のフェードから 500ms ごとのステップ点滅（`Animated.timing` を `duration: 0` / `delay: 500` で利用）に変更し、LCD らしい挙動に近づける（`Easing` のインポートも撤去）

### 背景・原因

- #5880 で Header の再レンダリング抑制のため `Clock` を Reanimated 4 化した
- Reanimated 4 が呼び出す `global._getAnimationTimestamp()` は **UI ランタイムにのみ** インストールされるバインディング (`Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp`)
- 何らかの経路で `valueSetter` 等が JS ランタイム側で評価されると `undefined` になりクラッシュする
- `Clock` を描画しているのは `HeaderSaikyo` / `HeaderE235` / `HeaderJL` のみのため、SAIKYO・YAMANOTE・JO・JL テーマでのみクラッシュしていた
- `useNativeDriver: true` の RN 標準 `Animated` でも JS スレッドを介さずネイティブスレッドだけで opacity をアニメーションできるため、#5880 の本来の目的（JS 再レンダー抑制）は維持できる

### 影響範囲

- Header 系コンポーネント 3 つ（`HeaderSaikyo`, `HeaderE235`, `HeaderJL`）配下の時計表示のみ
- 他のテーマ（東京メトロ・都営・東急・小田急・JR西日本・JR九州・LED・E231）は `Clock` を使っておらず影響なし

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実機確認:

- 埼京線テーマ・山手線テーマでクラッシュしないこと、コロンが 1 秒周期でステップ点滅することを実機で確認する想定（リリース前にレビューア側で再現確認を依頼）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
