### PR TITLE
設定モーダルの閉じるボタンを列車種別モーダルと同じ仕様に修正

### DIFF
--- a/src/components/SelectBoundSettingListModal.tsx
+++ b/src/components/SelectBoundSettingListModal.tsx
@@ -1,7 +1,14 @@
+import { BlurView } from 'expo-blur';
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { useMemo } from 'react';
-import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import {
@@ -20,8 +27,6 @@ import Typography from './Typography';
 const styles = StyleSheet.create({
   contentView: {
     width: '100%',
-    paddingVertical: 24,
-    paddingHorizontal: 24,
     minHeight: 256,
   },
   buttonsContainer: {
@@ -34,8 +39,21 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 96,
   },
-  closeButton: { marginTop: 24 },
+  closeButtonContainer: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: '100%',
+    height: 72,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  closeButton: { width: '100%' },
   closeButtonText: { fontWeight: 'bold' },
   trainTypeButton: {
     flexDirection: 'row',
@@ -272,15 +290,36 @@ export const SelectBoundSettingListModal: React.FC<Props> = ({
               </View>
             </TouchableOpacity>
           )}
-          <Button
-            style={styles.closeButton}
-            textStyle={styles.closeButtonText}
-            onPress={onClose}
-          >
-            {translate('close')}
-          </Button>
         </View>
       </ScrollView>
+      <View
+        style={[
+          styles.closeButtonContainer,
+          { backgroundColor: isLEDTheme ? '#212121' : undefined },
+        ]}
+      >
+        {Platform.OS === 'ios' && !isLEDTheme ? (
+          <BlurView
+            intensity={80}
+            tint="light"
+            style={StyleSheet.absoluteFill}
+          />
+        ) : Platform.OS === 'android' && !isLEDTheme ? (
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: 'rgba(255,255,255,0.92)' },
+            ]}
+          />
+        ) : null}
+        <Button
+          style={styles.closeButton}
+          textStyle={styles.closeButtonText}
+          onPress={onClose}
+        >
+          {translate('close')}
+        </Button>
+      </View>
     </CustomModal>
   );
 };


### PR DESCRIPTION
## 概要

長押しで表示される設定モーダル（`SelectBoundSettingListModal`）の閉じるボタンを、列車種別モーダル（`TrainTypeListModal`）と同じ仕様に揃え、モーダル下端に絶対位置で固定するよう修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 閉じるボタンを `ScrollView` 内のフローから取り出し、`position: 'absolute'` の `closeButtonContainer`（`bottom: 0` / `height: 72` / `width: '100%'`）でモーダル下端に固定
- iOS では `BlurView`（intensity 80 / light）、Android では `rgba(255,255,255,0.92)` の半透明オーバーレイ、LED テーマ時は `#212121` でフラット塗りと、`TrainTypeListModal` と完全に同じ装飾に統一
- `contentView` から `paddingVertical/paddingHorizontal: 24` を撤去し、代わりに `scrollContent` 側へ `paddingHorizontal: 24` / `paddingTop: 24` / `paddingBottom: 96` を付与（絶対配置のフッター 72 + 余白でコンテンツが隠れないよう確保）
- `closeButton` のスタイルを `marginTop: 24` から `width: '100%'` に変更

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 設定リストモーダルのUIを改善しました。プラットフォームとテーマに応じた背景効果と閉じるボタンの配置が最適化されています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5973)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->