### PR TITLE
逆走通知のバッテリー消費を抑えるため検知ロジックをatomに集約し通知重複防止とヒステリシスを強化

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -30,6 +30,7 @@ import {
   useCurrentLine,
   useFeedback,
   useWarningInfo,
+  useWrongDirectionDetectorEffect,
 } from '../hooks';
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import type { ThemePreference } from '../models/Theme';
@@ -65,6 +66,10 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   useCheckStoreVersion();
   useAppleWatch();
   useAndroidWearable();
+  // 逆方向検知ロジックの計算を 1 箇所だけで実行し、結果は atom 経由で他のフックに配る。
+  // useRefreshStation / useWarningInfo から個別に呼ぶと位置更新ごとに getDistance と
+  // state 更新が二重に走ってバッテリーを余計に消費するため、ここに集約している。
+  useWrongDirectionDetectorEffect();
 
   const user = useCachedInitAnonymousUser();
   const currentLine = useCurrentLine();

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -81,4 +81,7 @@ export { useUpdateLiveActivities } from './useUpdateLiveActivities';
 export { useValueRef } from './useValueRef';
 export { useWalkthroughCompleted } from './useWalkthroughCompleted';
 export { useWarningInfo } from './useWarningInfo';
-export { useWrongDirectionDetector } from './useWrongDirectionDetector';
+export {
+  useWrongDirectionDetector,
+  useWrongDirectionDetectorEffect,
+} from './useWrongDirectionDetector';

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -42,6 +42,7 @@ export const useRefreshStation = (): void => {
   const accuracy = location?.coords.accuracy;
 
   const nextStation = useNextStation();
+  const nextStationId = nextStation?.id ?? null;
   const approachingNotifiedIdRef = useRef<number | null>(null);
   const arrivedNotifiedIdRef = useRef<number | null>(null);
   const lastArrivedTimeRef = useRef<number>(0);
@@ -55,7 +56,9 @@ export const useRefreshStation = (): void => {
   const { arrivedThreshold, approachingThreshold } = useThreshold();
   const { isWrongDirection, isLoopLineWrongDirection } =
     useWrongDirectionDetector();
-  const wrongDirectionNotifiedRef = useRef(false);
+  // 同一の次駅区間で逆方向通知が複数回鳴るのを防ぐため、通知済みの次駅IDを記憶する。
+  // isWrongDirection の単なる false 復帰ではリセットせず、次駅が変わるまで保持する。
+  const lastNotifiedWrongDirectionStationIdRef = useRef<number | null>(null);
 
   // GPS精度に応じた実効閾値を算出する
   // 精度が悪い場合は判定圏を広げることで検知漏れを減らす
@@ -186,24 +189,37 @@ export const useRefreshStation = (): void => {
   ]);
 
   useEffect(() => {
+    // 次駅が変わった場合は通知済みフラグをクリアし、新しい区間で再通知できるようにする
     if (
-      wrongDirectionNotifyEnabled &&
-      (isWrongDirection || isLoopLineWrongDirection) &&
-      !wrongDirectionNotifiedRef.current
+      lastNotifiedWrongDirectionStationIdRef.current !== null &&
+      lastNotifiedWrongDirectionStationIdRef.current !== nextStationId
     ) {
-      const bodyKey = isLoopLineWrongDirection
-        ? 'wrongDirectionLoopLineWarning'
-        : 'wrongDirectionWarning';
-      sendNotificationAsync({
-        title: translate('wrongDirectionNotificationTitle'),
-        body: translate(bodyKey),
-      }).catch(() => {});
-      wrongDirectionNotifiedRef.current = true;
+      lastNotifiedWrongDirectionStationIdRef.current = null;
     }
-    if (!isWrongDirection && !isLoopLineWrongDirection) {
-      wrongDirectionNotifiedRef.current = false;
+
+    if (
+      !wrongDirectionNotifyEnabled ||
+      (!isWrongDirection && !isLoopLineWrongDirection) ||
+      nextStationId == null ||
+      lastNotifiedWrongDirectionStationIdRef.current === nextStationId
+    ) {
+      return;
     }
-  }, [isWrongDirection, isLoopLineWrongDirection, wrongDirectionNotifyEnabled]);
+
+    const bodyKey = isLoopLineWrongDirection
+      ? 'wrongDirectionLoopLineWarning'
+      : 'wrongDirectionWarning';
+    sendNotificationAsync({
+      title: translate('wrongDirectionNotificationTitle'),
+      body: translate(bodyKey),
+    }).catch(() => {});
+    lastNotifiedWrongDirectionStationIdRef.current = nextStationId;
+  }, [
+    isWrongDirection,
+    isLoopLineWrongDirection,
+    nextStationId,
+    wrongDirectionNotifyEnabled,
+  ]);
 
   useEffect(() => {
     if (!nearestStation) {

--- a/src/hooks/useWrongDirectionDetector.test.tsx
+++ b/src/hooks/useWrongDirectionDetector.test.tsx
@@ -1,0 +1,218 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
+import { act, renderHook } from '@testing-library/react-native';
+import type * as Location from 'expo-location';
+import { Provider, useAtomValue } from 'jotai';
+import { createStore } from 'jotai/vanilla';
+import type React from 'react';
+import type { Station } from '~/@types/graphql';
+import { locationAtom } from '~/store/atoms/location';
+import navigationState from '~/store/atoms/navigation';
+import stationState from '~/store/atoms/station';
+import wrongDirectionAtom from '~/store/atoms/wrongDirection';
+import { useLoopLine } from './useLoopLine';
+import { useNextStation } from './useNextStation';
+import {
+  useWrongDirectionDetector,
+  useWrongDirectionDetectorEffect,
+} from './useWrongDirectionDetector';
+
+jest.mock('./useNextStation', () => ({
+  __esModule: true,
+  useNextStation: jest.fn(),
+}));
+
+jest.mock('./useLoopLine', () => ({
+  __esModule: true,
+  useLoopLine: jest.fn(),
+}));
+
+const mockUseNextStation = useNextStation as jest.MockedFunction<
+  typeof useNextStation
+>;
+const mockUseLoopLine = useLoopLine as jest.MockedFunction<typeof useLoopLine>;
+
+// 緯度1度 ≒ 111,320m の前提で、東向き(経度)に進む点を作る
+// 0.0001 度 ≒ 11.13 m
+const BASE_LAT = 35.0;
+const BASE_LON = 135.0;
+const NEXT_STATION_LON = 135.005; // 約 556m 東にある「次駅」
+const NEXT_STATION: Station = {
+  id: 999,
+  groupId: 999,
+  name: '次駅',
+  nameRoman: 'Next',
+  latitude: BASE_LAT,
+  longitude: NEXT_STATION_LON,
+} as Station;
+
+const makeLocation = (
+  lon: number,
+  accuracy = 10,
+  timestamp = Date.now()
+): Location.LocationObject => ({
+  coords: {
+    latitude: BASE_LAT,
+    longitude: lon,
+    accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: 0,
+  },
+  timestamp,
+});
+
+const seedStore = (store: ReturnType<typeof createStore>) => {
+  // 「逆走通知が動くべき」前提条件を満たす状態を作る
+  store.set(stationState, {
+    arrived: false,
+    approaching: false,
+    station: null,
+    stations: [],
+    stationsCache: [],
+    pendingStation: null,
+    pendingStations: [],
+    selectedDirection: 'INBOUND',
+    // selectedBound は id があれば十分。型を満たすため最小限に。
+    selectedBound: { id: 1 } as Station,
+    wantedDestination: null,
+  });
+  store.set(navigationState, (prev) => ({
+    ...prev,
+    autoModeEnabled: false,
+  }));
+};
+
+const setLocationLon = (
+  store: ReturnType<typeof createStore>,
+  lon: number,
+  accuracy = 10
+) => {
+  store.set(
+    locationAtom,
+    makeLocation(
+      lon,
+      accuracy,
+      store.get(locationAtom)?.timestamp
+        ? (store.get(locationAtom) as Location.LocationObject).timestamp + 1000
+        : 1000
+    )
+  );
+};
+
+const renderDetector = (store: ReturnType<typeof createStore>) => {
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(
+    () => {
+      useWrongDirectionDetectorEffect();
+      return useAtomValue(wrongDirectionAtom);
+    },
+    { wrapper }
+  );
+};
+
+describe('useWrongDirectionDetector (hysteresis)', () => {
+  beforeEach(() => {
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine: false,
+      isYamanoteLine: false,
+      isOsakaLoopLine: false,
+      isMeijoLine: false,
+      isOedoLine: false,
+      isPartiallyLoopLine: false,
+      inboundStationsForLoopLine: [],
+      outboundStationsForLoopLine: [],
+    });
+    mockUseNextStation.mockReturnValue(NEXT_STATION);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const advanceWest = (
+    store: ReturnType<typeof createStore>,
+    deltaLonSteps: number[]
+  ) => {
+    // 東に向かうべきところを「西に進む = 逆方向」として、経度を負方向にずらす
+    let lon = BASE_LON;
+    for (const step of deltaLonSteps) {
+      lon += step;
+      act(() => setLocationLon(store, lon));
+    }
+  };
+
+  it('4回連続で次駅から遠ざかり、累積300m以上で逆方向と判定する', () => {
+    const store = createStore();
+    seedStore(store);
+
+    const { result } = renderDetector(store);
+
+    // 初回位置を打ち込む（比較対象を作るため、判定はまだ走らない）
+    act(() => setLocationLon(store, BASE_LON));
+
+    // 1ステップ ≒ 100m 西進 (経度 -0.001 ≒ -85m。安全に余裕を持って-0.001)
+    advanceWest(store, [-0.001, -0.001, -0.001, -0.001, -0.001]);
+
+    expect(result.current.isWrongDirection).toBe(true);
+    expect(result.current.isLoopLineWrongDirection).toBe(false);
+  });
+
+  it('一度逆方向と判定された後、小さなGPSノイズ(数m以内の前進)で判定が解除されない', () => {
+    const store = createStore();
+    seedStore(store);
+
+    const { result } = renderDetector(store);
+
+    act(() => setLocationLon(store, BASE_LON));
+    advanceWest(store, [-0.001, -0.001, -0.001, -0.001, -0.001]);
+    expect(result.current.isWrongDirection).toBe(true);
+
+    // ノイズトレランス(10m)以内のごく小さな前進(東向き)を加える
+    // 0.00005 度 ≒ 5.5m
+    act(() => {
+      const prev = store.get(locationAtom) as Location.LocationObject;
+      store.set(locationAtom, {
+        ...prev,
+        coords: { ...prev.coords, longitude: prev.coords.longitude + 0.00005 },
+        timestamp: prev.timestamp + 1000,
+      });
+    });
+
+    // ノイズで判定は解除されない
+    expect(result.current.isWrongDirection).toBe(true);
+  });
+
+  it('到着フラグが立つと判定がリセットされる', () => {
+    const store = createStore();
+    seedStore(store);
+
+    const { result } = renderDetector(store);
+
+    act(() => setLocationLon(store, BASE_LON));
+    advanceWest(store, [-0.001, -0.001, -0.001, -0.001, -0.001]);
+    expect(result.current.isWrongDirection).toBe(true);
+
+    act(() => {
+      store.set(stationState, (prev) => ({ ...prev, arrived: true }));
+    });
+
+    expect(result.current.isWrongDirection).toBe(false);
+  });
+
+  it('公開フックは atom を読むだけで、Effectフックを呼ばなくても初期値を返す', () => {
+    const store = createStore();
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+    const { result } = renderHook(() => useWrongDirectionDetector(), {
+      wrapper,
+    });
+    expect(result.current).toEqual({
+      isWrongDirection: false,
+      isLoopLineWrongDirection: false,
+    });
+  });
+});

--- a/src/hooks/useWrongDirectionDetector.ts
+++ b/src/hooks/useWrongDirectionDetector.ts
@@ -79,13 +79,17 @@ export const useWrongDirectionDetectorEffect = (): void => {
   );
 
   // 検知状態を全てリセットするヘルパー（誤判定要因が発生した際の完全リセット用）
+  // detected=false の場合 writeState は loopLine 引数に関わらず両フラグを false にするため、
+  // ここでは isLoopLine を渡さない。これにより isLoopLine の変化で
+  // resetDetectionState の参照が更新されることを防ぎ、依存している useEffect の
+  // 不要な再実行（と意図しないリセット）を避ける。
   const resetDetectionState = useCallback(() => {
     prevDistanceRef.current = null;
     consecutiveIncreaseCountRef.current = 0;
     cumulativeIncreaseRef.current = 0;
     notifiedForStationIdRef.current = undefined;
-    writeState(false, isLoopLine);
-  }, [isLoopLine, writeState]);
+    writeState(false, false);
+  }, [writeState]);
 
   // 到着時にリセット
   useEffect(() => {

--- a/src/hooks/useWrongDirectionDetector.ts
+++ b/src/hooks/useWrongDirectionDetector.ts
@@ -1,10 +1,13 @@
 import getDistance from 'geolib/es/getDistance';
-import { useAtomValue } from 'jotai';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useEffect, useRef } from 'react';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import { locationAtom } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
 import stationState from '~/store/atoms/station';
+import wrongDirectionAtom, {
+  type WrongDirectionState,
+} from '~/store/atoms/wrongDirection';
 import { useLoopLine } from './useLoopLine';
 import { useNextStation } from './useNextStation';
 
@@ -12,16 +15,29 @@ import { useNextStation } from './useNextStation';
 const WRONG_DIRECTION_CONSECUTIVE_COUNT = 4;
 // 逆方向判定に必要な最小累積距離(m)
 const WRONG_DIRECTION_MIN_DISTANCE = 300;
+// GPSノイズとみなして無視する減少幅(m)。これ以下の減少では検知カウンタを維持する
+const WRONG_DIRECTION_NOISE_TOLERANCE = 10;
 
-export const useWrongDirectionDetector = (): {
-  isWrongDirection: boolean;
-  isLoopLineWrongDirection: boolean;
-} => {
+const INITIAL_STATE: WrongDirectionState = {
+  isWrongDirection: false,
+  isLoopLineWrongDirection: false,
+};
+
+/**
+ * 逆方向検知ロジックの本体。位置情報・路線条件から逆方向状態を判定し、
+ * 結果を `wrongDirectionAtom` に書き込む。
+ *
+ * このフックはコンポーネントツリーで **1 回だけ** マウントする想定。
+ * 複数箇所から呼ぶと位置更新ごとに `getDistance` 計算と state 更新が
+ * 重複して走り、バッテリーを余計に消費する。
+ */
+export const useWrongDirectionDetectorEffect = (): void => {
   const location = useAtomValue(locationAtom);
   const { arrived, selectedBound } = useAtomValue(stationState);
   const { autoModeEnabled } = useAtomValue(navigationState);
   const nextStation = useNextStation();
   const { isLoopLine } = useLoopLine();
+  const setWrongDirection = useSetAtom(wrongDirectionAtom);
 
   const latitude = location?.coords.latitude;
   const longitude = location?.coords.longitude;
@@ -43,17 +59,33 @@ export const useWrongDirectionDetector = (): {
   const notifiedForStationIdRef = useRef<number | null | undefined>(undefined);
   // 前回のnextStation ID（駅変更検知用）
   const prevNextStationIdRef = useRef<number | null | undefined>(undefined);
+  // 現在の判定結果ローカルコピー（atom再書き込みのスキップ判定用）
+  const detectedRef = useRef(false);
 
-  const [wrongDirectionDetected, setWrongDirectionDetected] = useState(false);
+  // atom の値を一括で更新するヘルパー
+  const writeState = useCallback(
+    (detected: boolean, loopLine: boolean) => {
+      if (!detected && !detectedRef.current) {
+        // false → false の重複書き込みを避け、不要な再レンダリングを抑制する
+        return;
+      }
+      detectedRef.current = detected;
+      setWrongDirection({
+        isWrongDirection: !loopLine && detected,
+        isLoopLineWrongDirection: loopLine && detected,
+      });
+    },
+    [setWrongDirection]
+  );
 
-  // 検知状態を全てリセットするヘルパー
+  // 検知状態を全てリセットするヘルパー（誤判定要因が発生した際の完全リセット用）
   const resetDetectionState = useCallback(() => {
     prevDistanceRef.current = null;
     consecutiveIncreaseCountRef.current = 0;
     cumulativeIncreaseRef.current = 0;
     notifiedForStationIdRef.current = undefined;
-    setWrongDirectionDetected(false);
-  }, []);
+    writeState(false, isLoopLine);
+  }, [isLoopLine, writeState]);
 
   // 到着時にリセット
   useEffect(() => {
@@ -111,11 +143,18 @@ export const useWrongDirectionDetector = (): {
     const increase = currentDistance - prevDistance;
 
     if (increase > 0) {
+      // 遠ざかった: 連続カウンタと累積距離を伸ばす
       consecutiveIncreaseCountRef.current += 1;
       cumulativeIncreaseRef.current += increase;
-    } else {
-      resetDetectionState();
+    } else if (increase < -WRONG_DIRECTION_NOISE_TOLERANCE) {
+      // 明確に近づいた: 連続カウンタをリセット
+      // ただし wrongDirectionDetected 自体は据え置き、通知発火済みフラグも維持する。
+      // 一度逆方向と判定された後、GPSノイズで一時的に近づいたとしても、
+      // 次駅が変わるか到着するまでは「逆方向状態」のまま扱う
+      consecutiveIncreaseCountRef.current = 0;
+      cumulativeIncreaseRef.current = 0;
     }
+    // 上記いずれにも当てはまらない小さな減少は GPS ノイズとして無視する
 
     if (
       consecutiveIncreaseCountRef.current >=
@@ -130,11 +169,12 @@ export const useWrongDirectionDetector = (): {
         return;
       }
       notifiedForStationIdRef.current = nextStationId;
-      setWrongDirectionDetected(true);
+      writeState(true, isLoopLine);
     }
   }, [
     accuracy,
     autoModeEnabled,
+    isLoopLine,
     latitude,
     longitude,
     nextStationId,
@@ -142,10 +182,15 @@ export const useWrongDirectionDetector = (): {
     nextStationLon,
     resetDetectionState,
     selectedBoundId,
+    writeState,
   ]);
+};
 
-  return {
-    isWrongDirection: !isLoopLine && wrongDirectionDetected,
-    isLoopLineWrongDirection: isLoopLine && wrongDirectionDetected,
-  };
+/**
+ * 逆方向検知結果を購読する公開フック。
+ * 実体は `wrongDirectionAtom` を読むだけなので、複数箇所から呼んでも安全。
+ * 計算ロジック本体は `useWrongDirectionDetectorEffect` 側で 1 度だけ動く。
+ */
+export const useWrongDirectionDetector = (): WrongDirectionState => {
+  return useAtomValue(wrongDirectionAtom) ?? INITIAL_STATE;
 };

--- a/src/store/atoms/wrongDirection.ts
+++ b/src/store/atoms/wrongDirection.ts
@@ -1,0 +1,13 @@
+import { atom } from 'jotai';
+
+export interface WrongDirectionState {
+  isWrongDirection: boolean;
+  isLoopLineWrongDirection: boolean;
+}
+
+const wrongDirectionAtom = atom<WrongDirectionState>({
+  isWrongDirection: false,
+  isLoopLineWrongDirection: false,
+});
+
+export default wrongDirectionAtom;


### PR DESCRIPTION
## 概要

設定画面で逆走通知を ON にするとバッテリー消費が速くなる問題への対処。逆方向検知ロジックを atom に集約して二重計算を解消し、GPS ノイズによる通知の連続再発火を防ぐ。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 逆方向検知結果用 atom `src/store/atoms/wrongDirection.ts` を新設し、検知結果を `{ isWrongDirection, isLoopLineWrongDirection }` 形で一元管理。
- `useWrongDirectionDetector` を atom 読み取り専用に縮退し、計算ロジック本体は `useWrongDirectionDetectorEffect` として切り出して `Permitted.tsx` で 1 度だけマウントするよう変更（従来は `useRefreshStation` と `useWarningInfo` の 2 箇所から呼ばれており、位置更新ごとに `getDistance` 計算と state 更新が二重に実行されていた）。
- 検知ロジックに 10m のノイズトレランスを導入。小さな距離減少では `wrongDirectionDetected` を `false` に戻さず、完全リセットは `arrived` / `selectedBound` 変更 / 次駅変更 / 前提条件不成立時のみに限定。
- `useRefreshStation` の逆走通知発火 effect で、重複防止 ref を boolean から **次駅 ID** ベースに変更。`isWrongDirection` の一時的な false 復帰だけでは再発火させず、同一区間で通知が連続して鳴るのを防ぐ。
- 上記挙動を検証する Jest テスト `useWrongDirectionDetector.test.tsx` を追加（ヒステリシス成立・小ノイズで判定が維持されること・到着でリセットされること・公開フックの初期値）。

### 回帰リスクと緩和

- 逆走警告パネル (`useWarningInfo`) の表示は ON/OFF に関係なく従来通り動作する（atom 経由で同じ結果を購読）。
- ヒステリシス強化により誤検知の解除条件が緩むが、`arrived` / `selectedBound` / 次駅変更 / GPS精度劣化のいずれかで完全リセットされるため、本来の「区間移行」場面での誤検知持ち越しは発生しない。
- 通知のクールダウンを次駅 ID 紐付けに変更したため、同一区間で再通知したくなるユースケースは存在しない（次駅が変わるかブランチがクリアされれば再発火可能）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（1531 件、全パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWAnMAfRQY4C63tNdgAN8c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 誤進行検出の処理をアプリ全体で共有する仕組みに統合し、検出状態を中央で管理して配信するように変更

* **バグ修正**
  * 同一路線・駅区間での重複通知を抑制するロジックを導入
  * GPSの小さな揺らぎに影響されにくくし、誤検出の抑制精度を向上
  * 駅到着時に誤進行判定が確実にリセットされるよう修正

* **テスト**
  * 誤進行検出のヒステリシスやリセット挙動を検証するテストを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5934)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->