### PR TITLE
TrainTypeBoxで\nを含む種別の2行目が表示されない不具合を修正

### DIFF
--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -281,6 +281,17 @@ const TrainTypeBox: React.FC<Props> = ({
     [prevTrainTypeName]
   );
 
+  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
+  const baseFontSize = (isTablet ? 18 * 1.5 : 18) * fontSizeScale;
+  const computedFontSize =
+    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const computedLineHeight =
+    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
+  const prevComputedFontSize =
+    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const prevComputedLineHeight =
+    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+
   return (
     <View>
       <View style={styles.box}>
@@ -321,7 +332,8 @@ const TrainTypeBox: React.FC<Props> = ({
                 {
                   letterSpacing,
                   marginLeft,
-                  fontSize: (isTablet ? 18 * 1.5 : 18) * fontSizeScale,
+                  fontSize: computedFontSize,
+                  lineHeight: computedLineHeight,
                 },
               ],
             ]}
@@ -341,7 +353,8 @@ const TrainTypeBox: React.FC<Props> = ({
             {
               letterSpacing: prevLetterSpacing,
               marginLeft: prevMarginLeft,
-              fontSize: (isTablet ? 18 * 1.5 : 18) * fontSizeScale,
+              fontSize: prevComputedFontSize,
+              lineHeight: prevComputedLineHeight,
             },
           ]}
           adjustsFontSizeToFit

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -29,6 +29,7 @@ import navigationState from '../store/atoms/navigation';
 import { themeAtom } from '../store/atoms/theme';
 import tuningState from '../store/atoms/tuning';
 import { translate } from '../translation';
+import { computeTwoLineTypography } from '../utils/computeTwoLineTypography';
 import isTablet from '../utils/isTablet';
 import { isBusLine } from '../utils/line';
 import truncateTrainType from '../utils/truncateTrainType';
@@ -281,16 +282,18 @@ const TrainTypeBox: React.FC<Props> = ({
     [prevTrainTypeName]
   );
 
-  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
-  const baseFontSize = (isTablet ? 18 * 1.5 : 18) * fontSizeScale;
-  const computedFontSize =
-    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const computedLineHeight =
-    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
-  const prevComputedFontSize =
-    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const prevComputedLineHeight =
-    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+  const {
+    fontSize: computedFontSize,
+    lineHeight: computedLineHeight,
+    prevFontSize: prevComputedFontSize,
+    prevLineHeight: prevComputedLineHeight,
+  } = computeTwoLineTypography({
+    baseFontSize: 18,
+    isTablet,
+    fontSizeScale,
+    numberOfLines,
+    prevNumberOfLines,
+  });
 
   return (
     <View>

--- a/src/components/TrainTypeBoxJRKyushu.tsx
+++ b/src/components/TrainTypeBoxJRKyushu.tsx
@@ -21,6 +21,7 @@ import navigationState from '../store/atoms/navigation';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import tuningState from '../store/atoms/tuning';
 import { translate } from '../translation';
+import { computeTwoLineTypography } from '../utils/computeTwoLineTypography';
 import isTablet from '../utils/isTablet';
 import { isBusLine } from '../utils/line';
 import truncateTrainType from '../utils/truncateTrainType';
@@ -218,16 +219,17 @@ const TrainTypeBoxJRKyushu: React.FC<Props> = ({ trainType }: Props) => {
     [prevTrainTypeName]
   );
 
-  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
-  const baseFontSize = isTablet ? 21 * 1.5 : 21;
-  const computedFontSize =
-    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const computedLineHeight =
-    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
-  const prevComputedFontSize =
-    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const prevComputedLineHeight =
-    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+  const {
+    fontSize: computedFontSize,
+    lineHeight: computedLineHeight,
+    prevFontSize: prevComputedFontSize,
+    prevLineHeight: prevComputedLineHeight,
+  } = computeTwoLineTypography({
+    baseFontSize: 21,
+    isTablet,
+    numberOfLines,
+    prevNumberOfLines,
+  });
 
   return (
     <View>

--- a/src/components/TrainTypeBoxJRKyushu.tsx
+++ b/src/components/TrainTypeBoxJRKyushu.tsx
@@ -218,6 +218,17 @@ const TrainTypeBoxJRKyushu: React.FC<Props> = ({ trainType }: Props) => {
     [prevTrainTypeName]
   );
 
+  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
+  const baseFontSize = isTablet ? 21 * 1.5 : 21;
+  const computedFontSize =
+    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const computedLineHeight =
+    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
+  const prevComputedFontSize =
+    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const prevComputedLineHeight =
+    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+
   return (
     <View>
       <View style={styles.box}>
@@ -231,6 +242,8 @@ const TrainTypeBoxJRKyushu: React.FC<Props> = ({ trainType }: Props) => {
               {
                 letterSpacing,
                 marginLeft,
+                fontSize: computedFontSize,
+                lineHeight: computedLineHeight,
               },
             ]}
             adjustsFontSizeToFit
@@ -249,6 +262,8 @@ const TrainTypeBoxJRKyushu: React.FC<Props> = ({ trainType }: Props) => {
             {
               letterSpacing: prevLetterSpacing,
               marginLeft: prevMarginLeft,
+              fontSize: prevComputedFontSize,
+              lineHeight: prevComputedLineHeight,
             },
           ]}
           adjustsFontSizeToFit

--- a/src/components/TrainTypeBoxSaikyo.tsx
+++ b/src/components/TrainTypeBoxSaikyo.tsx
@@ -249,6 +249,17 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
     [prevTrainTypeText]
   );
 
+  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
+  const baseFontSize = isTablet ? 18 * 1.5 : 18;
+  const computedFontSize =
+    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const computedLineHeight =
+    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
+  const prevComputedFontSize =
+    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
+  const prevComputedLineHeight =
+    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+
   return (
     <View style={styles.root}>
       <View style={styles.container}>
@@ -283,6 +294,8 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
               {
                 paddingLeft,
                 letterSpacing,
+                fontSize: computedFontSize,
+                lineHeight: computedLineHeight,
               },
             ]}
           >
@@ -301,6 +314,8 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
               {
                 paddingLeft: prevPaddingLeft,
                 letterSpacing: prevLetterSpacing,
+                fontSize: prevComputedFontSize,
+                lineHeight: prevComputedLineHeight,
               },
             ]}
           >

