### PR TITLE
useTTSText のアナウンステンプレートをミニエンジン化してリファクタリング

### DIFF
--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -1,0 +1,96 @@
+import type { Line, Station } from '../../@types/graphql';
+import katakanaToHiragana from '../../utils/kanaToHiragana';
+import { wrapPhoneme } from '../../utils/phoneme';
+
+/** 既存実装と同じ規則で sub alias を被せる。両方未指定なら 各駅停車 のフォールバック sub を返す。 */
+export const replaceJapaneseText = (
+  name: string | null | undefined,
+  nameKatakana: string | null | undefined
+): string => {
+  if (!name && !nameKatakana) {
+    return '<sub alias="かくえきていしゃ">各駅停車</sub>';
+  }
+  if (!nameKatakana) {
+    return name ?? '';
+  }
+  return `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`;
+};
+
+const replaceLineNameJa = (line: Pick<Line, 'nameShort' | 'nameKatakana'>) =>
+  replaceJapaneseText(line.nameShort, line.nameKatakana);
+
+const replaceStationNameJa = (
+  station: Pick<Station, 'name' | 'nameKatakana'>
+) => replaceJapaneseText(station.name, station.nameKatakana);
+
+/** 路線名を sub alias 付きで `、` 連結する。 */
+export const formatLinesListJa = (lines: Line[]): string =>
+  lines.map(replaceLineNameJa).join('、');
+
+/** 駅名を sub alias 付きで `、` 連結する。 */
+export const formatStationsListJa = (stations: Station[]): string =>
+  stations.map(replaceStationNameJa).join('、');
+
+/**
+ * 路線名を `the A,<break time="200ms"/> the B,<break time="200ms"/> and the C` 形式で組み立てる。
+ *
+ * 末尾ピリオドは付けない。理由:
+ * - TY / JR_KYUSHU は list を文中に埋め込む (`transfer to LIST, Please...` や `transfer to LIST at X.`) ため、
+ *   ピリオドを足すと文法が壊れる
+ * - YAMANOTE NEXT / SAIKYO NEXT / JR_KYUSHU ARRIVING は単数のときだけピリオドを落とす挙動 (※既知の不整合 #5914)
+ * - 文末で使うテーマはテンプレ側で `.` を付与する
+ */
+export const formatLinesListEn = (lines: Line[]): string => {
+  if (lines.length === 0) return '';
+  if (lines.length === 1) {
+    const l = lines[0];
+    if (!l) return '';
+    return `the ${wrapPhoneme(l.nameTtsSegments, l.nameRoman)}`;
+  }
+  const items = lines.map((l, i) => {
+    const name = wrapPhoneme(l.nameTtsSegments, l.nameRoman);
+    if (i === lines.length - 1) return `and the ${name}`;
+    return `the ${name},<break time="200ms"/>`;
+  });
+  return items.join(' ');
+};
+
+/**
+ * JR_WEST 用: `終点、X、Y、Z` 形式で先頭5駅を `、` 連結する。
+ * 終着駅 (= selectedBound) と一致する駅には `終点、` を冠する。
+ */
+export const formatJrWestStopsListJa = (
+  stops: Station[],
+  isBoundStop: (s: Station) => boolean
+): string =>
+  stops
+    .slice(0, 5)
+    .map((s) =>
+      isBoundStop(s)
+        ? `終点、${replaceStationNameJa(s)}`
+        : replaceStationNameJa(s)
+    )
+    .join('、');
+
+/**
+ * JR_WEST 用 (英語): `X, Y terminal, Z` 形式で先頭5駅を `, ` 連結する。
+ * 終着駅には末尾に ` terminal` を付与する。
+ */
+export const formatJrWestStopsListEn = (
+  stops: Station[],
+  isBoundStop: (s: Station) => boolean
+): string =>
+  stops
+    .slice(0, 5)
+    .map((s) => {
+      const name = wrapPhoneme(s.nameTtsSegments, s.nameRoman);
+      return isBoundStop(s) ? `${name} terminal` : name;
+    })
+    .join(', ');
+
+/** TY 用: 直通先1路線目のみを `on the X` 形式に整形する。該当がなければ空文字。 */
+export const formatFirstConnectedLineEnPhrase = (lines: Line[]): string => {
+  const first = lines[0];
+  if (!first?.nameTtsSegments?.length) return '';
+  return `on the ${wrapPhoneme(first.nameTtsSegments, first.nameRoman)}`;
+};

--- a/src/hooks/tts/templateEngine.test.ts
+++ b/src/hooks/tts/templateEngine.test.ts
@@ -114,5 +114,11 @@ describe('templateEngine', () => {
     test('throws on stray endif', () => {
       expect(() => compile('A{/if}B')).toThrow(/\/if/);
     });
+
+    test('throws on duplicate else', () => {
+      expect(() => compile('{#if x}A{:else}B{:else}C{/if}')).toThrow(
+        /Duplicate/
+      );
+    });
   });
 });

--- a/src/hooks/tts/templateEngine.test.ts
+++ b/src/hooks/tts/templateEngine.test.ts
@@ -1,0 +1,118 @@
+import { compile } from './templateEngine';
+
+describe('templateEngine', () => {
+  describe('variable substitution', () => {
+    test('inserts string variables', () => {
+      const render = compile('Hello, {name}!');
+      expect(render({ name: 'World' })).toBe('Hello, World!');
+    });
+
+    test('inserts multiple variables', () => {
+      const render = compile('{greeting}, {name}!');
+      expect(render({ greeting: 'Hi', name: 'Bob' })).toBe('Hi, Bob!');
+    });
+
+    test('treats null/undefined/false as empty', () => {
+      const render = compile('[{a}][{b}][{c}]');
+      expect(render({ a: null, b: undefined, c: false })).toBe('[][][]');
+    });
+
+    test('inserts numbers', () => {
+      const render = compile('count={n}');
+      expect(render({ n: 42 })).toBe('count=42');
+    });
+
+    test('preserves curly braces that are not valid placeholders', () => {
+      const render = compile('a{ b }c');
+      expect(render({})).toBe('a{ b }c');
+    });
+
+    test('preserves SSML tags verbatim', () => {
+      const render = compile('hello<break time="200ms"/>{name}');
+      expect(render({ name: 'X' })).toBe('hello<break time="200ms"/>X');
+    });
+  });
+
+  describe('if blocks', () => {
+    test('renders then-branch when truthy', () => {
+      const render = compile('A{#if flag}B{/if}C');
+      expect(render({ flag: true })).toBe('ABC');
+    });
+
+    test('omits then-branch when falsy', () => {
+      const render = compile('A{#if flag}B{/if}C');
+      expect(render({ flag: false })).toBe('AC');
+    });
+
+    test('treats empty string as falsy', () => {
+      const render = compile('A{#if x}Y{/if}B');
+      expect(render({ x: '' })).toBe('AB');
+    });
+
+    test('treats non-empty string as truthy', () => {
+      const render = compile('A{#if x}Y{/if}B');
+      expect(render({ x: 'hi' })).toBe('AYB');
+    });
+
+    test('treats 0 as falsy and non-zero number as truthy', () => {
+      const render = compile('{#if n}yes{/if}');
+      expect(render({ n: 0 })).toBe('');
+      expect(render({ n: 1 })).toBe('yes');
+    });
+
+    test('renders else-branch when falsy', () => {
+      const render = compile('{#if flag}T{:else}F{/if}');
+      expect(render({ flag: true })).toBe('T');
+      expect(render({ flag: false })).toBe('F');
+    });
+
+    test('supports variables inside if blocks', () => {
+      const render = compile('{#if has}value={v}{/if}');
+      expect(render({ has: true, v: 'hello' })).toBe('value=hello');
+      expect(render({ has: false, v: 'hello' })).toBe('');
+    });
+
+    test('supports nested if blocks', () => {
+      const render = compile('{#if a}A{#if b}B{/if}C{/if}');
+      expect(render({ a: true, b: true })).toBe('ABC');
+      expect(render({ a: true, b: false })).toBe('AC');
+      expect(render({ a: false, b: true })).toBe('');
+    });
+
+    test('supports nested if/else', () => {
+      const render = compile(
+        '{#if a}{#if b}AB{:else}A_{/if}{:else}{#if b}_B{:else}__{/if}{/if}'
+      );
+      expect(render({ a: true, b: true })).toBe('AB');
+      expect(render({ a: true, b: false })).toBe('A_');
+      expect(render({ a: false, b: true })).toBe('_B');
+      expect(render({ a: false, b: false })).toBe('__');
+    });
+  });
+
+  describe('whitespace preservation', () => {
+    test('keeps leading/trailing whitespace verbatim', () => {
+      const render = compile('  A  {x}  B  ');
+      expect(render({ x: 'X' })).toBe('  A  X  B  ');
+    });
+
+    test('preserves spaces around omitted if blocks', () => {
+      const render = compile('A {#if f}B {/if}C');
+      expect(render({ f: false })).toBe('A C');
+    });
+  });
+
+  describe('errors', () => {
+    test('throws on unclosed if', () => {
+      expect(() => compile('A{#if x}B')).toThrow(/Unclosed/);
+    });
+
+    test('throws on stray else', () => {
+      expect(() => compile('A{:else}B')).toThrow(/:else/);
+    });
+
+    test('throws on stray endif', () => {
+      expect(() => compile('A{/if}B')).toThrow(/\/if/);
+    });
+  });
+});

