### PR TITLE
バス路線の列車種別を自動選択し長い系統名表示に対応

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -353,6 +353,7 @@ export type TrainType = {
 
 export enum TrainTypeKind {
   Branch = 'Branch',
+  BusRoute = 'BusRoute',
   CommuterRapid = 'CommuterRapid',
   Default = 'Default',
   Express = 'Express',

--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -468,7 +468,12 @@ export const CommonCard: React.FC<Props> = ({
           </View>
         )}
         <View style={styles.texts}>
-          <Typography style={styles.title} numberOfLines={1}>
+          <Typography
+            style={styles.title}
+            // バス系統名は長くなりがちなので 2 行まで許容する
+            numberOfLines={isBus ? 2 : 1}
+            adjustsFontSizeToFit
+          >
             {titlePrefix ? (
               <Typography style={styles.titleAffix}>{titlePrefix}</Typography>
             ) : null}

--- a/src/constants/simulationMode.ts
+++ b/src/constants/simulationMode.ts
@@ -27,6 +27,8 @@ export const TRAIN_TYPE_KIND_MAX_SPEEDS_IN_M_S: Record<
   [TrainTypeKind.Express]: null,
   [TrainTypeKind.LimitedExpress]: 36.1111111111, // 130km/h
   [TrainTypeKind.HighSpeedRapid]: 36.1111111111, // 130km/h
+  // バス系統は useSimulationMode 側で isBus 分岐により BUS_MAX_SPEED_IN_M_S が適用されるため null
+  [TrainTypeKind.BusRoute]: null,
 } as const;
 // 路線種別による加速度
 export const LINE_TYPE_MAX_ACCEL_IN_M_S: Record<LineType, number> = {

--- a/src/hooks/useLineSelection.test.tsx
+++ b/src/hooks/useLineSelection.test.tsx
@@ -3,6 +3,7 @@ import { act, render } from '@testing-library/react-native';
 import { useAtomValue, useSetAtom } from 'jotai';
 import type React from 'react';
 import type { Line, TrainType } from '~/@types/graphql';
+import { TransportType } from '~/@types/graphql';
 import { createLine, createStation } from '~/utils/test/factories';
 import type { LineState } from '../store/atoms/line';
 import type { NavigationState } from '../store/atoms/navigation';
@@ -199,6 +200,110 @@ describe('useLineSelection', () => {
     const navSetter = mockSetNavigationState.mock.calls[0][0];
     const navResult = navSetter(createNavigationState());
     expect(navResult.fetchedTrainTypes).toEqual([]);
+    expect(navResult.pendingTrainType).toBeNull();
+  });
+
+  it('バス路線で hasTrainTypes の場合に最初の列車種別を自動選択し lineGroup の駅を取得する', async () => {
+    const { mockSetStationState, mockSetNavigationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    // 路線駅一覧（station.trainType は無い: バスは station 単位で trainType を持たない）
+    const lineStations = [createStation(10), createStation(20)];
+    mockFetchByLineId.mockResolvedValue({
+      data: { lineStations },
+    });
+
+    // 自動選択される最初の列車種別と、その lineGroup の駅一覧
+    const trainTypes = [
+      { id: 1, groupId: 500, name: 'A系統' } as TrainType,
+      { id: 2, groupId: 501, name: 'B系統' } as TrainType,
+    ];
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: trainTypes },
+    });
+    const groupStations = [createStation(10), createStation(30)];
+    mockFetchByGroupId.mockResolvedValue({
+      data: { lineGroupStations: groupStations },
+    });
+
+    const line = createLine(100, {
+      transportType: TransportType.Bus,
+      station: { id: 10, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      await hookRef.current?.handleLineSelected(line);
+    });
+
+    // 最初の列車種別の groupId で駅一覧を取得している
+    expect(mockFetchByGroupId).toHaveBeenCalledWith({
+      variables: { lineGroupId: 500 },
+    });
+
+    // navigationState の更新で pendingTrainType が先頭の列車種別に設定されている
+    const navSetterCalls = mockSetNavigationState.mock.calls;
+    const lastNavSetter = navSetterCalls[navSetterCalls.length - 1][0];
+    const navResult = lastNavSetter(createNavigationState());
+    expect(navResult.fetchedTrainTypes).toEqual(trainTypes);
+    expect(navResult.pendingTrainType).toEqual(trainTypes[0]);
+
+    // stationState の最後の更新で lineGroup の駅一覧に差し替わっている
+    const stationSetterCalls = mockSetStationState.mock.calls;
+    const lastStationSetter =
+      stationSetterCalls[stationSetterCalls.length - 1][0];
+    const stationResult = lastStationSetter(createStationState());
+    expect(stationResult.pendingStations).toEqual(groupStations);
+    expect(stationResult.pendingStation?.id).toBe(10);
+  });
+
+  it('鉄道路線で hasTrainTypes でも station.trainType が無ければ自動選択しない', async () => {
+    const { mockSetNavigationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    const lineStations = [createStation(10)];
+    mockFetchByLineId.mockResolvedValue({
+      data: { lineStations },
+    });
+    const trainTypes = [{ id: 1, groupId: 500, name: '快速' } as TrainType];
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: trainTypes },
+    });
+
+    const line = createLine(100, {
+      transportType: TransportType.Rail,
+      station: { id: 10, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      await hookRef.current?.handleLineSelected(line);
+    });
+
+    // 鉄道は自動フォールバックしないので groupId 経由の駅取得は呼ばれない
+    expect(mockFetchByGroupId).not.toHaveBeenCalled();
+
+    const navSetterCalls = mockSetNavigationState.mock.calls;
+    const lastNavSetter = navSetterCalls[navSetterCalls.length - 1][0];
+    const navResult = lastNavSetter(createNavigationState());
     expect(navResult.pendingTrainType).toBeNull();
   });
 

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -11,6 +11,7 @@ import {
   GET_STATION_TRAIN_TYPES_LIGHT,
 } from '~/lib/graphql/queries';
 import type { SavedRoute } from '~/models/SavedRoute';
