### PR TITLE
タブレットで「方面」サフィックスのフォントサイズが駅名と同じになる不具合を修正

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
   titleAffix: {
-    fontSize: RFValue(13),
+    fontSize: isTablet ? 13 : RFValue(13),
     fontWeight: 'bold',
     color: '#fff',
   },


### PR DESCRIPTION
## 概要

タブレットで方面選択モーダル（`SelectBoundModal` / `CommonCard`）の「方面」サフィックスのフォントサイズが駅名と同等以上に大きく描画されてしまう不具合を修正する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/CommonCard.tsx` の `titleAffix` スタイルの `fontSize` を `RFValue(13)` から `isTablet ? 13 : RFValue(13)` に変更。
- `RFValue` は端末の画面高さに比例して値が増えるため、タブレットでは固定サイズの駅名 (`title: fontSize: 21`) と同等以上の値となり、「方面」が小さく見えなくなっていた。タブレットでは固定値 `13` を採用し、スマホでの見た目（`RFValue(13)`）は従来通り維持する。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01XcaDaiPU4Qv3yPoJP6f5Pp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル調整**
  * タブレット表示における文字サイズの表示ロジックを最適化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5940)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->