### PR TITLE
CommonCardの列車種別カッコ縮小表示で全角カッコにも対応する

### DIFF
--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -342,7 +342,7 @@ export const CommonCard: React.FC<Props> = ({
       if (isJapanese) {
         // 「○○方面」末尾の「方面」を分離（カッコ内の「方面」は対象外）
         const match = /^(.+?)方面$/.exec(main);
-        if (match && !match[1].endsWith(')')) {
+        if (match && !match[1].endsWith(')') && !match[1].endsWith('）')) {
           main = match[1];
           suffix = '方面';
         }
@@ -357,7 +357,7 @@ export const CommonCard: React.FC<Props> = ({
     }
     return {
       titlePrefix: prefix,
-      titleParts: main.split(/(\([^)]*\))/),
+      titleParts: main.split(/([（(][^）)]*[）)])/),
       titleSuffix: suffix,
     };
   }, [titleOrLineName, shrinkBoundAffix]);
@@ -470,7 +470,7 @@ export const CommonCard: React.FC<Props> = ({
               <Typography style={styles.titleAffix}>{titlePrefix}</Typography>
             ) : null}
             {titleParts.map((part, index) =>
-              /^\(.*\)$/.test(part) ? (
+              /^[（(][^）)]*[）)]$/.test(part) ? (
                 <Typography key={`${index}-${part}`} style={styles.titleParens}>
                   {index > 0 && !/\s$/.test(titleParts[index - 1] ?? '')
                     ? ' '

--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -154,6 +154,9 @@ const styles = StyleSheet.create({
   },
 });
 
+const PAREN_GROUP_REGEX = /([（(][^）)]*[）)])/;
+const PAREN_WRAPPED_REGEX = /^[（(][^）)]*[）)]$/;
+
 type SubtitleProps = {
   inboundText: string;
   outboundText: string;
@@ -357,7 +360,7 @@ export const CommonCard: React.FC<Props> = ({
     }
     return {
       titlePrefix: prefix,
-      titleParts: main.split(/([（(][^）)]*[）)])/),
+      titleParts: main.split(PAREN_GROUP_REGEX),
       titleSuffix: suffix,
     };
   }, [titleOrLineName, shrinkBoundAffix]);
@@ -470,7 +473,7 @@ export const CommonCard: React.FC<Props> = ({
               <Typography style={styles.titleAffix}>{titlePrefix}</Typography>
             ) : null}
             {titleParts.map((part, index) =>
-              /^[（(][^）)]*[）)]$/.test(part) ? (
+              PAREN_WRAPPED_REGEX.test(part) ? (
                 <Typography key={`${index}-${part}`} style={styles.titleParens}>
                   {index > 0 && !/\s$/.test(titleParts[index - 1] ?? '')
                     ? ' '


### PR DESCRIPTION
## 概要

`CommonCard` の列車種別タイトル分割ロジックで、半角カッコ `()` のみが縮小表示対象となっており、全角カッコ `（）` を含むデータが来た場合にカッコ内も本文と同じフォントサイズで描画されてしまう潜在的な問題を修正しました。直前のPR #5950 で `SelectBoundSettingListModal` 側を同様に修正したため、表示処理を揃えるためのフォローアップです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/CommonCard.tsx` のカッコ分割正規表現 `/(\([^)]*\))/` を `/([（(][^）)]*[）)])/` に変更し、全角・半角どちらのカッコでも縮小フォント側に振り分けられるようにした。
- 縮小判定用テスト `/^\(.*\)$/` も同じ文字クラスを使う `/^[（(][^）)]*[）)]$/` に変更。
- `shrinkBoundAffix` の「カッコ内の方面を分離対象から除外する」ガード `match[1].endsWith(')')` に、全角閉じカッコ `）` の判定も追加。これにより `急行（○○方面）方面` のような全角カッコを含む稀なケースでも「方面」が二重に分離されない。
- 上記2つの正規表現をモジュールスコープの `PAREN_GROUP_REGEX` / `PAREN_WRAPPED_REGEX` 定数に抽出し、split 側と test 側で乖離しないようにした（CodeRabbit のレビュー指摘対応）。

列車種別名や路線名はGraphQL API経由で取得する動的データのため、コードベース内では実値を確認できません。CodeRabbit の予防的指摘に沿って、API側がどちらのカッコを使っていても安全な側に揃えています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * タイトルの括弧処理を改善しました。半角・全角の両方の括弧を一貫して扱い、小括弧付き表記の表示スタイル（括弧非表示オプション含む）が正しく適用されます。
  * 「方面」などのサフィックス分割を不要な分割を避ける形で調整しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5951)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->