### PR TITLE
SentryプロファイリングをUI Profilingに移行し@sentry/react-nativeをv8.11.1にアップグレード

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ if (process.env.NODE_ENV === 'production') {
     dsn: SENTRY_DSN,
     enableAutoSessionTracking: true,
     tracesSampleRate: 1.0,
-    profilesSampleRate: 1.0,
+    profilingOptions: {
+      profileSessionSampleRate: 1.0,
+      lifecycle: 'trace',
+      startOnAppStart: true,
+    },
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     integrations: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@react-native-masked-view/masked-view": "0.3.2",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.3.1",
-        "@sentry/react-native": "~7.11.0",
+        "@sentry/react-native": "~8.11.1",
         "dayjs": "^1.11.19",
         "expo": "~55.0.15",
         "expo-application": "~55.0.14",
@@ -6265,127 +6265,126 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.37.0.tgz",
-      "integrity": "sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.51.0.tgz",
+      "integrity": "sha512-lNKBS4P7RUvf1niojXQWe9bU3gnBUCbST4Dj0pSiyat1N96cXVyHkeE+uGxowD0RrVWhs+kGHiVX3FcmRWF6sA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.37.0"
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.37.0.tgz",
-      "integrity": "sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.51.0.tgz",
+      "integrity": "sha512-bCM95bcpphx28e6aU0bwRLxOgwosYsdNzezM1sM0pVOkb0TB3hDFRamramVDK+/Hp1o8qmRxS4c5w/A7YBZGkA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.37.0"
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.37.0.tgz",
-      "integrity": "sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.51.0.tgz",
+      "integrity": "sha512-jCpI5HXSwK6ZT2HX70+mDRciAocHzSiDk4DTgvzV69Wvd+Ei5WLgE+d39eaEPsm8lUC0Ydntb5sJIB6uG9D4bw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.37.0",
-        "@sentry/core": "10.37.0"
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.37.0.tgz",
-      "integrity": "sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.51.0.tgz",
+      "integrity": "sha512-8PW1Pp+Yl3lPwYqhBCr5SgkuhDanu9ZLzUqD2bPKL/ElqbM2eDVIWxq4z4ZzePrmZa6IcCjTv6sVQJ7Z4dLyLA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.37.0",
-        "@sentry/core": "10.37.0"
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.8.0.tgz",
-      "integrity": "sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.1.tgz",
+      "integrity": "sha512-QQ9AL5EXIbSK26ObLVtiU6l3tCUdpGSJ/6VwDkPhC3qvtoksSlcoU9Yzm7XC0NBcvu1N2abL5R7gckKGZ4JewQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.37.0.tgz",
-      "integrity": "sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.51.0.tgz",
+      "integrity": "sha512-Zdc0sKfenxUtW/OGhtJ7xHFN44bXR7YqxJ1zBDzlZfW0nTbeTTUZBq9z5NUw6qdS0Vs/i3V4qzAKTbRKWfqSEA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.37.0",
-        "@sentry-internal/feedback": "10.37.0",
-        "@sentry-internal/replay": "10.37.0",
-        "@sentry-internal/replay-canvas": "10.37.0",
-        "@sentry/core": "10.37.0"
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry-internal/feedback": "10.51.0",
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry-internal/replay-canvas": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.4.tgz",
-      "integrity": "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.4.1.tgz",
+      "integrity": "sha512-xY9WcIg+/B/bJxY1KbP0XrDZGPQaFNjIOVJbXNbwVtRujiG6DEwVHqGJhADjPa8rilLQVDOUumVMwLbAUCmh6A==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
         "which": "^2.0.2"
       },
       "bin": {
         "sentry-cli": "bin/sentry-cli"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.58.4",
-        "@sentry/cli-linux-arm": "2.58.4",
-        "@sentry/cli-linux-arm64": "2.58.4",
-        "@sentry/cli-linux-i686": "2.58.4",
-        "@sentry/cli-linux-x64": "2.58.4",
-        "@sentry/cli-win32-arm64": "2.58.4",
-        "@sentry/cli-win32-i686": "2.58.4",
-        "@sentry/cli-win32-x64": "2.58.4"
+        "@sentry/cli-darwin": "3.4.1",
+        "@sentry/cli-linux-arm": "3.4.1",
+        "@sentry/cli-linux-arm64": "3.4.1",
+        "@sentry/cli-linux-i686": "3.4.1",
+        "@sentry/cli-linux-x64": "3.4.1",
+        "@sentry/cli-win32-arm64": "3.4.1",
+        "@sentry/cli-win32-i686": "3.4.1",
+        "@sentry/cli-win32-x64": "3.4.1"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.4.tgz",
-      "integrity": "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.1.tgz",
+      "integrity": "sha512-44foor4g/nfFaOaEZYQnxBrAW7TOMO4LatYsRjPI8dAoqXNVsl+P77FIk0gGAFnTwbt5gREXeeOn6j8DA9NyZg==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.4.tgz",
-      "integrity": "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.4.1.tgz",
+      "integrity": "sha512-XIT4ICA86vwrZWfbvKRiY9HgMg1aJNv1VJgNuiWu/3ysk0H4U7U4rJl6SQNbthgNGpcxvFdXmHbujKv7VZdv5w==",
       "cpu": [
         "arm"
       ],
@@ -6397,13 +6396,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.4.tgz",
-      "integrity": "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.4.1.tgz",
+      "integrity": "sha512-rYWeBxVEiYMZ5hUe16qkpCmJQBc+lxT50sls/CqO5WTN3VlrSRlJsd+jMTKUNesM0j4PMEi82Xy7rovD8a+2tA==",
       "cpu": [
         "arm64"
       ],
@@ -6415,13 +6414,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.4.tgz",
-      "integrity": "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.4.1.tgz",
+      "integrity": "sha512-yirtGGummlarcrPmIm4cg5vEA5gYnL/GJ6FLV6yfq1zAeMzEWnl7kaWIVsoTZ8qBi7vmHpy0APlH5LXxK4QXNw==",
       "cpu": [
         "x86",
         "ia32"
@@ -6434,13 +6433,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.4.tgz",
-      "integrity": "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.1.tgz",
+      "integrity": "sha512-r2wJq9Bt1eRFtnAo3vWACfAN3IdV5gRfLnH8rbtDsg7pqdM0MP7tgAjzJDLptLGP02ndPhJfeJ1mXjcDY1MqqQ==",
       "cpu": [
         "x64"
       ],
@@ -6452,13 +6451,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.4.tgz",
-      "integrity": "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.1.tgz",
+      "integrity": "sha512-IWg2FeB9OzxDky3q885MqepN2QEujyGdbcCB0VbHB3zRpT2D2fbk87FIy64JGoZkPVmoI4d7Mbxa+XKFS4jlrw==",
       "cpu": [
         "arm64"
       ],
@@ -6468,13 +6467,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.4.tgz",
-      "integrity": "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.4.1.tgz",
+      "integrity": "sha512-RlKYU1Cdyk0uqRa9llKA6yVxg2QK0CXX0bogv89lIfABgZ4o1o45zcwVmEQLrD5rrIQmUcIJHWysQVnSyydJkA==",
       "cpu": [
         "x86",
         "ia32"
@@ -6485,13 +6484,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.4.tgz",
-      "integrity": "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.4.1.tgz",
+      "integrity": "sha512-MgKSglGeD+zOIEdbZrt+P9v9ExkMrHKwlIK8hnJA8qNVjmPuOW9yR4khzdVIYd3cdujAQQhLcV3gEB9ceR4PxQ==",
       "cpu": [
         "x64"
       ],
@@ -6501,26 +6500,53 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.37.0.tgz",
-      "integrity": "sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/react": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.37.0.tgz",
-      "integrity": "sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ==",
+    "node_modules/@sentry/expo-upload-sourcemaps": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.11.1.tgz",
+      "integrity": "sha512-xtWJqJotkZGI6M5luexR+9PJKudZHrrKTQ97rbnEBlM6G9CU9FzgLuJzgrxC4+hdM9h21VhIblam3IUtcK2bUg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.37.0",
-        "@sentry/core": "10.37.0"
+        "@sentry/cli": "3.4.1"
+      },
+      "bin": {
+        "expo-upload-sourcemaps": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@expo/env": "*",
+        "dotenv": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/env": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.51.0.tgz",
+      "integrity": "sha512-RRHHqjNvjji6ebIqdlAr453AkST8Vm4cxdu1vWm772IgbzTO7Jx46Cj6Bt2/GjMyH0YLE5euDaAOQhFMmpvAOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
@@ -6530,19 +6556,23 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.11.0.tgz",
-      "integrity": "sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg==",
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.11.1.tgz",
+      "integrity": "sha512-TpGWoyNrPNKe3AN6/I2e+C3Z0iCXvw3HQeZwORRg+6vks1eLhCPTQsN49qoUiyQEAI49Sxxv+fbfA5dM+FijPA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "4.8.0",
-        "@sentry/browser": "10.37.0",
-        "@sentry/cli": "2.58.4",
-        "@sentry/core": "10.37.0",
-        "@sentry/react": "10.37.0",
-        "@sentry/types": "10.37.0"
+        "@sentry/babel-plugin-component-annotate": "5.2.1",
+        "@sentry/browser": "10.51.0",
+        "@sentry/cli": "3.4.1",
+        "@sentry/core": "10.51.0",
+        "@sentry/expo-upload-sourcemaps": "8.11.1",
+        "@sentry/react": "10.51.0",
+        "@sentry/types": "10.51.0"
       },
       "bin": {
+        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
@@ -6557,12 +6587,12 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.37.0.tgz",
-      "integrity": "sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.51.0.tgz",
+      "integrity": "sha512-/0nTcXk82RKtGGv0mxmY56o+BE85lBuSWG9chtSEfeypvxHFyWn3D7td9rPmjboDMtytC24cYbUzx55jb2OjQA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.37.0"
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
@@ -7192,6 +7222,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -9269,7 +9300,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -11082,6 +11113,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -18103,6 +18135,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.3.1",
-    "@sentry/react-native": "~7.11.0",
+    "@sentry/react-native": "~8.11.1",
     "dayjs": "^1.11.19",
     "expo": "~55.0.15",
     "expo-application": "~55.0.14",


### PR DESCRIPTION
## 概要

Sentry でプロファイルが取得できない事象を調査し、`@sentry/react-native` を `~7.11.0` → `~8.11.1` にメジャーアップグレードしたうえで、Sentry 推奨の UI Profiling（継続プロファイリング）構成に切り替えた。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `package.json` / `package-lock.json`: `@sentry/react-native` を `~7.11.0` から `~8.11.1` にアップグレード。
- `index.js`: 旧式の `profilesSampleRate: 1.0`（トランザクションベース）を廃止し、Sentry 推奨の `profilingOptions` ベースの UI Profiling 設定に置き換え:
  - `profileSessionSampleRate: 1.0`
  - `lifecycle: 'trace'`（サンプリングされたスパンが存在する間だけプロファイラを稼働させる）
  - `startOnAppStart: true`（App Start プロファイルを起動時から取得）

### 経緯（プロファイルが届かなかった原因）

- 7.11.0 では Hermes プロファイラの teardown 時クラッシュ（`pthread_kill SIGABRT`）が未修正で、プロファイル送信が落ちることがあった（v8.10.0 で修正）。
- iOS の UI Profiling は v7.12.0 で追加されており、7.11.0 では iOS 側がそもそも対応していなかった。
- v8.9.1 では iOS UI Profiling オプションが silently ignored となる不具合も修正されている。
- 設定の漏れではなく SDK バージョンに起因した既知の不具合の影響であり、最新の SDK へ追従しつつ推奨 API に乗り換えることで根治を狙う。

v8 のネイティブ最低要件（iOS 15+, Xcode 16.4+, AGP 7.4+, Kotlin 1.8+）は現行の Expo 55 / RN 0.83 環境で既に満たされており、ネイティブ側の追加変更は不要。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01USJzDaJC7uriQRnBeknSnK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * エラー追跡サービスの初期化設定を更新し、セッションプロファイリング機能を有効化しました。これによりアプリケーションのパフォーマンス監視がより詳細になります。
  * エラー追跡ライブラリの依存関係をバージョン8.11.1に更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5963)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->