### PR TITLE
都営風テーマでナンバリング非表示のiPad向け駅名位置をバー上に揃える

### DIFF
--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -93,8 +93,11 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
 
   const horizontalAdditionalStyle = useMemo(() => {
     if (!hasNumbering) {
+      // iPadでは stationNumber が position: 'relative' で約20px分の高さを占めるため、
+      // ナンバリングが無い場合に marginBottom を縮めすぎると駅名がバーへ沈み込む。
+      // with-numbering と同じ値を使い、stationNumber 不在分だけ自然に下がるに留める。
       return {
-        marginBottom: isTablet ? dim.height / 14 : dim.height / 10,
+        marginBottom: dim.height / 10,
         width: isTablet ? dim.height / 3 : dim.height / 2.5,
       };
     }


### PR DESCRIPTION
## 概要

iPad で都営風テーマを使用しており、対象路線の各駅にナンバリングが設定されていない場合、斜めに描画される駅名が大きく下方向にずれてバーへ食い込む不具合を修正する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `LineBoardToei` の `StationNameToei` で `hasNumbering === false` の `marginBottom` を、タブレットのみ `dim.height / 14` から `dim.height / 10`（ナンバリング有りと同値）に揃えた。スマホ側は元から `dim.height / 10` のため挙動は変わらない。
- iPad では `stationNumber` が `position: 'relative'` で約 20px のレイアウト枠を占めていたため、PR #5889 で `marginBottom` を縮めかつ `stationNumber` を非描画にした合算でおよそ 50px 沈み込んでいた。`stationNumber` 不在分だけ駅名が自然に下がるに留めることで、PR #5889 が意図した「下部の空きを詰める」効果は維持しつつ、バーへの沈み込みを解消する。
- 経緯を理解した上で再修正できるよう、コードコメントとして残した。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01NKRQEP1AjdRgC4dtAS73Wi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 駅名表示のレイアウト調整を改善しました。タブレットデバイス上での余白計算を最適化し、表示の一貫性を向上させています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->