### PR TITLE
逆走通知設定がOFFのときは検知ロジック自体を停止してCPU消費とatom書き込みを完全に止める

### DIFF
--- a/src/hooks/useWrongDirectionDetector.test.tsx
+++ b/src/hooks/useWrongDirectionDetector.test.tsx
@@ -7,6 +7,7 @@ import type React from 'react';
 import type { Station } from '~/@types/graphql';
 import { locationAtom } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
+import notifyState from '~/store/atoms/notify';
 import stationState from '~/store/atoms/station';
 import wrongDirectionAtom from '~/store/atoms/wrongDirection';
 import { useLoopLine } from './useLoopLine';
@@ -62,7 +63,10 @@ const makeLocation = (
   timestamp,
 });
 
-const seedStore = (store: ReturnType<typeof createStore>) => {
+const seedStore = (
+  store: ReturnType<typeof createStore>,
+  { wrongDirectionNotifyEnabled = true } = {}
+) => {
   // 「逆走通知が動くべき」前提条件を満たす状態を作る
   store.set(stationState, {
     arrived: false,
@@ -81,6 +85,10 @@ const seedStore = (store: ReturnType<typeof createStore>) => {
     ...prev,
     autoModeEnabled: false,
   }));
+  store.set(notifyState, {
+    targetStationIds: [],
+    wrongDirectionNotifyEnabled,
+  });
 };
 
 const setLocationLon = (
@@ -200,6 +208,40 @@ describe('useWrongDirectionDetector (hysteresis)', () => {
     });
 
     expect(result.current.isWrongDirection).toBe(false);
+  });
+
+  it('wrongDirectionNotifyEnabled が false のときは逆方向と判定されない', () => {
+    const store = createStore();
+    seedStore(store, { wrongDirectionNotifyEnabled: false });
+
+    const { result } = renderDetector(store);
+
+    act(() => setLocationLon(store, BASE_LON));
+    advanceWest(store, [-0.001, -0.001, -0.001, -0.001, -0.001]);
+
+    expect(result.current.isWrongDirection).toBe(false);
+    expect(result.current.isLoopLineWrongDirection).toBe(false);
+  });
+
+  it('逆方向と判定された状態で wrongDirectionNotifyEnabled が false に変わるとリセットされる', () => {
+    const store = createStore();
+    seedStore(store);
+
+    const { result } = renderDetector(store);
+
+    act(() => setLocationLon(store, BASE_LON));
+    advanceWest(store, [-0.001, -0.001, -0.001, -0.001, -0.001]);
+    expect(result.current.isWrongDirection).toBe(true);
+
+    act(() => {
+      store.set(notifyState, (prev) => ({
+        ...prev,
+        wrongDirectionNotifyEnabled: false,
+      }));
+    });
+
+    expect(result.current.isWrongDirection).toBe(false);
+    expect(result.current.isLoopLineWrongDirection).toBe(false);
   });
 
   it('公開フックは atom を読むだけで、Effectフックを呼ばなくても初期値を返す', () => {

--- a/src/hooks/useWrongDirectionDetector.ts
+++ b/src/hooks/useWrongDirectionDetector.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import { locationAtom } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
+import notifyState from '~/store/atoms/notify';
 import stationState from '~/store/atoms/station';
 import wrongDirectionAtom, {
   type WrongDirectionState,
@@ -35,6 +36,7 @@ export const useWrongDirectionDetectorEffect = (): void => {
   const location = useAtomValue(locationAtom);
   const { arrived, selectedBound } = useAtomValue(stationState);
   const { autoModeEnabled } = useAtomValue(navigationState);
+  const { wrongDirectionNotifyEnabled } = useAtomValue(notifyState);
   const nextStation = useNextStation();
   const { isLoopLine } = useLoopLine();
   const setWrongDirection = useSetAtom(wrongDirectionAtom);
@@ -108,7 +110,14 @@ export const useWrongDirectionDetectorEffect = (): void => {
   // 位置更新ごとに距離変化を計算し、逆方向判定を行う
   useEffect(() => {
     // 前提条件を満たさない場合は検知状態をリセットして終了
+    // 逆走通知設定が OFF の場合も検知を完全停止する。
+    // 検知ロジック自体を止めることで `getDistance` 計算と atom 書き込みが
+    // 発生しなくなり、位置更新ごとの CPU 消費を最小化する。
+    // 結果として画面の逆走警告パネル（useWarningInfo の `isWrongDirection`
+    // 分岐）も出なくなるが、他の警告（offline / badAccuracy など）は
+    // 影響を受けない。
     if (
+      !wrongDirectionNotifyEnabled ||
       selectedBoundId == null ||
       autoModeEnabled ||
       latitude == null ||
@@ -186,6 +195,7 @@ export const useWrongDirectionDetectorEffect = (): void => {
     nextStationLon,
     resetDetectionState,
     selectedBoundId,
+    wrongDirectionNotifyEnabled,
     writeState,
   ]);
 };


### PR DESCRIPTION
## 概要

逆走通知設定が OFF のときも検知ロジック (`useWrongDirectionDetectorEffect`) が常時動いていたため、位置情報更新のたびに `getDistance` 計算と atom 書き込みが発生していた。OFF のときは検知ロジック自体を完全停止し、CPU 消費とバッテリー消費を最小化する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useWrongDirectionDetectorEffect` の早期 return 条件に `wrongDirectionNotifyEnabled === false` を追加。OFF のとき `resetDetectionState()` で atom を初期値に戻し、`getDistance` 計算と atom 書き込みを完全停止する。
- `notifyState` atom を依存に追加し、`wrongDirectionNotifyEnabled` を useEffect の依存配列に含めることで、ON ⇄ OFF の切り替え時にリセットが反映されるようにした。
- `useWarningInfo` のコードは一切触らない。OFF 時は `isWrongDirection` / `isLoopLineWrongDirection` が常に `false` で渡るので、`useWarningInfo` の逆走警告分岐 (`useWarningInfo.ts:131-142`) を素通りするだけで、他の警告（offline / badAccuracy / autoMode / longPressNotice 等）は従来通り表示される。
- テスト追加 (`useWrongDirectionDetector.test.tsx`): OFF 時に検知が動かないこと、判定中に ON → OFF へ切り替えるとリセットされること。

### 回帰リスクと緩和

- OFF にした時点で「ユーザーは逆走警告を必要としていない」と解釈し、画面の逆走警告パネルも出さなくする方針 (事前にユーザー確認済み)。他の警告は影響を受けない。
- 検知計算が完全に止まるので、長距離移動中の CPU・バッテリー消費が OFF 時にさらに削減される（#5934 で導入した「二重実行解消」「ヒステリシス」に上乗せ）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（`useWrongDirectionDetector.test.tsx` 6 件全パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWAnMAfRQY4C63tNdgAN8c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 不正な方向検出機能の有効/無効を制御できるようにしました。

* **テスト**
  * 不正な方向検出機能の制御フラグに関するテストカバレッジを拡充しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5957)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->