### PR TITLE
画面長押しで開く設定モーダルからテーマを選べるテーマ一覧モーダルを追加

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -6,7 +6,13 @@ import * as Haptics from 'expo-haptics';
 import { addScreenshotListener } from 'expo-screen-capture';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Alert, Linking, Platform, StyleSheet, View } from 'react-native';
 import { LongPressGestureHandler, State } from 'react-native-gesture-handler';
 import Share from 'react-native-share';
@@ -14,11 +20,14 @@ import ViewShot from 'react-native-view-shot';
 import reportModalVisibleAtom from '~/store/atoms/reportModal';
 import tuningState from '~/store/atoms/tuning';
 import { isDevApp } from '~/utils/isDevApp';
+import { getSettingsThemes } from '~/utils/theme';
 import {
   ALL_AVAILABLE_LANGUAGES,
   APP_STORE_URL,
   ASYNC_STORAGE_KEYS,
+  AUTO_THEME_GRADIENT_COLORS,
   GOOGLE_PLAY_URL,
+  IN_USE_COLOR_MAP,
   LONG_PRESS_DURATION,
   parenthesisRegexp,
 } from '../constants';
@@ -32,7 +41,7 @@ import {
   useWarningInfo,
 } from '../hooks';
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
-import type { ThemePreference } from '../models/Theme';
+import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import notifyState from '../store/atoms/notify';
 import speechState from '../store/atoms/speech';
@@ -41,6 +50,7 @@ import { themePreferenceAtom } from '../store/atoms/theme';
 import { isJapanese, translate } from '../translation';
 import NewReportModal from './NewReportModal';
 import { SelectBoundSettingListModal } from './SelectBoundSettingListModal';
+import { ThemeListModal } from './ThemeListModal';
 import { TrainTypeListModal } from './TrainTypeListModal';
 import WarningPanel from './WarningPanel';
 
@@ -57,10 +67,12 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setSpeech = useSetAtom(speechState);
   const setNotify = useSetAtom(notifyState);
   const setTuning = useSetAtom(tuningState);
