### PR TITLE
Sentry のプロジェクト名をハードコードに変更

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -24,7 +24,7 @@ export default ({ config }: ConfigContext) => ({
       {
         url: 'https://sentry.io/',
         note: 'Use SENTRY_AUTH_TOKEN env to authenticate with Sentry.',
-        project: process.env.SENTRY_PROJECT_NAME || '',
+        project: 'trainlcd',
         organization: 'tinykitten',
       },
     ],


### PR DESCRIPTION
## 概要

Sentry の source map upload プラグインに渡す `project` を `process.env.SENTRY_PROJECT_NAME || ''` から `'trainlcd'` のハードコードに変更する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `app.config.ts` の Sentry プラグイン設定で `project` を `'trainlcd'` 固定値に変更し、`SENTRY_PROJECT_NAME` 環境変数への依存を撤去。

## テスト

<!-- 省略: コード本体（src/** ほか）に変更なし -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