--- a/src/hooks/tts/templateEngine.ts
+++ b/src/hooks/tts/templateEngine.ts
@@ -73,6 +73,9 @@ const parse = (template: string): Node[] => {
       if (!ifNode) {
         throw new Error('{:else} outside of {#if}');
       }
+      if (ifNode.alternate !== null) {
+        throw new Error('Duplicate {:else} in {#if} block');
+      }
       ifNode.alternate = [];
       stack[stack.length - 1] = { children: ifNode.alternate, ifNode };
     } else if (tag === '{/if}') {

--- a/src/hooks/tts/templateEngine.ts
+++ b/src/hooks/tts/templateEngine.ts
@@ -1,0 +1,128 @@
+/**
+ * useTTSText 用の極小テンプレートエンジン。
+ *
+ * 構文:
+ *   {name}                     - context[name] を文字列化して挿入 (null/undefined/false は空文字)
+ *   {#if name}...{/if}         - context[name] が truthy ならブロックを展開
+ *   {#if name}...{:else}...{/if}
+ *
+ * 反復は意図的に未サポート。配列はテンプレート利用側で文字列に組み立ててから渡す。
+ *
+ * トークン書式は識別子のみで、空白や記号を含めない (`{nextStationJa}` は OK、`{ next }` は不可)。
+ * これにより SSML 内の `<break time="200ms"/>` のような波括弧を含まない記号列との衝突を回避する。
+ */
+
+export type TemplateContext = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export type TemplateRenderer = (ctx: TemplateContext) => string;
+
+type IfNode = {
+  kind: 'if';
+  cond: string;
+  consequent: Node[];
+  alternate: Node[] | null;
+};
+type Node =
+  | { kind: 'text'; text: string }
+  | { kind: 'var'; name: string }
+  | IfNode;
+
+type Frame = { children: Node[]; ifNode?: IfNode };
+
+const TAG_RE = /\{(?:#if (\w+)|:else|\/if|(\w+))\}/g;
+
+const isTruthy = (v: unknown): boolean =>
+  !(v === null || v === undefined || v === false || v === '' || v === 0);
+
+const parse = (template: string): Node[] => {
+  const root: Node[] = [];
+  const stack: Frame[] = [{ children: root }];
+  let lastIndex = 0;
+
+  TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = TAG_RE.exec(template);
+  while (m !== null) {
+    const top = stack[stack.length - 1];
+    if (!top) throw new Error('Template parser stack underflow');
+
+    if (m.index > lastIndex) {
+      top.children.push({
+        kind: 'text',
+        text: template.slice(lastIndex, m.index),
+      });
+    }
+
+    const ifName = m[1];
+    const varName = m[2];
+    const tag = m[0];
+
+    if (ifName) {
+      const node: IfNode = {
+        kind: 'if',
+        cond: ifName,
+        consequent: [],
+        alternate: null,
+      };
+      top.children.push(node);
+      stack.push({ children: node.consequent, ifNode: node });
+    } else if (tag === '{:else}') {
+      const ifNode = top.ifNode;
+      if (!ifNode) {
+        throw new Error('{:else} outside of {#if}');
+      }
+      ifNode.alternate = [];
+      stack[stack.length - 1] = { children: ifNode.alternate, ifNode };
+    } else if (tag === '{/if}') {
+      if (stack.length <= 1) {
+        throw new Error('{/if} without matching {#if}');
+      }
+      stack.pop();
+    } else if (varName) {
+      top.children.push({ kind: 'var', name: varName });
+    }
+
+    lastIndex = TAG_RE.lastIndex;
+    m = TAG_RE.exec(template);
+  }
+
+  if (lastIndex < template.length) {
+    const top = stack[stack.length - 1];
+    if (!top) throw new Error('Template parser stack underflow');
+    top.children.push({ kind: 'text', text: template.slice(lastIndex) });
+  }
+
+  if (stack.length > 1) {
+    throw new Error('Unclosed {#if} block');
+  }
+
+  return root;
+};
+
+const renderNodes = (nodes: Node[], ctx: TemplateContext): string => {
+  let out = '';
+  for (const node of nodes) {
+    if (node.kind === 'text') {
+      out += node.text;
+    } else if (node.kind === 'var') {
+      const v = ctx[node.name];
+      if (v !== null && v !== undefined && v !== false) {
+        out += String(v);
+      }
+    } else {
+      const branch = isTruthy(ctx[node.cond])
+        ? node.consequent
+        : node.alternate;
+      if (branch) out += renderNodes(branch, ctx);
+    }
+  }
+  return out;
+};
+
+/** テンプレート文字列をコンパイルし、context を受け取って文字列を返す関数を返す。 */
+export const compile = (template: string): TemplateRenderer => {
+  const ast = parse(template);
+  return (ctx) => renderNodes(ast, ctx);
+};

--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -1,0 +1,331 @@
+import { APP_THEME, type AppTheme } from '../../models/Theme';
+import { compile, type TemplateRenderer } from './templateEngine';
+
+/** 複数行文字列を結合して compile に渡す。空白を一切挿入しないので、テンプレ内の空白は自前で書く。 */
+const t = (...parts: string[]): TemplateRenderer => compile(parts.join(''));
+
+type ThemeTemplate = { NEXT: TemplateRenderer; ARRIVING: TemplateRenderer };
+
+const TOKYO_METRO: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}',
+    '{currentLineJa}をご利用くださいまして、ありがとうございます。',
+    '次は、{nextStationJa}です。',
+    'この電車は、',
+    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
+    '{trainTypeJa}、{boundForJa}ゆきです。',
+    '{#if hasTrainTypeAndAfterNext}',
+    '{nextStationJa}の次は、',
+    '{#if isAfterNextStopTerminus}終点、{/if}',
+    '{afterNextStationJa}に停まります。',
+    '{/if}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様はお乗り換えです。{/if}',
+    '{:else}',
+    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    '{#if hasTrainTypeAndAfterNext}',
+    '{nextStationJa}の次は、',
+    '{#if isAfterNextStopTerminus}終点、{/if}',
+    '{afterNextStationJa}に停まります。',
+    '{/if}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様はお乗り換えです。{/if}',
+    '{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{nextStationJa}{#if isNextStopTerminus}終点{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    '{#if isNextStopTerminus}{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}'
+  ),
+};
+
+const TY: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}',
+    '{currentLineJa}をご利用くださいまして、ありがとうございます。',
+    'この電車は',
+    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
+    '{trainTypeJa}、{boundForJa}ゆきです。',
+    '{/if}',
+    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}をご利用のお客様はお乗り換えです。{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}をご利用のお客様はお乗り換えです。{/if}',
+    '{#if hasAfterNextStation}',
+    '{nextStationJa}を出ますと、',
+    '{#if isAfterNextStopTerminus}終点、{/if}',
+    '{afterNextStationJa}に停まります。',
+    '{/if}',
+    '{#if isNextStopTerminus} {currentLineJa}をご利用くださいまして、ありがとうございました。{/if}'
+  ),
+};
+
+const YAMANOTE: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。この電車は、{boundForJa}ゆきです。{/if}',
+    '次は、{nextStationJa}、{nextStationJa}{#if isNextStopTerminus}、終点です{/if}。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}',
+    '{transferLinesListJa}は、お乗り換えです。',
+    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{/if}'
+  ),
+};
+
+const SAIKYO: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。この電車は、{boundForJa}ゆきです。{/if}',
+    '次は、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}',
+    '{transferLinesListJa}は、お乗り換えです。',
+    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{/if}'
+  ),
+};
+
+const JR_WEST: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}',
+    '今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。',
+    'この電車は、{trainTypeJaPlain}、',
+    '{#if hasViaStation}{viaStationJa}方面、{/if}',
+    '{boundForJa}ゆきです。',
+    '{/if}',
+    '{#if shouldAnnounceJrWestStopList}',
+    '{jrWestStopsListJa}の順に停まります。',
+    '{#if lastAnnouncedStopIsBound}{:else}{lastAnnouncedStopJa}から先は、後ほどご案内いたします。{/if}',
+    '{/if}',
+    '次は、{#if nextStationIsBound}終点、{/if}{nextStationJa}、{nextStationJa}です。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}'
+  ),
+  ARRIVING: t(
+    '{#if isNextStopTerminus}',
+    'ご乗車ありがとうございました。',
+    'まもなく{nextStationJa}、{nextStationJa}です。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    '今日も{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。',
+    '{nextStationJa}、{nextStationJa}です。',
+    '{:else}',
+    'まもなく、{nextStationJa}、{nextStationJa}です。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    '{#if hasAfterNextStation}{nextStationJa}を出ますと、次は、{afterNextStationJa}に停まります。{/if}',
+    '{/if}'
+  ),
+};
+
+const TOEI: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}{currentLineJa}をご利用くださいまして、ありがとうございます。{/if}',
+    '次は、{nextStationJa}、{nextStationJa}。 ',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    'この電車は、',
+    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
+    '{trainTypeJa}、{boundForJa}ゆきです。',
+    '{#if hasTrainTypeAndAfterNext}',
+    '{nextStationJa}の次は、',
+    '{#if isAfterNextStopTerminus}終点、{/if}',
+    '{afterNextStationJa}に停まります。',
+    '{/if}',
+    '{#if hasBetweenStations}通過する、{betweenStationsListJa}へおいでの方はお乗り換えです。{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
+    '{#if hasTrainTypeAndAfterNext}',
+    '{nextStationJa}の次は、',
+    '{#if isAfterNextStopTerminus}終点、{/if}',
+    '{afterNextStationJa}に停まります。',
+    '{/if}',
+    '{#if hasBetweenStations}通過する、{betweenStationsListJa}へおいでの方はお乗り換えです。{/if}',
+    '{#if isNextStopTerminus} {currentLineJa}をご利用くださいまして、ありがとうございました。{/if}'
+  ),
+};
+
+const JR_KYUSHU: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}この列車は{trainTypeJaKyushu}、{boundForJa}行きです。{/if}',
+    '次は{#if nextStationIsBound}終点、{/if}{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}{nextStationJa}では、{transferLinesListJa}にお乗り換えいただけます。{/if}'
+  ),
+  ARRIVING: t(
+    'まもなく、{#if nextStationIsBound}終点、{/if}{nextStationJa}、{nextStationJa}。',
+    '{#if hasTransferLines}',
+    '{transferLinesListJa}にお乗り換えいただけます。',
+    '{#if nextStationIsBound}{currentLineShortJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{/if}'
+  ),
+};
+
+const TOKYO_METRO_EN: ThemeTemplate = {
+  NEXT: t(
+    'The next stop is {nextStationEn}',
+    '{#if hasNextStationNumberText} {nextStationNumberText}{:else}.{/if}',
+    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}',
+    '{#if firstSpeech}',
+    ' This train is the ',
+    '{#if yamanoteTrainTypeEn}{yamanoteTrainTypeEn} train',
+    '{:else}{currentTrainTypeOrLocalEn} Service on the {currentLineEn}{/if}',
+    ' bound for {boundForEn}. ',
+    '{#if hasTrainTypeAndAfterNext}',
+    'The next stop after {nextStationEn}, is {afterNextStationEn}',
+    '{#if isAfterNextStopTerminus} terminal{/if}.',
+    '{/if}',
+    '{#if hasBetweenStations} For stations in between, Please change trains at the next stop.{/if}',
+    '{/if}'
+  ),
+  ARRIVING: t(
+    'Arriving at {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, the last stop.{/if} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}{/if}. ',
+    '{#if isNextStopTerminus}Thank you for using the {currentLineEn}.{/if}'
+  ),
+};
+
+const TY_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}',
+    'Thank you for using the {currentLineEn}. ',
+    'This is the {trainTypeEn} train ',
+    '{connectedLineEnPhrase}',
+    ' to {boundForEn}. ',
+    '{/if}',
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, the last stop{/if} ',
+    '{#if hasTransferLines}Passengers changing to {transferLinesEnList}, Please transfer at this station.{/if}'
+  ),
+  ARRIVING: t(
+    'We will soon make a brief stop at {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, the last stop{/if}',
+    '{#if hasTransferLines} Passengers changing to {transferLinesEnList}, Please transfer at this station.{/if}',
+    '{#if hasTrainTypeAndAfterNext} The stop after {nextStationEn}, will be {afterNextStationEn}{#if isAfterNextStopTerminus} the last stop{/if}.{/if}',
+    '{#if isNextStopTerminus} Thank you for using the {currentLineEn}.{/if}'
+  ),
+};
+
+const YAMANOTE_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}This is the {currentLineEn} train bound for {boundForEn}. {/if}',
+    'The next station is {nextStationEn} {nextStationNumberText} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}{#if hasMultipleTransferLines}.{/if}{/if}'
+  ),
+  ARRIVING: t(
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, terminal.{/if} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}{/if}. ',
+    '{#if isNextStopTerminus}Thank you for traveling with us, and look forward to serving you again.{/if}'
+  ),
+};
+
+const SAIKYO_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}This is the {currentLineEn} train bound for {boundForEn}. {/if}',
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, terminal{/if} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}{#if hasMultipleTransferLines}.{/if}{/if}'
+  ),
+  ARRIVING: t(
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, terminal.{/if} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if} ',
+    '{#if isNextStopTerminus}Thank you for traveling with us, and look forward to serving you again.{/if}'
+  ),
+};
+
+const JR_WEST_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}',
+    'Thank you for using {currentLineCompanyEn}. ',
+    'This is the {trainTypeEn} Service bound for {boundForEn} ',
+    '{#if hasViaStation}via {viaStationEn}{/if}. ',
+    '{/if}',
+    '{#if shouldAnnounceJrWestStopList}',
+    'We will be stopping at {jrWestStopsListEn}. ',
+    '{#if lastAnnouncedStopIsBound}{:else}Stops after {lastAnnouncedStopEn} will be announced later. {/if}',
+    '{/if}',
+    'The next stop is {nextStationEn}{#if nextStationIsBound} terminal{/if}',
+    '{#if hasNextStationNumberLineSymbol} station number {nextStationNumberTextNoPeriod}.{:else}.{/if} ',
+    '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if}'
+  ),
+  ARRIVING: t(
+    'We will soon be making a brief stop at {nextStationEn}',
+    '{#if hasNextStationNumberLineSymbol} station number {nextStationNumberTextNoPeriod}.{:else}.{/if} ',
+    '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if} ',
+    '{#if hasAfterNextStation}After leaving {nextStationEn}, We will be stopping at {afterNextStationEn}.{/if}'
+  ),
+};
+
+const TOEI_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}Thank you for using the {currentLineEn}. {/if}',
+    'This is the {trainTypeEn} train bound for {boundForEn}. ',
+    'The next station is {nextStationEn} {nextStationNumberText} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
+  ),
+  ARRIVING: t(
+    'We will soon be arriving at {nextStationEn} {nextStationNumberText} ',
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}',
+    '{#if hasTrainTypeAndAfterNext} The stop after {nextStationEn}, will be {afterNextStationEn}{#if isAfterNextStopTerminus} the last stop{/if}.{/if}',
+    '{#if isNextStopTerminus} Thank you for using the {currentLineEn}.{/if}'
+  ),
+};
+
+const JR_KYUSHU_EN: ThemeTemplate = {
+  NEXT: t(
+    '{#if firstSpeech}This is a {trainTypeEn} train bound for {boundForEn}.{/if} ',
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if nextStationIsBound} terminal{/if}. ',
+    '{#if hasTransferLines}You can transfer to {transferLinesEnList} at {nextStationEn}.{/if}'
+  ),
+  ARRIVING: t(
+    'We will soon be arriving at {nextStationEn}',
+    '{#if nextStationIsBound} terminal{/if} {nextStationNumberText}. ',
+    '{#if hasTransferLines}',
+    'You can transfer to {transferLinesEnList}{#if hasMultipleTransferLines}.{/if} at {nextStationEn}. ',
+    '{#if nextStationIsBound}Thank you for using the {currentLineEn}.{/if}',
+    '{/if}'
+  ),
+};
+
+const EMPTY_RENDERER: TemplateRenderer = () => '';
+const EMPTY_THEME: ThemeTemplate = {
+  NEXT: EMPTY_RENDERER,
+  ARRIVING: EMPTY_RENDERER,
+};
+
+export const JA_TEMPLATES: Record<AppTheme, ThemeTemplate> = {
+  [APP_THEME.TOKYO_METRO]: TOKYO_METRO,
+  [APP_THEME.TY]: TY,
+  [APP_THEME.YAMANOTE]: YAMANOTE,
+  [APP_THEME.JR_WEST]: JR_WEST,
+  [APP_THEME.SAIKYO]: SAIKYO,
+  [APP_THEME.TOEI]: TOEI,
+  [APP_THEME.JR_KYUSHU]: JR_KYUSHU,
+  [APP_THEME.LED]: EMPTY_THEME,
+  [APP_THEME.JO]: EMPTY_THEME,
+  [APP_THEME.JL]: EMPTY_THEME,
+  [APP_THEME.ODAKYU]: EMPTY_THEME,
+  [APP_THEME.E231]: EMPTY_THEME,
+};
+
+export const EN_TEMPLATES: Record<AppTheme, ThemeTemplate> = {
+  [APP_THEME.TOKYO_METRO]: TOKYO_METRO_EN,
+  [APP_THEME.TY]: TY_EN,
+  [APP_THEME.YAMANOTE]: YAMANOTE_EN,
+  [APP_THEME.JR_WEST]: JR_WEST_EN,
+  [APP_THEME.SAIKYO]: SAIKYO_EN,
+  [APP_THEME.TOEI]: TOEI_EN,
+  [APP_THEME.JR_KYUSHU]: JR_KYUSHU_EN,
+  [APP_THEME.LED]: EMPTY_THEME,
+  [APP_THEME.JO]: EMPTY_THEME,
+  [APP_THEME.JL]: EMPTY_THEME,
+  [APP_THEME.ODAKYU]: EMPTY_THEME,
+  [APP_THEME.E231]: EMPTY_THEME,
+};

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -1,13 +1,23 @@
 import { useAtomValue } from 'jotai';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '../constants';
 import { APP_THEME, type AppTheme } from '../models/Theme';
 import stationState from '../store/atoms/station';
 import { themeAtom } from '../store/atoms/theme';
 import getIsPass from '../utils/isPass';
