### PR TITLE
駅名のカッコ書きを TTS で読み上げないように案内テンプレへ渡す前に取り除く (#1175)

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -141,6 +141,13 @@ describe('stripParensForTTS', () => {
     expect(stripParensForTTS('A(b)C（d）E')).toBe('ACE');
   });
 
+  it('collapses leftover whitespace and trims edges', () => {
+    expect(stripParensForTTS('A (b)  C')).toBe('A C');
+    expect(stripParensForTTS('Dentetsu-Toyama (Toyota Mobility)')).toBe(
+      'Dentetsu-Toyama'
+    );
+  });
+
   it('passes through values without parentheses untouched', () => {
     expect(stripParensForTTS('新宿')).toBe('新宿');
   });
@@ -197,15 +204,13 @@ describe('stripStationParensForTTS', () => {
     const stripped = stripStationParensForTTS(baseStation);
     expect(stripped.name).toBe('電鉄富山');
     expect(stripped.nameKatakana).toBe('デンテツトヤマ');
-    expect(stripped.nameRoman).toBe('Dentetsu-Toyama ');
+    expect(stripped.nameRoman).toBe('Dentetsu-Toyama');
   });
 
   it('strips parentheses from nameTtsSegments fields', () => {
     const stripped = stripStationParensForTTS(baseStation);
-    expect(stripped.nameTtsSegments?.[0]?.surface).toBe('Dentetsu-Toyama ');
-    expect(stripped.nameTtsSegments?.[0]?.fallbackText).toBe(
-      'Dentetsu-Toyama '
-    );
+    expect(stripped.nameTtsSegments?.[0]?.surface).toBe('Dentetsu-Toyama');
+    expect(stripped.nameTtsSegments?.[0]?.fallbackText).toBe('Dentetsu-Toyama');
   });
 
   it('preserves non-TTS fields like groupId and stationNumbers', () => {

--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -1,8 +1,10 @@
-import type { Line } from '~/@types/graphql';
+import type { Line, Station } from '~/@types/graphql';
 import { TtsAlphabet } from '~/@types/graphql';
 import {
   formatFirstConnectedLineEnPhrase,
   replaceJapaneseText,
+  stripParensForTTS,
+  stripStationParensForTTS,
 } from './formatters';
 
 describe('replaceJapaneseText', () => {
@@ -119,5 +121,114 @@ describe('formatFirstConnectedLineEnPhrase', () => {
       nameRoman: null,
     });
     expect(formatFirstConnectedLineEnPhrase([line])).toBe('');
+  });
+});
+
+describe('stripParensForTTS', () => {
+  it('removes half-width parentheses and their contents', () => {
+    expect(stripParensForTTS('電鉄富山(トヨタモビリティ富山)')).toBe(
+      '電鉄富山'
+    );
+  });
+
+  it('removes full-width parentheses and their contents', () => {
+    expect(stripParensForTTS('電鉄富山（トヨタモビリティ富山）')).toBe(
+      '電鉄富山'
+    );
+  });
+
+  it('removes multiple parenthesised groups in a single string', () => {
+    expect(stripParensForTTS('A(b)C（d）E')).toBe('ACE');
+  });
+
+  it('passes through values without parentheses untouched', () => {
+    expect(stripParensForTTS('新宿')).toBe('新宿');
+  });
+
+  it('preserves null and undefined inputs', () => {
+    expect(stripParensForTTS(null)).toBeNull();
+    expect(stripParensForTTS(undefined)).toBeUndefined();
+  });
+});
+
+describe('stripStationParensForTTS', () => {
+  const baseStation: Station = {
+    __typename: 'Station',
+    address: null,
+    closedAt: null,
+    distance: null,
+    groupId: 1,
+    hasTrainTypes: null,
+    id: 1,
+    latitude: null,
+    line: null,
+    lines: null,
+    longitude: null,
+    name: '電鉄富山(トヨタモビリティ富山)',
+    nameChinese: null,
+    nameIpa: null,
+    nameKatakana: 'デンテツトヤマ(トヨタモビリティトヤマ)',
+    nameKorean: null,
+    nameRoman: 'Dentetsu-Toyama (Toyota Mobility Toyama)',
+    nameRomanIpa: null,
+    nameTtsSegments: [
+      {
+        __typename: 'TtsSegment',
+        alphabet: TtsAlphabet.Plain,
+        fallbackText: 'Dentetsu-Toyama (fallback)',
+        lang: null,
+        pronunciation: null,
+        separator: null,
+        surface: 'Dentetsu-Toyama (Toyota Mobility Toyama)',
+      },
+    ],
+    openedAt: null,
+    postalCode: null,
+    prefectureId: null,
+    stationNumbers: null,
+    status: null,
+    stopCondition: null,
+    threeLetterCode: null,
+    trainType: null,
+    transportType: null,
+  };
+
+  it('strips parentheses from name / nameKatakana / nameRoman', () => {
+    const stripped = stripStationParensForTTS(baseStation);
+    expect(stripped.name).toBe('電鉄富山');
+    expect(stripped.nameKatakana).toBe('デンテツトヤマ');
+    expect(stripped.nameRoman).toBe('Dentetsu-Toyama ');
+  });
+
+  it('strips parentheses from nameTtsSegments fields', () => {
+    const stripped = stripStationParensForTTS(baseStation);
+    expect(stripped.nameTtsSegments?.[0]?.surface).toBe('Dentetsu-Toyama ');
+    expect(stripped.nameTtsSegments?.[0]?.fallbackText).toBe(
+      'Dentetsu-Toyama '
+    );
+  });
+
+  it('preserves non-TTS fields like groupId and stationNumbers', () => {
+    const stripped = stripStationParensForTTS({
+      ...baseStation,
+      stationNumbers: [
+        {
+          __typename: 'StationNumber',
+          lineSymbol: 'T',
+          lineSymbolColor: '#000',
+          lineSymbolShape: 'ROUND',
+          stationNumber: 'T-01',
+        },
+      ],
+    });
+    expect(stripped.groupId).toBe(1);
+    expect(stripped.stationNumbers?.[0]?.stationNumber).toBe('T-01');
+  });
+
+  it('returns a new object without mutating the source', () => {
+    const original = { ...baseStation };
+    const stripped = stripStationParensForTTS(baseStation);
+    expect(stripped).not.toBe(baseStation);
+    expect(baseStation.name).toBe(original.name);
   });
 });

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -8,10 +8,20 @@ import { wrapPhoneme } from '../../utils/phoneme';
 // できないため、TTS パイプライン専用に別定義する (issue #1175)。
 const ttsParensRegexp = /[（(][^（）()]*[）)]/g;
 
-/** TTS で読み上げる文字列からカッコ (半角・全角) と中身を取り除く。 */
+/**
+ * TTS で読み上げる文字列からカッコ (半角・全角) と中身を取り除く。
+ * 取り除いたあとに連続空白を 1 つに畳み、両端の空白も落として
+ * `nameRoman` などで残る不自然な空白が読み上げに乗らないようにする。
+ */
 export const stripParensForTTS = <T extends string | null | undefined>(
   value: T
-): T => (value == null ? value : (value.replace(ttsParensRegexp, '') as T));
+): T => {
+  if (value == null) return value;
+  return value
+    .replace(ttsParensRegexp, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim() as T;
+};
 
 const stripTtsSegmentParens = (seg: TtsSegment): TtsSegment => ({
   ...seg,

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -1,6 +1,39 @@
-import type { Line, Station } from '../../@types/graphql';
+import type { Line, Station, TtsSegment } from '../../@types/graphql';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import { wrapPhoneme } from '../../utils/phoneme';
+
+// 駅名に併記されたカッコ書き (例: 命名権スポンサー名 `電鉄富山(トヨタモビリティ富山)`)
+// を TTS で読み上げないために、半角・全角のカッコと中身を取り除く。
+// 既存の `parenthesisRegexp` は半角のみで駅 API が全角を返すケースをカバー
+// できないため、TTS パイプライン専用に別定義する (issue #1175)。
+const ttsParensRegexp = /[（(][^（）()]*[）)]/g;
+
+/** TTS で読み上げる文字列からカッコ (半角・全角) と中身を取り除く。 */
+export const stripParensForTTS = <T extends string | null | undefined>(
+  value: T
+): T => (value == null ? value : (value.replace(ttsParensRegexp, '') as T));
+
+const stripTtsSegmentParens = (seg: TtsSegment): TtsSegment => ({
+  ...seg,
+  surface: stripParensForTTS(seg.surface),
+  fallbackText: stripParensForTTS(seg.fallbackText),
+});
+
+/**
+ * Station の TTS 関連フィールド (name / nameKatakana / nameRoman /
+ * nameTtsSegments) からカッコ書きを取り除いた新しい Station を返す。
+ *
+ * `<sub alias="...">name</sub>` のような SSML 構築前にこれを通すことで、
+ * alias 側 (= 実際に読み上げられる読み) にもカッコ内のスポンサー名などが
+ * 残らないようにする (issue #1175)。表示用データには影響しない。
+ */
+export const stripStationParensForTTS = (station: Station): Station => ({
+  ...station,
+  name: stripParensForTTS(station.name),
+  nameKatakana: stripParensForTTS(station.nameKatakana),
+  nameRoman: stripParensForTTS(station.nameRoman),
+  nameTtsSegments: station.nameTtsSegments?.map(stripTtsSegmentParens),
+});
 
 /**
  * 既存実装と同じ規則で sub alias を被せる。

--- a/src/hooks/useBusTTSText.ts
+++ b/src/hooks/useBusTTSText.ts
@@ -8,6 +8,7 @@ import { themeAtom } from '../store/atoms/theme';
 import getIsPass from '../utils/isPass';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { wrapPhoneme as ph } from '../utils/phoneme';
+import { stripStationParensForTTS } from './tts/formatters';
 import { useAfterNextStation } from './useAfterNextStation';
 import { useBounds } from './useBounds';
 import { useCurrentLine } from './useCurrentLine';
@@ -116,17 +117,33 @@ export const useBusTTSText = (
     [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
   );
 
-  const nextStation = nextStationOrigin ?? null;
+  // 駅名に併記されたカッコ書き (命名権スポンサー名など) を TTS で読み上げないため、
+  // template に渡す手前で TTS 関連フィールドからカッコと中身を落としておく
+  // (issue #1175)。表示用データには影響させない。
+  const nextStation = useMemo(
+    () =>
+      nextStationOrigin ? stripStationParensForTTS(nextStationOrigin) : null,
+    [nextStationOrigin]
+  );
 
   // 直通時、同じGroupIDの駅が違う駅として扱われるのを防ぐ(ex. 渋谷の次は渋谷に止まります)
-  const slicedStations = Array.from(
-    new Set(slicedStationsOrigin.map((s) => s.groupId))
-  )
-    .map((gid) => slicedStationsOrigin.find((s) => s.groupId === gid))
-    .filter((s) => !!s) as Station[];
+  const slicedStations = useMemo(
+    () =>
+      Array.from(new Set(slicedStationsOrigin.map((s) => s.groupId)))
+        .map((gid) => slicedStationsOrigin.find((s) => s.groupId === gid))
+        .filter((s): s is Station => !!s)
+        .map(stripStationParensForTTS),
+    [slicedStationsOrigin]
+  );
 
   const afterNextStationOrigin = useAfterNextStation();
-  const afterNextStation = afterNextStationOrigin;
+  const afterNextStation = useMemo(
+    () =>
+      afterNextStationOrigin
+        ? stripStationParensForTTS(afterNextStationOrigin)
+        : undefined,
+    [afterNextStationOrigin]
+  );
 
   const nextStationIndex = useMemo(
     () => slicedStations.findIndex((s) => s.groupId === nextStation?.groupId),

--- a/src/hooks/useBusTTSText.ts
+++ b/src/hooks/useBusTTSText.ts
@@ -84,21 +84,28 @@ export const useBusTTSText = (
     [selectedBoundOrigin]
   );
 
+  // directionalStops のカッコ書きも TTS で読み上げないため、
+  // boundForJa / boundForEn に渡す前に取り除く (issue #1175)。
+  const directionalStopsForTTS = useMemo(
+    () => directionalStops.map(stripStationParensForTTS),
+    [directionalStops]
+  );
+
   const boundForJa = useMemo(
     () =>
       isLoopLine
         ? // NOTE: メジャーな駅だからreplaceJapaneseTextは要らない...はず
           loopLineBoundJa?.boundFor?.replace(/・/g, '<break time="250ms"/>')
         : replaceJapaneseText(
-            `${directionalStops?.map((s) => s?.name).join('・')}${
+            `${directionalStopsForTTS.map((s) => s?.name).join('・')}${
               isPartiallyLoopLine ? '方面' : ''
             }`,
-            `${directionalStops?.map((s) => s?.nameKatakana).join('・')}${
+            `${directionalStopsForTTS.map((s) => s?.nameKatakana).join('・')}${
               isPartiallyLoopLine ? 'ホウメン' : ''
             }`
           ),
     [
-      directionalStops,
+      directionalStopsForTTS,
       isLoopLine,
       isPartiallyLoopLine,
       loopLineBoundJa?.boundFor,
@@ -110,11 +117,10 @@ export const useBusTTSText = (
     () =>
       isLoopLine
         ? (loopLineBoundEn?.boundFor?.replaceAll('&', ' and ') ?? '')
-        : (directionalStops
-            ?.map((s) => ph(s?.nameTtsSegments, s?.nameRoman))
-            .join(' and ') ?? ''),
-
-    [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
+        : directionalStopsForTTS
+            .map((s) => ph(s?.nameTtsSegments, s?.nameRoman))
+            .join(' and '),
+    [directionalStopsForTTS, isLoopLine, loopLineBoundEn?.boundFor]
   );
 
   // 駅名に併記されたカッコ書き (命名権スポンサー名など) を TTS で読み上げないため、

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -766,6 +766,71 @@ describe('terminus announcement (#5915)', () => {
   );
 });
 
+describe('station name parens are not read aloud (issue #1175)', () => {
+  // 駅名に併記されたカッコ書き (命名権スポンサー名など) を TTS で
+  // 読み上げない。`<sub alias>` の中身も含めてカッコと中身が抜ける。
+  const buildStationWithParens = (): Station => {
+    const base = TOEI_SHINJUKU_LINE_STATIONS[1];
+    return {
+      ...base,
+      name: `${base.name}(トヨタモビリティ富山)`,
+      nameKatakana: `${base.nameKatakana}(トヨタモビリティトヤマ)`,
+      nameRoman: `${base.nameRoman} (Toyota Mobility Toyama)`,
+      nameTtsSegments: base.nameTtsSegments?.map((seg) => ({
+        ...seg,
+        surface: seg.surface
+          ? `${seg.surface} (Toyota Mobility Toyama)`
+          : seg.surface,
+        fallbackText: seg.fallbackText
+          ? `${seg.fallbackText} (Toyota Mobility Toyama)`
+          : seg.fallbackText,
+      })),
+    };
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    setupMockUseNextStation(buildStationWithParens());
+    require('~/hooks/useNumbering').useNumbering.mockReturnValue([
+      {
+        lineSymbol: 'S',
+        lineSymbolColor: '#B0BF1E',
+        lineSymbolShape: 'ROUND',
+        stationNumber: 'S-02',
+      },
+      '',
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('strips parens contents from JA SSML including <sub alias>', () => {
+    const { result } = renderHook(
+      () => useTTSTextWithJotaiAndNumbering('TOKYO_METRO', 'NEXT'),
+      { wrapper }
+    );
+    const [jaText] = result.current.text;
+    expect(jaText ?? '').not.toContain('トヨタモビリティ富山');
+    expect(jaText ?? '').not.toContain('トヨタモビリティトヤマ');
+    expect(jaText ?? '').not.toContain('(');
+    expect(jaText ?? '').not.toContain(')');
+  });
+
+  test('strips parens contents from EN SSML', () => {
+    const { result } = renderHook(
+      () => useTTSTextWithJotaiAndNumbering('TOKYO_METRO', 'NEXT'),
+      { wrapper }
+    );
+    const [, enText] = result.current.text;
+    expect(enText ?? '').not.toContain('Toyota Mobility Toyama');
+    expect(enText ?? '').not.toContain('(');
+    expect(enText ?? '').not.toContain(')');
+  });
+});
+
 describe('nextStation null guard (#5917)', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -130,21 +130,28 @@ export const useTTSText = (
 
   const yamanoteTrainTypeEn = isYamanoteLine ? 'Yamanote Line' : null;
 
+  // directionalStops のカッコ書きも TTS で読み上げないため、
+  // boundForJa / boundForEn に渡す前に取り除く (issue #1175)。
+  const directionalStopsForTTS = useMemo(
+    () => directionalStops.map(stripStationParensForTTS),
+    [directionalStops]
+  );
+
   const boundForJa = useMemo(
     () =>
       isLoopLine
         ? // NOTE: メジャーな駅だからreplaceJapaneseTextは要らない...はず
           loopLineBoundJa?.boundFor?.replace(/・/g, '<break time="250ms"/>')
         : replaceJapaneseText(
-            `${directionalStops?.map((s) => s?.name).join('・')}${
+            `${directionalStopsForTTS.map((s) => s?.name).join('・')}${
               isPartiallyLoopLine ? '方面' : ''
             }`,
-            `${directionalStops?.map((s) => s?.nameKatakana).join('・')}${
+            `${directionalStopsForTTS.map((s) => s?.nameKatakana).join('・')}${
               isPartiallyLoopLine ? 'ホウメン' : ''
             }`
           ),
     [
-      directionalStops,
+      directionalStopsForTTS,
       isLoopLine,
       isPartiallyLoopLine,
       loopLineBoundJa?.boundFor,
@@ -155,10 +162,10 @@ export const useTTSText = (
     () =>
       isLoopLine
         ? (loopLineBoundEn?.boundFor?.replaceAll('&', ' and ') ?? '')
-        : (directionalStops
-            ?.map((s) => ph(s?.nameTtsSegments, s?.nameRoman))
-            .join(' and ') ?? ''),
-    [directionalStops, isLoopLine, loopLineBoundEn?.boundFor]
+        : directionalStopsForTTS
+            .map((s) => ph(s?.nameTtsSegments, s?.nameRoman))
+            .join(' and '),
+    [directionalStopsForTTS, isLoopLine, loopLineBoundEn?.boundFor]
   );
 
   const nextStationNumberText = useMemo(() => {

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -15,6 +15,7 @@ import {
   formatLinesListJa,
   formatStationsListJa,
   replaceJapaneseText,
+  stripStationParensForTTS,
 } from './tts/formatters';
 import type { TemplateContext } from './tts/templateEngine';
 import { EN_TEMPLATES, JA_TEMPLATES } from './tts/templates';
@@ -185,7 +186,14 @@ export const useTTSText = (
     }${symbol} ${num}.`;
   }, [nextStationNumber, theme]);
 
-  const nextStation = nextStationOrigin ?? null;
+  // 駅名に併記されたカッコ書き (命名権スポンサー名など) を TTS で読み上げないため、
+  // context に渡す手前で name / nameKatakana / nameRoman / nameTtsSegments から
+  // カッコと中身を落としておく (issue #1175)。表示用データには影響させない。
+  const nextStation = useMemo(
+    () =>
+      nextStationOrigin ? stripStationParensForTTS(nextStationOrigin) : null,
+    [nextStationOrigin]
+  );
 
   // 直通時、同じGroupIDの駅が違う駅として扱われるのを防ぐ(ex. 渋谷の次は渋谷に止まります)
   // 以前は new Set + find のチェーンで毎レンダー O(n²) だった。
@@ -197,12 +205,19 @@ export const useTTSText = (
       if (s.groupId == null) continue;
       if (seen.has(s.groupId)) continue;
       seen.add(s.groupId);
-      result.push(s);
+      result.push(stripStationParensForTTS(s));
     }
     return result;
   }, [slicedStationsOrigin]);
 
-  const afterNextStation = useAfterNextStation();
+  const afterNextStationOrigin = useAfterNextStation();
+  const afterNextStation = useMemo(
+    () =>
+      afterNextStationOrigin
+        ? stripStationParensForTTS(afterNextStationOrigin)
+        : undefined,
+    [afterNextStationOrigin]
+  );
 
   const nextStationIndex = useMemo(
     () => slicedStations.findIndex((s) => s.groupId === nextStation?.groupId),


### PR DESCRIPTION
## 概要

駅名に併記されたカッコ書き (例: 命名権スポンサー名 `電鉄富山(トヨタモビリティ富山)`) が TTS で読み上げられてしまう問題を修正する。`<sub alias="...">` の中身 (= 実際に音声化される読み) にもスポンサー名が混入していたため、案内テンプレに渡す前段で駅データの TTS 関連フィールドからカッコと中身を取り除く方針に切り替える。表示用データには影響させない。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/formatters.ts` に TTS 専用ヘルパを追加。
  - `stripParensForTTS(value)`: 半角・全角両対応で文字列からカッコと中身を取り除く。既存の `parenthesisRegexp` は半角のみで駅 API が全角を返すケースをカバーできないため別定義。
  - `stripStationParensForTTS(station)`: `name` / `nameKatakana` / `nameRoman` / `nameTtsSegments[].surface` / `fallbackText` をまとめて落とした新しい Station を返す (非破壊)。
- `src/hooks/useTTSText.ts`: `nextStation` / `slicedStations` / `afterNextStation` を `stripStationParensForTTS` 経由に。`allStops` / `viaStation` / `lastAnnouncedStop` / `betweenNextStation` も自動的にカバーされる。
- `src/hooks/useBusTTSText.ts`: 同様に適用。あわせて `slicedStations` を `useMemo` 化し、型ガードも `s is Station` で明示。
- テスト追加:
  - `src/hooks/tts/formatters.test.ts`: 文字列ヘルパ (半角/全角/複数/非対象) と Station ヘルパ (各フィールド適用 / 非 TTS フィールド保持 / 非破壊) を検証。
  - `src/hooks/useTTSText.test.tsx`: `(トヨタモビリティ富山)` を含む駅をモックし、JA/EN SSML にカッコと中身が出ない integration テストを追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes TrainLCD/Issues#1175

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 駅名の括弧（半角・全角）で囲まれたスポンサー等の文言が音声読み上げで発話されないよう改善しました。駅名（日本語表記・カタカナ・ローマ字）やTTS用セグメント、経路案内文（bound 表現）など読み上げ対象の各所で適用されます。

* **テスト**
  * 括弧除去の動作を網羅するテストを追加し、日本語・英語の生成SSMLで括弧内が除外されることを検証しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5926)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->