### PR TITLE
ディープリンクで他路線直通の経路全体を sids パラメータで表現できるようにする

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -764,6 +764,72 @@ describe('useDeepLink', () => {
     expect(mockSetStationState).not.toHaveBeenCalled();
   });
 
+  it('sidsでdirが省略された場合はINBOUNDとして扱う', async () => {
+    const stationA = createStation(1131211, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+    const stationB = createStation(1131310, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1131211,1131310' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+    mockFetchByIds.mockResolvedValue({
+      data: { stations: [stationA, stationB] },
+    });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const stationResult = stationSetter(createStationState());
+    expect(stationResult.selectedDirection).toBe<LineDirection>('INBOUND');
+    expect(stationResult.selectedBound?.id).toBe(1131310);
+  });
+
+  it('sidsでdirが不正値の場合はstateを変更しない', async () => {
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310&dir=2'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1131211,1131310', dir: '2' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchByIds).not.toHaveBeenCalled();
+    expect(mockSetStationState).not.toHaveBeenCalled();
+  });
+
   it('sidsに不正なトークンが含まれる場合はstateを変更しない', async () => {
     mockGetInitialURL.mockResolvedValue(
       'CanaryTrainLCD://route?sids=1131211,123x,2800217&dir=0'

--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -122,27 +122,33 @@ describe('useDeepLink', () => {
   const setupQueries = ({
     groupLoading = false,
     lineLoading = false,
+    idsLoading = false,
     groupError,
     lineError,
+    idsError,
   }: {
     groupLoading?: boolean;
     lineLoading?: boolean;
+    idsLoading?: boolean;
     groupError?: Error;
     lineError?: Error;
+    idsError?: Error;
   } = {}) => {
     const mockFetchByGroup = jest.fn();
     const mockFetchByLine = jest.fn();
+    const mockFetchByIds = jest.fn();
     const queryResults = [
       [mockFetchByGroup, { loading: groupLoading, error: groupError }],
       [mockFetchByLine, { loading: lineLoading, error: lineError }],
+      [mockFetchByIds, { loading: idsLoading, error: idsError }],
     ];
     let queryCallIdx = 0;
     mockUseLazyQuery.mockImplementation(() => {
-      const result = queryResults[queryCallIdx % 2];
+      const result = queryResults[queryCallIdx % queryResults.length];
       queryCallIdx++;
       return result;
     });
-    return { mockFetchByGroup, mockFetchByLine };
+    return { mockFetchByGroup, mockFetchByLine, mockFetchByIds };
   };
 
   afterEach(() => {
@@ -613,6 +619,279 @@ describe('useDeepLink', () => {
 
     warnSpy.mockRestore();
     jest.useRealTimers();
+  });
+
+  it('sidsが指定された場合はstations(ids)で取得し順序を保つ', async () => {
+    // server returns stations in a different order than the requested ids
+    const stationA = createStation(1131211, {
+      groupId: 11312,
+      line: { id: 11302, nameShort: 'Yamanote' },
+      trainType: createTrainType(),
+    } as Parameters<typeof createStation>[1]);
+    const stationB = createStation(1131310, {
+      groupId: 11313,
+      line: { id: 11302, nameShort: 'Yamanote' },
+    } as Parameters<typeof createStation>[1]);
+    const stationC = createStation(2800217, {
+      groupId: 28002,
+      line: { id: 28005, nameShort: 'Marunouchi' },
+    } as Parameters<typeof createStation>[1]);
+    const stationD = createStation(2800218, {
+      groupId: 28003,
+      line: { id: 28005, nameShort: 'Marunouchi' },
+    } as Parameters<typeof createStation>[1]);
+
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218&dir=0'
+    );
+    mockParse.mockReturnValue({
+      queryParams: {
+        sids: '1131211,1131310,2800217,2800218',
+        dir: '0',
+      },
+    });
+
+    const { mockSetStationState, mockSetNavigationState, mockSetLineState } =
+      setupAtoms();
+    const { mockFetchByIds, mockFetchByLine, mockFetchByGroup } =
+      setupQueries();
+    mockFetchByIds.mockResolvedValue({
+      // intentionally reordered
+      data: { stations: [stationD, stationB, stationC, stationA] },
+    });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    expect(mockFetchByIds).toHaveBeenCalledWith({
+      variables: { ids: [1131211, 1131310, 2800217, 2800218] },
+    });
+    // legacy queries must not be called when sids takes the new path
+    expect(mockFetchByLine).not.toHaveBeenCalled();
+    expect(mockFetchByGroup).not.toHaveBeenCalled();
+
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const stationResult = stationSetter(createStationState());
+    expect(stationResult.stations.map((s: { id: number }) => s.id)).toEqual([
+      1131211, 1131310, 2800217, 2800218,
+    ]);
+    expect(stationResult.station?.id).toBe(1131211);
+    expect(stationResult.selectedDirection).toBe<LineDirection>('INBOUND');
+    expect(stationResult.selectedBound?.id).toBe(2800218);
+
+    const lineSetter = mockSetLineState.mock.calls[0][0];
+    const lineResult = lineSetter(createLineState());
+    expect(lineResult.selectedLine?.id).toBe(11302);
+
+    const navSetter = mockSetNavigationState.mock.calls[0][0];
+    const navResult = navSetter(createNavigationState());
+    expect(navResult.trainType?.typeId).toBe('local');
+    expect(navResult.autoModeEnabled).toBe(false);
+  });
+
+  it('sidsとdir=1の場合はselectedBoundが先頭駅になる', async () => {
+    const stationA = createStation(1131211, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+    const stationB = createStation(1131310, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310&dir=1'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1131211,1131310', dir: '1' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+    mockFetchByIds.mockResolvedValue({
+      data: { stations: [stationA, stationB] },
+    });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const stationResult = stationSetter(createStationState());
+    expect(stationResult.selectedDirection).toBe<LineDirection>('OUTBOUND');
+    expect(stationResult.selectedBound?.id).toBe(1131211);
+  });
+
+  it('sidsが1件以下の場合はstateを変更しない', async () => {
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211&dir=0'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1131211', dir: '0' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchByIds).not.toHaveBeenCalled();
+    expect(mockSetStationState).not.toHaveBeenCalled();
+  });
+
+  it('sidsの解決結果が空の場合はstateを変更しない', async () => {
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1,2,3&dir=0'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1,2,3', dir: '0' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+    mockFetchByIds.mockResolvedValue({ data: { stations: [] } });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    expect(mockSetStationState).not.toHaveBeenCalled();
+  });
+
+  it('sidsが指定されている場合はsgid/lid/lgidを無視する', async () => {
+    const station = createStation(1131211, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310&sgid=99&lid=999&lgid=42&dir=0'
+    );
+    mockParse.mockReturnValue({
+      queryParams: {
+        sids: '1131211,1131310',
+        sgid: '99',
+        lid: '999',
+        lgid: '42',
+        dir: '0',
+      },
+    });
+
+    setupAtoms();
+    const { mockFetchByIds, mockFetchByLine, mockFetchByGroup } =
+      setupQueries();
+    mockFetchByIds.mockResolvedValue({
+      data: { stations: [station] },
+    });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    expect(mockFetchByLine).not.toHaveBeenCalled();
+    expect(mockFetchByGroup).not.toHaveBeenCalled();
+  });
+
+  it('sidsにautoとthemeを併用できる', async () => {
+    const stationA = createStation(1131211, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+    const stationB = createStation(1131310, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,1131310&dir=0&auto=1&theme=AUTO'
+    );
+    mockParse.mockReturnValue({
+      queryParams: {
+        sids: '1131211,1131310',
+        dir: '0',
+        auto: '1',
+        theme: 'AUTO',
+      },
+    });
+
+    const mockSetThemePreference = jest.fn();
+    const mockSetStationState = jest.fn();
+    const mockSetNavigationState = jest.fn();
+    const mockSetLineState = jest.fn();
+    // matches the hook's useSetAtom call order:
+    // stationState, navigationState, lineState, themePreferenceAtom
+    const setters = [
+      mockSetStationState,
+      mockSetNavigationState,
+      mockSetLineState,
+      mockSetThemePreference,
+    ];
+    let atomCallIdx = 0;
+    mockUseSetAtom.mockImplementation(() => {
+      const result = setters[atomCallIdx % setters.length];
+      atomCallIdx++;
+      return result;
+    });
+
+    const { mockFetchByIds } = setupQueries();
+    mockFetchByIds.mockResolvedValue({
+      data: { stations: [stationA, stationB] },
+    });
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchByIds).toHaveBeenCalled();
+    });
+
+    expect(mockSetThemePreference).toHaveBeenCalledWith('AUTO');
+    const navSetter = mockSetNavigationState.mock.calls[0][0];
+    const navResult = navSetter(createNavigationState());
+    expect(navResult.autoModeEnabled).toBe(true);
   });
 
   it('ナビゲーターがリトライ中に準備完了した場合はナビゲートする', async () => {

--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -764,6 +764,33 @@ describe('useDeepLink', () => {
     expect(mockSetStationState).not.toHaveBeenCalled();
   });
 
+  it('sidsに不正なトークンが含まれる場合はstateを変更しない', async () => {
+    mockGetInitialURL.mockResolvedValue(
+      'CanaryTrainLCD://route?sids=1131211,123x,2800217&dir=0'
+    );
+    mockParse.mockReturnValue({
+      queryParams: { sids: '1131211,123x,2800217', dir: '0' },
+    });
+
+    const { mockSetStationState } = setupAtoms();
+    const { mockFetchByIds } = setupQueries();
+
+    render(
+      <HookBridge
+        onReady={() => {
+          /* noop */
+        }}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchByIds).not.toHaveBeenCalled();
+    expect(mockSetStationState).not.toHaveBeenCalled();
+  });
+
   it('sidsの解決結果が空の場合はstateを変更しない', async () => {
     mockGetInitialURL.mockResolvedValue(
       'CanaryTrainLCD://route?sids=1,2,3&dir=0'

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -317,13 +317,16 @@ export const useDeepLink = () => {
 
       // New `sids` form takes precedence and ignores sgid/lid/lgid entirely.
       if (typeof sids === 'string' && sids.length > 0) {
-        const stationIds = sids
-          .split(',')
-          .map((raw) => Number.parseInt(raw.trim(), 10))
-          .filter((id) => Number.isInteger(id) && id > 0);
-        if (stationIds.length < 2) {
+        const rawStationIds = sids.split(',').map((raw) => raw.trim());
+        // Reject the entire link if any token is not a strict positive integer
+        // (Number.parseInt would silently accept "123x" as 123).
+        if (
+          rawStationIds.length < 2 ||
+          rawStationIds.some((raw) => !/^[1-9]\d*$/.test(raw))
+        ) {
           return;
         }
+        const stationIds = rawStationIds.map((raw) => Number(raw));
         await openRouteByStationIds({
           stationIds,
           direction,

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -7,6 +7,7 @@ import type { Station, TrainType } from '~/@types/graphql';
 import {
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
+  GET_STATIONS_BY_IDS,
 } from '~/lib/graphql/queries';
 import type { LineDirection } from '../models/Bound';
 import { APP_THEME, type ThemePreference } from '../models/Theme';
@@ -34,6 +35,14 @@ type GetLineGroupStationsData = {
 
 type GetLineGroupStationsVariables = {
   lineGroupId: number;
+};
+
+type GetStationsByIdsData = {
+  stations: Station[];
+};
+
+type GetStationsByIdsVariables = {
+  ids: number[];
 };
 
 const navigateToMainAction = CommonActions.navigate({
@@ -83,6 +92,12 @@ export const useDeepLink = () => {
   ] = useLazyQuery<GetLineStationsData, GetLineStationsVariables>(
     GET_LINE_STATIONS
   );
+  const [
+    fetchStationsByIds,
+    { loading: fetchStationsByIdsLoading, error: fetchStationsByIdsError },
+  ] = useLazyQuery<GetStationsByIdsData, GetStationsByIdsVariables>(
+    GET_STATIONS_BY_IDS
+  );
 
   const applyRoute = useCallback(
     (station: Station, stations: Station[], direction: LineDirection) => {
@@ -130,6 +145,85 @@ export const useDeepLink = () => {
       );
     }
   }, []);
+
+  const openRouteByStationIds = useCallback(
+    async ({
+      stationIds,
+      direction,
+      autoMode,
+      theme,
+    }: {
+      stationIds: number[];
+      direction: 0 | 1;
+      autoMode: boolean;
+      theme: ThemePreference | undefined;
+    }) => {
+      if (theme) {
+        setThemePreference(theme);
+      }
+
+      const { data } = await fetchStationsByIds({
+        variables: { ids: stationIds },
+      });
+      const fetched = data?.stations ?? [];
+      if (fetched.length === 0) {
+        return;
+      }
+
+      // Preserve the order specified in the deep link; server response order is
+      // not guaranteed and stations not resolved are silently dropped.
+      const byId = new Map(fetched.map((sta) => [sta.id, sta] as const));
+      const stations = stationIds
+        .map((id) => byId.get(id))
+        .filter((sta): sta is Station => sta != null);
+      if (stations.length === 0) {
+        return;
+      }
+
+      const head = stations[0];
+      const line = head.line;
+      if (!line) {
+        return;
+      }
+      const lineDirection: LineDirection =
+        direction === 0 ? 'INBOUND' : 'OUTBOUND';
+
+      setLineState((prev) => ({
+        ...prev,
+        selectedLine: line,
+        pendingLine: null,
+      }));
+      setStationState((prev) => ({
+        ...prev,
+        station: head,
+        stations,
+        selectedBound:
+          lineDirection === 'INBOUND'
+            ? stations[stations.length - 1]
+            : stations[0],
+        selectedDirection: lineDirection,
+        pendingStation: null,
+        pendingStations: [],
+        wantedDestination: null,
+      }));
+      setNavigationState((prev) => ({
+        ...prev,
+        leftStations: [],
+        trainType: (head.trainType ?? null) as TrainType | null,
+        autoModeEnabled: autoMode ? true : prev.autoModeEnabled,
+      }));
+
+      await navigateToMain();
+    },
+    [
+      fetchStationsByIds,
+      navigateToMain,
+      setLineState,
+      setNavigationState,
+      setStationState,
+      setThemePreference,
+    ]
+  );
 
   // lineId is always required: it serves as the fallback query key when
   // lineGroupId is absent and is validated upstream in handleUrl.
@@ -206,20 +300,13 @@ export const useDeepLink = () => {
       if (!parsed.queryParams) {
         return;
       }
-      const { sgid, dir, lgid, lid, auto, theme } = parsed.queryParams;
+      const { sgid, dir, lgid, lid, sids, auto, theme } = parsed.queryParams;
 
-      const stationGroupId = Number(sgid);
       const direction = Number(dir);
-      const lineId = Number(lid);
-
-      if (!stationGroupId || !lineId) {
-        return;
-      }
       if (direction !== 0 && direction !== 1) {
         return;
       }
 
-      const lineGroupId = lgid ? Number(lgid) : undefined;
       const autoMode = auto === '1';
       const parsedTheme =
         typeof theme === 'string' &&
@@ -227,6 +314,33 @@ export const useDeepLink = () => {
           (Object.values(APP_THEME) as string[]).includes(theme))
           ? (theme as ThemePreference)
           : undefined;
+
+      // New `sids` form takes precedence and ignores sgid/lid/lgid entirely.
+      if (typeof sids === 'string' && sids.length > 0) {
+        const stationIds = sids
+          .split(',')
+          .map((raw) => Number.parseInt(raw.trim(), 10))
+          .filter((id) => Number.isInteger(id) && id > 0);
+        if (stationIds.length < 2) {
+          return;
+        }
+        await openRouteByStationIds({
+          stationIds,
+          direction,
+          autoMode,
+          theme: parsedTheme,
+        });
+        return;
+      }
+
+      const stationGroupId = Number(sgid);
+      const lineId = Number(lid);
+
+      if (!stationGroupId || !lineId) {
+        return;
+      }
+
+      const lineGroupId = lgid ? Number(lgid) : undefined;
 
       await openLink({
         stationGroupId,
@@ -237,7 +351,7 @@ export const useDeepLink = () => {
         theme: parsedTheme,
       });
     },
-    [openLink]
+    [openLink, openRouteByStationIds]
   );
 
   const [initialUrlProcessed, setInitialUrlProcessed] = useState(false);
@@ -271,7 +385,12 @@ export const useDeepLink = () => {
   return {
     initialUrlProcessed,
     isLoading:
-      fetchStationsByLineGroupIdLoading || fetchStationsByLineIdLoading,
-    error: fetchStationsByLineGroupIdError || fetchStationsByLineIdError,
+      fetchStationsByLineGroupIdLoading ||
+      fetchStationsByLineIdLoading ||
+      fetchStationsByIdsLoading,
+    error:
+      fetchStationsByLineGroupIdError ||
+      fetchStationsByLineIdError ||
+      fetchStationsByIdsError,
   };
 };

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -302,11 +302,6 @@ export const useDeepLink = () => {
       }
       const { sgid, dir, lgid, lid, sids, auto, theme } = parsed.queryParams;
 
-      const direction = Number(dir);
-      if (direction !== 0 && direction !== 1) {
-        return;
-      }
-
       const autoMode = auto === '1';
       const parsedTheme =
         typeof theme === 'string' &&
@@ -326,13 +321,26 @@ export const useDeepLink = () => {
         ) {
           return;
         }
+        // `dir` defaults to 0 (INBOUND) when omitted for sids-based links;
+        // explicit invalid values still cause a no-op.
+        const sidsDirection =
+          typeof dir === 'string' && dir.length > 0 ? Number(dir) : 0;
+        if (sidsDirection !== 0 && sidsDirection !== 1) {
+          return;
+        }
         const stationIds = rawStationIds.map((raw) => Number(raw));
         await openRouteByStationIds({
           stationIds,
-          direction,
+          direction: sidsDirection,
           autoMode,
           theme: parsedTheme,
         });
+        return;
+      }
+
+      // Legacy `sgid`/`lid` form: `dir` is required.
+      const direction = Number(dir);
+      if (direction !== 0 && direction !== 1) {
         return;
       }
 

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -368,6 +368,16 @@ export const GET_LINE_GROUP_STATIONS = gql`
   }
 `;
 
+// Query for getting multiple stations by their IDs (per-operator unique row IDs)
+export const GET_STATIONS_BY_IDS = gql`
+  ${STATION_FRAGMENT}
+  query GetStationsByIds($ids: [Int!]!) {
+    stations(ids: $ids) {
+      ...StationFields
+    }
+  }
+`;
+
 // Lightweight fragment for route/train-type selection (TrainTypeListModal + computeCurrentStationInRoutes)
 export const LINE_ROUTE_FRAGMENT = gql`
   ${LINE_SYMBOL_FRAGMENT}


### PR DESCRIPTION
## 概要

ディープリンクで他路線直通・経路全体を表現できるようにする。新パラメータ `sids` (Station ID のカンマ区切りリスト) を追加し、列挙された駅列の順序通りに `stationState.stations` を投入する。既存の `sgid` / `lid` / `lgid` ベースのリンクは動作変化なし。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/graphql/queries.ts`: `GET_STATIONS_BY_IDS` クエリ (`stations(ids: [Int!]!)`) を追加
- `src/hooks/useDeepLink.ts`:
  - `handleUrl` に `sids` パラメータの分岐を追加。`sids` がある場合は `sgid` / `lid` / `lgid` を無視
  - 新規ヘルパー `openRouteByStationIds` を追加し、駅 ID 配列を順序保持で取得→`stationState.stations` に投入。`selectedLine` は先頭駅の `.line` から直接取得 (各 `Station` 行で路線が一意に決まるため、隣接関係から推定する必要なし)
  - `dir` に応じて `selectedBound` を末尾 (INBOUND) / 先頭 (OUTBOUND) に振り分け
  - `isLoading` / `error` 集約に新フェッチを追加
- `src/hooks/useDeepLink.test.tsx`: sids ベースのテストを 6 件追加 (順序保持・dir=1 の bound 切替・1 件以下で no-op・解決結果ゼロで no-op・sgid/lid/lgid 無視・auto/theme 併用)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest --testPathPattern=useDeepLink` で 20/20 テスト pass を確認。

## 関連Issue

Closes #6002

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ディープリンクで複数ステーションIDを指定できるようになりました。指定順を保持して経路を再現し、古い識別子は無視されます。ID指定時にテーマ適用や自動モードの反映も行われます。
  * 無効なIDや件数不足、解決結果が空、または不正トークンの場合は状態を変更しない安全な挙動を導入しました。

* **Tests**
  * 新ルートや境界条件（選択方向、テーマ/自動モード併用、無効トークン等）を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->