-import katakanaToHiragana from '../utils/kanaToHiragana';
 import { wrapPhoneme as ph } from '../utils/phoneme';
+import {
+  formatFirstConnectedLineEnPhrase,
+  formatJrWestStopsListEn,
+  formatJrWestStopsListJa,
+  formatLinesListEn,
+  formatLinesListJa,
+  formatStationsListJa,
+  replaceJapaneseText,
+} from './tts/formatters';
+import type { TemplateContext } from './tts/templateEngine';
+import { EN_TEMPLATES, JA_TEMPLATES } from './tts/templates';
 import { useAfterNextStation } from './useAfterNextStation';
 import { useBounds } from './useBounds';
 import { useConnectedLines } from './useConnectedLines';
@@ -40,21 +50,6 @@ const resolveTemplateTheme = (theme: AppTheme): AppTheme => {
   return theme;
 };
 
-const EMPTY_TTS_TEXT = {
-  [APP_THEME.TOKYO_METRO]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.TY]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.YAMANOTE]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.JR_WEST]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.SAIKYO]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.TOEI]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.LED]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.JO]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.JL]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.JR_KYUSHU]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.ODAKYU]: { NEXT: '', ARRIVING: '' },
-  [APP_THEME.E231]: { NEXT: '', ARRIVING: '' },
-};
-
 export const useTTSText = (
   firstSpeech = true,
   enabled = false
@@ -69,11 +64,8 @@ export const useTTSText = (
   const station = useCurrentStation();
   const currentLineOrigin = useCurrentLine();
 
-  const connectedLinesOrigin = useConnectedLines();
-  const transferLinesOrigin = useTransferLines();
-
-  const connectedLines = connectedLinesOrigin;
-  const transferLines = transferLinesOrigin;
+  const connectedLines = useConnectedLines();
+  const transferLines = useTransferLines();
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false, 'JA');
   const loopLineBoundEn = useLoopLineBound(false, 'EN');
@@ -86,13 +78,8 @@ export const useTTSText = (
   const getStationNumberIndex = useStationNumberIndexFunc();
 
   const nextStationNumber = useMemo(() => {
-    if (!nextStationOrigin) {
-      return;
-    }
-
-    if (!nextStationOrigin.stationNumbers) {
-      return;
-    }
+    if (!nextStationOrigin) return;
+    if (!nextStationOrigin.stationNumbers) return;
 
     const stationNumberIndex = getStationNumberIndex(nextStationOrigin);
 
@@ -107,19 +94,6 @@ export const useTTSText = (
 
     return nextStationOrigin.stationNumbers[stationNumberIndex];
   }, [getStationNumberIndex, nextStationOrigin]);
-
-  const replaceJapaneseText = useCallback(
-    (
-      name: string | undefined | null,
-      nameKatakana: string | undefined | null
-    ) =>
-      !name && !nameKatakana
-        ? `<sub alias="かくえきていしゃ">各駅停車</sub>`
-        : !nameKatakana
-          ? (name ?? '')
-          : `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`,
-    []
-  );
 
   const currentLine = currentLineOrigin ?? null;
 
@@ -147,9 +121,7 @@ export const useTTSText = (
   );
 
   const yamanoteTrainTypeJa = useMemo(() => {
-    if (!isYamanoteLine || !selectedDirection) {
-      return null;
-    }
+    if (!isYamanoteLine || !selectedDirection) return null;
     return selectedDirection === 'INBOUND'
       ? 'やまのて線内回り'
       : 'やまのて線外回り';
@@ -175,7 +147,6 @@ export const useTTSText = (
       isLoopLine,
       isPartiallyLoopLine,
       loopLineBoundJa?.boundFor,
-      replaceJapaneseText,
     ]
   );
 
@@ -186,24 +157,16 @@ export const useTTSText = (
         : (directionalStops
             ?.map((s) => ph(s?.nameTtsSegments, s?.nameRoman))
             .join(' and ') ?? ''),
-
     [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
   );
 
   const nextStationNumberText = useMemo(() => {
-    if (!nextStationNumber) {
-      return '';
-    }
-
-    if (!nextStationNumber?.stationNumber) {
-      return '';
-    }
+    if (!nextStationNumber) return '';
+    if (!nextStationNumber?.stationNumber) return '';
 
     const split = nextStationNumber.stationNumber.split('-');
 
-    if (!split.length) {
-      return '';
-    }
+    if (!split.length) return '';
     if (split.length === 1) {
       return `${theme === APP_THEME.JR_WEST ? '' : 'Station Number '}<say-as interpret-as="cardinal">${Number(
         nextStationNumber.stationNumber
@@ -239,8 +202,7 @@ export const useTTSText = (
     return result;
   }, [slicedStationsOrigin]);
 
-  const afterNextStationOrigin = useAfterNextStation();
-  const afterNextStation = afterNextStationOrigin;
+  const afterNextStation = useAfterNextStation();
 
   const nextStationIndex = useMemo(
     () => slicedStations.findIndex((s) => s.groupId === nextStation?.groupId),
@@ -267,9 +229,7 @@ export const useTTSText = (
   const allStops = useMemo(
     () =>
       slicedStations.filter((s) => {
-        if (s.groupId === station?.groupId) {
-          return false;
-        }
+        if (s.groupId === station?.groupId) return false;
         return !getIsPass(s);
       }),
     [slicedStations, station]
@@ -290,9 +250,7 @@ export const useTTSText = (
       if (seen.has(s.groupId)) continue;
       seen.add(s.groupId);
       if (getIsPass(s)) continue;
-      if (s.groupId === station.groupId) {
-        return stopCount;
-      }
+      if (s.groupId === station.groupId) return stopCount;
       stopCount++;
     }
     return -1;
@@ -324,872 +282,170 @@ export const useTTSText = (
     return sortedStops[0];
   }, [allStops]);
 
-  const japaneseTemplate: Record<AppTheme, { [key: string]: string }> | null =
-    useMemo(() => {
-      if (!currentLine || !selectedBound) {
-        return EMPTY_TTS_TEXT;
-      }
+  const context = useMemo<TemplateContext | null>(() => {
+    if (!currentLine || !selectedBound) return null;
 
-      const map = {
-        [APP_THEME.TOKYO_METRO]: {
-          NEXT: firstSpeech
-            ? `${replaceJapaneseText(
-                currentLine.nameShort,
-                currentLine.nameKatakana
-              )}をご利用くださいまして、ありがとうございます。次は、${replaceJapaneseText(
-                nextStation?.name,
-                nextStation?.nameKatakana
-              )}です。この電車は、${
-                connectedLines.length
-                  ? `${connectedLines
-                      .map((l) =>
-                        replaceJapaneseText(l.nameShort, l.nameKatakana)
-                      )
-                      .join('、')}直通、`
-                  : ''
-              }${
-                yamanoteTrainTypeJa ??
-                (currentTrainType
-                  ? replaceJapaneseText(
-                      currentTrainType.name,
-                      currentTrainType.nameKatakana
-                    )
-                  : '各駅停車')
-              }、${boundForJa}ゆきです。${
-                currentTrainType && afterNextStation
-                  ? `${replaceJapaneseText(
-                      nextStation?.name,
-                      nextStation?.nameKatakana
-                    )}の次は、${
-                      isAfterNextStopTerminus ? '終点、' : ''
-                    }${replaceJapaneseText(
-                      afterNextStation?.name,
-                      afterNextStation?.nameKatakana
-                    )}に停まります。`
-                  : ''
-              }${
-                betweenNextStation.length
-                  ? `${betweenNextStation
-                      .map((s) => replaceJapaneseText(s.name, s.nameKatakana))
-                      .join('、')}へおいでのお客様はお乗り換えです。`
-                  : ''
-              }`
-            : `次は、${replaceJapaneseText(
-                nextStation?.name,
-                nextStation?.nameKatakana
-              )}${isNextStopTerminus ? '、終点' : ''}です。${
-                transferLines.length
-                  ? `${transferLines
-                      .map((l) =>
-                        replaceJapaneseText(l.nameShort, l.nameKatakana)
-                      )
-                      .join('、')}はお乗り換えです。`
-                  : ''
-              }${
-                currentTrainType && afterNextStation
-                  ? `${replaceJapaneseText(
-                      nextStation?.name,
-                      nextStation?.nameKatakana
-                    )}の次は、${
-                      isAfterNextStopTerminus ? '終点、' : ''
-                    }${replaceJapaneseText(
-                      afterNextStation?.name,
-                      afterNextStation?.nameKatakana
-                    )}に停まります。`
-                  : ''
-              }${
-                betweenNextStation.length
-                  ? `${betweenNextStation
-                      .map((s) => replaceJapaneseText(s.name, s.nameKatakana))
-                      .join('、')}へおいでのお客様はお乗り換えです。`
-                  : ''
-              }`,
-          ARRIVING: `まもなく、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }${isNextStopTerminus ? '終点' : ''}です。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }${
-            isNextStopTerminus
-              ? `${replaceJapaneseText(
-                  currentLine.company?.nameShort,
-                  currentLine.company?.nameKatakana
-                )}をご利用くださいまして、ありがとうございました。`
-              : ''
-          }`,
-        },
-        [APP_THEME.TY]: {
-          NEXT: `${
-            firstSpeech
-              ? `${replaceJapaneseText(
-                  currentLine.nameShort,
-                  currentLine.nameKatakana
-                )}をご利用くださいまして、ありがとうございます。この電車は${
-                  connectedLines.length
-                    ? `${connectedLines
-                        .map((l) =>
-                          replaceJapaneseText(l.nameShort, l.nameKatakana)
-                        )
-                        .join('、')}直通、`
-                    : ''
-                }${
-                  yamanoteTrainTypeJa ??
-                  (currentTrainType
-                    ? replaceJapaneseText(
-                        currentTrainType.name,
-                        currentTrainType.nameKatakana
-                      )
-                    : '各駅停車')
-                }、${boundForJa}ゆきです。`
-              : ''
-          }次は、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }${isNextStopTerminus ? '、終点' : ''}です。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}をご利用のお客様はお乗り換えです。`
-              : ''
-          }`,
-          ARRIVING: `まもなく、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }${isNextStopTerminus ? '、終点' : ''}です。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}をご利用のお客様はお乗り換えです。`
-              : ''
-          }${
-            afterNextStation
-              ? `${replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                )}を出ますと、${
-                  isAfterNextStopTerminus ? '終点、' : ''
-                }${replaceJapaneseText(
-                  afterNextStation.name,
-                  afterNextStation.nameKatakana
-                )}に停まります。`
-              : ''
-          }${
-            isNextStopTerminus
-              ? ` ${replaceJapaneseText(
-                  currentLine?.nameShort,
-                  currentLine?.nameKatakana
-                )}をご利用くださいまして、ありがとうございました。`
-              : ''
-          }`,
-        },
-        [APP_THEME.YAMANOTE]: {
-          NEXT: `${
-            firstSpeech
-              ? `今日も、${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございます。この電車は、${boundForJa}ゆきです。`
-              : ''
-          }次は、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }${isNextStopTerminus ? '、終点です' : ''}。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }`,
-          ARRIVING: `まもなく、${isNextStopTerminus ? '終点、' : ''}${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}は、お乗り換えです。${
-                  isNextStopTerminus
-                    ? `${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございました。`
-                    : ''
-                }`
-              : ''
-          }`,
-        },
-        [APP_THEME.JO]: {
-          NEXT: '',
-          ARRIVING: '',
-        },
-        [APP_THEME.JL]: { NEXT: '', ARRIVING: '' },
-        [APP_THEME.SAIKYO]: {
-          NEXT: `${
-            firstSpeech
-              ? `今日も、${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございます。この電車は、${boundForJa}ゆきです。`
-              : ''
-          }次は、${isNextStopTerminus ? '終点、' : ''}${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}は、お乗り換えです。`
-              : ''
-          }`,
-          ARRIVING: `まもなく、${isNextStopTerminus ? '終点、' : ''}${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}は、お乗り換えです。${
-                  isNextStopTerminus
-                    ? `${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございました。`
-                    : ''
-                }`
-              : ''
-          }`,
-        },
-        [APP_THEME.JR_WEST]: {
-          NEXT: `${
-            firstSpeech
-              ? `今日も、${
-                  currentLine.company?.nameShort
-                }をご利用くださいまして、ありがとうございます。この電車は、${
-                  yamanoteTrainTypeJa ??
-                  replaceJapaneseText(
-                    currentTrainType?.name,
-                    currentTrainType?.nameKatakana
-                  )
-                }、${
-                  viaStation
-                    ? `${replaceJapaneseText(
-                        viaStation.name,
-                        viaStation.nameKatakana
-                      )}方面、`
-                    : ''
-                }${boundForJa}ゆきです。`
-              : ''
-          }${
-            shouldAnnounceJrWestStopList
-              ? `${allStops
-                  .slice(0, 5)
-                  .map((s) =>
-                    s.groupId === selectedBound?.groupId && !isLoopLine
-                      ? `終点、${replaceJapaneseText(s.name, s.nameKatakana)}`
-                      : replaceJapaneseText(s.name, s.nameKatakana)
-                  )
-                  .join('、')}の順に停まります。${
-                  lastAnnouncedStop?.groupId === selectedBound?.groupId
-                    ? ''
-                    : `${replaceJapaneseText(
-                        lastAnnouncedStop?.name,
-                        lastAnnouncedStop?.nameKatakana
-                      )}から先は、後ほどご案内いたします。`
-                }`
-              : ''
-          }次は、${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? '終点、' : ''}${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }です。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }`,
-          ARRIVING: isNextStopTerminus
-            ? `ご乗車ありがとうございました。まもなく${
-                replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                ) ?? ''
-              }、${
-                replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                ) ?? ''
-              }です。${
-                transferLines.length
-                  ? `${transferLines
-                      .map((l) =>
-                        replaceJapaneseText(l.nameShort, l.nameKatakana)
-                      )
-                      .join('、')}はお乗り換えです。`
-                  : ''
-              }今日も${currentLine.company?.nameShort}をご利用くださいまして、ありがとうございました。${replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana)}、${replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana)}です。`
-            : `まもなく、${
-                replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                ) ?? ''
-              }、${
-                replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                ) ?? ''
-              }です。${
-                transferLines.length
-                  ? `${transferLines
-                      .map((l) =>
-                        replaceJapaneseText(l.nameShort, l.nameKatakana)
-                      )
-                      .join('、')}はお乗り換えです。`
-                  : ''
-              }${
-                afterNextStation
-                  ? `${replaceJapaneseText(
-                      nextStation?.name,
-                      nextStation?.nameKatakana
-                    )}を出ますと、次は、${replaceJapaneseText(
-                      afterNextStation.name,
-                      afterNextStation.nameKatakana
-                    )}に停まります。`
-                  : ''
-              }`,
-        },
-        [APP_THEME.TOEI]: {
-          NEXT: `${
-            firstSpeech
-              ? `${replaceJapaneseText(
-                  currentLine.nameShort,
-                  currentLine.nameKatakana
-                )}をご利用くださいまして、ありがとうございます。`
-              : ''
-          }次は、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }。 ${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }この電車は、${
-            connectedLines.length
-              ? `${connectedLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}直通、`
-              : ''
-          }${
-            yamanoteTrainTypeJa ??
-            (currentTrainType
-              ? replaceJapaneseText(
-                  currentTrainType.name,
-                  currentTrainType.nameKatakana
-                )
-              : '各駅停車')
-          }、${boundForJa}ゆきです。${
-            currentTrainType && afterNextStation
-              ? `${replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                )}の次は、${
-                  isAfterNextStopTerminus ? '終点、' : ''
-                }${replaceJapaneseText(
-                  afterNextStation?.name,
-                  afterNextStation?.nameKatakana
-                )}に停まります。`
-              : ''
-          }${
-            betweenNextStation.length
-              ? `通過する、${betweenNextStation
-                  .map((s) => replaceJapaneseText(s.name, s.nameKatakana))
-                  .join('、')}へおいでの方はお乗り換えです。`
-              : ''
-          }`,
-          ARRIVING: `まもなく、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }、${
-            replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
-            ''
-          }。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}はお乗り換えです。`
-              : ''
-          }${
-            currentTrainType && afterNextStation
-              ? `${replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                )}の次は、${
-                  isAfterNextStopTerminus ? '終点、' : ''
-                }${replaceJapaneseText(
-                  afterNextStation?.name,
-                  afterNextStation?.nameKatakana
-                )}に停まります。`
-              : ''
-          }${
-            betweenNextStation.length
-              ? `通過する、${betweenNextStation
-                  .map((s) => replaceJapaneseText(s.name, s.nameKatakana))
-                  .join('、')}へおいでの方はお乗り換えです。`
-              : ''
-          }${
-            isNextStopTerminus
-              ? ` ${replaceJapaneseText(
-                  currentLine?.nameShort,
-                  currentLine?.nameKatakana
-                )}をご利用くださいまして、ありがとうございました。`
-              : ''
-          }`,
-        },
-        [APP_THEME.LED]: {
-          NEXT: '',
-          ARRIVING: '',
-        },
-        [APP_THEME.JR_KYUSHU]: {
-          NEXT: `${
-            firstSpeech
-              ? `この列車は${
-                  yamanoteTrainTypeJa ??
-                  (currentTrainType
-                    ? replaceJapaneseText(
-                        currentTrainType.name,
-                        currentTrainType.nameKatakana
-                      )
-                    : '普通')
-                }、${boundForJa}行きです。`
-              : ''
-          }次は${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? '終点、' : ''}${replaceJapaneseText(
-            nextStation?.name,
-            nextStation?.nameKatakana
-          )}、${replaceJapaneseText(
-            nextStation?.name,
-            nextStation?.nameKatakana
-          )}。${
-            transferLines.length
-              ? `${replaceJapaneseText(
-                  nextStation?.name,
-                  nextStation?.nameKatakana
-                )}では、${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join('、')}にお乗り換えいただけます。`
-              : ''
-          }`,
-          ARRIVING: `まもなく、${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? '終点、' : ''}${replaceJapaneseText(
-            nextStation?.name,
-            nextStation?.nameKatakana
-          )}、${replaceJapaneseText(
-            nextStation?.name,
-            nextStation?.nameKatakana
-          )}。${
-            transferLines.length
-              ? `${transferLines
-                  .map((l) => replaceJapaneseText(l.nameShort, l.nameKatakana))
-                  .join(
-                    '、'
-                  )}にお乗り換えいただけます。${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? `${currentLine.nameShort}をご利用くださいまして、ありがとうございました。` : ''}`
-              : ''
-          }`,
-        },
-        [APP_THEME.ODAKYU]: { NEXT: '', ARRIVING: '' },
-        [APP_THEME.E231]: { NEXT: '', ARRIVING: '' },
-      };
-      return map;
-    }, [
-      afterNextStation,
-      allStops,
-      betweenNextStation,
-      boundForJa,
-      connectedLines,
-      currentLine,
-      currentTrainType,
+    const isBoundStop = (s: Station): boolean =>
+      s.groupId === selectedBound?.groupId && !isLoopLine;
+
+    return {
+      // フラグ
       firstSpeech,
-      isAfterNextStopTerminus,
-      isLoopLine,
       isNextStopTerminus,
-      lastAnnouncedStop,
-      nextStation?.name,
-      replaceJapaneseText,
-      selectedBound,
+      isAfterNextStopTerminus,
+      hasTransferLines: transferLines.length > 0,
+      hasMultipleTransferLines: transferLines.length > 1,
+      hasConnectedLines: connectedLines.length > 0,
+      hasBetweenStations: betweenNextStation.length > 0,
+      hasAfterNextStation: !!afterNextStation,
+      hasTrainTypeAndAfterNext: !!(currentTrainType && afterNextStation),
+      hasViaStation: !!viaStation,
+      nextStationIsBound:
+        nextStation?.groupId === selectedBound?.groupId && !isLoopLine,
+      lastAnnouncedStopIsBound:
+        lastAnnouncedStop?.groupId === selectedBound?.groupId,
       shouldAnnounceJrWestStopList,
-      transferLines,
-      viaStation,
-      yamanoteTrainTypeJa,
-      nextStation?.groupId,
-      selectedBound?.groupId,
-      nextStation?.nameKatakana,
-    ]);
+      hasNextStationNumberLineSymbol: !!nextStationNumber?.lineSymbol?.length,
+      hasNextStationNumberText: nextStationNumberText.length > 0,
+      yamanoteTrainTypeEn: yamanoteTrainTypeEn ?? '',
 
-  const englishTemplate: Record<AppTheme, { [key: string]: string }> | null =
-    useMemo(() => {
-      if (!currentLine || !selectedBound) {
-        return EMPTY_TTS_TEXT;
-      }
+      // 日本語
+      nextStationJa: replaceJapaneseText(
+        nextStation?.name,
+        nextStation?.nameKatakana
+      ),
+      currentLineJa: replaceJapaneseText(
+        currentLine.nameShort,
+        currentLine.nameKatakana
+      ),
+      currentLineShortJa: currentLine.nameShort ?? '',
+      currentLineCompanyJa: replaceJapaneseText(
+        currentLine.company?.nameShort,
+        currentLine.company?.nameKatakana
+      ),
+      currentLineCompanyShortJa: currentLine.company?.nameShort ?? '',
+      boundForJa: boundForJa ?? '',
+      // TOKYO_METRO/TY/TOEI 用 (各駅停車 デフォルト)
+      trainTypeJa:
+        yamanoteTrainTypeJa ??
+        (currentTrainType
+          ? replaceJapaneseText(
+              currentTrainType.name,
+              currentTrainType.nameKatakana
+            )
+          : '各駅停車'),
+      // JR_WEST 用 (デフォルトなし。currentTrainType が無い場合は replaceJapaneseText のフォールバックで sub 付き 各駅停車 が返る)
+      trainTypeJaPlain:
+        yamanoteTrainTypeJa ??
+        replaceJapaneseText(
+          currentTrainType?.name,
+          currentTrainType?.nameKatakana
+        ),
+      // JR_KYUSHU 用 (普通 デフォルト)
+      trainTypeJaKyushu:
+        yamanoteTrainTypeJa ??
+        (currentTrainType
+          ? replaceJapaneseText(
+              currentTrainType.name,
+              currentTrainType.nameKatakana
+            )
+          : '普通'),
+      transferLinesListJa: formatLinesListJa(transferLines),
+      connectedLinesListJa: formatLinesListJa(connectedLines),
+      betweenStationsListJa: formatStationsListJa(betweenNextStation),
+      afterNextStationJa: afterNextStation
+        ? replaceJapaneseText(
+            afterNextStation.name,
+            afterNextStation.nameKatakana
+          )
+        : '',
+      viaStationJa: viaStation
+        ? replaceJapaneseText(viaStation.name, viaStation.nameKatakana)
+        : '',
+      jrWestStopsListJa: formatJrWestStopsListJa(allStops, isBoundStop),
+      lastAnnouncedStopJa: lastAnnouncedStop
+        ? replaceJapaneseText(
+            lastAnnouncedStop.name,
+            lastAnnouncedStop.nameKatakana
+          )
+        : '',
 
-      const map = {
-        [APP_THEME.TOKYO_METRO]: {
-          NEXT: `The next stop is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${
-            nextStationNumberText.length ? ` ${nextStationNumberText}` : '.'
-          }${
-            transferLines.length
-              ? ` Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }${
-            firstSpeech
-              ? ` This train is the ${
-                  yamanoteTrainTypeEn
-                    ? `${yamanoteTrainTypeEn} train`
-                    : `${currentTrainType ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman) : 'Local'} Service on the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)}`
-                } bound for ${boundForEn}. ${
-                  currentTrainType && afterNextStation
-                    ? `The next stop after ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${`, is ${ph(afterNextStation?.nameTtsSegments, afterNextStation?.nameRoman)}${isAfterNextStopTerminus ? ' terminal' : ''}`}.`
-                    : ''
-                }${
-                  betweenNextStation.length
-                    ? ' For stations in between, Please change trains at the next stop.'
-                    : ''
-                }`
-              : ''
-          }`,
-          ARRIVING: `Arriving at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
-            isNextStopTerminus ? ', the last stop.' : ''
-          } ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }. ${
-            isNextStopTerminus
-              ? `Thank you for using the ${ph(currentLine?.nameTtsSegments, currentLine?.nameRoman)}.`
-              : ''
-          }`,
-        },
-        [APP_THEME.TY]: {
-          NEXT: `${
-            firstSpeech
-              ? `Thank you for using the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) || 'Local')} train ${
-                  connectedLines[0]?.nameTtsSegments?.length
-                    ? `on the ${ph(connectedLines[0]?.nameTtsSegments, connectedLines[0]?.nameRoman)}`
-                    : ''
-                } to ${boundForEn}. `
-              : ''
-          }The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
-            isNextStopTerminus ? ', the last stop' : ''
-          } ${
-            transferLines.length
-              ? `Passengers changing to ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                  )
-                  .join(
-                    ',<break time="200ms"/> '
-                  )}, Please transfer at this station.`
-              : ''
-          }`,
-          ARRIVING: `We will soon make a brief stop at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
-            isNextStopTerminus ? ', the last stop' : ''
-          }${
-            transferLines.length
-              ? ` Passengers changing to ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                  )
-                  .join(
-                    ',<break time="200ms"/> '
-                  )}, Please transfer at this station.`
-              : ''
-          }${
-            currentTrainType && afterNextStation
-              ? ` The stop after ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}, will be ${ph(afterNextStation.nameTtsSegments, afterNextStation.nameRoman)}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
-              : ''
-          }${
-            isNextStopTerminus
-              ? ` Thank you for using the ${ph(currentLine?.nameTtsSegments, currentLine?.nameRoman)}.`
-              : ''
-          }`,
-        },
-        [APP_THEME.YAMANOTE]: {
-          NEXT: `${
-            firstSpeech
-              ? `This is the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)} train bound for ${boundForEn}. `
-              : ''
-          }The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText} ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }`,
-          ARRIVING: `The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
-            isNextStopTerminus ? ', terminal.' : ''
-          } ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }. ${
-            isNextStopTerminus
-              ? 'Thank you for traveling with us, and look forward to serving you again.'
-              : ''
-          }`,
-        },
-        [APP_THEME.JO]: {
-          NEXT: '',
-          ARRIVING: '',
-        },
-        [APP_THEME.JL]: { NEXT: '', ARRIVING: '' },
-        [APP_THEME.SAIKYO]: {
-          NEXT: `${
-            firstSpeech
-              ? `This is the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)} train bound for ${boundForEn}. `
-              : ''
-          }The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${isNextStopTerminus ? ', terminal' : ''} ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }`,
-          ARRIVING: `The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${
-            isNextStopTerminus ? ', terminal.' : ''
-          } ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          } ${
-            isNextStopTerminus
-              ? 'Thank you for traveling with us, and look forward to serving you again.'
-              : ''
-          }`,
-        },
-        [APP_THEME.JR_WEST]: {
-          NEXT: `${
-            firstSpeech
-              ? `Thank you for using ${currentLine?.company?.nameEnglishShort}. This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) || 'Local')} Service bound for ${boundForEn} ${
-                  viaStation
-                    ? `via ${ph(viaStation.nameTtsSegments, viaStation.nameRoman)}`
-                    : ''
-                }. `
-              : ''
-          }${
-            shouldAnnounceJrWestStopList
-              ? `We will be stopping at ${allStops
-                  .slice(0, 5)
-                  .map((s) =>
-                    s.groupId === selectedBound?.groupId && !isLoopLine
-                      ? `${ph(s.nameTtsSegments, s.nameRoman)} terminal`
-                      : `${ph(s.nameTtsSegments, s.nameRoman)}`
-                  )
-                  .join(', ')}. ${
-                  lastAnnouncedStop?.groupId === selectedBound?.groupId
-                    ? ''
-                    : `Stops after ${ph(
-                        lastAnnouncedStop?.nameTtsSegments,
-                        lastAnnouncedStop?.nameRoman
-                      )} will be announced later. `
-                }`
-              : ''
-          }The next stop is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}${
-            nextStationNumber?.lineSymbol?.length
-              ? ` station number ${nextStationNumberText.replace(/\.$/, '')}.`
-              : '.'
-          } ${
-            transferLines.length
-              ? `Transfer here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }`,
-          ARRIVING: `We will soon be making a brief stop at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${
-            nextStationNumber?.lineSymbol?.length
-              ? ` station number ${nextStationNumberText.replace(/\.$/, '')}.`
-              : '.'
-          } ${
-            transferLines.length
-              ? `Transfer here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          } ${
-            afterNextStation
-              ? `After leaving ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}, We will be stopping at ${ph(afterNextStation.nameTtsSegments, afterNextStation.nameRoman)}.`
-              : ''
-          }`,
-        },
-        [APP_THEME.TOEI]: {
-          NEXT: `${
-            firstSpeech
-              ? `Thank you for using the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)}. `
-              : ''
-          }This is the ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) || 'Local')} train bound for ${boundForEn}. The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText} ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }`,
-          ARRIVING: `We will soon be arriving at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText} ${
-            transferLines.length
-              ? `Please change here for ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '.' : ',<break time="200ms"/>'}`
-                  )
-                  .join(' ')}`
-              : ''
-          }${
-            currentTrainType && afterNextStation
-              ? ` The stop after ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}, will be ${ph(afterNextStation.nameTtsSegments, afterNextStation.nameRoman)}${isAfterNextStopTerminus ? ' the last stop' : ''}.`
-              : ''
-          }${
-            isNextStopTerminus
-              ? ` Thank you for using the ${ph(currentLine?.nameTtsSegments, currentLine?.nameRoman)}.`
-              : ''
-          }`,
-        },
-        [APP_THEME.LED]: {
-          NEXT: '',
-          ARRIVING: '',
-        },
-        [APP_THEME.JR_KYUSHU]: {
-          NEXT: `${firstSpeech ? `This is a ${yamanoteTrainTypeEn ?? (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) || 'Local')} train bound for ${boundForEn}.` : ''} The next station is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)} ${nextStationNumberText}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''}. ${
-            transferLines.length
-              ? `You can transfer to ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(
-                    ' '
-                  )} at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}.`
-              : ''
-          }`,
-          ARRIVING: `We will soon be arriving at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? ' terminal' : ''} ${nextStationNumberText}. ${
-            transferLines.length
-              ? `You can transfer to ${transferLines
-                  .map((l, i, a) =>
-                    a.length > 1 && a.length - 1 === i
-                      ? `and the ${ph(l.nameTtsSegments, l.nameRoman)}.`
-                      : `the ${ph(l.nameTtsSegments, l.nameRoman)}${a.length === 1 ? '' : ',<break time="200ms"/>'}`
-                  )
-                  .join(
-                    ' '
-                  )} at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}. ${nextStation?.groupId === selectedBound?.groupId && !isLoopLine ? `Thank you for using the ${ph(currentLine.nameTtsSegments, currentLine.nameRoman)}.` : ''}`
-              : ''
-          }`,
-        },
-        [APP_THEME.ODAKYU]: { NEXT: '', ARRIVING: '' },
-        [APP_THEME.E231]: { NEXT: '', ARRIVING: '' },
-      };
-      return map;
-    }, [
-      afterNextStation,
-      allStops,
-      betweenNextStation.length,
+      // 英語
+      nextStationEn: ph(nextStation?.nameTtsSegments, nextStation?.nameRoman),
+      currentLineEn: ph(currentLine.nameTtsSegments, currentLine.nameRoman),
+      currentLineCompanyEn: currentLine.company?.nameEnglishShort ?? '',
       boundForEn,
-      connectedLines,
-      currentLine,
-      currentTrainType,
-      firstSpeech,
-      isAfterNextStopTerminus,
-      isLoopLine,
-      isNextStopTerminus,
-      lastAnnouncedStop,
-      nextStation?.groupId,
-      selectedBound?.groupId,
-      nextStation?.nameTtsSegments,
-      nextStationNumber?.lineSymbol?.length,
+      // 多くのテーマで使う共通形 (yamanote ?? phoneme || 'Local')
+      trainTypeEn:
+        yamanoteTrainTypeEn ??
+        (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) ||
+          'Local'),
+      // TOKYO_METRO 用 (currentTrainType の真偽で 'Local' フォールバック)
+      currentTrainTypeOrLocalEn: currentTrainType
+        ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman)
+        : 'Local',
+      transferLinesEnList: formatLinesListEn(transferLines),
+      connectedLineEnPhrase: formatFirstConnectedLineEnPhrase(connectedLines),
+      afterNextStationEn: afterNextStation
+        ? ph(afterNextStation.nameTtsSegments, afterNextStation.nameRoman)
+        : '',
+      viaStationEn: viaStation
+        ? ph(viaStation.nameTtsSegments, viaStation.nameRoman)
+        : '',
+      jrWestStopsListEn: formatJrWestStopsListEn(allStops, isBoundStop),
+      lastAnnouncedStopEn: lastAnnouncedStop
+        ? ph(lastAnnouncedStop.nameTtsSegments, lastAnnouncedStop.nameRoman)
+        : '',
       nextStationNumberText,