--- a/src/components/TrainTypeBoxSaikyo.tsx
+++ b/src/components/TrainTypeBoxSaikyo.tsx
@@ -22,6 +22,7 @@ import navigationState from '~/store/atoms/navigation';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
+import { computeTwoLineTypography } from '~/utils/computeTwoLineTypography';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
 import { getIsLocal, getIsRapid } from '~/utils/trainTypeString';
@@ -249,16 +250,17 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
     [prevTrainTypeText]
   );
 
-  // 2行になる場合は箱の高さに収まるようフォントサイズを縮め、行間も詰める
-  const baseFontSize = isTablet ? 18 * 1.5 : 18;
-  const computedFontSize =
-    numberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const computedLineHeight =
-    numberOfLines === 2 ? computedFontSize * 1.05 : undefined;
-  const prevComputedFontSize =
-    prevNumberOfLines === 2 ? baseFontSize * 0.7 : baseFontSize;
-  const prevComputedLineHeight =
-    prevNumberOfLines === 2 ? prevComputedFontSize * 1.05 : undefined;
+  const {
+    fontSize: computedFontSize,
+    lineHeight: computedLineHeight,
+    prevFontSize: prevComputedFontSize,
+    prevLineHeight: prevComputedLineHeight,
+  } = computeTwoLineTypography({
+    baseFontSize: 18,
+    isTablet,
+    numberOfLines,
+    prevNumberOfLines,
+  });
 
   return (
     <View style={styles.root}>

--- a/src/utils/computeTwoLineTypography.test.ts
+++ b/src/utils/computeTwoLineTypography.test.ts
@@ -1,0 +1,64 @@
+import { computeTwoLineTypography } from './computeTwoLineTypography';
+
+describe('computeTwoLineTypography', () => {
+  it('1行のときはbaseFontSizeをそのまま返し、lineHeightはundefined', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      numberOfLines: 1,
+      prevNumberOfLines: 1,
+    });
+    expect(result.fontSize).toBe(18);
+    expect(result.lineHeight).toBeUndefined();
+    expect(result.prevFontSize).toBe(18);
+    expect(result.prevLineHeight).toBeUndefined();
+  });
+
+  it('2行のときはfontSizeを0.7倍、lineHeightをfontSize×1.05に縮める', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      numberOfLines: 2,
+      prevNumberOfLines: 2,
+    });
+    expect(result.fontSize).toBeCloseTo(18 * 0.7);
+    expect(result.lineHeight).toBeCloseTo(18 * 0.7 * 1.05);
+    expect(result.prevFontSize).toBeCloseTo(18 * 0.7);
+    expect(result.prevLineHeight).toBeCloseTo(18 * 0.7 * 1.05);
+  });
+
+  it('isTablet=trueでフォントサイズを1.5倍する', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: true,
+      numberOfLines: 1,
+      prevNumberOfLines: 1,
+    });
+    expect(result.fontSize).toBe(18 * 1.5);
+  });
+
+  it('fontSizeScaleが指定されたときは効果的なベースに乗算される', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      fontSizeScale: 0.5,
+      numberOfLines: 1,
+      prevNumberOfLines: 1,
+    });
+    expect(result.fontSize).toBe(18 * 0.5);
+  });
+
+  it('currentとprevで異なるnumberOfLinesに対応する', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 21,
+      isTablet: true,
+      numberOfLines: 2,
+      prevNumberOfLines: 1,
+    });
+    const base = 21 * 1.5;
+    expect(result.fontSize).toBeCloseTo(base * 0.7);
+    expect(result.lineHeight).toBeCloseTo(base * 0.7 * 1.05);
+    expect(result.prevFontSize).toBe(base);
+    expect(result.prevLineHeight).toBeUndefined();
+  });
+});

