### PR TITLE
Sentry の初期化設定を簡素化

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,8 @@ import { setLocation } from './src/store/atoms/location';
 
 Sentry.init({
   dsn: SENTRY_DSN,
-  sendDefaultPii: true,
-  tracesSampleRate: 1.0,
-  profilesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
+  profilesSampleRate: 0.02,
 });
 
 if (!TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {

--- a/index.js
+++ b/index.js
@@ -6,30 +6,12 @@ import App from './src';
 import { LOCATION_TASK_NAME, MAX_PERMIT_ACCURACY } from './src/constants';
 import { setLocation } from './src/store/atoms/location';
 
-if (process.env.NODE_ENV === 'production') {
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    enableAutoSessionTracking: true,
-    tracesSampleRate: 1.0,
-    profilingOptions: {
-      profileSessionSampleRate: 1.0,
-      lifecycle: 'trace',
-      startOnAppStart: true,
-    },
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-    integrations: [
-      Sentry.mobileReplayIntegration({
-        maskAllText: true,
-        blockAllMedia: true,
-        privacyOptions: {
-          maskAllInputs: true,
-          blockClass: ['sensitive-screen', 'payment-view'],
-        },
-      }),
-    ],
-  });
-}
+Sentry.init({
+  dsn: SENTRY_DSN,
+  sendDefaultPii: true,
+  tracesSampleRate: 1.0,
+  profilesSampleRate: 1.0,
+});
 
 if (!TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {
   TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {


### PR DESCRIPTION
## 概要

Sentry の初期化設定を最小限の構成に整理し、サンプリングレートを抑える。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `process.env.NODE_ENV === 'production'` のガードを撤去し、Sentry を全環境で初期化するよう変更
- UI Profiling 向けの `profilingOptions`（`lifecycle`, `profileSessionSampleRate`, `startOnAppStart`）を廃止し、`profilesSampleRate` をフラット記法に整理
- `enableAutoSessionTracking`・Replay 関連設定（`replaysSessionSampleRate`, `replaysOnErrorSampleRate`, `mobileReplayIntegration`）を撤去
- `tracesSampleRate` を 0.1、`profilesSampleRate` を 0.02 に引き下げ
- `sendDefaultPii` の指定を撤去

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: 変更箇所がリポジトリ直下の `index.js` のみで、`src/**` 等のコード本体パスに該当しないため自動チェック項目は OFF にしている。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * エラートラッキングの初期化を全環境で統一しました。設定を簡素化し、トレースとプロファイルのサンプリング率をそれぞれ約10%／2%に設定して本質的な監視に集中させています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5966)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
