### PR TITLE
ディープリンク sids 形式で dir パラメータの解釈を廃止する

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -737,44 +737,50 @@ describe('useDeepLink', () => {
     expect(navResult.autoModeEnabled).toBe(false);
   });
 
-  it('sidsとdir=1の場合はselectedBoundが先頭駅になる', async () => {
-    const stationA = createStation(1131211, {
-      line: { id: 11302 },
-    } as Parameters<typeof createStation>[1]);
-    const stationB = createStation(1131310, {
-      line: { id: 11302 },
-    } as Parameters<typeof createStation>[1]);
+  it.each([
+    ['dir=0', { sids: '1131211,1131310', dir: '0' }],
+    ['dir=1', { sids: '1131211,1131310', dir: '1' }],
+    ['dir=任意の値', { sids: '1131211,1131310', dir: '42' }],
+    ['dir=非数値', { sids: '1131211,1131310', dir: 'abc' }],
+  ])(
+    'sidsで%sが渡されても無視されINBOUNDとして扱う',
+    async (_label, queryParams) => {
+      const stationA = createStation(1131211, {
+        line: { id: 11302 },
+      } as Parameters<typeof createStation>[1]);
+      const stationB = createStation(1131310, {
+        line: { id: 11302 },
+      } as Parameters<typeof createStation>[1]);
 
-    mockGetInitialURL.mockResolvedValue(
-      'CanaryTrainLCD://route?sids=1131211,1131310&dir=1'
-    );
-    mockParse.mockReturnValue({
-      queryParams: { sids: '1131211,1131310', dir: '1' },
-    });
+      mockGetInitialURL.mockResolvedValue(
+        `CanaryTrainLCD://route?sids=${queryParams.sids}&dir=${queryParams.dir}`
+      );
+      mockParse.mockReturnValue({ queryParams });
 
-    const { mockSetStationState } = setupAtoms();
-    const { mockFetchByIds } = setupQueries();
-    mockFetchByIds.mockResolvedValue({
-      data: { stations: [stationA, stationB] },
-    });
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: [stationA, stationB] },
+      });
 
-    render(
-      <HookBridge
-        onReady={() => {
-          /* noop */
-        }}
-      />
-    );
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
 
-    await waitFor(() => {
-      expect(mockFetchByIds).toHaveBeenCalled();
-    });
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
 
-    const stationSetter = mockSetStationState.mock.calls[0][0];
-    const stationResult = stationSetter(createStationState());
-    expect(stationResult.selectedDirection).toBe<LineDirection>('OUTBOUND');
-    expect(stationResult.selectedBound?.id).toBe(1131211);
-  });
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      expect(stationResult.selectedDirection).toBe<LineDirection>('INBOUND');
+      expect(stationResult.selectedBound?.id).toBe(1131310);
+    }
+  );
 
   it('sidsが1件以下の場合はstateを変更しない', async () => {
     mockGetInitialURL.mockResolvedValue(
@@ -842,33 +848,6 @@ describe('useDeepLink', () => {
     expect(stationResult.selectedBound?.id).toBe(1131310);
   });
 
-  it('sidsでdirが不正値の場合はstateを変更しない', async () => {
-    mockGetInitialURL.mockResolvedValue(
-      'CanaryTrainLCD://route?sids=1131211,1131310&dir=2'
-    );
-    mockParse.mockReturnValue({
-      queryParams: { sids: '1131211,1131310', dir: '2' },
-    });
-
-    const { mockSetStationState } = setupAtoms();
-    const { mockFetchByIds } = setupQueries();
-
-    render(
-      <HookBridge
-        onReady={() => {
-          /* noop */
-        }}
-      />
-    );
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    expect(mockFetchByIds).not.toHaveBeenCalled();
-    expect(mockSetStationState).not.toHaveBeenCalled();
-  });
-
   it('sidsに不正なトークンが含まれる場合はstateを変更しない', async () => {
     mockGetInitialURL.mockResolvedValue(
       'CanaryTrainLCD://route?sids=1131211,123x,2800217&dir=0'
@@ -923,13 +902,16 @@ describe('useDeepLink', () => {
     expect(mockSetStationState).not.toHaveBeenCalled();
   });
 
-  it('sidsが指定されている場合はsgid/lid/lgidを無視する', async () => {
-    const station = createStation(1131211, {
+  it('sidsが指定されている場合はsgid/lid/lgid/dirを無視する', async () => {
+    const stationA = createStation(1131211, {
+      line: { id: 11302 },
+    } as Parameters<typeof createStation>[1]);
+    const stationB = createStation(1131310, {
       line: { id: 11302 },
     } as Parameters<typeof createStation>[1]);
 
     mockGetInitialURL.mockResolvedValue(
-      'CanaryTrainLCD://route?sids=1131211,1131310&sgid=99&lid=999&lgid=42&dir=0'
+      'CanaryTrainLCD://route?sids=1131211,1131310&sgid=99&lid=999&lgid=42&dir=1'
     );
     mockParse.mockReturnValue({
       queryParams: {
@@ -937,15 +919,15 @@ describe('useDeepLink', () => {
         sgid: '99',
         lid: '999',
         lgid: '42',
-        dir: '0',
+        dir: '1',
       },
     });
 
-    setupAtoms();
+    const { mockSetStationState } = setupAtoms();
     const { mockFetchByIds, mockFetchByLine, mockFetchByGroup } =
       setupQueries();
     mockFetchByIds.mockResolvedValue({
-      data: { stations: [station] },
+      data: { stations: [stationA, stationB] },
     });
 
     render(
@@ -962,6 +944,13 @@ describe('useDeepLink', () => {
 
     expect(mockFetchByLine).not.toHaveBeenCalled();
     expect(mockFetchByGroup).not.toHaveBeenCalled();
+
+    // dir=1 is ignored: direction stays INBOUND and selectedBound is the last
+    // station, identical to the dir-omitted case.
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const stationResult = stationSetter(createStationState());
+    expect(stationResult.selectedDirection).toBe<LineDirection>('INBOUND');
+    expect(stationResult.selectedBound?.id).toBe(1131310);
   });
 
   it('sidsにautoとthemeを併用できる', async () => {

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -146,15 +146,16 @@ export const useDeepLink = () => {
     }
   }, []);
 
+  // sids deep links express intent purely through station order: the first
+  // entry is the origin and the last is the destination. Direction is fixed to
+  // INBOUND — callers reverse the sids list to share the opposite direction.
   const openRouteByStationIds = useCallback(
     async ({
       stationIds,
-      direction,
       autoMode,
       theme,
     }: {
       stationIds: number[];
-      direction: 0 | 1;
       autoMode: boolean;
       theme: ThemePreference | undefined;
     }) => {
@@ -185,8 +186,6 @@ export const useDeepLink = () => {
       if (!line) {
         return;
       }
-      const lineDirection: LineDirection =
-        direction === 0 ? 'INBOUND' : 'OUTBOUND';
 
       setLineState((prev) => ({
         ...prev,
@@ -197,11 +196,8 @@ export const useDeepLink = () => {
         ...prev,
         station: head,
         stations,
-        selectedBound:
-          lineDirection === 'INBOUND'
-            ? stations[stations.length - 1]
-            : stations[0],
-        selectedDirection: lineDirection,
+        selectedBound: stations[stations.length - 1],
+        selectedDirection: 'INBOUND',
         pendingStation: null,
         pendingStations: [],
         wantedDestination: null,
@@ -310,7 +306,8 @@ export const useDeepLink = () => {
           ? (theme as ThemePreference)
           : undefined;
 
-      // New `sids` form takes precedence and ignores sgid/lid/lgid entirely.
+      // New `sids` form takes precedence and ignores sgid/lid/lgid/dir
+      // entirely — station order alone encodes the intended direction.
       if (typeof sids === 'string' && sids.length > 0) {
         const rawStationIds = sids.split(',').map((raw) => raw.trim());
         // Reject the entire link if any token is not a strict positive integer
@@ -321,17 +318,9 @@ export const useDeepLink = () => {
         ) {
           return;
         }
-        // `dir` defaults to 0 (INBOUND) when omitted for sids-based links;
-        // explicit invalid values still cause a no-op.
-        const sidsDirection =
-          typeof dir === 'string' && dir.length > 0 ? Number(dir) : 0;
-        if (sidsDirection !== 0 && sidsDirection !== 1) {
-          return;
-        }
         const stationIds = rawStationIds.map((raw) => Number(raw));
         await openRouteByStationIds({
           stationIds,
-          direction: sidsDirection,
           autoMode,
           theme: parsedTheme,
         });


### PR DESCRIPTION
## 概要

sids ベースのディープリンクで `dir` パラメータの解釈を廃止する。sids は「ユーザーが並べた最後の駅 = 目的地」が定義そのものであり、`dir` は冗長だったため。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `handleUrl` の sids 分岐から `dir` の読み取り/バリデーションを削除。`sids` が指定された場合は `sgid` / `lid` / `lgid` に加えて `dir` も無視する
- `openRouteByStationIds` から `direction` 引数を撤去し、`selectedDirection` は常に `INBOUND`、`selectedBound` は常に末尾駅で固定する仕様に統一
- 単体テストを更新:
  - `dir=0` / `dir=1` / `dir=任意の値` / `dir=非数値` の 4 パターンを `it.each` で網羅し、いずれも INBOUND + 末尾駅 selectedBound になることを検証
  - 旧「dir=1 で selectedBound が先頭駅になる」「dir=2 で state 変更なし」テストを dir 無視仕様に置き換え
  - 「sids 指定時に sgid/lid/lgid を無視」テストを `dir` も含めた検証に拡張

レガシー形式 (`sgid` / `lid` / `lgid` + `dir`) の挙動は変更なし。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #6006

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 駅IDを使用して経路を指定する際、方向パラメータが無視されるように修正しました。指定した駅リストの最初の駅が起点、最後の駅が終点として自動的に解釈されるようになります。テストも追加・更新し、この動作を検証できるようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->