### PR TITLE
useTTSText の英語アナウンスで transferLines 末尾ピリオドの単複不整合を修正

### DIFF
--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -48,7 +48,6 @@ export const formatStationsListJa = (stations: Station[]): string =>
  * 末尾ピリオドは付けない。理由:
  * - TY / JR_KYUSHU は list を文中に埋め込む (`transfer to LIST, Please...` や `transfer to LIST at X.`) ため、
  *   ピリオドを足すと文法が壊れる
- * - YAMANOTE NEXT / SAIKYO NEXT / JR_KYUSHU ARRIVING は単数のときだけピリオドを落とす挙動 (※既知の不整合 #5914)
  * - 文末で使うテーマはテンプレ側で `.` を付与する
  */
 export const formatLinesListEn = (lines: Line[]): string => {

--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -214,7 +214,7 @@ const YAMANOTE_EN: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}This is the {currentLineEn} train bound for {boundForEn}. {/if}',
     'The next station is {nextStationEn} {nextStationNumberText} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}{#if hasMultipleTransferLines}.{/if}{/if}'
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
     'The next station is {nextStationEn} {nextStationNumberText}',
@@ -229,7 +229,7 @@ const SAIKYO_EN: ThemeTemplate = {
     '{#if firstSpeech}This is the {currentLineEn} train bound for {boundForEn}. {/if}',
     'The next station is {nextStationEn} {nextStationNumberText}',
     '{#if isNextStopTerminus}, terminal{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}{#if hasMultipleTransferLines}.{/if}{/if}'
+    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
     'The next station is {nextStationEn} {nextStationNumberText}',
@@ -288,7 +288,7 @@ const JR_KYUSHU_EN: ThemeTemplate = {
     'We will soon be arriving at {nextStationEn}',
     '{#if nextStationIsBound} terminal{/if} {nextStationNumberText}. ',
     '{#if hasTransferLines}',
-    'You can transfer to {transferLinesEnList}{#if hasMultipleTransferLines}.{/if} at {nextStationEn}. ',
+    'You can transfer to {transferLinesEnList} at {nextStationEn}. ',
     '{#if nextStationIsBound}Thank you for using the {currentLineEn}.{/if}',
     '{/if}'
   ),

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -436,6 +436,135 @@ describe('JR_WEST batch cycling', () => {
   });
 });
 