-      selectedBound,
-      shouldAnnounceJrWestStopList,
-      transferLines,
-      viaStation,
-      yamanoteTrainTypeEn,
-      nextStation?.nameRoman,
-    ]);
+      nextStationNumberTextNoPeriod: nextStationNumberText.replace(/\.$/, ''),
+    };
+  }, [
+    afterNextStation,
+    allStops,
+    betweenNextStation,
+    boundForEn,
+    boundForJa,
+    connectedLines,
+    currentLine,
+    currentTrainType,
+    firstSpeech,
+    isAfterNextStopTerminus,
+    isLoopLine,
+    isNextStopTerminus,
+    lastAnnouncedStop,
+    nextStation,
+    nextStationNumber?.lineSymbol?.length,
+    nextStationNumberText,
+    selectedBound,
+    shouldAnnounceJrWestStopList,
+    transferLines,
+    viaStation,
+    yamanoteTrainTypeEn,
+    yamanoteTrainTypeJa,
+  ]);
 
   const resolved = resolveTemplateTheme(theme);
 
-  const jaText = useMemo(
-    () => japaneseTemplate?.[resolved]?.[stoppingState] ?? '',
-    [japaneseTemplate, resolved, stoppingState]
-  );
+  const jaText = useMemo(() => {
+    if (!context) return '';
+    if (stoppingState !== 'NEXT' && stoppingState !== 'ARRIVING') return '';
+    return JA_TEMPLATES[resolved][stoppingState](context);
+  }, [context, resolved, stoppingState]);
 
