### PR TITLE
useTTSText のデータ欠落時の防御を強化

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -1,0 +1,108 @@
+import type { Line } from '~/@types/graphql';
+import { TtsAlphabet } from '~/@types/graphql';
+import {
+  formatFirstConnectedLineEnPhrase,
+  replaceJapaneseText,
+} from './formatters';
+
+describe('replaceJapaneseText', () => {
+  it('returns empty string when both name and nameKatakana are nullish', () => {
+    expect(replaceJapaneseText(null, null)).toBe('');
+    expect(replaceJapaneseText(undefined, undefined)).toBe('');
+    expect(replaceJapaneseText(null, undefined)).toBe('');
+    expect(replaceJapaneseText('', '')).toBe('');
+  });
+
+  it('returns the provided fallback when both args are nullish', () => {
+    expect(replaceJapaneseText(null, null, '各駅停車')).toBe('各駅停車');
+    expect(
+      replaceJapaneseText(
+        undefined,
+        undefined,
+        '<sub alias="かくえきていしゃ">各駅停車</sub>'
+      )
+    ).toBe('<sub alias="かくえきていしゃ">各駅停車</sub>');
+  });
+
+  it('returns name without sub alias when only name is provided', () => {
+    expect(replaceJapaneseText('新宿', null)).toBe('新宿');
+    expect(replaceJapaneseText('新宿', undefined)).toBe('新宿');
+  });
+
+  it('wraps name with sub alias when both name and nameKatakana are provided', () => {
+    expect(replaceJapaneseText('新宿', 'シンジュク')).toBe(
+      '<sub alias="しんじゅく">新宿</sub>'
+    );
+  });
+
+  it('does not fall back to 各駅停車 implicitly (#5917)', () => {
+    // 駅名・路線名のヘルパとして使われるため、誤って `各駅停車` を返してはならない。
+    expect(replaceJapaneseText(null, null)).not.toContain('各駅停車');
+  });
+});
+
+const makeLine = (overrides: Partial<Line>): Line =>
+  ({
+    __typename: 'Line',
+    id: 1,
+    nameShort: '',
+    nameKatakana: '',
+    nameFull: '',
+    nameTtsSegments: null,
+    nameRoman: null,
+    ...overrides,
+  }) as Line;
+
+describe('formatFirstConnectedLineEnPhrase', () => {
+  it('returns empty when lines is empty', () => {
+    expect(formatFirstConnectedLineEnPhrase([])).toBe('');
+  });
+
+  it('renders the phrase from nameTtsSegments when available', () => {
+    const line = makeLine({
+      nameTtsSegments: [
+        {
+          __typename: 'TtsSegment',
+          alphabet: TtsAlphabet.Plain,
+          fallbackText: null,
+          lang: null,
+          pronunciation: null,
+          separator: null,
+          surface: 'Tokyu Toyoko Line',
+        },
+      ],
+      nameRoman: 'Tokyu Toyoko Line',
+    });
+    expect(formatFirstConnectedLineEnPhrase([line])).toBe(
+      'on the Tokyu Toyoko Line'
+    );
+  });
+
+  it('falls back to nameRoman when nameTtsSegments is empty (#5917)', () => {
+    const line = makeLine({
+      nameTtsSegments: [],
+      nameRoman: 'Tokyu Toyoko Line',
+    });
+    expect(formatFirstConnectedLineEnPhrase([line])).toBe(
+      'on the Tokyu Toyoko Line'
+    );
+  });
+
+  it('falls back to nameRoman when nameTtsSegments is null', () => {
+    const line = makeLine({
+      nameTtsSegments: null,
+      nameRoman: 'Tokyu Toyoko Line',
+    });
+    expect(formatFirstConnectedLineEnPhrase([line])).toBe(
+      'on the Tokyu Toyoko Line'
+    );
+  });
+
+  it('returns empty when both nameTtsSegments and nameRoman are missing', () => {
+    const line = makeLine({
+      nameTtsSegments: null,
+      nameRoman: null,
+    });
+    expect(formatFirstConnectedLineEnPhrase([line])).toBe('');
+  });
+});

--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -39,6 +39,21 @@ describe('replaceJapaneseText', () => {
     // 駅名・路線名のヘルパとして使われるため、誤って `各駅停車` を返してはならない。
     expect(replaceJapaneseText(null, null)).not.toContain('各駅停車');
   });