+describe('single transferLine period consistency (#5914)', () => {
+  // 東京メトロ副都心線(id=28010)を除外し、次駅 (Shinjuku-sanchome) の
+  // 乗り換え路線を 東京メトロ丸ノ内線 1 本だけに絞る。
+  const FUKUTOSHIN_LINE_ID = 28010;
+
+  const buildSingleTransferNextStation = (): Station => {
+    const base = TOEI_SHINJUKU_LINE_STATIONS[1];
+    return {
+      ...base,
+      lines: base.lines?.filter((l) => l.id !== FUKUTOSHIN_LINE_ID) ?? [],
+    };
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    setupMockUseNextStation(buildSingleTransferNextStation());
+    require('~/hooks/useNumbering').useNumbering.mockReturnValue([
+      {
+        lineSymbol: 'S',
+        lineSymbolColor: '#B0BF1E',
+        lineSymbolShape: 'ROUND',
+        stationNumber: 'S-02',
+      },
+      '',
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const renderEn = (theme: AppTheme, state: HeaderStoppingState): string => {
+    const { result } = renderHook(
+      () => useTTSTextWithJotaiAndNumbering(theme, state),
+      { wrapper }
+    );
+    const [, enSSML] = result.current.text;
+    return enSSML ?? '';
+  };
+
+  test('TOKYO_METRO NEXT keeps the trailing period for length=1', () => {
+    expect(renderEn('TOKYO_METRO', 'NEXT')).toBe(
+      'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('TOKYO_METRO ARRIVING keeps the trailing period for length=1', () => {
+    expect(renderEn('TOKYO_METRO', 'ARRIVING')).toBe(
+      'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('TY NEXT renders list inline for length=1', () => {
+    expect(renderEn('TY', 'NEXT')).toBe(
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, Please transfer at this station.'
+    );
+  });
+
+  test('TY ARRIVING renders list inline for length=1', () => {
+    expect(renderEn('TY', 'ARRIVING')).toBe(
+      'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, Please transfer at this station.'
+    );
+  });
+
+  test('YAMANOTE NEXT appends period for length=1', () => {
+    expect(renderEn('YAMANOTE', 'NEXT')).toBe(
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('YAMANOTE ARRIVING appends period for length=1', () => {
+    expect(renderEn('YAMANOTE', 'ARRIVING')).toBe(
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('SAIKYO NEXT appends period for length=1', () => {
+    expect(renderEn('SAIKYO', 'NEXT')).toBe(
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('SAIKYO ARRIVING appends period for length=1', () => {
+    expect(renderEn('SAIKYO', 'ARRIVING')).toBe(
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('JR_WEST NEXT keeps trailing period for length=1', () => {
+    expect(renderEn('JR_WEST', 'NEXT')).toBe(
+      'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('JR_WEST ARRIVING keeps trailing period for length=1', () => {
+    expect(renderEn('JR_WEST', 'ARRIVING')).toBe(
+      'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.'
+    );
+  });
+
+  test('TOEI NEXT keeps trailing period for length=1', () => {
+    expect(renderEn('TOEI', 'NEXT')).toBe(
+      'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('TOEI ARRIVING keeps trailing period for length=1', () => {
+    expect(renderEn('TOEI', 'ARRIVING')).toBe(
+      'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+    );
+  });
+
+  test('JR_KYUSHU NEXT renders list inline without trailing period for length=1', () => {
+    expect(renderEn('JR_KYUSHU', 'NEXT')).toContain(
+      'You can transfer to the Tokyo Metro Marunouchi Line at Shinjuku-sanchome.'
+    );
+  });
+
+  test('JR_KYUSHU ARRIVING renders list inline without stray period for length=1', () => {
+    const en = renderEn('JR_KYUSHU', 'ARRIVING');
+    expect(en).toContain(
+      'You can transfer to the Tokyo Metro Marunouchi Line at Shinjuku-sanchome.'
+    );
+    // length=1 で "...Line. at X." のような不自然なピリオドが残らないこと
+    expect(en).not.toContain('Marunouchi Line. at');
+  });
+});
+
 describe('nextStation null guard (#5917)', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -297,7 +297,6 @@ export const useTTSText = (
       isNextStopTerminus,
       isAfterNextStopTerminus,
       hasTransferLines: transferLines.length > 0,
-      hasMultipleTransferLines: transferLines.length > 1,
       hasConnectedLines: connectedLines.length > 0,
       hasBetweenStations: betweenNextStation.length > 0,
       hasAfterNextStation: !!afterNextStation,


### PR DESCRIPTION
## 概要

`useTTSText` の英語テンプレートで、乗り換え路線リスト (`transferLines`) 末尾ピリオドの付与ルールがテーマごと・件数ごとに揃っていなかった (#5914) ので length=1 でも末尾 `.` を付けて複数件と整合させた。あわせて JR_KYUSHU ARRIVING では文中ピリオド (`Marunouchi Line. at Shinjuku-sanchome.`) を廃止し、`Marunouchi Line at Shinjuku-sanchome.` に統一した (英語として `at` の前にピリオドは不要なため)。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/templates.ts`:
  - `YAMANOTE_EN.NEXT` / `SAIKYO_EN.NEXT`: `{#if hasMultipleTransferLines}.{/if}` を素のピリオドに置換。length=1 でも末尾 `.` が付くようになり、複数件と整合。
  - `JR_KYUSHU_EN.ARRIVING`: `transferLinesEnList` 直後のピリオド分岐を完全に削除。length>=2 で起きていた `... Line. at Shinjuku-sanchome.` のような文中ピリオドを解消し、単複ともに `... Line at Shinjuku-sanchome.` に統一。
- `src/hooks/tts/formatters.ts`: `formatLinesListEn` のコメントから「単数のときだけピリオドを落とす挙動 (※既知の不整合 #5914)」の記述を削除。
- `src/hooks/useTTSText.ts`: テンプレート側で使われなくなった `hasMultipleTransferLines` context キーを削除。
- `src/hooks/useTTSText.test.tsx`: length=1 transferLines で各テーマ (TOKYO_METRO / TY / YAMANOTE / SAIKYO / JR_WEST / TOEI / JR_KYUSHU) の NEXT/ARRIVING を検証する describe ブロック (14 件) を追加。次駅 (Shinjuku-sanchome) の `lines` から東京メトロ副都心線を除外して `transferLines` を 1 件に絞り、英語 SSML の末尾ピリオドを検証。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行ログ:

- `npx cross-env TZ=UTC jest`: 152 suites / 1488 tests pass (新規 14 件含む)
- `npm run typecheck`: pass
- `npm run lint`: pass (Windows ローカルでは既存 CRLF/LF 警告 20 件あり。base ブランチと同数で、本 PR の変更とは無関係)

## 関連Issue

Closes #5914

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 英語版の乗り換え路線に関するTTSアナウンスの表現を統一し、一貫性を向上させました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5919)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->