### PR TITLE
タブレットで列車種別のカッコ内テキストが本文と同じサイズになる不具合を修正

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -98,7 +98,7 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
   titleParens: {
-    fontSize: RFValue(13),
+    fontSize: isTablet ? 13 : RFValue(13),
     fontWeight: 'bold',
     color: '#fff',
   },


### PR DESCRIPTION
## 概要

各モーダル（路線・行先・列車種別・経路・プリセット保存）で列車種別を表示する `CommonCard` のカッコ内テキストが、スマートフォンでは本文より小さく表示されるのに対し、タブレットでは本文と同等以上のサイズで描画されてしまう不具合を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/CommonCard.tsx` の `titleParens` スタイルの `fontSize` を `RFValue(13)` から `isTablet ? 13 : RFValue(13)` に変更し、タブレットでは固定値 `13` を使うようにした。
- `RFValue` は画面の高さに比例してスケールするため、縦解像度の大きいタブレットでは `RFValue(13)` が本文側の固定値 `21` に並ぶ／上回るサイズに膨らんでしまっていた。既存の `titleAffix`（「方面」接辞）と同じ補正方針に揃え、`CommonCard` を利用する全モーダル（`TrainTypeListModal` / `SelectBoundModal` / `RouteInfoModal` / `StationSearchModal` / `SavePresetNameModal`）に効くようにした。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1Hv1dxRCHB99RVjW3W7iA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * カードタイトル内の括弧付きテキストのフォントサイズが各デバイスタイプに応じて最適化されました。タブレットデバイスとその他のデバイスで異なるサイズが適用され、表示が改善されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5947)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->