### PR TITLE
ディープリンクの resolverError が次回 handleUrl 呼び出しで残留する不具合を修正

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -1641,6 +1641,82 @@ describe('useDeepLink', () => {
       ]);
     });
 
+    it('resolver失敗後にlegacy経路で成功すればerrorはnullに戻る', async () => {
+      // Apollo errors auto-reset between queries, but resolverError lives in
+      // local state — without an explicit reset the previous failure would
+      // leak into the next handleUrl call.
+      const mockIsReady = navigationRef.isReady as jest.Mock;
+      mockIsReady.mockReturnValue(true);
+
+      const stations = [
+        createStation(1, {
+          groupId: 1,
+          line: { id: 999, nameShort: 'Yamanote' },
+          trainType: createTrainType(),
+        } as Parameters<typeof createStation>[1]),
+        createStation(2, {
+          groupId: 2,
+          line: { id: 999, nameShort: 'Yamanote' },
+        } as Parameters<typeof createStation>[1]),
+      ];
+
+      // Skip the initial URL entirely; we drive both calls through the runtime
+      // listener. setupAtoms uses `% 3` for the hook's 4 useSetAtom slots,
+      // which destabilizes useCallback deps and re-runs the addEventListener
+      // effect after each re-render — feeding a persistent initial URL here
+      // would cause it to be re-processed on every re-render.
+      mockGetInitialURL.mockResolvedValue(null);
+      mockParse.mockImplementation((url: string) => {
+        if (url.includes('id=missing')) {
+          return { queryParams: { id: 'missing' } };
+        }
+        return {
+          queryParams: { lid: '999', sgid: '1', dir: '0' },
+        };
+      });
+
+      mockResolveSids.mockRejectedValue(
+        new Error('route resolver responded with 404')
+      );
+
+      setupAtoms();
+      const { mockFetchByLine } = setupQueries();
+      mockFetchByLine.mockResolvedValue({
+        data: { lineStations: stations },
+      });
+
+      const hookRef: { current: HookResult } = { current: null };
+      render(
+        <HookBridge
+          onReady={(value) => {
+            hookRef.current = value;
+          }}
+        />
+      );
+
+      // Always grab the most recently registered listener — the effect re-runs
+      // on every re-render due to the setupAtoms slot drift.
+      const fireLatestListener = async (url: string) => {
+        const lastCall = mockAddEventListener.mock.calls.at(-1) ?? [];
+        const listenerCallback = lastCall[1];
+        await act(async () => {
+          await listenerCallback({ url });
+        });
+      };
+
+      // 1. resolver-failing URL → resolverError gets populated
+      await fireLatestListener('CanaryTrainLCD://route?id=missing');
+      await waitFor(() => {
+        expect(hookRef.current?.error?.message).toContain('404');
+      });
+
+      // 2. legacy success URL → resolverError must be cleared
+      await fireLatestListener('CanaryTrainLCD://?lid=999&sgid=1&dir=0');
+      await waitFor(() => {
+        expect(hookRef.current?.error).toBeFalsy();
+      });
+    });
+
     it('resolver取得中はisLoadingがtrue', async () => {
       mockGetInitialURL.mockResolvedValue('CanaryTrainLCD://route?id=slow');
       mockParse.mockReturnValue({ queryParams: { id: 'slow' } });

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -318,6 +318,11 @@ export const useDeepLink = () => {
       if (!parsed.queryParams) {
         return;
       }
+      // Apollo-derived errors auto-reset on the next query, but resolverError
+      // is held in local state — without an explicit reset, a previous failure
+      // leaks into the next handleUrl call (including subsequent legacy-path
+      // successes). Clear it once we know the URL has parseable params.
+      setResolverError(null);
       const { sgid, dir, lgid, lid, sids, skips, id, auto, theme } =
         parsed.queryParams;
 


### PR DESCRIPTION
## 概要

`useDeepLink` の `handleUrl` で、前回 resolver 経路 (`?id=<code>`) の失敗で立った `resolverError` が次回呼び出し時にクリアされず、後続の resolver 再試行成功や legacy 経路 (`?sids=...` / `?sgid=...&lid=...`) の成功時にも stale なまま hook の `error` に残り続けていた不具合を修正する。

Apollo 由来の `fetchStations*Error` は Apollo Client が次回クエリで自動リセットするが、`resolverError` は自前 `useState` で保持しているため、明示的にクリアしない限り持ち越されてしまっていた。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useDeepLink.ts` の `handleUrl` 冒頭 (`parsed.queryParams` の空チェックを通過した直後) で `setResolverError(null)` を呼び、毎回エラー状態をリセットする。`queryParams` が falsy で早期 return する経路ではクリアしない (URL 構造が壊れているだけの no-op 経路を本機能の挙動から切り離すため)。
- `src/hooks/useDeepLink.test.tsx` に単体テスト「resolver 失敗後に legacy 経路で成功すれば error は null に戻る」を追加。resolver 404 を runtime URL listener で発火させて `error` が `404` を含むことを確認し、続けて legacy `?lid=999&sgid=1&dir=0` を発火させて `error` が falsy になることを検証する。
- 既存テストはすべて pass (全 62 件)。修正を一時的に外すと追加テストが失敗することを逆検証済み。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #6015

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ディープリンク処理において、エラー状態の不適切な引き継ぎを修正し、フォールバック機能の信頼性を向上させました。

* **Tests**
  * エラーシーン後の回復処理に関するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->