### PR TITLE
長文駅名がadjustsFontSizeToFitで過剰に縮小される不具合をminimumFontScale導入で修正

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -4,6 +4,7 @@ import { useClock } from '../hooks';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBoxE231';
@@ -242,6 +243,11 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
             <View style={styles.stationNameWrapper}>
               <Typography
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(
+                  stationText,
+                  0.5,
+                  styles.stationName.fontSize
+                )}
                 numberOfLines={1}
                 style={styles.stationName}
               >

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -5,6 +5,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useLoopLine } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { HeaderE235Props } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -227,6 +228,7 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
           <Typography
             style={styles.stationName}
             adjustsFontSizeToFit
+            minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
             numberOfLines={1}
           >
             {stationText}

--- a/src/components/HeaderEast/HeaderEast.tsx
+++ b/src/components/HeaderEast/HeaderEast.tsx
@@ -11,6 +11,7 @@ import { MARK_SHAPE, STATION_NAME_FONT_SIZE } from '../../constants';
 import { useHeaderAnimation } from '../../hooks';
 import isTablet from '../../utils/isTablet';
 import { RFValue } from '../../utils/rfValue';
+import { calcStationNameMinScale } from '../../utils/stationNameScale';
 import type { CommonHeaderProps } from '../Header.types';
 import NumberingIcon from '../NumberingIcon';
 import TrainTypeBox from '../TrainTypeBox';