-  const enText = useMemo(
-    () => englishTemplate?.[resolved]?.[stoppingState] ?? '',
-    [englishTemplate, resolved, stoppingState]
-  );
+  const enText = useMemo(() => {
+    if (!context) return '';
+    if (stoppingState !== 'NEXT' && stoppingState !== 'ARRIVING') return '';
+    return EN_TEMPLATES[resolved][stoppingState](context);
+  }, [context, resolved, stoppingState]);
 
   const nextJaText = useMemo(
-    () => japaneseTemplate?.[resolved]?.NEXT ?? '',
-    [japaneseTemplate, resolved]
+    () => (context ? JA_TEMPLATES[resolved].NEXT(context) : ''),
+    [context, resolved]
   );
 
   const nextEnText = useMemo(
-    () => englishTemplate?.[resolved]?.NEXT ?? '',
-    [englishTemplate, resolved]
+    () => (context ? EN_TEMPLATES[resolved].NEXT(context) : ''),
+    [context, resolved]
   );
 
   if (!enabled) {


### PR DESCRIPTION
## 概要

`useTTSText` の巨大化していたテンプレートリテラル群を、極小テンプレートエンジン + テーマ別宣言的テンプレート + リスト整形ヘルパに分離。挙動は byte-for-byte で維持し、既存のスナップショットテスト 31 件すべて pass。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/templateEngine.ts`: `{var}` と `{#if/:else/}` のみサポートする ~80 行のミニエンジンを新規追加 (反復は意図的に未サポート、配列は呼び出し側で文字列化して渡す)
- `src/hooks/tts/templates.ts`: テーマ別の NEXT/ARRIVING テンプレートを宣言的に定義 (JA/EN それぞれ)
- `src/hooks/tts/formatters.ts`: `formatLinesListJa` / `formatLinesListEn` / `formatJrWestStopsList*` 等のリスト整形ヘルパを新規追加
- `src/hooks/tts/templateEngine.test.ts`: エンジン単体の挙動テスト 20 件を追加
- `src/hooks/useTTSText.ts`: 1381 → 465 行 (約 -66%) に縮小。巨大な `japaneseTemplate` / `englishTemplate` useMemo を廃止し「context 構築 → テーマ解決 → render」の3ステップに再構成

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

既存の `src/hooks/useTTSText.test.tsx` 31 件 + 新規 `templateEngine.test.ts` 20 件、合計 51 件すべて pass を確認。

## 関連Issue

- Refs #5914 (リファクタ中に発見した英語 transferLines 末尾ピリオドの単複不整合。byte-for-byte 維持のため別チケット化)
- Refs #5915 (同じくリファクタ中に発見した終点アナウンス欠落。別チケット化)

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TTS用のテンプレートベース出力を導入し、テーマ別に日本語／英語の音声文を柔軟に生成。
  * 日本語の読み仮名挿入や英語の自然な列挙・端末表現など、発話向けフォーマットを追加。

* **Refactor**
  * TTS生成ロジックを整理し、再利用可能なテンプレートコンテキストで出力を安定化。

* **Tests**
  * テンプレートエンジンの網羅的な単体テストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5916)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->