### PR TITLE
CommonCard で対象駅の駅番号が無い場合はナンバリング記号を返さない

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -223,10 +223,33 @@ export const CommonCard: React.FC<Props> = ({
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const getLineMark = useGetLineMark();
-  const mark = useMemo(
-    () => getLineMark({ line, stationNumbers: targetStation?.stationNumbers }),
-    [getLineMark, line, targetStation?.stationNumbers]
-  );
+  const mark = useMemo(() => {
+    const m = getLineMark({
+      line,
+      stationNumbers: targetStation?.stationNumbers,
+    });
+    if (!m) {
+      return null;
+    }
+    // 路線シンボルはあるが当該駅の駅番号が無く、画像 (signPath) で代替もできない場合は
+    // NumberingIcon が中途半端な記号だけの描画になるためマーク自体を返さない
+    if (
+      line.lineSymbols?.length &&
+      targetStation &&
+      !m.signPath &&
+      !m.btUnionSignPaths?.length
+    ) {
+      const hasMatchingStationNumber = targetStation.stationNumbers?.some(
+        (sn) =>
+          sn?.stationNumber &&
+          line.lineSymbols?.some((sym) => sym?.symbol === sn?.lineSymbol)
+      );
+      if (!hasMatchingStationNumber) {
+        return null;
+      }
+    }
+    return m;
+  }, [getLineMark, line, targetStation]);
   const { bounds } = useBounds(stations);
 
   const isBus = isBusLine(line);


### PR DESCRIPTION
## 概要

`CommonCard` が、路線シンボルは設定されているのに当該駅の駅番号を持たない駅 (例: 川越線日新駅) を描画するとき、`NumberingIconSquare` が路線記号 (`JA`) だけ表示される中途半端な見た目になっていた。`getLineMark` 由来の `mark` を返さない条件を追加し、画像 (`signPath`) で代替もできない場合は既存の空プレースホルダー (`withoutMark`) にフォールバックするよう修正した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/CommonCard.tsx`: `mark` の `useMemo` を拡張し、`line.lineSymbols` があるのに `targetStation.stationNumbers` に対応する駅番号が存在せず、`signPath` / `btUnionSignPaths` の画像代替もできない場合は `null` を返すようにした。
- 川越線大宮駅 (`JA-26` が紐付く) のように駅番号が取れるケースは従来通りマークを返すため、表示は変わらない。
- 京急本線/泉岳寺のように当該駅では `KK` の駅番号が引けないが線そのものに `signPath` (KK ロゴ画像) があるケースは、画像代替が効くため `mark` を返し続け、表示崩れを起こさない。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint` は CommonCard.tsx については新規エラー無し (既存の他ファイルの CRLF 等の指摘は本 PR のスコープ外)。`npm run typecheck` はクリーン。`TransferLineMark` のテストはパス。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* マーク表示の処理を改善し、特定の条件下で不完全なマークが表示されるのを防ぐようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5923)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->