@@ -298,6 +299,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
             >
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   styles.stationName,
@@ -323,6 +325,10 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
             >
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(
+                  animation.prevStationText,
+                  0.55
+                )}
                 numberOfLines={1}
                 style={[
                   styles.stationName,

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -6,6 +6,7 @@ import { useLoopLine } from '~/hooks';
 import { STATION_NAME_FONT_SIZE } from '../constants';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -230,6 +231,7 @@ const HeaderJL: React.FC<CommonHeaderProps> = (props) => {
           <Typography
             style={styles.stationName}
             adjustsFontSizeToFit
+            minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
             numberOfLines={1}
           >
             {stationText}

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -5,6 +5,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useHeaderAnimation } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBoxJRKyushu from './TrainTypeBoxJRKyushu';
@@ -217,6 +218,7 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             <View style={styles.stationNameContainer}>
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   animation.topNameAnimatedStyles,
@@ -234,6 +236,10 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             <View style={styles.stationNameContainer}>
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(
+                  animation.prevStationText,
+                  0.55
+                )}
                 numberOfLines={1}
                 style={[
                   animation.bottomNameAnimatedStyles,

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -12,6 +12,7 @@ import {
 } from '../constants';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TransferLineMark from './TransferLineMark';
@@ -530,6 +531,7 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
           <View style={styles.stationNameContainer}>
             <Typography
               adjustsFontSizeToFit
+              minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
               numberOfLines={1}
               style={styles.stationName}
             >

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -12,6 +12,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useHeaderAnimation } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
+import { calcStationNameMinScale } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -240,6 +241,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             <View style={styles.stationNameContainer}>
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   animation.topNameAnimatedStyles,
@@ -258,6 +260,10 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             <View style={styles.stationNameContainer}>
               <RNAnimated.Text
                 adjustsFontSizeToFit
+                minimumFontScale={calcStationNameMinScale(
+                  animation.prevStationText,
+                  0.55
+                )}
                 numberOfLines={1}
                 style={[
                   animation.bottomNameAnimatedStyles,

--- a/src/utils/stationNameScale.test.ts
+++ b/src/utils/stationNameScale.test.ts
@@ -1,0 +1,54 @@
+import { Dimensions } from 'react-native';
+import { calcStationNameMinScale } from './stationNameScale';
+
+describe('calcStationNameMinScale', () => {
+  const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
+
+  beforeEach(() => {
+    // 実機のスマートフォン相当の画面幅でクランプ・補間挙動を再現する
+    mockDimensionsGet.mockReturnValue({
+      width: 400,
+      height: 800,
+      scale: 1,
+      fontScale: 1,
+    } as ReturnType<typeof Dimensions.get>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('空文字は早期 return で 1 を返す', () => {
+    expect(calcStationNameMinScale('', 0.6, 50)).toBe(1);
+  });
+
+  it('短い駅名は上限 1 にクランプされる', () => {
+    expect(calcStationNameMinScale('あ', 0.6, 50)).toBe(1);
+  });
+
+  it('極端に長い駅名はフロア値 0.1 にクランプされる', () => {
+    expect(calcStationNameMinScale('あ'.repeat(1000), 0.6, 50)).toBe(0.1);
+  });
+
+  it('中間長の駅名は (0.1, 1) の範囲内のスケールを返す', () => {
+    const scale = calcStationNameMinScale(
+      'はねだくうこうだいさんたーみなる',
+      0.55,
+      45
+    );
+    expect(scale).toBeGreaterThan(0.1);
+    expect(scale).toBeLessThan(1);
+  });
+
+  it('文字数に応じて単調にスケールが減少する', () => {
+    const shortScale = calcStationNameMinScale('みと', 0.55, 45);
+    const midScale = calcStationNameMinScale('はねだくうこう', 0.55, 45);
+    const longScale = calcStationNameMinScale(
+      'ちょうじゃがはまましおさいはまなすこうえんまえ',
+      0.55,
+      45
+    );
+    expect(shortScale).toBeGreaterThanOrEqual(midScale);
+    expect(midScale).toBeGreaterThan(longScale);
+  });
+});

--- a/src/utils/stationNameScale.ts
+++ b/src/utils/stationNameScale.ts
@@ -1,0 +1,25 @@
+import { Dimensions } from 'react-native';
+import { STATION_NAME_FONT_SIZE } from '../constants';
+
+const MIN_SCALE_FLOOR = 0.1;
+// 実フォントの 1 文字あたりの幅は fontSize より狭い（Roboto Bold + CJK でおよそ 0.65〜0.75）。
+// 1.0 寄りで見積もると KANA や長い英字駅名で「画面幅にはまだ余裕があるのにスケールが下がる」
+// 状態になるため、実描画に近い値まで下げる。
+const CHAR_WIDTH_RATIO = 0.7;
+
+// adjustsFontSizeToFit は minimumFontScale 未指定だと 0.01 倍まで縮むため、
+// 「はねだくうこうだいさんたーみなる」のような長文駅名で文字が潰れる。
+// 画面幅にぎりぎり収まるスケールをフロアにして、それ以下の縮小を防ぐ。
+export const calcStationNameMinScale = (
+  text: string,
+  widthRatio = 0.6,
+  baseFontSize: number = STATION_NAME_FONT_SIZE
+) => {
+  if (!text) {
+    return 1;
+  }
+  const availableWidth = Dimensions.get('window').width * widthRatio;
+  const requiredFontSize = availableWidth / (text.length * CHAR_WIDTH_RATIO);
+  const scale = requiredFontSize / baseFontSize;
+  return Math.min(1, Math.max(scale, MIN_SCALE_FLOOR));
+};


### PR DESCRIPTION
## 概要

ヘッダー駅名の `adjustsFontSizeToFit` に `minimumFontScale` が指定されておらず、「はねだくうこうだいさんたーみなる」「ちょうじゃがはまましおさいはまなすこうえんまえ」などの長文（特に KANA 表記）駅名で文字が判読不能なほど縮小される不具合を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 駅名の文字数と利用可能な画面幅から「幅いっぱいに収まるスケール」を算出する util `calcStationNameMinScale` を `src/utils/stationNameScale.ts` に追加。
- 全 Header 実装（`HeaderEast` / `HeaderE235` / `HeaderE231` / `HeaderSaikyo` / `HeaderJL` / `HeaderJRKyushu` / `HeaderJRWest`）の駅名 `Text` に `minimumFontScale` を渡し、`adjustsFontSizeToFit` のデフォルト（0.01 倍まで縮小）による潰れを防止。
- アニメーションを持つ Header では現在駅名と直前駅名（`prevStationText`）の双方に対して個別にスケールを算出。
- 実フォントの 1 文字あたりの描画幅補正 `CHAR_WIDTH_RATIO` を 0.7 に設定し、KANA など文字数が多くなる表記でも実体に近いスケールが得られるよう調整。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ステーション名の表示で最小フォント縮小率を算出・適用する仕組みを導入し、表示の一貫性を向上しました。
* **バグ修正**
  * 長いステーション名でも画面幅に応じて適切なサイズで表示されるようスケーリング挙動を改善しました。
* **テスト**
  * 最小スケール算出の挙動を確認する単体テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5988)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->