### PR TITLE
ディープリンク sids 形式で skips パラメータによる通過駅指定を追加

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -3,7 +3,7 @@ import { act, render, waitFor } from '@testing-library/react-native';
 import * as Linking from 'expo-linking';
 import { useSetAtom } from 'jotai';
 import type React from 'react';
-import type { TrainType } from '~/@types/graphql';
+import { StopCondition, type TrainType } from '~/@types/graphql';
 import { createStation } from '~/utils/test/factories';
 import type { LineDirection } from '../models/Bound';
 import { navigationRef } from '../stacks/rootNavigation';
@@ -1013,6 +1013,278 @@ describe('useDeepLink', () => {
     const navSetter = mockSetNavigationState.mock.calls[0][0];
     const navResult = navSetter(createNavigationState());
     expect(navResult.autoModeEnabled).toBe(true);
+  });
+
+  describe('skips parameter', () => {
+    const buildStations = () => [
+      createStation(1131211, {
+        line: { id: 11302 },
+        stopCondition: StopCondition.All,
+      } as Parameters<typeof createStation>[1]),
+      createStation(1131310, {
+        line: { id: 11302 },
+        stopCondition: StopCondition.All,
+      } as Parameters<typeof createStation>[1]),
+      createStation(2800217, {
+        line: { id: 11302 },
+        stopCondition: StopCondition.All,
+      } as Parameters<typeof createStation>[1]),
+      createStation(2800218, {
+        line: { id: 11302 },
+        stopCondition: StopCondition.All,
+      } as Parameters<typeof createStation>[1]),
+    ];
+
+    it('skipsで指定したインデックスのstopConditionをNotに上書きする', async () => {
+      const stations = buildStations();
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218&skips=1,2'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310,2800217,2800218',
+          skips: '1,2',
+        },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({ data: { stations } });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      const overridden = stationResult.stations.map(
+        (s: { stopCondition: StopCondition | null | undefined }) =>
+          s.stopCondition
+      );
+      expect(overridden).toEqual([
+        StopCondition.All,
+        StopCondition.Not,
+        StopCondition.Not,
+        StopCondition.All,
+      ]);
+    });
+
+    it('skips省略時は全駅のstopConditionを変更しない', async () => {
+      const stations = buildStations();
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218'
+      );
+      mockParse.mockReturnValue({
+        queryParams: { sids: '1131211,1131310,2800217,2800218' },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({ data: { stations } });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      // factory default is StopCondition.All — no station should be overridden
+      expect(
+        stationResult.stations.every(
+          (s: { stopCondition: StopCondition | null | undefined }) =>
+            s.stopCondition === StopCondition.All
+        )
+      ).toBe(true);
+    });
+
+    it('skipsが空文字の場合は全駅停車として扱う', async () => {
+      const stations = buildStations();
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218&skips='
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310,2800217,2800218',
+          skips: '',
+        },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({ data: { stations } });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      expect(
+        stationResult.stations.every(
+          (s: { stopCondition: StopCondition | null | undefined }) =>
+            s.stopCondition === StopCondition.All
+        )
+      ).toBe(true);
+    });
+
+    it('skipsで先頭駅も通過扱いにできる', async () => {
+      const stations = buildStations();
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218&skips=0'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310,2800217,2800218',
+          skips: '0',
+        },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({ data: { stations } });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      expect(stationResult.stations[0].stopCondition).toBe(StopCondition.Not);
+    });
+
+    it('サーバが一部の駅を返さなくても残りの駅のskipインデックスはずれない', async () => {
+      // server omits sids[1] (1131310) — fetched stations: [A, C, D]
+      const stations = [
+        createStation(1131211, {
+          line: { id: 11302 },
+          stopCondition: StopCondition.All,
+        } as Parameters<typeof createStation>[1]),
+        createStation(2800217, {
+          line: { id: 11302 },
+          stopCondition: StopCondition.All,
+        } as Parameters<typeof createStation>[1]),
+        createStation(2800218, {
+          line: { id: 11302 },
+          stopCondition: StopCondition.All,
+        } as Parameters<typeof createStation>[1]),
+      ];
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310,2800217,2800218&skips=2'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310,2800217,2800218',
+          skips: '2',
+        },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({ data: { stations } });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      // skip index 2 in the requested sids points to id 2800217 — that station
+      // (after filtering out missing 1131310) must still be the one marked Not.
+      const byId = new Map(
+        stationResult.stations.map(
+          (s: {
+            id: number;
+            stopCondition: StopCondition | null | undefined;
+          }) => [s.id, s.stopCondition] as const
+        )
+      );
+      expect(byId.get(1131211)).toBe(StopCondition.All);
+      expect(byId.get(2800217)).toBe(StopCondition.Not);
+      expect(byId.get(2800218)).toBe(StopCondition.All);
+    });
+
+    it.each([
+      ['範囲外 (=sids長)', '1131211,1131310', '2'],
+      ['範囲外 (>>sids長)', '1131211,1131310', '99'],
+      ['重複', '1131211,1131310,2800217', '1,1'],
+      ['昇順でない', '1131211,1131310,2800217', '2,1'],
+      ['負数', '1131211,1131310', '-1'],
+      ['小数', '1131211,1131310', '0.5'],
+      ['非整数文字', '1131211,1131310', '1x'],
+      ['指数表記', '1131211,1131310,2800217,2800218', '1e0'],
+      ['空トークン', '1131211,1131310', '0,'],
+      ['先頭ゼロ付き', '1131211,1131310,2800217', '01'],
+    ])('%sの場合はリンク全体をno-opする', async (_label, sids, skips) => {
+      mockGetInitialURL.mockResolvedValue(
+        `CanaryTrainLCD://route?sids=${sids}&skips=${skips}`
+      );
+      mockParse.mockReturnValue({
+        queryParams: { sids, skips },
+      });
+
+      const { mockSetStationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockFetchByIds).not.toHaveBeenCalled();
+      expect(mockSetStationState).not.toHaveBeenCalled();
+    });
   });
 
   it('ナビゲーターがリトライ中に準備完了した場合はナビゲートする', async () => {

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -3,7 +3,7 @@ import { CommonActions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import { useSetAtom } from 'jotai';
 import { useCallback, useEffect, useState } from 'react';
-import type { Station, TrainType } from '~/@types/graphql';
+import { type Station, StopCondition, type TrainType } from '~/@types/graphql';
 import {
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
@@ -149,13 +149,19 @@ export const useDeepLink = () => {
   // sids deep links express intent purely through station order: the first
   // entry is the origin and the last is the destination. Direction is fixed to
   // INBOUND — callers reverse the sids list to share the opposite direction.
+  // `skipIndices` marks 0-origin positions in `stationIds` whose stopCondition
+  // should be overridden to `Not` (通過扱い). Indices are resolved against the
+  // requested `stationIds` order, not the (possibly filtered) fetched result —
+  // missing stations are dropped without shifting other stations' skip state.
   const openRouteByStationIds = useCallback(
     async ({
       stationIds,
+      skipIndices,
       autoMode,
       theme,
     }: {
       stationIds: number[];
+      skipIndices: ReadonlySet<number> | null;
       autoMode: boolean;
       theme: ThemePreference | undefined;
     }) => {
@@ -175,7 +181,15 @@ export const useDeepLink = () => {
       // not guaranteed and stations not resolved are silently dropped.
       const byId = new Map(fetched.map((sta) => [sta.id, sta] as const));
       const stations = stationIds
-        .map((id) => byId.get(id))
+        .map((id, idx) => {
+          const sta = byId.get(id);
+          if (!sta) {
+            return undefined;
+          }
+          return skipIndices?.has(idx)
+            ? { ...sta, stopCondition: StopCondition.Not }
+            : sta;
+        })
         .filter((sta): sta is Station => sta != null);
       if (stations.length === 0) {
         return;
@@ -296,7 +310,8 @@ export const useDeepLink = () => {
       if (!parsed.queryParams) {
         return;
       }
-      const { sgid, dir, lgid, lid, sids, auto, theme } = parsed.queryParams;
+      const { sgid, dir, lgid, lid, sids, skips, auto, theme } =
+        parsed.queryParams;
 
       const autoMode = auto === '1';
       const parsedTheme =
@@ -319,8 +334,34 @@ export const useDeepLink = () => {
           return;
         }
         const stationIds = rawStationIds.map((raw) => Number(raw));
+
+        // Optional `skips` lists 0-origin indices into `stationIds` whose
+        // stations should be marked as 通過 (StopCondition.Not). The whole
+        // link is rejected on malformed input — non-integer, out-of-range,
+        // duplicate, or non-ascending — rather than silently ignoring it,
+        // so receivers never display a partially-misinterpreted route.
+        let skipIndices: ReadonlySet<number> | null = null;
+        if (typeof skips === 'string' && skips.length > 0) {
+          const rawSkips = skips.split(',').map((raw) => raw.trim());
+          if (rawSkips.some((raw) => !/^(0|[1-9]\d*)$/.test(raw))) {
+            return;
+          }
+          const parsedSkips = rawSkips.map((raw) => Number(raw));
+          for (let i = 0; i < parsedSkips.length; i++) {
+            if (parsedSkips[i] >= stationIds.length) {
+              return;
+            }
+            // Strict ascending order also rules out duplicates.
+            if (i > 0 && parsedSkips[i] <= parsedSkips[i - 1]) {
+              return;
+            }
+          }
+          skipIndices = new Set(parsedSkips);
+        }
+
         await openRouteByStationIds({
           stationIds,
+          skipIndices,
           autoMode,
           theme: parsedTheme,
         });


### PR DESCRIPTION
## 概要

#6005 案 A の実装。`sids` ディープリンクと並行する新パラメータ `skips` を追加し、0-origin インデックスで指定した駅の `stopCondition` を `StopCondition.Not`（通過扱い）に上書きできるようにする。

URL 例:

```text
TrainLCD://route?sids=1131211,1131310,2800217,2800218&skips=1,2
```

上記では `sids[1]` と `sids[2]` が通過扱いになり、それ以外は停車扱いとなる。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useDeepLink.handleUrl` で `skips` クエリパラメータをパースし、整数・厳密昇順・範囲内（重複なし）を検証する。
- `useDeepLink.openRouteByStationIds` に `skipIndices: ReadonlySet<number> | null` を追加し、要求した `stationIds` の 0-origin インデックスに対応する駅の `stopCondition` を `StopCondition.Not` に上書きする。
- インデックスは「要求した `stationIds`」基準で解釈する。サーバが一部の駅を返さず除外しても、残った駅の skip 位置はずれない。
- 不正値（非整数 / 範囲外 / 重複 / 非昇順）はリンク全体を no-op して受信側が部分的に誤解釈した経路を表示しないようにする。
- `skips` 省略時は `#6002` と完全に同一の挙動（全駅停車）。
- ユニットテストを追加: 上書きされること、省略時は変化しないこと、欠落駅があってもインデックスがずれないこと、不正値ケース 10 種で no-op になることを検証。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #6005

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ディープリンクで特定の駅をスキップする機能を追加しました。`skips`パラメータにより、経路設定時に駅の通過条件を指定できるようになりました。
  * 無効な入力（範囲外の指数、不正な形式）は自動的に無視されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->