### PR TITLE
localTypePrefix指定時に翻訳キーがtylocalになりキー解決に失敗していた不具合を修正

### DIFF
--- a/src/components/HeaderEast/config.test.ts
+++ b/src/components/HeaderEast/config.test.ts
@@ -1,0 +1,35 @@
+import en from '../../../assets/translations/en.json';
+import ja from '../../../assets/translations/ja.json';
+import { tokyoMetroConfig, tyConfig } from './config';
+
+describe('HeaderEast config translation keys', () => {
+  const configs = [
+    { name: 'tokyoMetroConfig', config: tokyoMetroConfig },
+    { name: 'tyConfig', config: tyConfig },
+  ] as const;
+
+  const deriveKeys = (prefix: string) => {
+    const base = prefix ? 'Local' : 'local';
+    return [
+      `${prefix}${base}`,
+      `${prefix}${base}En`,
+      `${prefix}${base}Zh`,
+      `${prefix}${base}Ko`,
+    ];
+  };
+
+  for (const { name, config } of configs) {
+    const prefix = config.trainTypeBox.localTypePrefix;
+    const keys = deriveKeys(prefix);
+
+    describe(`${name} (localTypePrefix="${prefix}")`, () => {
+      it.each(keys)('ja.json contains "%s"', (key) => {
+        expect(ja).toHaveProperty(key);
+      });
+
+      it.each(keys)('en.json contains "%s"', (key) => {
+        expect(en).toHaveProperty(key);
+      });
+    });
+  }
+});

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -116,31 +116,33 @@ const TrainTypeBox: React.FC<Props> = ({
 
   const isBus = isBusLine(currentLine);
 
+  const localKey = localTypePrefix ? 'Local' : 'local';
+
   const localTypeText = useMemo(() => {
     switch (headerLangState) {
       case 'EN':
-        return translate(`${localTypePrefix}localEn`);
+        return translate(`${localTypePrefix}${localKey}En`);
       case 'ZH':
-        return translate(`${localTypePrefix}localZh`);
+        return translate(`${localTypePrefix}${localKey}Zh`);
       case 'KO':
-        return translate(`${localTypePrefix}localKo`);
+        return translate(`${localTypePrefix}${localKey}Ko`);
       default:
-        return translate(`${localTypePrefix}local`);
+        return translate(`${localTypePrefix}${localKey}`);
     }
-  }, [headerLangState, localTypePrefix]);
+  }, [headerLangState, localTypePrefix, localKey]);
 
   const trainTypeNameJa = (trainType?.name || localTypeText)?.replace(
     parenthesisRegexp,
     ''
   );
   const trainTypeNameR = truncateTrainType(
-    trainType?.nameRoman || translate(`${localTypePrefix}localEn`)
+    trainType?.nameRoman || translate(`${localTypePrefix}${localKey}En`)
   );
   const trainTypeNameZh = truncateTrainType(
-    trainType?.nameChinese || translate(`${localTypePrefix}localZh`)
+    trainType?.nameChinese || translate(`${localTypePrefix}${localKey}Zh`)
   );
   const trainTypeNameKo = truncateTrainType(
-    trainType?.nameKorean || translate(`${localTypePrefix}localKo`)
+    trainType?.nameKorean || translate(`${localTypePrefix}${localKey}Ko`)
   );
 
   const lineNameJa = currentLine?.nameShort?.replace(parenthesisRegexp, '');


### PR DESCRIPTION
## 概要

`localTypePrefix` を導入した際に翻訳キーの命名規則とずれが生じ、`TrainTypeBox` が `tylocal` / `tylocalEn` / `tylocalZh` / `tylocalKo` という存在しないキーを参照していた不具合を修正します。翻訳キーは `tyLocal` / `tyLocalEn` / `tyLocalZh` / `tyLocalKo` のように `Local` 部分が大文字始まりで登録されているため、プレフィックスが付与されるときだけキー側も `Local` に切り替えるようにしました。あわせて、同種のずれを早期検出するための回帰防止ユニットテストを追加しています。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/TrainTypeBox.tsx` で `localTypePrefix` が非空のときに `Local`、空のときに `local` を参照するヘルパー `localKey` を追加し、`localTypeText` および `trainTypeNameR` / `trainTypeNameZh` / `trainTypeNameKo` の翻訳キー組み立てを `${localTypePrefix}${localKey}...` に置き換え。
- これにより `tyLocal` 系（プレフィックスあり）と `local` 系（プレフィックスなし）の両方が正しく解決されるようになります。
- `src/components/HeaderEast/config.test.ts` を新規追加し、`tokyoMetroConfig` と `tyConfig` の `localTypePrefix` から導出される 4 種の翻訳キー（`{prefix}{Local|local}` / `...En` / `...Zh` / `...Ko`）が `ja.json` と `en.json` の双方に揃っていることを検証。今後新たなテーマで `localTypePrefix` を増やした際にも翻訳キー漏れを CI で検出できます。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * ヘッダー設定における翻訳キーの完全性を検証するテストスイートを新たに追加しました。

* **Bug Fixes**
  * 列車タイプボックスの多言語翻訳キー生成ロジックを改善し、各言語での正確な翻訳参照を実現しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5987)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->