### PR TITLE
useTTSText のテンプレートで欠落していた終点アナウンスを補完

### DIFF
--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -103,7 +103,7 @@ const JR_WEST: ThemeTemplate = {
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}'
   ),
   ARRIVING: t(
-    '{#if isNextStopTerminus}',
+    '{#if nextStationIsBound}',
     '終点、{nextStationJa}です。',
     'ご乗車ありがとうございました。',
     'まもなく{nextStationJa}、{nextStationJa}です。',

--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -10,7 +10,7 @@ const TOKYO_METRO: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}',
     '{currentLineJa}をご利用くださいまして、ありがとうございます。',
-    '次は、{nextStationJa}です。',
+    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
     'この電車は、',
     '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
     '{trainTypeJa}、{boundForJa}ゆきです。',
@@ -69,10 +69,8 @@ const YAMANOTE: ThemeTemplate = {
   ),
   ARRIVING: t(
     'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}',
-    '{transferLinesListJa}は、お乗り換えです。',
-    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}',
-    '{/if}'
+    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}',
+    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}'
   ),
 };
 
@@ -84,10 +82,8 @@ const SAIKYO: ThemeTemplate = {
   ),
   ARRIVING: t(
     'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}',
-    '{transferLinesListJa}は、お乗り換えです。',
-    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}',
-    '{/if}'
+    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}',
+    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}'
   ),
 };
 
