### PR TITLE
TOEIバスTTSで「このバスは〜ゆきです」が毎回再生される不具合を修正

### DIFF
--- a/src/hooks/useBusTTSText.test.tsx
+++ b/src/hooks/useBusTTSText.test.tsx
@@ -332,6 +332,25 @@ describe('useBusTTSText', () => {
       expect(enText).toContain('This bus is bound for');
     });
 
+    // 回帰テスト: TOEIの「このバスは、〜ゆきです。」/ "This bus is bound for ..." は
+    // 初回放送 (firstSpeech=true) のみで再生される必要がある。
+    // 以前はテンプレート構造の都合で firstSpeech 条件の外に出ており、停車のたびに
+    // 繰り返し再生されていた。
+    test('should omit bound-for phrase on subsequent NEXT (firstSpeech=false)', () => {
+      const { result } = renderHook(
+        () => useBusTTSTextWithJotai('TOEI', 'NEXT', false),
+        {
+          wrapper: wrapper,
+        }
+      );
+      const [jaText, enText] = result.current.text;
+      expect(jaText).toContain('次は');
+      expect(jaText).not.toContain('このバスは');
+      expect(jaText).not.toContain('ご利用くださいまして');
+      expect(enText).not.toContain('This bus is bound for');
+      expect(enText).not.toContain('Thank you for using the');
+    });
+
     test('should generate ARRIVING text', () => {
       const { result } = renderHook(
         () => useBusTTSTextWithJotai('TOEI', 'ARRIVING'),

--- a/src/hooks/useBusTTSText.ts
+++ b/src/hooks/useBusTTSText.ts
@@ -446,7 +446,7 @@ export const useBusTTSText = (
           }、${
             replaceJapaneseText(nextStation?.name, nextStation?.nameKatakana) ??
             ''
-          }。このバスは、${boundForJa}ゆきです。${
+          }。${firstSpeech ? `このバスは、${boundForJa}ゆきです。` : ''}${
             afterNextStation
               ? `${replaceJapaneseText(
                   nextStation?.name,
@@ -690,9 +690,9 @@ export const useBusTTSText = (
         [APP_THEME.TOEI]: {
           NEXT: `${
             firstSpeech
-              ? `Thank you for using the ${station?.line?.company?.nameEnglishShort ?? ''}. `
+              ? `Thank you for using the ${station?.line?.company?.nameEnglishShort ?? ''}. This bus is bound for ${boundForEn}. `
               : ''
-          }This bus is bound for ${boundForEn}. The next stop is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}.`,
+          }The next stop is ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}.`,
           ARRIVING: `We will soon be arriving at ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}.${
             afterNextStation
               ? ` The stop after ${ph(nextStation?.nameTtsSegments, nextStation?.nameRoman)}, will be ${ph(


### PR DESCRIPTION
## 概要

TOEIテーマのバスTTSで、初回案内のはずの「このバスは、〜ゆきです。」(日本語) と "This bus is bound for ..." (英語) が `firstSpeech` 条件の外側に置かれており、各停車のたびに繰り返し再生されていた不具合を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useBusTTSText.ts` の `APP_THEME.TOEI` テンプレート (JA/EN) で、「このバスは、{boundForJa}ゆきです。」/ "This bus is bound for {boundForEn}." を `firstSpeech` の三項演算子の中に移動。
- 他テーマ (TOKYO_METRO / TY / YAMANOTE / SAIKYO / JR_WEST / JR_KYUSHU) は元々 `firstSpeech` 条件下にあり、TOEIだけ条件外だったのを揃えた。
- `src/hooks/useBusTTSText.test.tsx` に回帰テストを追加。TOEIテーマで `firstSpeech=false` のとき、JAに「このバスは」「ご利用くださいまして」、ENに "This bus is bound for"・"Thank you for using the" が含まれないことを検証する。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * TOEI テーマのバス案内通知で、初回放送以外は特定の導入フレーズが読み上げられないよう改善しました。初回放送では従来通り読み上げられます。

* **テスト**
  * バス TTS 出力の回帰テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/5996)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->