### PR TITLE
自動テーマで川越線を埼京線テーマに割り当て

### DIFF
--- a/src/utils/resolveThemeForLine.test.ts
+++ b/src/utils/resolveThemeForLine.test.ts
@@ -57,6 +57,10 @@ describe('resolveThemeForLine', () => {
     expect(resolveThemeForLine(makeLine({ id: 11321 }))).toBe(APP_THEME.SAIKYO);
   });
 
+  it('川越線(11322)はSAIKYOを返す', () => {
+    expect(resolveThemeForLine(makeLine({ id: 11322 }))).toBe(APP_THEME.SAIKYO);
+  });
+
   it('横須賀線(11308)はJOを返す', () => {
     expect(resolveThemeForLine(makeLine({ id: 11308 }))).toBe(APP_THEME.JO);
   });

--- a/src/utils/resolveThemeForLine.ts
+++ b/src/utils/resolveThemeForLine.ts
@@ -5,6 +5,7 @@ import { APP_THEME, type AppTheme } from '~/models/Theme';
 const LINE_ID_TO_THEME: Record<number, AppTheme> = {
   [YAMANOTE_LINE_ID]: APP_THEME.YAMANOTE,
   11321: APP_THEME.SAIKYO,
+  11322: APP_THEME.SAIKYO, // 川越線（埼京線と直通）
   11308: APP_THEME.JO,
   11314: APP_THEME.JO,
   11344: APP_THEME.JL,


### PR DESCRIPTION
## 概要

自動テーマ設定時、川越線(line ID `11322`)で埼京線テーマが選択されず、フォールバックの東京メトロテーマで動作していた不具合を修正します。`resolveThemeForLine` のマッピングに川越線を追加し、埼京線(`11321`)・りんかい線(`99337`)と同様に `APP_THEME.SAIKYO` を返すようにしました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/resolveThemeForLine.ts`: `LINE_ID_TO_THEME` に `11322: APP_THEME.SAIKYO`(川越線)を追加。
- `src/utils/resolveThemeForLine.test.ts`: 川越線(11322)が `SAIKYO` を返すケースを追加。

## テスト

- [x] `npm run lint` が通ること（変更ファイルに対して `npx biome check` を実行し成功を確認。既存の他ファイルの CRLF 由来の警告は本PRの差分とは無関係）
- [x] `npm test` が通ること（`resolveThemeForLine` テスト 22 件すべてパス）
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #5906

## スクリーンショット（任意）

UI コードへの直接的な変更は無く、テーマ解決ロジックのマッピング追加のみのため割愛。