+
+  it('returns fallback when name is nullish but nameKatakana is provided', () => {
+    // 以前は sub 内に `null` / `undefined` が混入していた。
+    expect(replaceJapaneseText(null, 'シンジュク')).toBe('');
+    expect(replaceJapaneseText(undefined, 'シンジュク')).toBe('');
+    expect(replaceJapaneseText(null, 'シンジュク', '各駅停車')).toBe(
+      '各駅停車'
+    );
+
+    // 念のため null / undefined の文字列が混入していないことも確認
+    expect(replaceJapaneseText(null, 'シンジュク')).not.toContain('null');
+    expect(replaceJapaneseText(undefined, 'シンジュク')).not.toContain(
+      'undefined'
+    );
+  });
 });
 
 const makeLine = (overrides: Partial<Line>): Line =>

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -4,22 +4,25 @@ import { wrapPhoneme } from '../../utils/phoneme';
 
 /**
  * 既存実装と同じ規則で sub alias を被せる。
- * 両方未指定なら `fallback` (デフォルト空文字) を返す。
+ * `name` が未指定なら `fallback` (デフォルト空文字) を返す。
  *
  * NOTE: 以前はヘルパ内で `各駅停車` を返していたが、駅名・路線名・会社名にも使われるため、
  * 値欠落時に `次は、各駅停車` のような無関係案内へ化ける問題があった (#5917)。
  * 各駅停車などの train type フォールバックが必要な呼び出し側は明示的に渡す。
+ *
+ * NOTE: `name` だけ nullish で `nameKatakana` が埋まっているケースでは sub 内に
+ * `null` / `undefined` が混入していたため、`name` がない時点で fallback に倒す。
  */
 export const replaceJapaneseText = (
   name: string | null | undefined,
   nameKatakana: string | null | undefined,
   fallback = ''
 ): string => {
-  if (!name && !nameKatakana) {
+  if (!name) {
     return fallback;
   }
   if (!nameKatakana) {
-    return name ?? '';
+    return name;
   }
   return `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`;
 };

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -2,13 +2,21 @@ import type { Line, Station } from '../../@types/graphql';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import { wrapPhoneme } from '../../utils/phoneme';
 
-/** 既存実装と同じ規則で sub alias を被せる。両方未指定なら 各駅停車 のフォールバック sub を返す。 */
+/**
+ * 既存実装と同じ規則で sub alias を被せる。
+ * 両方未指定なら `fallback` (デフォルト空文字) を返す。
+ *
+ * NOTE: 以前はヘルパ内で `各駅停車` を返していたが、駅名・路線名・会社名にも使われるため、
+ * 値欠落時に `次は、各駅停車` のような無関係案内へ化ける問題があった (#5917)。
+ * 各駅停車などの train type フォールバックが必要な呼び出し側は明示的に渡す。
+ */
 export const replaceJapaneseText = (
   name: string | null | undefined,
-  nameKatakana: string | null | undefined
+  nameKatakana: string | null | undefined,
+  fallback = ''
 ): string => {
   if (!name && !nameKatakana) {
-    return '<sub alias="かくえきていしゃ">各駅停車</sub>';
+    return fallback;
   }
   if (!nameKatakana) {
     return name ?? '';
@@ -88,9 +96,17 @@ export const formatJrWestStopsListEn = (
     })
     .join(', ');
 
-/** TY 用: 直通先1路線目のみを `on the X` 形式に整形する。該当がなければ空文字。 */
+/**
+ * TY 用: 直通先1路線目のみを `on the X` 形式に整形する。該当がなければ空文字。
+ *
+ * NOTE: 描画結果ベースで判定する。以前は `nameTtsSegments` の有無だけを見ていたため、
+ * segments が空でも `nameRoman` のみ埋まっているケースで wrapPhoneme の fallback が
+ * 効かず句が丸ごと消えていた (#5917)。
+ */
 export const formatFirstConnectedLineEnPhrase = (lines: Line[]): string => {
   const first = lines[0];
-  if (!first?.nameTtsSegments?.length) return '';
-  return `on the ${wrapPhoneme(first.nameTtsSegments, first.nameRoman)}`;
+  if (!first) return '';
+  const name = wrapPhoneme(first.nameTtsSegments, first.nameRoman);
+  if (!name) return '';
+  return `on the ${name}`;
 };

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -435,3 +435,37 @@ describe('JR_WEST batch cycling', () => {
     expect(result.current.text[1]).toContain('We will be stopping at');
   });
 });
