### PR TITLE
長押し設定モーダルの内容をScrollView化して縦幅不足時にスクロール可能にする

### DIFF
--- a/src/components/SelectBoundSettingListModal.tsx
+++ b/src/components/SelectBoundSettingListModal.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { useMemo } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import {
@@ -29,8 +29,10 @@ const styles = StyleSheet.create({
     marginTop: 24,
     width: '100%',
   },
-  container: {
-    justifyContent: 'center',
+  scrollView: {
+    width: '100%',
+  },
+  scrollContent: {
     alignItems: 'center',
   },
   closeButton: { marginTop: 24 },
@@ -150,7 +152,12 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
         },
       ]}
     >
-      <View style={styles.container}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
         <Heading style={styles.heading}>{translate('settings')}</Heading>
 
         <View style={styles.buttonsContainer}>
@@ -247,7 +254,7 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
             {translate('close')}
           </Button>
         </View>
-      </View>
+      </ScrollView>
     </CustomModal>
   );
 };


### PR DESCRIPTION
## 概要

長押しで開く設定モーダル(`SelectBoundSettingListModal`)は `CustomModal` 側で `maxHeight: '75%'` と `overflow: 'hidden'` が掛かっており、縦幅の余裕がない端末では下部のボタンが見切れて操作できないおそれがあった。本文を `ScrollView` でラップして、設定項目が増えても全項目に到達できるようにした。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `src/components/SelectBoundSettingListModal.tsx` の本文ラッパーを `View`(`styles.container`) から `ScrollView` に置き換え、`scrollView` / `scrollContent` スタイルを追加。
- `keyboardShouldPersistTaps="handled"` を指定し、スクロール中のボタン押下が阻害されないようにした。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01T9GHvFnuSQXmHpF2vJ35Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モーダルダイアログにスクロール機能を追加しました。大量のコンテンツを含む場合でもスムーズに操作できるようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5937)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->