### PR TITLE
Android 9〜11でもJobInfo Builderがno constraints例外を投げるためexpo-task-managerのパッチをAPI 28〜30分岐にも拡張

### DIFF
--- a/patches/expo-task-manager+55.0.14.patch
+++ b/patches/expo-task-manager+55.0.14.patch
@@ -2,9 +2,23 @@ diff --git a/node_modules/expo-task-manager/android/src/main/java/expo/modules/t
 index 4dd0e94..1d850e7 100644
 --- a/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
 +++ b/node_modules/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
-@@ -213,8 +213,20 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
-       // For Android 9 (API 28) to Android 11 (API 30)
-       jobBuilder.setImportantWhileForeground(true);
+@@ -210,11 +210,32 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
+       jobBuilder.setMinimumLatency(0)
+           .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
+     } else if (Build.VERSION.SDK_INT < 31) {
+-      // For Android 9 (API 28) to Android 11 (API 30)
+-      jobBuilder.setImportantWhileForeground(true);
++      // For Android 9 (API 28) to Android 11 (API 30).
++      // setImportantWhileForeground(true) alone is treated as a priority hint
++      // rather than a JobInfo constraint by the JobInfo.Builder validator on
++      // some OEM Android 9-11 builds (observed in production Sentry data on
++      // Sony / Sharp / Fujitsu / LG carrier-locked devices in Japan), so
++      // JobInfo.Builder.build() throws IllegalArgumentException("You're trying
++      // to build a job with no constraints, this is not allowed."). Apply the
++      // same minimum-latency + override-deadline fallback as the < API 28
++      // branch to ensure the builder always has an accepted constraint.
++      jobBuilder.setMinimumLatency(0)
++          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
      } else {
 -      // For Android 12 (API 31) and above
 -      jobBuilder.setExpedited(true);
@@ -23,5 +37,5 @@ index 4dd0e94..1d850e7 100644
 +      jobBuilder.setMinimumLatency(0)
 +          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
      }
- 
+
      return jobBuilder.build();


### PR DESCRIPTION
## 概要

Android 9〜11 (API 28〜30) で `expo-task-manager` の JobScheduler 経由のバックグラウンドジョブが `JobInfo.Builder.build()` で `IllegalArgumentException("You're trying to build a job with no constraints, this is not allowed.")` を投げてクラッシュする問題を、patches/expo-task-manager+55.0.14.patch の修正範囲を API 28〜30 分岐にも拡張することで回避する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/expo-task-manager+55.0.14.patch` の Android 9〜11 (`Build.VERSION.SDK_INT < 31`) 分岐に、`< API 28` 分岐と同じ `setMinimumLatency(0).setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)` のフォールバックを追加。
- 一部 OEM (Sony / Sharp / Fujitsu / LG の日本向けキャリア端末) の Android 9〜11 ビルドでは `setImportantWhileForeground(true)` だけでは `JobInfo.Builder` のバリデータが「制約あり」と認識せず例外を投げるため、最低限の制約を必ず1つ付与するようにした。
- 経緯と例外メッセージをコードコメントとして残し、後続メンテナがパッチの意図を追えるようにした。

## テスト

<!-- patches/ のみの変更で、JS/TS 側の lint・test・typecheck は影響を受けないため省略 -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Android 9～12以上のデバイスにおけるバックグラウンドタスク実行時のクラッシュを修正しました。OEM固有のシステム検証要件に対応し、より安定したジョブスケジューリングを実現します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5984)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->