+import { isBusLine } from '~/utils/line';
 import lineStateAtom from '../store/atoms/line';
 import { locationAtom } from '../store/atoms/location';
 import navigationState from '../store/atoms/navigation';
@@ -144,15 +145,37 @@ export const useLineSelection = (): UseLineSelectionResult => {
         const designatedTrainType =
           fetchedTrainTypes.find((tt) => tt.id === designatedTrainTypeId) ??
           null;
+        // バスは station.trainType を持たないため、最初の列車種別を自動選択する
+        const fallbackTrainType =
+          !designatedTrainType && isBusLine(line)
+            ? (fetchedTrainTypes[0] ?? null)
+            : null;
+        const initialTrainType = designatedTrainType ?? fallbackTrainType;
+
         setNavigationState((prev) => ({
           ...prev,
           fetchedTrainTypes,
-          pendingTrainType: designatedTrainType as TrainType | null,
+          pendingTrainType: initialTrainType as TrainType | null,
         }));
+
+        if (fallbackTrainType?.groupId != null) {
+          const groupResult = await fetchStationsByLineGroupId({
+            variables: { lineGroupId: fallbackTrainType.groupId },
+          });
+          const lineGroupStations = groupResult.data?.lineGroupStations ?? [];
+          setStationState((prev) => ({
+            ...prev,
+            pendingStations: lineGroupStations,
+            pendingStation:
+              lineGroupStations.find((s) => s.id === lineStationId) ??
+              prev.pendingStation,
+          }));
+        }
       }
     },
     [
       fetchTrainTypes,
+      fetchStationsByLineGroupId,
       setNavigationState,
       setStationState,
       setLineState,


### PR DESCRIPTION
## 概要

バス路線で `hasTrainTypes === true` のとき、系統選択を行わなくても先頭の列車種別が自動選択されるようにする。あわせて、バスの系統名は長くなりがちなため `CommonCard` のタイトル表示を縮小・複数行に対応させる。`TrainTypeKind` にバス系統用の `BusRoute` を追加した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `TrainTypeKind` に `BusRoute` を追加し、シミュレーション速度マップ (`TRAIN_TYPE_KIND_MAX_SPEEDS_IN_M_S`) にも対応エントリを追加（`isBus` 早期分岐により値自体は実質参照されないため `null`）。
- `useLineSelection.handleLineSelected` で、バス路線かつ `hasTrainTypes` の場合に駅側の `trainType` が無いケースを検出し、`fetchedTrainTypes[0]` を `pendingTrainType` として自動選択。続けて `fetchStationsByLineGroupId` でその系統の駅一覧を取得し `pendingStations` を差し替える。鉄道路線は従来挙動を維持。
- `CommonCard` の title 用 `Typography` に `adjustsFontSizeToFit` を付与し、`isBusLine(line)` のとき `numberOfLines` を 2 に拡張。長いバス系統名がフォント縮小と 2 行で収まるようにする。
- 上記挙動の回帰防止として `useLineSelection.test.tsx` にバス自動選択ケースと「鉄道は自動選択しない」ガードケースを追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * バス路線に対応しました。バス系統の表示設定を最適化し、シミュレーションモード内でバスの速度パラメータを適用可能にしました。

* **Bug Fixes**
  * バス路線の駅選択時に列車種別が正しく初期化されるよう改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5992)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->