### PR TITLE
通勤快速 (CommuterRapid) 種別の表示・ナンバリング・テーマ色を追加

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -353,6 +353,7 @@ export type TrainType = {
 
 export enum TrainTypeKind {
   Branch = 'Branch',
+  CommuterRapid = 'CommuterRapid',
   Default = 'Default',
   Express = 'Express',
   HighSpeedRapid = 'HighSpeedRapid',

--- a/src/components/HeaderJRWest.test.tsx
+++ b/src/components/HeaderJRWest.test.tsx
@@ -414,6 +414,18 @@ describe('HeaderJRWest', () => {
       }).not.toThrow();
     });
 
+    it('should handle commuter rapid train type', () => {
+      const { useCurrentTrainType } = require('~/hooks');
+      useCurrentTrainType.mockReturnValue({
+        name: '通勤快速',
+        kind: TrainTypeKind.CommuterRapid,
+      });
+
+      expect(() => {
+        render(<HeaderJRWest {...createMockHeaderProps()} />);
+      }).not.toThrow();
+    });
+
     it('should handle regional rapid train type', () => {
       const { useCurrentTrainType } = require('~/hooks');
       useCurrentTrainType.mockReturnValue({

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -430,6 +430,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
         return fetchJRWLtdExpressLogo();
       case TrainTypeKind.Rapid:
       case TrainTypeKind.HighSpeedRapid:
+      case TrainTypeKind.CommuterRapid:
         return fetchJRWRapidLogo();
       default:
         return fetchJRWLocalLogo();

--- a/src/components/TrainTypeBoxE231.test.tsx
+++ b/src/components/TrainTypeBoxE231.test.tsx
@@ -1,0 +1,222 @@
+import { render } from '@testing-library/react-native';
+import type React from 'react';
+import type { TrainType } from '~/@types/graphql';
+import { TrainTypeKind } from '~/@types/graphql';
+
+// SvgのText要素を通常のText要素として扱うことで、getByTextでテキスト検証できるようにする
+jest.mock('react-native-svg', () => {
+  const _React = require('react');
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: { children?: React.ReactNode }) => (
+      <View {...(props as object)} />
+    ),
+    Svg: (props: { children?: React.ReactNode }) => (
+      <View {...(props as object)} />
+    ),
+    G: (props: { children?: React.ReactNode }) => (
+      <View {...(props as object)} />
+    ),
+    Text: ({
+      children,
+      fill,
+      ...rest
+    }: {
+      children?: React.ReactNode;
+      fill?: string;
+    }) => {
+      // strokeのみ・fill="none"の要素は描画文字としてはダブるためスキップする
+      if (fill === 'none') {
+        return null;
+      }
+      return <Text {...(rest as object)}>{children}</Text>;
+    },
+  };
+});
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(),
+  atom: jest.fn((val) => val),
+}));
+
+jest.mock('~/hooks', () => ({
+  useCurrentLine: jest.fn(() => ({
+    id: 1,
+    nameShort: 'テスト',
+    lineType: 'Normal',
+  })),
+}));
+
+jest.mock('~/store/atoms/navigation', () => ({
+  __esModule: true,
+  default: { headerStateAtom: 'headerState' },
+}));
+
+jest.mock('~/store/atoms/theme', () => ({
+  isLEDThemeAtom: { isLEDThemeAtom: 'isLEDTheme' },
+}));
+
+jest.mock('~/translation', () => ({
+  translate: jest.fn((key: string) => {
+    const dict: Record<string, string> = {
+      local: '普通',
+      localEn: 'Local',
+      localZh: '普通',
+      localKo: '보통',
+    };
+    return dict[key] ?? key;
+  }),
+}));
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+jest.mock('~/utils/rfValue', () => ({
+  RFValue: jest.fn((v: number) => v),
+}));
+
+jest.mock('~/utils/truncateTrainType', () => ({
+  __esModule: true,
+  default: jest.fn((name: string | null | undefined) => name ?? ''),
+}));
+
+jest.mock('~/utils/line', () => ({
+  isBusLine: jest.fn(() => false),
+}));
+
+import TrainTypeBoxE231 from './TrainTypeBoxE231';
+
+const baseTrainType = (overrides: Partial<TrainType> = {}): TrainType => ({
+  __typename: 'TrainType',
+  id: 1,
+  typeId: 1,
+  groupId: 1,
+  name: '通勤快速',
+  nameKatakana: 'ツウキンカイソク',
+  nameRoman: 'Commuter Rapid',
+  nameIpa: null,
+  nameRomanIpa: null,
+  nameTtsSegments: null,
+  nameChinese: '通勤快速',
+  nameKorean: '통근쾌속',
+  color: '#FF0000',
+  direction: null,
+  kind: TrainTypeKind.CommuterRapid,
+  line: null,
+  lines: null,
+  ...overrides,
+});
+
+const setHeaderLangState = (
+  state: 'CURRENT' | 'CURRENT_EN' | 'CURRENT_ZH' | 'CURRENT_KO'
+) => {
+  const { useAtomValue } = require('jotai');
+  (useAtomValue as jest.Mock).mockImplementation((atom: unknown) => {
+    if (atom === require('~/store/atoms/theme').isLEDThemeAtom) {
+      return false;
+    }
+    return { headerState: state };
+  });
+};
+
+describe('TrainTypeBoxE231 - CommuterRapid種別の表示', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('日本語表示 (CURRENT)', () => {
+    beforeEach(() => setHeaderLangState('CURRENT'));
+
+    it('4文字以下の名称はそのまま2行に分割して表示される', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231 trainType={baseTrainType({ name: '通勤快速' })} />
+      );
+      // formatCjk: 4文字 → "通勤\n快速"
+      expect(getByText('通勤')).toBeTruthy();
+      expect(getByText('快速')).toBeTruthy();
+    });
+
+    it('5文字以上の名称はkindベースの短縮名にフォールバックする', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231
+          trainType={baseTrainType({ name: '通勤快速サービス' })}
+        />
+      );
+      // SHORT_NAME_JA[CommuterRapid] = "通勤\n快速"
+      expect(getByText('通勤')).toBeTruthy();
+      expect(getByText('快速')).toBeTruthy();
+    });
+  });
+
+  describe('英語表示 (CURRENT_EN)', () => {
+    beforeEach(() => setHeaderLangState('CURRENT_EN'));
+
+    it('日本語名が「通勤快速」のときSHORT_NAME_EN経由で"Commuter\\nRapid"が表示される', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231 trainType={baseTrainType({ name: '通勤快速' })} />
+      );
+      expect(getByText('Commuter')).toBeTruthy();
+      expect(getByText('Rapid')).toBeTruthy();
+    });
+
+    it('日本語名が長くjaAbbreviated経路に入っても"Commuter\\nRapid"が表示される', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231
+          trainType={baseTrainType({ name: '通勤快速サービス' })}
+        />
+      );
+      expect(getByText('Commuter')).toBeTruthy();
+      expect(getByText('Rapid')).toBeTruthy();
+    });
+
+    it('CommuterRapid以外（Rapid）の場合は"Rapid"のみが表示される', () => {
+      const { queryByText, getByText } = render(
+        <TrainTypeBoxE231
+          trainType={baseTrainType({
+            name: 'よくわからない長い快速',
+            kind: TrainTypeKind.Rapid,
+          })}
+        />
+      );
+      expect(getByText('Rapid')).toBeTruthy();
+      expect(queryByText('Commuter')).toBeNull();
+    });
+  });
+
+  describe('中国語表示 (CURRENT_ZH)', () => {
+    beforeEach(() => setHeaderLangState('CURRENT_ZH'));
+
+    it('5文字以上の場合、SHORT_NAME_ZH[CommuterRapid]の"通勤\\n快速"が表示される', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231
+          trainType={baseTrainType({
+            name: '通勤快速サービス',
+            nameChinese: '通勤快速服务',
+          })}
+        />
+      );
+      expect(getByText('通勤')).toBeTruthy();
+      expect(getByText('快速')).toBeTruthy();
+    });
+  });
+
+  describe('韓国語表示 (CURRENT_KO)', () => {
+    beforeEach(() => setHeaderLangState('CURRENT_KO'));
+
+    it('5文字以上の場合、SHORT_NAME_KO[CommuterRapid]の"통근\\n쾌속"が表示される', () => {
+      const { getByText } = render(
+        <TrainTypeBoxE231
+          trainType={baseTrainType({
+            name: '通勤快速サービス',
+            nameKorean: '통근쾌속서비스',
+          })}
+        />
+      );
+      expect(getByText('통근')).toBeTruthy();
+      expect(getByText('쾌속')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/TrainTypeBoxE231.tsx
+++ b/src/components/TrainTypeBoxE231.tsx
@@ -58,6 +58,7 @@ const SHORT_NAME_JA: Record<string, string> = {
   [TrainTypeKind.Default]: '各駅\n停車',
   [TrainTypeKind.Branch]: '各駅\n停車',
   [TrainTypeKind.Rapid]: '快速',
+  [TrainTypeKind.CommuterRapid]: '通勤\n快速',
   [TrainTypeKind.HighSpeedRapid]: '特快',
   [TrainTypeKind.Express]: '急行',
   [TrainTypeKind.LimitedExpress]: '特急',
@@ -67,6 +68,7 @@ const SHORT_NAME_ZH: Record<string, string> = {
   [TrainTypeKind.Default]: '各站\n停车',
   [TrainTypeKind.Branch]: '各站\n停车',
   [TrainTypeKind.Rapid]: '快速',
+  [TrainTypeKind.CommuterRapid]: '通勤\n快速',
   [TrainTypeKind.HighSpeedRapid]: '特快',
   [TrainTypeKind.Express]: '急行',
   [TrainTypeKind.LimitedExpress]: '特急',
@@ -76,6 +78,7 @@ const SHORT_NAME_KO: Record<string, string> = {
   [TrainTypeKind.Default]: '각역\n정차',
   [TrainTypeKind.Branch]: '각역\n정차',
   [TrainTypeKind.Rapid]: '쾌속',
+  [TrainTypeKind.CommuterRapid]: '통근\n쾌속',
   [TrainTypeKind.HighSpeedRapid]: '특쾌',
   [TrainTypeKind.Express]: '급행',
   [TrainTypeKind.LimitedExpress]: '특급',
@@ -205,6 +208,9 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
           ) {
             return 'Exp.';
           }
+          if (trainType?.kind === TrainTypeKind.CommuterRapid) {
+            return 'Commuter\nRapid';
+          }
           if (
             trainType?.kind === TrainTypeKind.Rapid ||
             trainType?.kind === TrainTypeKind.HighSpeedRapid
@@ -223,6 +229,9 @@ const TrainTypeBoxE231: React.FC<Props> = ({ trainType }: Props) => {
           trainType?.kind === TrainTypeKind.LimitedExpress
         ) {
           return 'Exp.';
+        }
+        if (trainType?.kind === TrainTypeKind.CommuterRapid) {
+          return 'Commuter\nRapid';
         }
         if (
           trainType?.kind === TrainTypeKind.Rapid ||

--- a/src/components/TrainTypeBoxSaikyo.test.tsx
+++ b/src/components/TrainTypeBoxSaikyo.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
 import type { TrainType } from '~/@types/graphql';
+import { TrainTypeKind } from '~/@types/graphql';
 import TrainTypeBoxSaikyo from './TrainTypeBoxSaikyo';
 
 // Mock dependencies
@@ -21,6 +22,29 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('~/hooks/useLazyPrevious', () => ({
   useLazyPrevious: jest.fn((value) => value),
 }));
+
+// LinearGradientのcolors propをDOM上から取得できるようにする
+jest.mock('expo-linear-gradient', () => {
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({
+      colors,
+      children,
+      style,
+    }: {
+      colors: string[];
+      children?: React.ReactNode;
+      style?: unknown;
+    }) => (
+      <View
+        style={style as object}
+        testID={`linear-gradient:${(colors ?? []).join('|')}`}
+      >
+        {children}
+      </View>
+    ),
+  };
+});
 
 // Create a minimal test component to test the split function crash fix
 const TestSplitFunction = ({
@@ -130,6 +154,75 @@ describe('TrainTypeBoxSaikyo', () => {
       expect(() => {
         render(<TrainTypeBoxSaikyo lineColor="#000" trainType={null} />);
       }).not.toThrow();
+    });
+  });
+
+  describe('trainTypeColor (種別色) の決定', () => {
+    const buildTrainType = (kind: TrainTypeKind | null): TrainType => ({
+      ...mockTrainType,
+      color: '#abcdef',
+      kind,
+    });
+
+    // trainTypeColorはLinearGradientの2層目（最後のcolors）に
+    // `${trainTypeColor}bb` / `${trainTypeColor}ff` として渡されるため、
+    // testIDから該当色を持つLinearGradientが存在するか検証する
+    const hasGradientWithColor = (
+      queryAllByTestId: (id: RegExp) => unknown[],
+      color: string
+    ): boolean =>
+      queryAllByTestId(new RegExp(`^linear-gradient:${color}bb\\|${color}ff$`))
+        .length > 0;
+
+    it('CommuterRapidの場合、専用色 #dc143c が適用される', () => {
+      const { queryAllByTestId } = render(
+        <TrainTypeBoxSaikyo
+          lineColor="#000000"
+          trainType={buildTrainType(TrainTypeKind.CommuterRapid)}
+        />
+      );
+      expect(hasGradientWithColor(queryAllByTestId, '#dc143c')).toBe(true);
+    });
+
+    it('Rapidの場合、Rapid色 #1e8ad2 が適用される（CommuterRapidとは異なる）', () => {
+      const { queryAllByTestId } = render(
+        <TrainTypeBoxSaikyo
+          lineColor="#000000"
+          trainType={buildTrainType(TrainTypeKind.Rapid)}
+        />
+      );
+      expect(hasGradientWithColor(queryAllByTestId, '#1e8ad2')).toBe(true);
+      expect(hasGradientWithColor(queryAllByTestId, '#dc143c')).toBe(false);
+    });
+
+    it('HighSpeedRapidの場合、Rapid色 #1e8ad2 が適用される', () => {
+      const { queryAllByTestId } = render(
+        <TrainTypeBoxSaikyo
+          lineColor="#000000"
+          trainType={buildTrainType(TrainTypeKind.HighSpeedRapid)}
+        />
+      );
+      expect(hasGradientWithColor(queryAllByTestId, '#1e8ad2')).toBe(true);
+    });
+
+    it('Default (各駅停車) の場合、lineColorが適用される', () => {
+      const { queryAllByTestId } = render(
+        <TrainTypeBoxSaikyo
+          lineColor="#abcd12"
+          trainType={buildTrainType(TrainTypeKind.Default)}
+        />
+      );
+      expect(hasGradientWithColor(queryAllByTestId, '#abcd12')).toBe(true);
+    });
+
+    it('LimitedExpressなど他の種別はtrainType.colorが優先される', () => {
+      const { queryAllByTestId } = render(
+        <TrainTypeBoxSaikyo
+          lineColor="#000000"
+          trainType={buildTrainType(TrainTypeKind.LimitedExpress)}
+        />
+      );
+      expect(hasGradientWithColor(queryAllByTestId, '#abcdef')).toBe(true);
     });
   });
 });

--- a/src/components/TrainTypeBoxSaikyo.tsx
+++ b/src/components/TrainTypeBoxSaikyo.tsx
@@ -25,7 +25,11 @@ import { translate } from '~/translation';
 import { computeTwoLineTypography } from '~/utils/computeTwoLineTypography';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
-import { getIsLocal, getIsRapid } from '~/utils/trainTypeString';
+import {
+  getIsCommuterRapid,
+  getIsLocal,
+  getIsRapid,
+} from '~/utils/trainTypeString';
 import truncateTrainType from '~/utils/truncateTrainType';
 
 type Props = {
@@ -96,6 +100,9 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
   const trainTypeColor = useMemo(() => {
     if (getIsLocal(trainType)) {
       return lineColor;
+    }
+    if (getIsCommuterRapid(trainType)) {
+      return '#dc143c';
     }
     if (getIsRapid(trainType)) {
       return '#1e8ad2';

--- a/src/constants/simulationMode.ts
+++ b/src/constants/simulationMode.ts
@@ -23,6 +23,7 @@ export const TRAIN_TYPE_KIND_MAX_SPEEDS_IN_M_S: Record<
   [TrainTypeKind.Branch]: null,
   [TrainTypeKind.Default]: null,
   [TrainTypeKind.Rapid]: null,
+  [TrainTypeKind.CommuterRapid]: null,
   [TrainTypeKind.Express]: null,
   [TrainTypeKind.LimitedExpress]: 36.1111111111, // 130km/h
   [TrainTypeKind.HighSpeedRapid]: 36.1111111111, // 130km/h

--- a/src/hooks/useNumbering.test.tsx
+++ b/src/hooks/useNumbering.test.tsx
@@ -2,7 +2,8 @@ import { render, waitFor } from '@testing-library/react-native';
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { Text } from 'react-native';
-import { StopCondition } from '~/@types/graphql';
+import { StopCondition, TrainTypeKind } from '~/@types/graphql';
+import { JOBAN_LINE_IDS } from '~/constants';
 import {
   createLine,
   createStation,
@@ -243,6 +244,111 @@ describe('useNumbering', () => {
       // firstStop=trueでもpriorCurrent=falseなので、arrivedとgetIsPassの結果による
       // この場合、arrived=falseなので次駅の番号を探すが、nextStationがundefined
       expect(getByTestId('threeLetterCode').props.children).toBe('undefined');
+    });
+  });
+
+  describe('常磐線快速系統 (Joban Line rapid)', () => {
+    const jobanLineId = JOBAN_LINE_IDS[0];
+
+    const buildJobanRapidScenario = (kind: TrainTypeKind) => {
+      const stationNumbers = [
+        createStationNumber('JL', '20'),
+        createStationNumber('JJ', '07'),
+      ];
+      const currentStation = createStation(1, {
+        stationNumbers,
+        stopCondition: StopCondition.All,
+        threeLetterCode: 'UEN',
+      });
+
+      mockUseAtomValue.mockReturnValue({
+        arrived: true,
+        selectedBound: currentStation,
+      });
+      mockUseCurrentLine.mockReturnValue(createLine(jobanLineId));
+      mockUseCurrentStation.mockReturnValue(currentStation);
+      mockUseNextStation.mockReturnValue(undefined);
+      mockUseCurrentTrainType.mockReturnValue({
+        __typename: 'TrainType',
+        id: 1,
+        typeId: 1,
+        groupId: 1,
+        name: '快速系統',
+        nameKatakana: 'カイソク',
+        nameRoman: 'Rapid',
+        nameIpa: null,
+        nameRomanIpa: null,
+        nameTtsSegments: null,
+        nameChinese: null,
+        nameKorean: null,
+        color: '#000000',
+        direction: null,
+        kind,
+        line: null,
+        lines: null,
+      });
+    };
+
+    it('CommuterRapidの場合、JJプレフィックスのstationNumberを返す', async () => {
+      buildJobanRapidScenario(TrainTypeKind.CommuterRapid);
+
+      const { getByTestId } = render(<TestComponent priorCurrent={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JJ', stationNumber: '07' })
+        );
+      });
+    });
+
+    it('Rapidの場合、JJプレフィックスのstationNumberを返す（既存挙動）', async () => {
+      buildJobanRapidScenario(TrainTypeKind.Rapid);
+
+      const { getByTestId } = render(<TestComponent priorCurrent={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JJ', stationNumber: '07' })
+        );
+      });
+    });
+
+    it('HighSpeedRapidの場合、JJプレフィックスのstationNumberを返す（既存挙動）', async () => {
+      buildJobanRapidScenario(TrainTypeKind.HighSpeedRapid);
+
+      const { getByTestId } = render(<TestComponent priorCurrent={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JJ', stationNumber: '07' })
+        );
+      });
+    });
+
+    it('Defaultの場合、JJプレフィックスではなく通常のstationNumberを返す', async () => {
+      buildJobanRapidScenario(TrainTypeKind.Default);
+
+      const { getByTestId } = render(<TestComponent priorCurrent={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JL', stationNumber: '20' })
+        );
+      });
+    });
+
+    it('常磐線以外の場合、CommuterRapidでも通常のstationNumberを返す', async () => {
+      buildJobanRapidScenario(TrainTypeKind.CommuterRapid);
+      // 路線を常磐線以外で上書き
+      mockUseCurrentLine.mockReturnValue(createLine(99999));
+
+      const { getByTestId } = render(<TestComponent priorCurrent={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JL', stationNumber: '20' })
+        );
+      });
     });
   });
 

--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -52,6 +52,7 @@ export const useNumbering = (
       currentLine.id !== null &&
       JOBAN_LINE_IDS.includes(currentLine.id) &&
       (trainType?.kind === TrainTypeKind.Rapid ||
+        trainType?.kind === TrainTypeKind.CommuterRapid ||
         trainType?.kind === TrainTypeKind.HighSpeedRapid),
     [currentLine, trainType?.kind]
   );

--- a/src/utils/trainTypeString.test.ts
+++ b/src/utils/trainTypeString.test.ts
@@ -2,9 +2,11 @@ import type { TrainType } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
 import {
   findBranchLine,
+  findCommuterRapidType,
   findLocalType,
   findLtdExpType,
   findRapidType,
+  getIsCommuterRapid,
   getIsLocal,
   getIsLtdExp,
   getIsRapid,
@@ -61,6 +63,11 @@ describe('getIsLocal', () => {
     expect(getIsLocal(trainType)).toBe(false);
   });
 
+  it('kindがCommuterRapidの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.CommuterRapid);
+    expect(getIsLocal(trainType)).toBe(false);
+  });
+
   it('trainTypeがnullの場合、trueを返す（デフォルト動作）', () => {
     expect(getIsLocal(null)).toBe(true);
   });
@@ -102,6 +109,11 @@ describe('getIsRapid', () => {
     expect(getIsRapid(trainType)).toBe(false);
   });
 
+  it('kindがCommuterRapidの場合、trueを返す（CommuterRapidもRapid系として扱う）', () => {
+    const trainType = createTrainType(TrainTypeKind.CommuterRapid);
+    expect(getIsRapid(trainType)).toBe(true);
+  });
+
   it('trainTypeがnullの場合、falseを返す', () => {
     expect(getIsRapid(null)).toBe(false);
   });
@@ -109,6 +121,52 @@ describe('getIsRapid', () => {
   it('kindがnullの場合、falseを返す', () => {
     const trainType = createTrainType(null);
     expect(getIsRapid(trainType)).toBe(false);
+  });
+});
+
+describe('getIsCommuterRapid', () => {
+  it('kindがCommuterRapidの場合、trueを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.CommuterRapid);
+    expect(getIsCommuterRapid(trainType)).toBe(true);
+  });
+
+  it('kindがRapidの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.Rapid);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('kindがHighSpeedRapidの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.HighSpeedRapid);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('kindがDefaultの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.Default);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('kindがLimitedExpressの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.LimitedExpress);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('kindがExpressの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.Express);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('kindがBranchの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.Branch);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
+  });
+
+  it('trainTypeがnullの場合、falseを返す', () => {
+    expect(getIsCommuterRapid(null)).toBe(false);
+  });
+
+  it('kindがnullの場合、falseを返す', () => {
+    const trainType = createTrainType(null);
+    expect(getIsCommuterRapid(trainType)).toBe(false);
   });
 });
 
@@ -130,6 +188,11 @@ describe('getIsLtdExp', () => {
 
   it('kindがHighSpeedRapidの場合、falseを返す', () => {
     const trainType = createTrainType(TrainTypeKind.HighSpeedRapid);
+    expect(getIsLtdExp(trainType)).toBe(false);
+  });
+
+  it('kindがCommuterRapidの場合、falseを返す', () => {
+    const trainType = createTrainType(TrainTypeKind.CommuterRapid);
     expect(getIsLtdExp(trainType)).toBe(false);
   });
 
@@ -240,12 +303,57 @@ describe('findRapidType', () => {
     expect(findRapidType(trainTypes)).toBeNull();
   });
 
+  it('CommuterRapidも対象として返す（Rapid系として扱われる）', () => {
+    const localType = createTrainType(TrainTypeKind.Default);
+    const commuterRapidType = createTrainType(TrainTypeKind.CommuterRapid);
+    const trainTypes = [localType, commuterRapidType];
+    expect(findRapidType(trainTypes)).toBe(commuterRapidType);
+  });
+
   it('trainTypesがnullの場合、nullを返す', () => {
     expect(findRapidType(null)).toBeNull();
   });
 
   it('trainTypesが空配列の場合、nullを返す', () => {
     expect(findRapidType([])).toBeNull();
+  });
+});
+
+describe('findCommuterRapidType', () => {
+  it('CommuterRapid種別が見つかった場合、その種別を返す', () => {
+    const commuterRapidType = createTrainType(TrainTypeKind.CommuterRapid);
+    const localType = createTrainType(TrainTypeKind.Default);
+    const trainTypes = [localType, commuterRapidType];
+    expect(findCommuterRapidType(trainTypes)).toBe(commuterRapidType);
+  });
+
+  it('CommuterRapid種別がない場合、nullを返す（RapidやHighSpeedRapidは対象外）', () => {
+    const localType = createTrainType(TrainTypeKind.Default);
+    const rapidType = createTrainType(TrainTypeKind.Rapid);
+    const highSpeedRapidType = createTrainType(TrainTypeKind.HighSpeedRapid);
+    const trainTypes = [localType, rapidType, highSpeedRapidType];
+    expect(findCommuterRapidType(trainTypes)).toBeNull();
+  });
+
+  it('trainTypesがnullの場合、nullを返す', () => {
+    expect(findCommuterRapidType(null)).toBeNull();
+  });
+
+  it('trainTypesが空配列の場合、nullを返す', () => {
+    expect(findCommuterRapidType([])).toBeNull();
+  });
+
+  it('複数のCommuterRapid種別がある場合、最初のものを返す', () => {
+    const commuterRapidType1 = {
+      ...createTrainType(TrainTypeKind.CommuterRapid),
+      id: 1,
+    };
+    const commuterRapidType2 = {
+      ...createTrainType(TrainTypeKind.CommuterRapid),
+      id: 2,
+    };
+    const trainTypes = [commuterRapidType1, commuterRapidType2];
+    expect(findCommuterRapidType(trainTypes)).toBe(commuterRapidType1);
   });
 });
 

--- a/src/utils/trainTypeString.ts
+++ b/src/utils/trainTypeString.ts
@@ -4,7 +4,11 @@ import { type TrainType, TrainTypeKind } from '~/@types/graphql';
 export const getIsLocal = (tt: TrainType | null): boolean =>
   (tt?.kind ?? TrainTypeKind.Default) === TrainTypeKind.Default;
 export const getIsRapid = (tt: TrainType | null): boolean =>
-  tt?.kind === TrainTypeKind.Rapid || tt?.kind === TrainTypeKind.HighSpeedRapid;
+  tt?.kind === TrainTypeKind.Rapid ||
+  tt?.kind === TrainTypeKind.HighSpeedRapid ||
+  tt?.kind === TrainTypeKind.CommuterRapid;
+export const getIsCommuterRapid = (tt: TrainType | null): boolean =>
+  tt?.kind === TrainTypeKind.CommuterRapid;
 export const getIsLtdExp = (tt: TrainType | null): boolean =>
   tt?.kind === TrainTypeKind.LimitedExpress;
 
@@ -16,6 +20,9 @@ export const findBranchLine = (trainTypes: TrainType[]): TrainType | null =>
 export const findRapidType = (
   trainTypes: TrainType[] | null
 ): TrainType | null => trainTypes?.find((tt) => getIsRapid(tt)) ?? null;
+export const findCommuterRapidType = (
+  trainTypes: TrainType[] | null
+): TrainType | null => trainTypes?.find((tt) => getIsCommuterRapid(tt)) ?? null;
 export const findLtdExpType = (
   trainTypes: TrainType[] | null
 ): TrainType | null => trainTypes?.find((tt) => getIsLtdExp(tt)) ?? null;


### PR DESCRIPTION
## 概要

StationAPI 側で追加された `TrainTypeKind.CommuterRapid`（通勤快速）に MobileApp 側を追従させ、表示・ナンバリング・テーマ色などのアプリ挙動に通勤快速を組み込む。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/@types/graphql.d.ts`: `TrainTypeKind` に `CommuterRapid` を追加。
- `src/utils/trainTypeString.ts`: `getIsCommuterRapid` / `findCommuterRapidType` を追加。`getIsRapid` は `CommuterRapid` も Rapid 系として扱うように拡張。
- `src/components/HeaderJRWest.tsx`: `CommuterRapid` でも JR 西日本の Rapid ロゴを返すよう分岐を追加。
- `src/components/TrainTypeBoxE231.tsx`: 短縮名辞書（日本語・中国語・韓国語）に通勤快速を追加し、英語表示で `Commuter\nRapid` を返すよう分岐を追加。
- `src/components/TrainTypeBoxSaikyo.tsx`: 通勤快速の専用テーマ色 `#dc143c` を `getIsRapid` の前に判定して適用。
- `src/hooks/useNumbering.ts`: 常磐線で `CommuterRapid` も JJ 系統のナンバリング対象に含める。
- `src/constants/simulationMode.ts`: `TRAIN_TYPE_KIND_MAX_SPEEDS_IN_M_S[CommuterRapid] = null` を追加。
- 各種ユニットテストを追加・更新（`TrainTypeBoxE231.test.tsx` を新規追加、`getIsRapid` / `findRapidType` の期待値を新挙動に合わせて修正）。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 通勤快速（CommuterRapid）列車種別に対応しました。列車種別の表示、色設定、案内表示が正しく機能するようになります。

* **テスト**
  * 列車種別の処理に関する包括的なテストケースを追加しました。

* **その他の改善**
  * 列車種別の判定ロジックと表示ロジックを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->