@@ -108,6 +104,7 @@ const JR_WEST: ThemeTemplate = {
   ),
   ARRIVING: t(
     '{#if isNextStopTerminus}',
+    '終点、{nextStationJa}です。',
     'ご乗車ありがとうございました。',
     'まもなく{nextStationJa}、{nextStationJa}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
@@ -124,7 +121,7 @@ const JR_WEST: ThemeTemplate = {
 const TOEI: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}{currentLineJa}をご利用くださいまして、ありがとうございます。{/if}',
-    '次は、{nextStationJa}、{nextStationJa}。 ',
+    '次は、{nextStationJa}、{nextStationJa}{#if isNextStopTerminus}、終点です{/if}。 ',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
     'この電車は、',
     '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
@@ -137,7 +134,7 @@ const TOEI: ThemeTemplate = {
     '{#if hasBetweenStations}通過する、{betweenStationsListJa}へおいでの方はお乗り換えです。{/if}'
   ),
   ARRIVING: t(
-    'まもなく、{nextStationJa}、{nextStationJa}。',
+    'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
     '{#if hasTrainTypeAndAfterNext}',
     '{nextStationJa}の次は、',
@@ -157,10 +154,8 @@ const JR_KYUSHU: ThemeTemplate = {
   ),
   ARRIVING: t(
     'まもなく、{#if nextStationIsBound}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}',
-    '{transferLinesListJa}にお乗り換えいただけます。',
-    '{#if nextStationIsBound}{currentLineShortJa}をご利用くださいまして、ありがとうございました。{/if}',
-    '{/if}'
+    '{#if hasTransferLines}{transferLinesListJa}にお乗り換えいただけます。{/if}',
+    '{#if nextStationIsBound}{currentLineShortJa}をご利用くださいまして、ありがとうございました。{/if}'
   ),
 };
 
@@ -168,6 +163,7 @@ const TOKYO_METRO_EN: ThemeTemplate = {
   NEXT: t(
     'The next stop is {nextStationEn}',
     '{#if hasNextStationNumberText} {nextStationNumberText}{:else}.{/if}',
+    '{#if isNextStopTerminus} The last stop.{/if}',
     '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}',
     '{#if firstSpeech}',
     ' This train is the ',
@@ -213,7 +209,8 @@ const TY_EN: ThemeTemplate = {
 const YAMANOTE_EN: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}This is the {currentLineEn} train bound for {boundForEn}. {/if}',
-    'The next station is {nextStationEn} {nextStationNumberText} ',
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, terminal.{/if} ',
     '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
@@ -255,7 +252,7 @@ const JR_WEST_EN: ThemeTemplate = {
     '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
-    'We will soon be making a brief stop at {nextStationEn}',
+    'We will soon be making a brief stop at {nextStationEn}{#if nextStationIsBound} terminal{/if}',
     '{#if hasNextStationNumberLineSymbol} station number {nextStationNumberTextNoPeriod}.{:else}.{/if} ',
     '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if} ',
     '{#if hasAfterNextStation}After leaving {nextStationEn}, We will be stopping at {afterNextStationEn}.{/if}'
@@ -266,11 +263,13 @@ const TOEI_EN: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}Thank you for using the {currentLineEn}. {/if}',
     'This is the {trainTypeEn} train bound for {boundForEn}. ',
-    'The next station is {nextStationEn} {nextStationNumberText} ',
+    'The next station is {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, the last stop{/if} ',
     '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
-    'We will soon be arriving at {nextStationEn} {nextStationNumberText} ',
+    'We will soon be arriving at {nextStationEn} {nextStationNumberText}',
+    '{#if isNextStopTerminus}, the last stop{/if} ',
     '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}',
     '{#if hasTrainTypeAndAfterNext} The stop after {nextStationEn}, will be {afterNextStationEn}{#if isAfterNextStopTerminus} the last stop{/if}.{/if}',
     '{#if isNextStopTerminus} Thank you for using the {currentLineEn}.{/if}'

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -565,6 +565,189 @@ describe('single transferLine period consistency (#5914)', () => {
   });
 });
 
+describe('terminus announcement (#5915)', () => {
+  // 各テーマ NEXT / ARRIVING で「次の駅が終点」のときに
+  // JA/EN いずれにも「終点 / terminal / last stop」相当の語が含まれることを検証。
+
+  const TERMINUS_INDEX = TOEI_SHINJUKU_LINE_STATIONS.length - 1;
+  const TERMINUS = TOEI_SHINJUKU_LINE_STATIONS[TERMINUS_INDEX];
+
+  const useTerminusHelper = ({
+    theme,
+    headerState,
+    boundIndex = TERMINUS_INDEX,
+    nextStationIndex = TERMINUS_INDEX,
+  }: {
+    theme: AppTheme;
+    headerState: HeaderStoppingState;
+    boundIndex?: number;
+    nextStationIndex?: number;
+  }) => {
+    const setLineState = useSetAtom(lineState);
+    const setStationState = useSetAtom(stationState);
+
+    useEffect(() => {
+      // 次駅 = TERMINUS の前提では「現在駅 = 終点の一つ手前」を想定。
+      // ただし selectedBound を中間駅にする検証では nextStationIndex を任意指定する。
+      const station =
+        TOEI_SHINJUKU_LINE_STATIONS[Math.max(0, nextStationIndex - 1)];
+      const stations = TOEI_SHINJUKU_LINE_STATIONS;
+      const selectedDirection = 'INBOUND' as LineDirection;
+      const selectedLine = TOEI_SHINJUKU_LINE_LOCAL;
+      const selectedBound = TOEI_SHINJUKU_LINE_STATIONS[boundIndex];
+
+      const arrived = headerState === 'CURRENT';
+      const approaching = headerState === 'ARRIVING';
+
+      store.set(themePreferenceAtom, theme);
+      setStationState((prev) => ({
+        ...prev,
+        station,
+        stations,
+        selectedDirection,
+        arrived,
+        selectedBound,
+        approaching,
+      }));
+      setLineState((prev) => ({ ...prev, selectedLine }));
+    }, [boundIndex, headerState, nextStationIndex, setLineState, setStationState, theme]);
+
+    return useTTSText(false, true);
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    require('~/hooks/useNumbering').useNumbering.mockReturnValue([
+      {
+        lineSymbol: 'S',
+        lineSymbolColor: '#B0BF1E',
+        lineSymbolShape: 'ROUND',
+        stationNumber: `S-${String(TERMINUS_INDEX + 1).padStart(2, '0')}`,
+      },
+      '',
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const renderTexts = (
+    theme: AppTheme,
+    headerState: HeaderStoppingState,
+    overrides: { boundIndex?: number; nextStationIndex?: number } = {}
+  ): [string, string] => {
+    setupMockUseNextStation(
+      TOEI_SHINJUKU_LINE_STATIONS[
+        overrides.nextStationIndex ?? TERMINUS_INDEX
+      ]
+    );
+    const { result } = renderHook(
+      () => useTerminusHelper({ theme, headerState, ...overrides }),
+      { wrapper }
+    );
+    const [ja, en] = result.current.text;
+    return [ja ?? '', en ?? ''];
+  };
+
+  // useIsTerminus は stations[0] / stations[last] と一致するときに true を返す。
+  // TERMINUS のテーマ群はその判定に従う。
+  type TerminusCase = {
+    theme: AppTheme;
+    state: HeaderStoppingState;
+    ja: string;
+    en: string[];
+  };
+
+  const TERMINUS_CASES: TerminusCase[] = [
+    { theme: 'TOKYO_METRO', state: 'NEXT', ja: '終点', en: ['last stop'] },
+    { theme: 'TOKYO_METRO', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
+    { theme: 'TY', state: 'NEXT', ja: '終点', en: ['last stop'] },
+    { theme: 'TY', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
+    { theme: 'YAMANOTE', state: 'NEXT', ja: '終点', en: ['terminal'] },
+    { theme: 'YAMANOTE', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
+    { theme: 'SAIKYO', state: 'NEXT', ja: '終点', en: ['terminal'] },
+    { theme: 'SAIKYO', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
+    { theme: 'TOEI', state: 'NEXT', ja: '終点', en: ['last stop'] },
+    { theme: 'TOEI', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
+    // JR_WEST / JR_KYUSHU は nextStationIsBound 判定だが、selectedBound が
+    // 物理的な終点と一致するこのケースでは isNextStopTerminus も true になる。
+    { theme: 'JR_WEST', state: 'NEXT', ja: '終点', en: ['terminal'] },
+    { theme: 'JR_WEST', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
+    { theme: 'JR_KYUSHU', state: 'NEXT', ja: '終点', en: ['terminal'] },
+    { theme: 'JR_KYUSHU', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
+  ];
+
+  test.each(TERMINUS_CASES)(
+    'announces terminus for $theme / $state in both languages',
+    ({ theme, state, ja, en }) => {
+      const [jaText, enText] = renderTexts(theme as AppTheme, state);
+      expect(jaText).toContain(ja);
+      for (const phrase of en) {
+        expect(enText).toContain(phrase);
+      }
+    }
+  );
+
+  // selectedBound が物理的終点ではない中間駅のとき、nextStationIsBound 判定を
+  // 採っているテーマ (JR_WEST / JR_KYUSHU) では引き続き 終点 / terminal を発話する。
+  const MID_BOUND_INDEX = 5; // 神保町
+  const MID_BOUND_CASES = [
+    { theme: 'JR_WEST', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
+    { theme: 'JR_KYUSHU', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
+    { theme: 'JR_KYUSHU', state: 'ARRIVING' as HeaderStoppingState, en: 'terminal' },
+  ];
+
+  test.each(MID_BOUND_CASES)(
+    'announces terminus when bound is a mid-line station for $theme / $state',
+    ({ theme, state, en }) => {
+      const [jaText, enText] = renderTexts(theme as AppTheme, state, {
+        boundIndex: MID_BOUND_INDEX,
+        nextStationIndex: MID_BOUND_INDEX,
+      });
+      expect(jaText).toContain('終点');
+      expect(enText).toContain(en);
+    }
+  );
+
+  // 念のため、selectedBound = TERMINUS の通常ケースで JR_WEST ARRIVING JA に
+  // 追加された「終点、X です。」が含まれることを検証する。
+  test('JR_WEST ARRIVING JA prepends 終点 before thanks', () => {
+    const [jaText] = renderTexts('JR_WEST', 'ARRIVING');
+    expect(jaText).toMatch(/終点、.+です。ご乗車ありがとうございました。/);
+  });
+
+  // YAMANOTE / SAIKYO / JR_KYUSHU ARRIVING の thanks が hasTransferLines に
+  // 依存せず終点時に発話されることを検証する (※1)。
+  // 乗り換え路線を取り除いた終点駅をモックすることで、修正前は thanks が
+  // 出なかった経路を踏ませる。
+  test.each([
+    ['YAMANOTE', 'ご利用くださいまして、ありがとうございました'],
+    ['SAIKYO', 'ご利用くださいまして、ありがとうございました'],
+    ['JR_KYUSHU', 'ご利用くださいまして、ありがとうございました'],
+  ])(
+    '%s ARRIVING JA announces thanks even when terminus has no transferLines',
+    (theme, thanksPhrase) => {
+      const terminusWithoutTransfers: Station = {
+        ...TERMINUS,
+        lines: [],
+      };
+      (useNextStation as jest.Mock).mockReturnValue(terminusWithoutTransfers);
+      const { result } = renderHook(
+        () =>
+          useTerminusHelper({
+            theme: theme as AppTheme,
+            headerState: 'ARRIVING',
+          }),
+        { wrapper }
+      );
+      const [jaText] = result.current.text;
+      expect(jaText ?? '').toContain(thanksPhrase);
+    }
+  );
+});
+
 describe('nextStation null guard (#5917)', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -610,7 +610,14 @@ describe('terminus announcement (#5915)', () => {
         approaching,
       }));
       setLineState((prev) => ({ ...prev, selectedLine }));
-    }, [boundIndex, headerState, nextStationIndex, setLineState, setStationState, theme]);
+    }, [
+      boundIndex,
+      headerState,
+      nextStationIndex,
+      setLineState,
+      setStationState,
+      theme,
+    ]);
 
     return useTTSText(false, true);
   };
@@ -639,9 +646,7 @@ describe('terminus announcement (#5915)', () => {
     overrides: { boundIndex?: number; nextStationIndex?: number } = {}
   ): [string, string] => {
     setupMockUseNextStation(
-      TOEI_SHINJUKU_LINE_STATIONS[
-        overrides.nextStationIndex ?? TERMINUS_INDEX
-      ]
+      TOEI_SHINJUKU_LINE_STATIONS[overrides.nextStationIndex ?? TERMINUS_INDEX]
     );
     const { result } = renderHook(
       () => useTerminusHelper({ theme, headerState, ...overrides }),
@@ -695,8 +700,16 @@ describe('terminus announcement (#5915)', () => {
   const MID_BOUND_INDEX = 5; // 神保町
   const MID_BOUND_CASES = [
     { theme: 'JR_WEST', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
-    { theme: 'JR_KYUSHU', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
-    { theme: 'JR_KYUSHU', state: 'ARRIVING' as HeaderStoppingState, en: 'terminal' },
+    {
+      theme: 'JR_KYUSHU',
+      state: 'NEXT' as HeaderStoppingState,
+      en: 'terminal',
+    },
+    {
+      theme: 'JR_KYUSHU',
+      state: 'ARRIVING' as HeaderStoppingState,
+      en: 'terminal',
+    },
   ];
 
   test.each(MID_BOUND_CASES)(

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -701,6 +701,11 @@ describe('terminus announcement (#5915)', () => {
   const MID_BOUND_CASES = [
     { theme: 'JR_WEST', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
     {
+      theme: 'JR_WEST',
+      state: 'ARRIVING' as HeaderStoppingState,
+      en: 'terminal',
+    },
+    {
       theme: 'JR_KYUSHU',
       state: 'NEXT' as HeaderStoppingState,
       en: 'terminal',


### PR DESCRIPTION
## 概要

`useTTSText` の各テーマ NEXT / ARRIVING で欠落していた「次の駅が終点」のアナウンス（JA: 「終点」 / EN: "terminal" / "the last stop"）を補完する。bug ラベル付き Issue #5915 への対応。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/templates.ts`: 以下のテンプレートに終点アナウンスを追加・調整した。
  - TOKYO_METRO NEXT JA（firstSpeech=true 側）: `次は、X、終点です。` を発話。
  - TOKYO_METRO NEXT EN: `The next stop is X. ... The last stop.` を発話。
  - YAMANOTE NEXT EN: ARRIVING と同じ `, terminal.` 形を追加。
  - JR_WEST ARRIVING JA: `ご乗車ありがとうございました。` の前に `終点、X です。` を追加。
  - JR_WEST ARRIVING EN: `... brief stop at X terminal ...` を発話。
  - TOEI NEXT JA: 末尾に `、終点です` を追加。
  - TOEI ARRIVING JA: `まもなく、終点、X、X。` の prefix を追加。
  - TOEI NEXT/ARRIVING EN: `, the last stop` を追加。
- `src/hooks/tts/templates.ts`: 副次バグ修正（Issue の ※1）。YAMANOTE / SAIKYO / JR_KYUSHU の ARRIVING で `transferLines.length` が真のときだけ thanks メッセージが出ていた問題を、ブロック構造を平坦化して `isNextStopTerminus` / `nextStationIsBound` のみで発話されるよう修正。
- 判定ロジックは Issue の方針に従い、TOKYO_METRO / TY / YAMANOTE / SAIKYO / TOEI は `isNextStopTerminus`、JR_WEST / JR_KYUSHU は `nextStationIsBound` を使用。既存テーマの慣習に揃えている。
- `src/hooks/useTTSText.test.tsx`: `terminus announcement (#5915)` describe を追加。
  - 各テーマで `nextStation = stations[last]` の状態で NEXT / ARRIVING を呼び、JA に `終点` / EN に `terminal` または `last stop` が含まれることを検証（全 14 ケース）。
  - JR_WEST / JR_KYUSHU は `selectedBound` を中間駅 (神保町) に設定したケースも追加検証（3 ケース）。
  - JR_WEST ARRIVING JA の `終点、X です。ご乗車...` 連結を正規表現で検証。
  - ※1 修正検証: 終点駅から `lines` を削除して `transferLines` を空にしたうえで、YAMANOTE / SAIKYO / JR_KYUSHU の ARRIVING で thanks 文が発話されることを検証。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

検証メモ:

- `npm test`: 1509 / 1509 passed（`useTTSText.test.tsx` 単体は 67 / 67 passed）。
- `npm run typecheck`: exit 0。
- `npm run lint`: 当該変更前後で `Found 20 errors.` のまま増減なし。20 件はすべて Windows 環境固有の CRLF フォーマット差分で、CI 環境（Linux）では発生しない既知のローカル差分。

## 関連Issue

Closes #5915

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 終点（ラストストップ／terminal）表現を複数路線テーマ（日本語・英語）で調整し、到着/次発時の案内文をより自然で正確に表示するよう改善しました
  * 乗換・終点に関する条件付けを整理し、案内の冗長さや欠落を低減しました

* **テスト**
  * 終点表現の挙動を検証する包括的なテストスイートを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5920)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->