### PR TITLE
TTS の乗換案内で同じ路線名を繰り返し読み上げないよう重複を除外

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -1,6 +1,7 @@
 import type { Line, Station } from '~/@types/graphql';
 import { TtsAlphabet } from '~/@types/graphql';
 import {
+  dedupeLinesByTtsName,
   formatFirstConnectedLineEnPhrase,
   replaceJapaneseText,
   stripParensForTTS,
@@ -69,6 +70,66 @@ const makeLine = (overrides: Partial<Line>): Line =>
     nameRoman: null,
     ...overrides,
   }) as Line;
+
+describe('dedupeLinesByTtsName', () => {
+  it('returns the same array reference when length <= 1', () => {
+    const empty: Line[] = [];
+    expect(dedupeLinesByTtsName(empty)).toBe(empty);
+
+    const single = [makeLine({ id: 1, nameShort: 'A' })];
+    expect(dedupeLinesByTtsName(single)).toBe(single);
+  });
+
+  it('removes later lines whose nameShort already appeared', () => {
+    // 博多駅の方面別 鹿児島本線 を模した重複ケース。
+    const lines = [
+      makeLine({
+        id: 11,
+        nameShort: '鹿児島本線',
+        nameRoman: 'Kagoshima Line',
+      }),
+      makeLine({
+        id: 12,
+        nameShort: '鹿児島本線',
+        nameRoman: 'Kagoshima Line',
+      }),
+      makeLine({
+        id: 13,
+        nameShort: '福北ゆたか線',
+        nameRoman: 'Fukuhoku Yutaka Line',
+      }),
+    ];
+    const result = dedupeLinesByTtsName(lines);
+    expect(result.map((l) => l.id)).toEqual([11, 13]);
+  });
+
+  it('preserves the first occurrence order', () => {
+    const lines = [
+      makeLine({ id: 1, nameShort: 'A' }),
+      makeLine({ id: 2, nameShort: 'B' }),
+      makeLine({ id: 3, nameShort: 'A' }),
+      makeLine({ id: 4, nameShort: 'C' }),
+    ];
+    const result = dedupeLinesByTtsName(lines);
+    expect(result.map((l) => l.id)).toEqual([1, 2, 4]);
+  });
+
+  it('falls back to nameRoman when nameShort is missing', () => {
+    const lines = [
+      makeLine({ id: 1, nameShort: null, nameRoman: 'Foo Line' }),
+      makeLine({ id: 2, nameShort: null, nameRoman: 'Foo Line' }),
+    ];
+    expect(dedupeLinesByTtsName(lines).map((l) => l.id)).toEqual([1]);
+  });
+
+  it('keeps lines with no usable key (does not collapse all nameless lines)', () => {
+    const lines = [
+      makeLine({ id: 1, nameShort: null, nameRoman: null }),
+      makeLine({ id: 2, nameShort: null, nameRoman: null }),
+    ];
+    expect(dedupeLinesByTtsName(lines).map((l) => l.id)).toEqual([1, 2]);
+  });
+});
 
 describe('formatFirstConnectedLineEnPhrase', () => {
   it('returns empty when lines is empty', () => {

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -81,6 +81,29 @@ const replaceStationNameJa = (
 export const formatLinesListJa = (lines: Line[]): string =>
   lines.map(replaceLineNameJa).join('、');
 
+/**
+ * 同じ路線名が複数レコードに分かれて返ってくるケース (例: 博多駅の方面別
+ * 鹿児島本線) で、TTS の乗換案内が同じ路線名を連続で読み上げるのを防ぐため、
+ * `nameShort` (fallback で `nameRoman`) が一致する Line を最初の出現だけ残して
+ * 間引く。表示用の経路は両方残したいので、TTS 直前のこの段でのみ適用する。
+ * `useTransferLinesFromStation` が `nameShort` / `nameRoman` から既にカッコ書き
+ * を取り除いているため、ここでは生の文字列比較で十分。
+ */
+export const dedupeLinesByTtsName = (lines: Line[]): Line[] => {
+  if (lines.length <= 1) return lines;
+  const seen = new Set<string>();
+  const result: Line[] = [];
+  for (const line of lines) {
+    const key = line.nameShort ?? line.nameRoman ?? '';
+    if (key) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    result.push(line);
+  }
+  return result;
+};
+
 /** 駅名を sub alias 付きで `、` 連結する。 */
 export const formatStationsListJa = (stations: Station[]): string =>
   stations.map(replaceStationNameJa).join('、');

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -8,6 +8,7 @@ import { themeAtom } from '../store/atoms/theme';
 import getIsPass from '../utils/isPass';
 import { wrapPhoneme as ph } from '../utils/phoneme';
 import {
+  dedupeLinesByTtsName,
   formatFirstConnectedLineEnPhrase,
   formatJrWestStopsListEn,
   formatJrWestStopsListJa,
@@ -67,6 +68,13 @@ export const useTTSText = (
 
   const connectedLines = useConnectedLines();
   const transferLines = useTransferLines();
+  // 博多駅の鹿児島本線のように、データ上は方面別に同じ路線名が
+  // 別レコードで登録されているケースがある。表示用には両方残したいが、
+  // TTS では同じ路線名を続けて読み上げないように重複を除外する。
+  const ttsTransferLines = useMemo(
+    () => dedupeLinesByTtsName(transferLines),
+    [transferLines]
+  );
   const currentTrainTypeOrigin = useCurrentTrainType();
   const loopLineBoundJa = useLoopLineBound(false, 'JA');
   const loopLineBoundEn = useLoopLineBound(false, 'EN');
@@ -318,7 +326,7 @@ export const useTTSText = (
       firstSpeech,
       isNextStopTerminus,
       isAfterNextStopTerminus,
-      hasTransferLines: transferLines.length > 0,
+      hasTransferLines: ttsTransferLines.length > 0,
       hasConnectedLines: connectedLines.length > 0,
       hasBetweenStations: betweenNextStation.length > 0,
       hasAfterNextStation: !!afterNextStation,
@@ -378,7 +386,7 @@ export const useTTSText = (
               currentTrainType.nameKatakana
             )
           : '普通'),
-      transferLinesListJa: formatLinesListJa(transferLines),
+      transferLinesListJa: formatLinesListJa(ttsTransferLines),
       connectedLinesListJa: formatLinesListJa(connectedLines),
       betweenStationsListJa: formatStationsListJa(betweenNextStation),
       afterNextStationJa: afterNextStation
@@ -412,7 +420,7 @@ export const useTTSText = (
       currentTrainTypeOrLocalEn: currentTrainType
         ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman)
         : 'Local',
-      transferLinesEnList: formatLinesListEn(transferLines),
+      transferLinesEnList: formatLinesListEn(ttsTransferLines),
       connectedLineEnPhrase: formatFirstConnectedLineEnPhrase(connectedLines),
       afterNextStationEn: afterNextStation
         ? ph(afterNextStation.nameTtsSegments, afterNextStation.nameRoman)
@@ -446,7 +454,7 @@ export const useTTSText = (
     nextStationNumberText,
     selectedBound,
     shouldAnnounceJrWestStopList,
-    transferLines,
+    ttsTransferLines,
     viaStation,
     yamanoteTrainTypeEn,
     yamanoteTrainTypeJa,


### PR DESCRIPTION
## 概要

TTS の乗換案内で、データ上は方面別に同じ路線名が複数レコード登録されているケース (例: 博多駅の鹿児島本線) で、同じ路線名が連続して読み上げられていた挙動を、TTS パイプライン側で 1 回だけに集約するよう修正します。表示用の経路情報には影響させず、TTS 直前でのみ重複を除外します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/formatters.ts`: `nameShort` (fallback で `nameRoman`) が一致する `Line` を最初の出現だけ残す `dedupeLinesByTtsName` を追加。`useTransferLinesFromStation` 側で既に括弧書きが落とされているため、生の文字列比較で十分に機能する。
- `src/hooks/useTTSText.ts`: `useTransferLines` の結果を `dedupeLinesByTtsName` でメモ化した `ttsTransferLines` を経由させ、`hasTransferLines` / `transferLinesListJa` / `transferLinesEnList` の組み立てに使用。表示系コンポーネント (`LineBoard*` / `Transfers` 等) は従来どおり元の `transferLines` を参照するため、画面上は両レコードが残る。
- `src/hooks/tts/formatters.test.ts`: `dedupeLinesByTtsName` の単体テストを追加 (博多駅の鹿児島本線重複ケース、順序維持、`nameRoman` フォールバック、キー欠落時の挙動)。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx cross-env TZ=UTC jest --testPathPattern="(formatters\.test|useTTSText\.test|useTransferLines)"` で 4 suites / 110 tests pass を確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * TTS（テキスト音声変換）で、重複する経路名が繰り返し読み上げられるのを防止する機能を追加しました。

* **テスト**
  * 新機能の包括的なテストケースを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5930)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->