### PR TITLE
ディープリンクのレガシー経路で sgid/lid/lgid を厳密な正整数バリデーションで検証する

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -320,6 +320,45 @@ describe('useDeepLink', () => {
     expect(mockSetStationState).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['sgidが小数', { lid: '999', sgid: '1.5', dir: '0' }],
+    ['sgidがInfinity', { lid: '999', sgid: 'Infinity', dir: '0' }],
+    ['sgidが0', { lid: '999', sgid: '0', dir: '0' }],
+    ['sgidに余分な文字', { lid: '999', sgid: '123x', dir: '0' }],
+    ['lidが小数', { lid: '1.5', sgid: '1', dir: '0' }],
+    ['lidが指数表記', { lid: '1e3', sgid: '1', dir: '0' }],
+    ['lgidが小数', { lid: '999', sgid: '1', lgid: '1.5', dir: '0' }],
+    ['lgidが不正値', { lid: '999', sgid: '1', lgid: 'abc', dir: '0' }],
+  ])(
+    'レガシー経路で%sの場合はstateを変更しない',
+    async (_label, queryParams) => {
+      mockGetInitialURL.mockResolvedValue('CanaryTrainLCD://?legacy');
+      mockParse.mockReturnValue({ queryParams });
+
+      const { mockSetStationState, mockSetNavigationState, mockSetLineState } =
+        setupAtoms();
+      const { mockFetchByLine, mockFetchByGroup } = setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockFetchByLine).not.toHaveBeenCalled();
+      expect(mockFetchByGroup).not.toHaveBeenCalled();
+      expect(mockSetStationState).not.toHaveBeenCalled();
+      expect(mockSetNavigationState).not.toHaveBeenCalled();
+      expect(mockSetLineState).not.toHaveBeenCalled();
+    }
+  );
+
   it('駅が見つからなければstateを変更しない', async () => {
     mockGetInitialURL.mockResolvedValue(
       'CanaryTrainLCD://?lid=999&sgid=99&dir=0'

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -344,14 +344,31 @@ export const useDeepLink = () => {
         return;
       }
 
-      const stationGroupId = Number(sgid);
-      const lineId = Number(lid);
-
-      if (!stationGroupId || !lineId) {
+      // Match the strict positive-integer validation used for `sids` so that
+      // values like "1.5" or "Infinity" no longer leak into GraphQL `Int`
+      // variables. `lgid` is optional but, when present, must be a positive
+      // integer; otherwise we reject the entire link instead of silently
+      // falling through to the lineId path with a malformed value.
+      const rawStationGroupId = typeof sgid === 'string' ? sgid.trim() : '';
+      const rawLineId = typeof lid === 'string' ? lid.trim() : '';
+      if (
+        !/^[1-9]\d*$/.test(rawStationGroupId) ||
+        !/^[1-9]\d*$/.test(rawLineId)
+      ) {
         return;
       }
 
-      const lineGroupId = lgid ? Number(lgid) : undefined;
+      const stationGroupId = Number(rawStationGroupId);
+      const lineId = Number(rawLineId);
+
+      let lineGroupId: number | undefined;
+      if (typeof lgid === 'string' && lgid.trim().length > 0) {
+        const rawLineGroupId = lgid.trim();
+        if (!/^[1-9]\d*$/.test(rawLineGroupId)) {
+          return;
+        }
+        lineGroupId = Number(rawLineGroupId);
+      }
 
       await openLink({
         stationGroupId,


### PR DESCRIPTION
## 概要

`useDeepLink` のレガシー経路（`sgid` / `lid` / `lgid` 形式）で `Number()` + truthy 判定のみだったため、`1.5` や `Infinity` のような値がそのまま GraphQL の `Int` 変数に渡り、下流でエラーになる可能性がありました。先行 PR #6003 で `sids` 側に導入済みの `/^[1-9]\d*$/` バリデーションに揃え、不正値の場合はリンク全体を no-op にします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useDeepLink.ts`: `handleUrl` のレガシー分岐で `sgid` / `lid` を `/^[1-9]\d*$/` の厳密な正整数として検証。`lgid` は省略可だが、指定された場合は同じ正規表現で検証し、不正なら `lineId` パスへフォールスルーせずリンク全体を no-op にする。
- `src/hooks/useDeepLink.test.tsx`: `it.each` で 8 ケース（sgid の小数 / Infinity / 0 / 余分文字、lid の小数 / 指数表記、lgid の小数 / 任意文字列）を追加し、いずれもクエリ非発火・state 不変であることを担保。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #6004

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL深リンク機能のパラメータ検証を強化しました。小数や不正な値などの無効なパラメータをより確実に検出・拒否するようになります。

* **Tests**
  * パラメータ検証の妥当性を確認するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->