-  const setThemePreference = useSetAtom(themePreferenceAtom);
+  const [themePreference, setThemePreference] = useAtom(themePreferenceAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
   const [sendingReport, setSendingReport] = useState(false);
   const [screenShotBase64, setScreenShotBase64] = useState('');
+  const [isThemeListModalVisible, setIsThemeListModalVisible] = useState(false);
+  const pendingThemeListModalRef = useRef(false);
 
   useCheckStoreVersion();
   useAppleWatch();
@@ -94,6 +106,60 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const styles = StyleSheet.create({
     container: { width: '100%', height: '100%' },
   });
+
+  const themeOptions = useMemo(() => getSettingsThemes(), []);
+
+  const themeLabel = useMemo(() => {
+    const found = themeOptions.find((t) => t.value === themePreference);
+    return found?.label ?? translate('autoTheme');
+  }, [themeOptions, themePreference]);
+
+  const themeRowColor = useMemo(() => {
+    if (themePreference === THEME_PREFERENCE.AUTO) {
+      return AUTO_THEME_GRADIENT_COLORS[0];
+    }
+    return IN_USE_COLOR_MAP[themePreference as keyof typeof IN_USE_COLOR_MAP];
+  }, [themePreference]);
+
+  const handleThemePress = useCallback(() => {
+    pendingThemeListModalRef.current = true;
+    closeSettingListModal();
+  }, [closeSettingListModal]);
+
+  const handleSettingListClose = useCallback(() => {
+    handleSettingListCloseAnimationEnd();
+    if (pendingThemeListModalRef.current) {
+      pendingThemeListModalRef.current = false;
+      setIsThemeListModalVisible(true);
+    }
+  }, [handleSettingListCloseAnimationEnd]);
+
+  const handleThemeListClose = useCallback(() => {
+    setIsThemeListModalVisible(false);
+  }, []);
+
+  const handleThemeSelect = useCallback(
+    async (preference: ThemePreference) => {
+      setIsThemeListModalVisible(false);
+      if (preference === themePreference) {
+        return;
+      }
+      try {
+        await AsyncStorage.setItem(
+          ASYNC_STORAGE_KEYS.THEME_PREFERENCE,
+          preference
+        );
+        setThemePreference(preference);
+      } catch (err) {
+        console.error(err);
+        Alert.alert(
+          translate('errorTitle'),
+          translate('failedToSavePreference')
+        );
+      }
+    },
+    [setThemePreference, themePreference]
+  );
 
   const handleReport = useCallback(async () => {
     const captureError = (err: unknown) => {
@@ -570,8 +636,11 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         trainTypeColor={trainTypeColor}
         trainTypeLoading={trainTypeSelectLoading}
         onTrainTypePress={handleTrainTypePress}
-        onCloseAnimationEnd={handleSettingListCloseAnimationEnd}
+        onCloseAnimationEnd={handleSettingListClose}
         trainTypeDisabled={trainTypeDisabled}
+        themeLabel={themeLabel}
+        themeColor={themeRowColor}
+        onThemePress={handleThemePress}
       />
       <TrainTypeListModal
         visible={isTrainTypeModalVisible}
@@ -579,6 +648,12 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         loading={fetchTrainTypesLoading}
         onClose={closeTrainTypeModal}
         onSelect={handleTrainTypeModalSelect}
+      />
+      <ThemeListModal
+        visible={isThemeListModalVisible}
+        currentPreference={themePreference}
+        onClose={handleThemeListClose}
+        onSelect={handleThemeSelect}
       />
       {/* NOTE: このViewを外すとフィードバックモーダルのレイアウトが崩御する */}
       <View>

--- a/src/components/SelectBoundSettingListModal.test.tsx
+++ b/src/components/SelectBoundSettingListModal.test.tsx
@@ -112,4 +112,48 @@ describe('SelectBoundSettingListModal', () => {
       expect(onTrainTypePress).not.toHaveBeenCalled();
     });
   });
+
+  describe('テーマボタン', () => {
+    it('onThemePressが未指定の場合、テーマボタンが表示されない', () => {
+      const { queryByText } = render(
+        <SelectBoundSettingListModal {...defaultProps} />
+      );
+      expect(queryByText('theme')).toBeNull();
+    });
+
+    it('onThemePressが指定されている場合、テーマボタンが表示される', () => {
+      const { getByText } = render(
+        <SelectBoundSettingListModal
+          {...defaultProps}
+          onThemePress={jest.fn()}
+          themeLabel="東京メトロ風"
+        />
+      );
+      expect(getByText('theme')).toBeTruthy();
+      expect(getByText('東京メトロ風')).toBeTruthy();
+    });
+
+    it('themeLabelが空の場合、フォールバックテキストが表示される', () => {
+      const { getByText } = render(
+        <SelectBoundSettingListModal
+          {...defaultProps}
+          onThemePress={jest.fn()}
+        />
+      );
+      expect(getByText('autoTheme')).toBeTruthy();
+    });
+
+    it('テーマボタンを押すとonThemePressが呼ばれる', () => {
+      const onThemePress = jest.fn();
+      const { getByText } = render(
+        <SelectBoundSettingListModal
+          {...defaultProps}
+          onThemePress={onThemePress}
+          themeLabel="自動"
+        />
+      );
+      fireEvent.press(getByText('theme'));
+      expect(onThemePress).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/SelectBoundSettingListModal.tsx
+++ b/src/components/SelectBoundSettingListModal.tsx
@@ -87,6 +87,9 @@ type Props = {
   trainTypeLoading?: boolean;
   onTrainTypePress?: () => void;
   trainTypeDisabled?: boolean;
+  themeLabel?: string;
+  themeColor?: string;
+  onThemePress?: () => void;
 };
 
 export const SelectBoundSettingListModal: React.FC<Props> = ({
@@ -100,6 +103,9 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
   trainTypeLoading,
   onTrainTypePress,
   trainTypeDisabled,
+  themeLabel,
+  themeColor,
+  onThemePress,
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
@@ -111,6 +117,16 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
   const trainTypeTextColor = useMemo(
     () => getTrainTypeTextColor(trainTypeColor),
     [trainTypeColor]
+  );
+
+  const themeTextColor = useMemo(
+    () => getTrainTypeTextColor(themeColor),
+    [themeColor]
+  );
+
+  const normalizedThemeColor = useMemo(
+    () => normalizeTrainTypeColor(themeColor),
+    [themeColor]
   );
 
   return (
@@ -189,6 +205,38 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
                   </View>
                 </>
               )}
+            </TouchableOpacity>
+          )}
+          {onThemePress && (
+            <TouchableOpacity
+              onPress={onThemePress}
+              style={[
+                styles.trainTypeButton,
+                {
+                  backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
+                  borderRadius: isLEDTheme ? 0 : 8,
+                },
+              ]}
+            >
+              <Typography style={styles.trainTypeLabel}>
+                {translate('theme')}
+              </Typography>
+              <View
+                style={[
+                  styles.trainTypeNamePanel,
+                  {
+                    backgroundColor: normalizedThemeColor,
+                    borderRadius: isLEDTheme ? 0 : 8,
+                  },
+                ]}
+              >
+                <Typography
+                  style={[styles.trainTypeNameText, { color: themeTextColor }]}
+                  numberOfLines={1}
+                >
+                  {themeLabel ?? translate('autoTheme')}
+                </Typography>
+              </View>
             </TouchableOpacity>
           )}
           <Button

--- a/src/components/ThemeListModal.test.tsx
+++ b/src/components/ThemeListModal.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import type React from 'react';
+import { THEME_PREFERENCE } from '~/models/Theme';
+import { ThemeListModal } from './ThemeListModal';
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('@gorhom/portal', () => ({
+  Portal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock('react-native-app-clip', () => ({
+  isClip: jest.fn(() => false),
+}));
+
+jest.mock('../translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: false,
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: false,
+}));
+
+const defaultProps = {
+  visible: true,
+  currentPreference: THEME_PREFERENCE.AUTO,
+  onClose: jest.fn(),
+  onSelect: jest.fn(),
+};
+
+describe('ThemeListModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('全テーマの選択肢が表示される', () => {
+    const { getByText } = render(<ThemeListModal {...defaultProps} />);
+    // 翻訳キーをそのまま返すモックなので、各テーマのラベルキーが描画される
+    expect(getByText('autoTheme')).toBeTruthy();
+    expect(getByText('tokyoMetroLike')).toBeTruthy();
+    expect(getByText('ledLike')).toBeTruthy();
+  });
+
+  it('現在選択中のテーマは inUse、その他は select と表示される', () => {
+    const { getAllByText } = render(
+      <ThemeListModal
+        {...defaultProps}
+        currentPreference={THEME_PREFERENCE.TOKYO_METRO}
+      />
+    );
+    expect(getAllByText('inUse')).toHaveLength(1);
+    // 全テーマ数 - 1（選択中以外）が select 表示
+    expect(getAllByText('select').length).toBeGreaterThan(1);
+  });
+
+  it('テーマを押すと onSelect がそのテーマで呼ばれる', () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <ThemeListModal {...defaultProps} onSelect={onSelect} />
+    );
+    fireEvent.press(getByText('tokyoMetroLike'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(THEME_PREFERENCE.TOKYO_METRO);
+  });
+
+  it('閉じるボタンを押すと onClose が呼ばれる', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <ThemeListModal {...defaultProps} onClose={onClose} />
+    );
+    fireEvent.press(getByText('close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ThemeListModal.test.tsx
+++ b/src/components/ThemeListModal.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native';
 import type React from 'react';
 import { THEME_PREFERENCE } from '~/models/Theme';
+import { getSettingsThemes } from '~/utils/theme';
 import { ThemeListModal } from './ThemeListModal';
 
 jest.mock('jotai', () => ({
@@ -42,15 +43,16 @@ describe('ThemeListModal', () => {
     jest.clearAllMocks();
   });
 
-  it('全テーマの選択肢が表示される', () => {
+  it('getSettingsThemes() の全テーマがレンダリングされる', () => {
+    const themes = getSettingsThemes();
     const { getByText } = render(<ThemeListModal {...defaultProps} />);
-    // 翻訳キーをそのまま返すモックなので、各テーマのラベルキーが描画される
-    expect(getByText('autoTheme')).toBeTruthy();
-    expect(getByText('tokyoMetroLike')).toBeTruthy();
-    expect(getByText('ledLike')).toBeTruthy();
+    for (const theme of themes) {
+      expect(getByText(theme.label)).toBeTruthy();
+    }
   });
 
-  it('現在選択中のテーマは inUse、その他は select と表示される', () => {
+  it('現在選択中のテーマのみ inUse、他は全て select と表示される', () => {
+    const themes = getSettingsThemes();
     const { getAllByText } = render(
       <ThemeListModal
         {...defaultProps}
@@ -58,8 +60,7 @@ describe('ThemeListModal', () => {
       />
     );
     expect(getAllByText('inUse')).toHaveLength(1);
-    // 全テーマ数 - 1（選択中以外）が select 表示
-    expect(getAllByText('select').length).toBeGreaterThan(1);
+    expect(getAllByText('select')).toHaveLength(themes.length - 1);
   });
 
   it('テーマを押すと onSelect がそのテーマで呼ばれる', () => {

--- a/src/components/ThemeListModal.tsx
+++ b/src/components/ThemeListModal.tsx
@@ -1,0 +1,203 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAtomValue } from 'jotai';
+import { lighten } from 'polished';
+import type React from 'react';
+import { useCallback, useMemo } from 'react';
+import {
+  FlatList,
+  Platform,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import {
+  AUTO_THEME_GRADIENT_COLORS,
+  IN_USE_COLOR_MAP,
+  LED_THEME_BG_COLOR,
+} from '~/constants';
+import { THEME_PREFERENCE, type ThemePreference } from '~/models/Theme';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+import isTablet from '~/utils/isTablet';
+import { RFValue } from '~/utils/rfValue';
+import { getSettingsThemes, type SettingsTheme } from '~/utils/theme';
+import Button from './Button';
+import { CustomModal } from './CustomModal';
+import { Heading } from './Heading';
+import { StatePanel } from './ToggleButton';
+import Typography from './Typography';
+
+const ITEM_HEIGHT = 72;
+const HEADER_HEIGHT = 64;
+const FOOTER_HEIGHT = 72;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  contentView: {
+    width: '100%',
+    overflow: 'hidden',
+  },
+  headerContainer: {
+    height: HEADER_HEIGHT,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  closeButtonContainer: {
+    height: FOOTER_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  closeButton: { width: '100%' },
+  closeButtonText: { fontWeight: 'bold' },
+  listContent: {
+    paddingHorizontal: 24,
+    paddingBottom: 8,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: ITEM_HEIGHT,
+    paddingHorizontal: 16,
+  },
+  swatch: {
+    width: 44,
+    height: 44,
+    overflow: 'hidden',
+    marginRight: 16,
+  },
+  swatchInner: { flex: 1 },
+  title: {
+    flex: 1,
+    fontSize: isTablet ? RFValue(12) : RFValue(14),
+    fontWeight: 'bold',
+  },
+});
+
+type Props = {
+  visible: boolean;
+  currentPreference: ThemePreference;
+  onClose: () => void;
+  onSelect: (preference: ThemePreference) => void;
+};
+
+export const ThemeListModal: React.FC<Props> = ({
+  visible,
+  currentPreference,
+  onClose,
+  onSelect,
+}) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const { height: windowHeight } = useWindowDimensions();
+
+  const items = useMemo(() => getSettingsThemes(), []);
+
+  const dynamicHeight = useMemo(() => {
+    const content = HEADER_HEIGHT + items.length * ITEM_HEIGHT + FOOTER_HEIGHT;
+    return Math.min(content, windowHeight * 0.8);
+  }, [items.length, windowHeight]);
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: SettingsTheme; index: number }) => {
+      const isAuto = item.value === THEME_PREFERENCE.AUTO;
+      const themeColor = isAuto
+        ? AUTO_THEME_GRADIENT_COLORS[0]
+        : IN_USE_COLOR_MAP[item.value as keyof typeof IN_USE_COLOR_MAP];
+      const isFirst = index === 0;
+      const isLast = index === items.length - 1;
+      const selected = currentPreference === item.value;
+
+      return (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={item.label}
+          accessibilityState={{ selected }}
+          onPress={() => onSelect(item.value)}
+          style={[
+            styles.item,
+            {
+              backgroundColor: isLEDTheme ? '#333' : '#fff',
+              borderTopLeftRadius: isFirst && !isLEDTheme ? 12 : 0,
+              borderTopRightRadius: isFirst && !isLEDTheme ? 12 : 0,
+              borderBottomLeftRadius: isLast && !isLEDTheme ? 12 : 0,
+              borderBottomRightRadius: isLast && !isLEDTheme ? 12 : 0,
+            },
+          ]}
+        >
+          <View style={[styles.swatch, { borderRadius: isLEDTheme ? 0 : 8 }]}>
+            <LinearGradient
+              colors={
+                isAuto
+                  ? AUTO_THEME_GRADIENT_COLORS
+                  : [themeColor, lighten(0.1, themeColor)]
+              }
+              style={styles.swatchInner}
+            />
+          </View>
+          <Typography style={styles.title}>{item.label}</Typography>
+          <StatePanel
+            state={selected}
+            onText={translate('inUse')}
+            offText={translate('select')}
+          />
+        </Pressable>
+      );
+    },
+    [items.length, currentPreference, isLEDTheme, onSelect]
+  );
+
+  const keyExtractor = useCallback((item: SettingsTheme) => item.value, []);
+
+  return (
+    <CustomModal
+      visible={visible}
+      onClose={onClose}
+      backdropStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      containerStyle={styles.root}
+      contentContainerStyle={[
+        styles.contentView,
+        {
+          height: dynamicHeight,
+          backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#FAFAFA',
+          borderRadius: isLEDTheme ? 0 : 8,
+        },
+        isTablet && {
+          width: '80%',
+          maxHeight: '80%',
+          borderRadius: isLEDTheme ? 0 : 16,
+        },
+      ]}
+    >
+      <View
+        style={[
+          styles.headerContainer,
+          { backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#FAFAFA' },
+        ]}
+      >
+        <Heading>{translate('theme')}</Heading>
+      </View>
+      <FlatList<SettingsTheme>
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        contentContainerStyle={styles.listContent}
+        removeClippedSubviews={Platform.OS === 'android'}
+      />
+      <View style={styles.closeButtonContainer}>
+        <Button
+          style={styles.closeButton}
+          textStyle={styles.closeButtonText}
+          onPress={onClose}
+        >
+          {translate('close')}
+        </Button>
+      </View>
+    </CustomModal>
+  );
+};

--- a/src/components/ThemeListModal.tsx
+++ b/src/components/ThemeListModal.tsx
@@ -192,6 +192,7 @@ export const ThemeListModal: React.FC<Props> = ({
         style={styles.list}
         contentContainerStyle={styles.listContent}
         removeClippedSubviews={Platform.OS === 'android'}
+        initialNumToRender={items.length}
       />
       <View style={styles.closeButtonContainer}>
         <Button

--- a/src/components/ThemeListModal.tsx
+++ b/src/components/ThemeListModal.tsx
@@ -43,6 +43,9 @@ const styles = StyleSheet.create({
     width: '100%',
     overflow: 'hidden',
   },
+  list: {
+    flex: 1,
+  },
   headerContainer: {
     height: HEADER_HEIGHT,
     justifyContent: 'center',
@@ -186,6 +189,7 @@ export const ThemeListModal: React.FC<Props> = ({
         data={items}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
+        style={styles.list}
         contentContainerStyle={styles.listContent}
         removeClippedSubviews={Platform.OS === 'android'}
       />


### PR DESCRIPTION
## 概要

長押しで開く設定モーダルから、テーマ（自動・路線各社風・LED 等）を直接選べるテーマ一覧モーダルを追加した。これまでテーマ変更には設定画面まで遷移する必要があったが、走行中の画面から離れずに切り替えできるようにする。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `SelectBoundSettingListModal` に `themeLabel` / `themeColor` / `onThemePress` プロップを追加し、列車種別ボタンと同じ視覚で「テーマ」行（現在のテーマ名 + 色サンプル）を表示する。
- `ThemeListModal` を新規追加。`getSettingsThemes()` を用いて全テーマを色グラデーション + 「使用中 / 選ぶ」状態パネル付きで列挙し、LED テーマ時もデザインが破綻しないよう分岐済み。
- `Permitted` で `themePreferenceAtom` から現在のテーマ設定を取得し、列車種別モーダルと同じ「設定モーダルを閉じてアニメーション完了後に次モーダルを開く」フローでテーマ一覧モーダルを開く。選択時は `AsyncStorage` への保存 + atom 更新を行い、既存の `ThemeSettings` 画面と同じ永続化経路に揃える。
- `SelectBoundSettingListModal.test.tsx` にテーマ行の表示/非表示・押下時のコールバック呼び出し・`themeLabel` 未指定時のフォールバック表示など 4 ケースを追加。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_012Ct66LGK5oTpkGLbpd7a2k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 設定画面にテーマ選択モーダルを追加。設定リストからテーマ一覧を開いて選べます。
  * 設定リストにテーマ行を表示し、現在のテーマ名と色が反映されます。選択は自動保存されUIに反映。

* **Bug Fixes / UX**
  * 設定リストの閉鎖アニメーション後にテーマモーダルがスムーズに開くよう改善。

* **Tests**
  * テーマ表示・切替・閉じる操作を検証するテストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5933)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->