### PR TITLE
都営風テーマiPadでナンバリング非表示時の斜め駅名がバーへ沈み込む不具合を修正

### DIFF
--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -64,6 +64,9 @@ const localStyles = StyleSheet.create({
     bottom: isTablet ? 0 : 64,
     textAlign: 'center',
   },
+  stationNumberPlaceholder: {
+    opacity: 0,
+  },
 });
 
 const styles = { ...commonLineBoardStyles, ...localStyles };
@@ -93,9 +96,6 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
 
   const horizontalAdditionalStyle = useMemo(() => {
     if (!hasNumbering) {
-      // iPadでは stationNumber が position: 'relative' で約20px分の高さを占めるため、
-      // ナンバリングが無い場合に marginBottom を縮めすぎると駅名がバーへ沈み込む。
-      // with-numbering と同じ値を使い、stationNumber 不在分だけ自然に下がるに留める。
       return {
         marginBottom: dim.height / 10,
         width: isTablet ? dim.height / 3 : dim.height / 2.5,
@@ -413,6 +413,17 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
             numberOfLines={1}
           >
             {numberingObj.stationNumber}
+          </Typography>
+        ) : isTablet ? (
+          // iPadではstationNumberがposition:'relative'で高さを占めるため、
+          // ナンバリング非表示時も同サイズの不可視プレースホルダーを描画し、
+          // 駅名（特に斜め表示）がバーへ沈み込むのを防ぐ
+          <Typography
+            style={[styles.stationNumber, styles.stationNumberPlaceholder]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          >
+            {' '}
           </Typography>
         ) : null}
         <BackgroundBars line={line} barLeft={barLeft} barWidth={barWidth} />


### PR DESCRIPTION
## 概要

iPad で都営風テーマ (`LineBoardToei`) を使用しており、かつ各駅にナンバリングが設定されていない場合に、斜め回転表示の駅名がバーの下に沈み込む不具合を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- iPad では `stationNumber` が `position: 'relative'` でレイアウト上の高さを占めるため、ナンバリング非表示の駅では `nameCommon` がその分下方向に詰まり、`-55deg` 回転した駅名がバー領域へ侵入していた。
- ナンバリング非表示かつ iPad のときに `stationNumber` と同じスタイル（`opacity: 0` 適用）を持つ不可視の `Typography` プレースホルダーを描画し、with-numbering ケースと完全に同じ縦方向レイアウトに揃えるよう修正。
- これに伴い不正確になった `horizontalAdditionalStyle` 内の旧コメント (`c925c7d` で追加されたもの) を削除。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01XLBEhkjr2GghQFBwf11aSr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* タブレット端末での駅情報の表示レイアウトを改善し、駅番号が表示されない場合でも駅名の位置が安定するようにしました。これによりタブレット上での視認性が向上します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5944)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->