### PR TITLE
NumberingIconSquareのスリーレターコード背景が親幅に追従して右側に間延びする不具合を修正

### DIFF
--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -39,8 +39,11 @@ const styles = StyleSheet.create({
   // TLC デフォルト: ヘッダー等の大きなスペース用 (0.7x)
   tlcRoot: {
     justifyContent: 'center',
+    alignItems: 'center',
   },
   tlcContainer: {
+    alignItems: 'center',
+    alignSelf: 'center',
     backgroundColor: '#231e1f',
     borderWidth: 1,
     borderColor: 'white',


### PR DESCRIPTION
## 概要

ヘッダーに表示される `NumberingIconSquare` で、スリーレターコード（TLC）付きアイコンの黒背景が親コンテナの幅まで引き伸ばされ、右側に間延びする不具合を修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/NumberingIconSquare.tsx` の `tlcRoot` と `tlcContainer` に `alignItems: 'center'` を追加し、`tlcContainer` には併せて `alignSelf: 'center'` を追加。
- React Native の `View` の `alignItems` 既定値 `stretch` により、`tlcContainer`（TLC の黒背景）が親（ヘッダー等の広い領域）の幅まで広がっていたのを、コンテンツ幅に収まるようにする。
- 同時に、TLC テキストと下段の駅ナンバリングアイコンを水平方向に中央揃えする。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrXQyu1Svcybkcw6vSYvxL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * インターフェースの要素の中央配置を改善しました。これにより、より整理された視覚的なレイアウトが実現されています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5960)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->