### PR TITLE
設定モーダルのカッコ内テキストを親と同じ色にしタブレットで小さく表示する

### DIFF
--- a/src/components/SelectBoundSettingListModal.tsx
+++ b/src/components/SelectBoundSettingListModal.tsx
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   trainTypeNameParens: {
-    fontSize: RFValue(9),
+    fontSize: isTablet ? RFValue(7) : RFValue(9),
     fontWeight: 'bold',
   },
   trainTypeDisabledText: {
@@ -82,11 +82,14 @@ const styles = StyleSheet.create({
   heading: { width: '100%' },
 });
 
-const renderWithSmallParens = (text: string) => {
+const renderWithSmallParens = (text: string, color: string) => {
   const parts = text.split(/([（(][^）)]*[）)])/);
   return parts.map((part, index) =>
     /^[（(][^）)]*[）)]$/.test(part) ? (
-      <Typography key={`${index}-${part}`} style={styles.trainTypeNameParens}>
+      <Typography
+        key={`${index}-${part}`}
+        style={[styles.trainTypeNameParens, { color }]}
+      >
         {part}
       </Typography>
     ) : (
@@ -225,7 +228,8 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
                       numberOfLines={1}
                     >
                       {renderWithSmallParens(
-                        trainTypeName || translate('trainTypeDefault')
+                        trainTypeName || translate('trainTypeDefault'),
+                        trainTypeTextColor
                       )}
                     </Typography>
                   </View>
@@ -260,7 +264,10 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
                   style={[styles.trainTypeNameText, { color: themeTextColor }]}
                   numberOfLines={1}
                 >
-                  {renderWithSmallParens(themeLabel ?? translate('autoTheme'))}
+                  {renderWithSmallParens(
+                    themeLabel ?? translate('autoTheme'),
+                    themeTextColor
+                  )}
                 </Typography>
               </View>
             </TouchableOpacity>


### PR DESCRIPTION
## 概要

設定モーダルの列車種別パネル（およびテーマパネル）でカッコ内テキストを描画する際、ネストした `Typography` が親の色を継承せずデフォルト色 `#333` で描画されてしまい、色付きパネル上で本文と異なる黒文字になっていました。あわせてタブレットでサイズ差が視認しにくかったため、タブレット時のフォントサイズも縮小します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/SelectBoundSettingListModal.tsx` の `renderWithSmallParens` に `color` 引数を追加し、内側の `Typography` にインラインで色を渡すよう変更。`Typography` がbaseで `color: '#333'` を当て直す仕様のため、親色を明示的に再指定しないとカッコ部分のみ黒文字になる問題を解消。
- 列車種別ボタン・テーマボタン双方の呼び出し側で `trainTypeTextColor` / `themeTextColor` を渡すよう更新。
- `trainTypeNameParens` の `fontSize` を `RFValue(9)` から `isTablet ? RFValue(7) : RFValue(9)` に変更。タブレットで本文 `RFValue(12)` ≒24pt に対しカッコが18ptで差が分かりにくかったため、タブレット側のベースを下げて約14ptに（≒58%比率）。スマホ側は従来通り。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1Hv1dxRCHB99RVjW3W7iA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * 列車タイプとテーマの表示で、括弧内のテキストがカラー表示に対応しました
  * タブレット画面でのフォントサイズレスポンスが調整されました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5954)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->