### PR TITLE
Android 16でTaskBroadcastReceiverが落ちる問題を回避するためexpo-task-managerにJobInfo制約を強制するパッチを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "trainlcd",
       "version": "10.4.3",
+      "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^4.0.7",
         "@expo-google-fonts/roboto": "^0.2.3",
@@ -107,6 +108,7 @@
         "babel-preset-expo": "~55.0.9",
         "jest": "^29.2.1",
         "jest-expo": "~55.0.16",
+        "patch-package": "^8.0.1",
         "react-native-dotenv": "^3.4.8",
         "react-native-worklets": "0.7.4",
         "typescript": "~5.9.2"
@@ -7140,6 +7142,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -8225,6 +8234,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -9096,6 +9124,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -10445,6 +10491,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/firebase": {
       "version": "12.10.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.10.0.tgz",
@@ -10918,6 +10974,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -11561,6 +11630,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -12648,6 +12724,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-to-pretty-yaml": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
@@ -12682,6 +12778,26 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -14558,6 +14674,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -14862,6 +14988,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -15149,6 +15285,114 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-case": {
@@ -17105,6 +17349,24 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -17947,6 +18209,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "expo-screen-orientation": "~55.0.13",
         "expo-splash-screen": "~55.0.18",
         "expo-sqlite": "~55.0.15",
-        "expo-task-manager": "~55.0.14",
+        "expo-task-manager": "55.0.14",
         "expo-web-browser": "~55.0.14",
         "geolib": "^3.3.4",
         "graphql": "^16.11.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "expo-screen-orientation": "~55.0.13",
     "expo-splash-screen": "~55.0.18",
     "expo-sqlite": "~55.0.15",
-    "expo-task-manager": "~55.0.14",
+    "expo-task-manager": "55.0.14",
     "expo-web-browser": "~55.0.14",
     "geolib": "^3.3.4",
     "graphql": "^16.11.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "watch:test": "TZ=UTC jest --watch",
     "gql:codegen": "graphql-codegen --config utils/codegen.ts",
-    "version:bump": "node scripts/bump-version.js"
+    "version:bump": "node scripts/bump-version.js",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@apollo/client": "^4.0.7",
@@ -112,6 +113,7 @@
     "babel-preset-expo": "~55.0.9",
     "jest": "^29.2.1",
     "jest-expo": "~55.0.16",
+    "patch-package": "^8.0.1",
     "react-native-dotenv": "^3.4.8",
     "react-native-worklets": "0.7.4",
     "typescript": "~5.9.2"

--- a/patches/expo-task-manager+55.0.14.patch
+++ b/patches/expo-task-manager+55.0.14.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java b/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+index 4dd0e94..f6d1886 100644
+--- a/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
++++ b/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+@@ -213,8 +213,16 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
+       // For Android 9 (API 28) to Android 11 (API 30)
+       jobBuilder.setImportantWhileForeground(true);
+     } else {
+-      // For Android 12 (API 31) and above
+-      jobBuilder.setExpedited(true);
++      // For Android 12 (API 31) and above.
++      // setExpedited(true) alone causes JobInfo.Builder.build() to throw
++      // IllegalArgumentException("You're trying to build a job with no constraints,
++      // this is not allowed.") on Android 14+/16 because expedited jobs do not
++      // register an early/late/functional constraint, and the build-time validator
++      // counts none of setPersisted/setRequiresDeviceIdle(false) as a constraint.
++      // Falling back to a minimum-latency + override-deadline pair satisfies the
++      // validator and avoids the additional expedited-vs-persisted conflict.
++      jobBuilder.setMinimumLatency(0)
++          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
+     }
+ 
+     return jobBuilder.build();

--- a/patches/expo-task-manager+55.0.14.patch
+++ b/patches/expo-task-manager+55.0.14.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java b/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
-index 4dd0e94..f6d1886 100644
+index 4dd0e94..1d850e7 100644
 --- a/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
 +++ b/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
-@@ -213,8 +213,16 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
+@@ -213,8 +213,20 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
        // For Android 9 (API 28) to Android 11 (API 30)
        jobBuilder.setImportantWhileForeground(true);
      } else {
@@ -14,8 +14,12 @@ index 4dd0e94..f6d1886 100644
 +      // this is not allowed.") on Android 14+/16 because expedited jobs do not
 +      // register an early/late/functional constraint, and the build-time validator
 +      // counts none of setPersisted/setRequiresDeviceIdle(false) as a constraint.
-+      // Falling back to a minimum-latency + override-deadline pair satisfies the
-+      // validator and avoids the additional expedited-vs-persisted conflict.
++      // We apply the minimum-latency + override-deadline fallback uniformly across
++      // API 31+ rather than gating on SDK_INT >= 36, because OEM/patch-level
++      // variance on Android 14 and 15 can still trip the same crash. The loss of
++      // expedited priority on Android 12/13 is offset by the foreground location
++      // service keeping the process alive and the watchPositionAsync bypass on
++      // the JS side.
 +      jobBuilder.setMinimumLatency(0)
 +          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
      }


### PR DESCRIPTION
## 概要

Android 16 (API 36) でフォアグラウンド復帰時に `expo.modules.taskManager.TaskBroadcastReceiver` が `IllegalArgumentException: You're trying to build a job with no constraints, this is not allowed.` で落ち、アプリプロセスが強制終了される問題を回避するため、`expo-task-manager@55.0.14` の `TaskManagerUtils.createJobInfo` に patch-package で JobScheduler の制約を必ず付与するパッチを当てる。

upstream（`expo/expo` main / `sdk-55`）の最新ソースおよび CHANGELOG を確認したが、本症状を解消する修正は入っていないため、当面は patch-package で対応する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/expo-task-manager+55.0.14.patch` を新規追加。`TaskManagerUtils.createJobInfo` の API 31+ 分岐を `setExpedited(true)` 単独から `setMinimumLatency(0).setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)` に置換し、JobScheduler の build-time バリデーション（早期/遅延/機能制約のいずれかが必須）を満たすようにした
- `package.json` の devDependencies に `patch-package@^8.0.1` を追加し、`postinstall: patch-package` スクリプトを追記して `npm install` 時にパッチが自動適用されるようにした
- `package-lock.json` を `patch-package` 追加に伴って更新

### なぜ expedited を捨てるのか

- 期限付きジョブ (`setOverrideDeadline`) は expedited 属性と排他のため両立不可
- 本アプリでは Android 16 (API 36) 向けに `NEEDS_JOBSCHEDULER_BYPASS` で `Location.watchPositionAsync` の直接コールバックを併用しており (`src/hooks/useStartBackgroundLocationUpdates.ts`)、JobScheduler 経路の優先度が落ちても位置更新の即時性は維持される
- 期限ベース (上限 60 秒) に切り替えても、フォアグラウンドサービスがプロセスを保持している限り JobScheduler は即時にジョブを実行するため実害は出にくい

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm install` を実行すると `postinstall` フックで `expo-task-manager@55.0.14 ✔` のパッチ適用ログが出ることをローカルで確認済み。Jest は 154 suites / 1541 tests がすべて pass。

実機 Android 16 端末でフォアグラウンド復帰時のクラッシュが再発しないことの確認は手元では実施できていないため、レビュー後にデバイス検証が必要。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jtza95wnxhs8YUmSwUbP5m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android 12以上で発生していた特定のジョブ設定エラーを回避する修正を行いました。

* **Chores**
  * パッチ管理ツールを開発依存に追加し、インストール後に自動実行されるよう設定しました。

* **メンテナンス**
  * 一部依存のバージョン指定を厳密化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5976)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->