+
+describe('nextStation null guard (#5917)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    require('~/hooks/useNumbering').useNumbering.mockReturnValue([null, '']);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('should return empty text when nextStation is null', () => {
+    // nextStation 未解決のとき、context が組み立たず text / nextText は空文字配列になる。
+    // 以前は replaceJapaneseText のフォールバックで `次は、各駅停車です。` のような誤案内が流れていた。
+    (useNextStation as jest.Mock).mockReturnValue(null);
+    const { result } = renderHook(
+      () => useTTSTextWithJotaiAndNumbering('TOKYO_METRO', 'NEXT'),
+      { wrapper }
+    );
+
+    const [jaText, enText] = result.current.text;
+    const [nextJaText, nextEnText] = result.current.nextText;
+
+    expect(jaText).toBe('');
+    expect(enText).toBe('');
+    expect(nextJaText).toBe('');
+    expect(nextEnText).toBe('');
+
+    // 念のため、無関係案内の 各駅停車 が流れていないことも確認
+    expect(jaText).not.toContain('各駅停車');
+    expect(nextJaText).not.toContain('各駅停車');
+  });
+});

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -283,7 +283,10 @@ export const useTTSText = (
   }, [allStops]);
 
   const context = useMemo<TemplateContext | null>(() => {
-    if (!currentLine || !selectedBound) return null;
+    // nextStation が未解決のまま context を組み立てると
+    // `次は、各駅停車です` のような無関係案内が流れる可能性があるため
+    // currentLine / selectedBound と同様に early return のゲートに含める (#5917)。
+    if (!currentLine || !selectedBound || !nextStation) return null;
 
     const isBoundStop = (s: Station): boolean =>
       s.groupId === selectedBound?.groupId && !isLoopLine;
@@ -334,13 +337,17 @@ export const useTTSText = (
               currentTrainType.nameKatakana
             )
           : '各駅停車'),
-      // JR_WEST 用 (デフォルトなし。currentTrainType が無い場合は replaceJapaneseText のフォールバックで sub 付き 各駅停車 が返る)
+      // JR_WEST 用 (各駅停車 デフォルト)。
+      // 以前は replaceJapaneseText の暗黙フォールバックに依存していたが、
+      // ヘルパは値欠落時に空文字を返すよう変更されたため、ここで明示する (#5917)。
       trainTypeJaPlain:
         yamanoteTrainTypeJa ??
-        replaceJapaneseText(
-          currentTrainType?.name,
-          currentTrainType?.nameKatakana
-        ),
+        (currentTrainType
+          ? replaceJapaneseText(
+              currentTrainType.name,
+              currentTrainType.nameKatakana
+            )
+          : '各駅停車'),
       // JR_KYUSHU 用 (普通 デフォルト)
       trainTypeJaKyushu:
         yamanoteTrainTypeJa ??


### PR DESCRIPTION
## 概要

`useTTSText` および分離後の `src/hooks/tts/` で、データ欠落時の防御が甘く `次は、各駅停車です` のような無関係案内が流れる可能性があったため、4 箇所をまとめて防御強化した。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `replaceJapaneseText` (`src/hooks/tts/formatters.ts`): 値欠落時にハードコードされた `<sub alias="かくえきていしゃ">各駅停車</sub>` を返していた汎用フォールバックを撤廃。第 3 引数 `fallback` (デフォルト `''`) を追加し、呼び出し側が必要なときだけ明示できる形にした。
- `replaceJapaneseText` 追加修正: `name` のみ nullish で `nameKatakana` が埋まっているケースで `<sub alias="...">null</sub>` のように `null` / `undefined` 文字列が混入していたため、`name` がない時点で `fallback` に倒すよう一段目ガードを変更。
- `formatFirstConnectedLineEnPhrase` (同ファイル): `nameTtsSegments` の有無ではなく、`wrapPhoneme(...)` の描画結果で句の出力を判定するよう変更。`nameRoman` のみ埋まっているケースで `on the ...` 句が消えなくなった。
- `useTTSText` の context 構築 (`src/hooks/useTTSText.ts`): `currentLine` / `selectedBound` と同列に `nextStation` も early return ゲートに追加。未解決状態で誤案内が流れるのを防止。
- `trainTypeJaPlain` (JR_WEST 用) の call site: helper の暗黙フォールバックに依存していたため、明示的に `'各駅停車'` を指定。他テーマ (TOKYO_METRO/TY/TOEI/JR_KYUSHU) と同じく call site 明示の形に揃えた。
- 単体テストを追加: `replaceJapaneseText` / `formatFirstConnectedLineEnPhrase` (`src/hooks/tts/formatters.test.ts` 新規) と、`nextStation = null` で `text` / `nextText` が空文字配列になることを検証 (`src/hooks/useTTSText.test.tsx`)。`(name=null, kana=truthy)` の `null` / `undefined` 混入を防ぐ回帰テストも追加。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test`: 1474 / 1474 passing (新規 13 件含む)。`npm run typecheck` はエラーなし。`npm run lint` はローカル Windows checkout の CRLF/LF 差分のみで、git 上は LF 保存なので CI (Linux) では発生しない見込み。

## 関連Issue

Closes #5917

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 音声テキスト生成の回帰テストを追加し、名前欠落やnextStationがnullの場合の挙動を検証

* **改善**
  * 日本語テキスト置換にカスタムフォールバックを導入
  * 英語フレーズ生成の判定ロジックを更新
  * テンプレート生成時に必要な路線情報の要件と日本語車種の明示的フォールバックを強化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5918)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->