--- a/src/utils/computeTwoLineTypography.ts
+++ b/src/utils/computeTwoLineTypography.ts
@@ -1,0 +1,54 @@
+// 改行入り種別ラベル(numberOfLines=2)が箱の高さに収まらない問題を回避するため、
+// 2行レイアウト時にフォントサイズを縮め、行間を詰めて収まるサイズへ調整する。
+// TrainTypeBox / TrainTypeBoxSaikyo / TrainTypeBoxJRKyushu で同じ計算を共有する。
+
+const TABLET_FONT_MULTIPLIER = 1.5;
+const TWO_LINE_FONT_SCALE = 0.7;
+const TWO_LINE_LINE_HEIGHT_MULTIPLIER = 1.05;
+
+export type TwoLineTypographyArgs = {
+  /** スマホ時の基準フォントサイズ。タブレット時は内部で 1.5 倍される */
+  baseFontSize: number;
+  /** Platform.select の戻り値をそのまま渡せるよう undefined を許容 (Web 等は非タブレット扱い) */
+  isTablet: boolean | undefined;
+  /** 任意の追加スケール (TrainTypeBox の fontSizeScale prop 用)。既定 1 */
+  fontSizeScale?: number;
+  numberOfLines: 1 | 2;
+  prevNumberOfLines: 1 | 2;
+};
+
+export type TwoLineTypographyResult = {
+  fontSize: number;
+  lineHeight: number | undefined;
+  prevFontSize: number;
+  prevLineHeight: number | undefined;
+};
+
+const resolve = (effectiveBase: number, lines: 1 | 2) => {
+  const fontSize =
+    lines === 2 ? effectiveBase * TWO_LINE_FONT_SCALE : effectiveBase;
+  const lineHeight =
+    lines === 2 ? fontSize * TWO_LINE_LINE_HEIGHT_MULTIPLIER : undefined;
+  return { fontSize, lineHeight };
+};
+
+export const computeTwoLineTypography = ({
+  baseFontSize,
+  isTablet,
+  fontSizeScale = 1,
+  numberOfLines,
+  prevNumberOfLines,
+}: TwoLineTypographyArgs): TwoLineTypographyResult => {
+  const effectiveBase =
+    baseFontSize * (isTablet ? TABLET_FONT_MULTIPLIER : 1) * fontSizeScale;
+
+  const current = resolve(effectiveBase, numberOfLines);
+  const prev = resolve(effectiveBase, prevNumberOfLines);
+
+  return {
+    fontSize: current.fontSize,
+    lineHeight: current.lineHeight,
+    prevFontSize: prev.fontSize,
+    prevLineHeight: prev.lineHeight,
+  };
+};


### PR DESCRIPTION
## 概要

`trainType.name` に `\n` が含まれる種別（例: `SLぐんま`）で TrainTypeBox の2行目が表示されない不具合を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `numberOfLines === 2` のときに `fontSize` を 0.7 倍へ縮小し、明示的な `lineHeight`（`fontSize × 1.05`）を指定することで、2行が確実にボックス内に収まるよう調整
- 同パターンを共有する `src/components/TrainTypeBox.tsx` / `src/components/TrainTypeBoxSaikyo.tsx` / `src/components/TrainTypeBoxJRKyushu.tsx` の3コンポーネントに一括適用

### 原因

これらの TrainTypeBox 系コンポーネントは `trainType.name` に改行が含まれる場合に `numberOfLines={2}` を渡しているが、ボックスの高さ（スマホ 30.25px / タブレット 55px）が既定の `fontSize`（18 / 27）の2行分には足りていなかった。`adjustsFontSizeToFit` も Android などでは複数行テキストを十分に縮小しないため、2行目が切れて表示されない状態だった。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---

https://claude.ai/code/session_01Kbe9BWgbPtgAKDXumy3psh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数の列車タイプラベルコンポーネントでテキストサイズとレイアウト計算を改善しました。
  * タブレットおよび異なるテキスト行数に対応した動的なサイズ調整を実装しました。

* **テスト**
  * 新しいタイポグラフィ計算ロジックに関する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->