### PR TITLE
ディープリンクで列車種別 (TrainType) をカスタム指定できるようにする

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -1319,6 +1319,7 @@ describe('useDeepLink', () => {
       mockResolveSids.mockResolvedValue({
         stationIds: [1131211, 1131310],
         skipIndices: null,
+        trainType: null,
       });
 
       const { mockSetStationState } = setupAtoms();
@@ -1500,6 +1501,7 @@ describe('useDeepLink', () => {
       mockResolveSids.mockResolvedValue({
         stationIds: [1131211, 1131310],
         skipIndices: null,
+        trainType: null,
       });
 
       setupAtoms();
@@ -1548,6 +1550,7 @@ describe('useDeepLink', () => {
       mockResolveSids.mockResolvedValue({
         stationIds: [1131211, 1131310],
         skipIndices: null,
+        trainType: null,
       });
 
       const mockSetThemePreference = jest.fn();
@@ -1609,6 +1612,7 @@ describe('useDeepLink', () => {
       mockResolveSids.mockResolvedValue({
         stationIds: [1131211, 1131310, 2800217, 2800218],
         skipIndices: new Set([1, 2]),
+        trainType: null,
       });
 
       const { mockSetStationState } = setupAtoms();
@@ -1751,9 +1755,423 @@ describe('useDeepLink', () => {
         resolveResolver({
           stationIds: [1131211, 1131310],
           skipIndices: null,
+          trainType: null,
         });
         await Promise.resolve();
       });
+    });
+
+    it('resolverがtrainTypeを返した場合はnavigationStateに反映される', async () => {
+      const stationA = createStation(1131211, {
+        line: { id: 11302 },
+        trainType: createTrainType({ typeId: 9999 }),
+      } as Parameters<typeof createStation>[1]);
+      const stationB = createStation(1131310, {
+        line: { id: 11302 },
+        trainType: createTrainType({ typeId: 9999 }),
+      } as Parameters<typeof createStation>[1]);
+
+      mockGetInitialURL.mockResolvedValue('CanaryTrainLCD://route?id=withTT');
+      mockParse.mockReturnValue({ queryParams: { id: 'withTT' } });
+
+      mockResolveSids.mockResolvedValue({
+        stationIds: [1131211, 1131310],
+        skipIndices: null,
+        trainType: {
+          __typename: 'TrainTypeNested',
+          name: '快速',
+          color: '#ff0000',
+          kind: null,
+          direction: null,
+          nameRoman: null,
+          nameKatakana: null,
+          nameChinese: null,
+          nameKorean: null,
+          nameIpa: null,
+          nameRomanIpa: null,
+          id: null,
+          typeId: null,
+          groupId: null,
+          line: null,
+          lines: null,
+          nameTtsSegments: null,
+        },
+      });
+
+      const { mockSetStationState, mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: [stationA, stationB] },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      expect(navResult.trainType).toMatchObject({
+        name: '快速',
+        color: '#ff0000',
+      });
+      // server-derived typeId must not leak into the override
+      expect(navResult.trainType?.typeId).toBeNull();
+
+      // every station in stationState carries the override so useCurrentTrainType
+      // (which looks at stations[].trainType when transferring lines) keeps the
+      // shared TrainType stable.
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      for (const sta of stationResult.stations) {
+        expect(sta.trainType).toMatchObject({
+          name: '快速',
+          color: '#ff0000',
+        });
+      }
+    });
+  });
+
+  describe('tt* parameters (custom TrainType override)', () => {
+    const mockResolveSids = resolveSidsFromShortId as jest.MockedFunction<
+      typeof resolveSidsFromShortId
+    >;
+
+    afterEach(() => {
+      mockResolveSids.mockReset();
+    });
+
+    const buildTwoStations = () => [
+      createStation(1131211, {
+        line: { id: 11302 },
+        trainType: createTrainType({ typeId: 9999 }),
+      } as Parameters<typeof createStation>[1]),
+      createStation(1131310, {
+        line: { id: 11302 },
+        trainType: createTrainType({ typeId: 9999 }),
+      } as Parameters<typeof createStation>[1]),
+    ];
+
+    it('sids 形式で ttname + ttcolor が指定されたら navigationState.trainType が上書きされる', async () => {
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310&ttname=%E5%BF%AB%E9%80%9F&ttcolor=%23ff0000'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310',
+          ttname: '快速',
+          ttcolor: '#ff0000',
+        },
+      });
+
+      const { mockSetStationState, mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: buildTwoStations() },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      expect(navResult.trainType).toMatchObject({
+        __typename: 'TrainTypeNested',
+        name: '快速',
+        color: '#ff0000',
+      });
+      // override never carries a server typeId / groupId
+      expect(navResult.trainType?.typeId).toBeNull();
+      expect(navResult.trainType?.groupId).toBeNull();
+
+      // stations[].trainType is replaced too, so useCurrentTrainType stays
+      // pinned to the override even on line transfers.
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      for (const sta of stationResult.stations) {
+        expect(sta.trainType?.name).toBe('快速');
+        expect(sta.trainType?.color).toBe('#ff0000');
+        expect(sta.trainType?.typeId).toBeNull();
+      }
+    });
+
+    it('sgid+lid 形式でも ttname + ttcolor が反映される', async () => {
+      const stations = [
+        createStation(1, {
+          groupId: 1,
+          line: { id: 999, nameShort: 'Yamanote' },
+          trainType: createTrainType({ typeId: 9999 }),
+        } as Parameters<typeof createStation>[1]),
+        createStation(2, {
+          groupId: 2,
+          line: { id: 999, nameShort: 'Yamanote' },
+          trainType: createTrainType({ typeId: 9999 }),
+        } as Parameters<typeof createStation>[1]),
+      ];
+
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://?lid=999&sgid=1&dir=0&ttname=%E5%BF%AB%E9%80%9F&ttcolor=%23ff0000'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          lid: '999',
+          sgid: '1',
+          dir: '0',
+          ttname: '快速',
+          ttcolor: '#ff0000',
+        },
+      });
+
+      const { mockSetStationState, mockSetNavigationState } = setupAtoms();
+      const { mockFetchByLine } = setupQueries();
+      mockFetchByLine.mockResolvedValue({
+        data: { lineStations: stations },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByLine).toHaveBeenCalled();
+      });
+
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      expect(navResult.trainType?.name).toBe('快速');
+      expect(navResult.trainType?.color).toBe('#ff0000');
+
+      const stationSetter = mockSetStationState.mock.calls[0][0];
+      const stationResult = stationSetter(createStationState());
+      for (const sta of stationResult.stations) {
+        expect(sta.trainType?.name).toBe('快速');
+      }
+    });
+
+    it('ttkind / ttnameroman 等の任意フィールドも反映される', async () => {
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310&ttname=Rapid&ttcolor=%23ff0000&ttkind=Rapid&ttnameroman=Rapid'
+      );
+      mockParse.mockReturnValue({
+        queryParams: {
+          sids: '1131211,1131310',
+          ttname: 'Rapid',
+          ttcolor: '#ff0000',
+          ttkind: 'Rapid',
+          ttnameroman: 'Rapid',
+        },
+      });
+
+      const { mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: buildTwoStations() },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      expect(navResult.trainType).toMatchObject({
+        name: 'Rapid',
+        color: '#ff0000',
+        kind: 'Rapid',
+        nameRoman: 'Rapid',
+      });
+    });
+
+    it.each([
+      [
+        'ttname 欠落で他フィールドあり',
+        { ttcolor: '#ff0000', ttkind: 'Rapid' },
+      ],
+      ['ttcolor 欠落で他フィールドあり', { ttname: '快速', ttkind: 'Rapid' }],
+      ['ttkind だけ', { ttkind: 'Rapid' }],
+      ['ttnameroman だけ', { ttnameroman: 'Rapid' }],
+      ['ttcolor が #RRGGBB 形式外', { ttname: '快速', ttcolor: 'red' }],
+      ['ttcolor が #fff (3桁)', { ttname: '快速', ttcolor: '#fff' }],
+      [
+        'ttkind が enum 外',
+        { ttname: '快速', ttcolor: '#ff0000', ttkind: 'Unknown' },
+      ],
+    ])(
+      'sids 形式: %s の場合はリンク全体を no-op',
+      async (_label, extraParams) => {
+        mockGetInitialURL.mockResolvedValue(
+          'CanaryTrainLCD://route?sids=1131211,1131310'
+        );
+        mockParse.mockReturnValue({
+          queryParams: {
+            sids: '1131211,1131310',
+            ...extraParams,
+          },
+        });
+
+        const { mockSetStationState } = setupAtoms();
+        const { mockFetchByIds } = setupQueries();
+
+        render(
+          <HookBridge
+            onReady={() => {
+              /* noop */
+            }}
+          />
+        );
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mockFetchByIds).not.toHaveBeenCalled();
+        expect(mockSetStationState).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([
+      ['ttname 欠落', { ttcolor: '#ff0000' }],
+      ['ttcolor 欠落', { ttname: '快速' }],
+      [
+        'ttkind が enum 外',
+        { ttname: '快速', ttcolor: '#ff0000', ttkind: 'Unknown' },
+      ],
+    ])(
+      'sgid+lid 形式: %s の場合はリンク全体を no-op',
+      async (_label, extraParams) => {
+        mockGetInitialURL.mockResolvedValue(
+          'CanaryTrainLCD://?lid=999&sgid=1&dir=0'
+        );
+        mockParse.mockReturnValue({
+          queryParams: {
+            lid: '999',
+            sgid: '1',
+            dir: '0',
+            ...extraParams,
+          },
+        });
+
+        const { mockSetStationState } = setupAtoms();
+        const { mockFetchByLine, mockFetchByGroup } = setupQueries();
+
+        render(
+          <HookBridge
+            onReady={() => {
+              /* noop */
+            }}
+          />
+        );
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mockFetchByLine).not.toHaveBeenCalled();
+        expect(mockFetchByGroup).not.toHaveBeenCalled();
+        expect(mockSetStationState).not.toHaveBeenCalled();
+      }
+    );
+
+    it('id 形式の場合は URL の tt* は無視される (resolver の trainType だけが使われる)', async () => {
+      // URL has tt* but `?id=` wins precedence — even an invalid tt* combo here
+      // must not reject the link, because the resolver payload is the
+      // authoritative source.
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?id=abc&ttname=%E5%BF%AB%E9%80%9F&ttcolor=notHex'
+      );
+      mockParse.mockReturnValue({
+        queryParams: { id: 'abc', ttname: '快速', ttcolor: 'notHex' },
+      });
+
+      mockResolveSids.mockResolvedValue({
+        stationIds: [1131211, 1131310],
+        skipIndices: null,
+        trainType: null,
+      });
+
+      const { mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: buildTwoStations() },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      // resolver supplied null trainType, so navigationState.trainType falls
+      // back to the head station's server-derived trainType.
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      expect(navResult.trainType?.typeId).toBe(9999);
+    });
+
+    it('ttname / ttcolor が両方とも未指定なら override はせずレガシー挙動', async () => {
+      mockGetInitialURL.mockResolvedValue(
+        'CanaryTrainLCD://route?sids=1131211,1131310'
+      );
+      mockParse.mockReturnValue({
+        queryParams: { sids: '1131211,1131310' },
+      });
+
+      const { mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+      mockFetchByIds.mockResolvedValue({
+        data: { stations: buildTwoStations() },
+      });
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchByIds).toHaveBeenCalled();
+      });
+
+      const navSetter = mockSetNavigationState.mock.calls[0][0];
+      const navResult = navSetter(createNavigationState());
+      // head station's server-derived trainType is preserved as-is
+      expect(navResult.trainType?.typeId).toBe(9999);
     });
   });
 

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -3,7 +3,13 @@ import { CommonActions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import { useSetAtom } from 'jotai';
 import { useCallback, useEffect, useState } from 'react';
-import { type Station, StopCondition, type TrainType } from '~/@types/graphql';
+import {
+  type Station,
+  StopCondition,
+  type TrainType,
+  type TrainTypeNested,
+} from '~/@types/graphql';
+import { parseTrainTypeOverride } from '~/lib/deepLinkTrainType';
 import {
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
@@ -107,12 +113,47 @@ export const useDeepLink = () => {
   const [resolverError, setResolverError] = useState<Error | null>(null);
   const [resolverLoading, setResolverLoading] = useState(false);
 
+  // When the deep link supplied a custom TrainType, every fetched station's
+  // `trainType` is replaced with the override. `useCurrentTrainType` reads
+  // `currentStation?.trainType` (and falls back to other stations[].trainType
+  // when transferring lines), so only overriding `navigationState.trainType`
+  // would be undone on the next render. Replacing it on every station keeps
+  // the override stable throughout the shared route — which is what the user
+  // signed up for when they encoded `ttname` / `ttcolor` in the URL.
+  const applyOverrideToStations = useCallback(
+    (stations: Station[], override: TrainTypeNested | null): Station[] => {
+      if (!override) {
+        return stations;
+      }
+      return stations.map(
+        (station) =>
+          ({
+            ...station,
+            trainType: override,
+          }) as Station
+      );
+    },
+    []
+  );
+
   const applyRoute = useCallback(
-    (station: Station, stations: Station[], direction: LineDirection) => {
+    (
+      station: Station,
+      stations: Station[],
+      direction: LineDirection,
+      trainTypeOverride: TrainTypeNested | null
+    ) => {
       const line = station?.line;
       if (!line) {
         return;
       }
+
+      const overriddenStations = applyOverrideToStations(
+        stations,
+        trainTypeOverride
+      );
+      const overriddenHead =
+        overriddenStations.find((s) => s.id === station.id) ?? station;
 
       setLineState((prev) => ({
         ...prev,
@@ -121,10 +162,12 @@ export const useDeepLink = () => {
       }));
       setStationState((prev) => ({
         ...prev,
-        station,
-        stations,
+        station: overriddenHead,
+        stations: overriddenStations,
         selectedBound:
-          direction === 'INBOUND' ? stations[stations.length - 1] : stations[0],
+          direction === 'INBOUND'
+            ? overriddenStations[overriddenStations.length - 1]
+            : overriddenStations[0],
         selectedDirection: direction,
         pendingStation: null,
         pendingStations: [],
@@ -133,10 +176,12 @@ export const useDeepLink = () => {
       setNavigationState((prev) => ({
         ...prev,
         leftStations: [],
-        trainType: (station.trainType ?? null) as TrainType | null,
+        trainType: (trainTypeOverride ??
+          overriddenHead.trainType ??
+          null) as TrainType | null,
       }));
     },
-    [setLineState, setStationState, setNavigationState]
+    [applyOverrideToStations, setLineState, setStationState, setNavigationState]
   );
 
   const navigateToMain = useCallback(async () => {
@@ -165,11 +210,13 @@ export const useDeepLink = () => {
     async ({
       stationIds,
       skipIndices,
+      trainTypeOverride,
       autoMode,
       theme,
     }: {
       stationIds: number[];
       skipIndices: ReadonlySet<number> | null;
+      trainTypeOverride: TrainTypeNested | null;
       autoMode: boolean;
       theme: ThemePreference | undefined;
     }) => {
@@ -188,7 +235,7 @@ export const useDeepLink = () => {
       // Preserve the order specified in the deep link; server response order is
       // not guaranteed and stations not resolved are silently dropped.
       const byId = new Map(fetched.map((sta) => [sta.id, sta] as const));
-      const stations = stationIds
+      const baseStations = stationIds
         .map((id, idx) => {
           const sta = byId.get(id);
           if (!sta) {
@@ -199,9 +246,11 @@ export const useDeepLink = () => {
             : sta;
         })
         .filter((sta): sta is Station => sta != null);
-      if (stations.length === 0) {
+      if (baseStations.length === 0) {
         return;
       }
+
+      const stations = applyOverrideToStations(baseStations, trainTypeOverride);
 
       const head = stations[0];
       const line = head.line;
@@ -227,13 +276,16 @@ export const useDeepLink = () => {
       setNavigationState((prev) => ({
         ...prev,
         leftStations: [],
-        trainType: (head.trainType ?? null) as TrainType | null,
+        trainType: (trainTypeOverride ??
+          head.trainType ??
+          null) as TrainType | null,
         autoModeEnabled: autoMode ? true : prev.autoModeEnabled,
       }));
 
       await navigateToMain();
     },
     [
+      applyOverrideToStations,
       fetchStationsByIds,
       navigateToMain,
       setLineState,
@@ -251,6 +303,7 @@ export const useDeepLink = () => {
       direction,
       lineGroupId,
       lineId,
+      trainTypeOverride,
       autoMode,
       theme,
     }: {
@@ -258,6 +311,7 @@ export const useDeepLink = () => {
       direction: 0 | 1;
       lineGroupId: number | undefined;
       lineId: number;
+      trainTypeOverride: TrainTypeNested | null;
       autoMode: boolean;
       theme: ThemePreference | undefined;
     }) => {
@@ -278,7 +332,7 @@ export const useDeepLink = () => {
           return;
         }
 
-        applyRoute(station, stations, lineDirection);
+        applyRoute(station, stations, lineDirection, trainTypeOverride);
         if (autoMode) {
           setNavigationState((prev) => ({ ...prev, autoModeEnabled: true }));
         }
@@ -296,7 +350,7 @@ export const useDeepLink = () => {
         return;
       }
 
-      applyRoute(station, stations, lineDirection);
+      applyRoute(station, stations, lineDirection, trainTypeOverride);
       if (autoMode) {
         setNavigationState((prev) => ({ ...prev, autoModeEnabled: true }));
       }
@@ -323,8 +377,26 @@ export const useDeepLink = () => {
       // leaks into the next handleUrl call (including subsequent legacy-path
       // successes). Clear it once we know the URL has parseable params.
       setResolverError(null);
-      const { sgid, dir, lgid, lid, sids, skips, id, auto, theme } =
-        parsed.queryParams;
+      const {
+        sgid,
+        dir,
+        lgid,
+        lid,
+        sids,
+        skips,
+        id,
+        auto,
+        theme,
+        ttname,
+        ttcolor,
+        ttkind,
+        ttnameroman,
+        ttnamekatakana,
+        ttnamechinese,
+        ttnamekorean,
+        ttnameipa,
+        ttnameromanipa,
+      } = parsed.queryParams;
 
       const autoMode = auto === '1';
       const parsedTheme =
@@ -351,13 +423,16 @@ export const useDeepLink = () => {
         );
         setResolverLoading(true);
         try {
-          const { stationIds, skipIndices } = await resolveSidsFromShortId(
-            id,
-            controller.signal
-          );
+          // `tt*` URL params are ignored on the `?id=` path: the resolver
+          // payload is the single source of TrainType truth for short codes,
+          // and any malformed trainType in that payload causes resolver to
+          // throw, which we catch and surface as `resolverError` below.
+          const { stationIds, skipIndices, trainType } =
+            await resolveSidsFromShortId(id, controller.signal);
           await openRouteByStationIds({
             stationIds,
             skipIndices,
+            trainTypeOverride: trainType,
             autoMode,
             theme: parsedTheme,
           });
@@ -369,6 +444,30 @@ export const useDeepLink = () => {
         }
         return;
       }
+
+      // `tt*` parameters override the head station's TrainType for both
+      // `sids` and `sgid`+`lid` URL forms. `direction` is intentionally not
+      // forwarded: the URL forms encode direction through station order /
+      // the legacy `dir` flag, so accepting it here would duplicate intent.
+      // Validation failure (missing required field, malformed color, enum
+      // miss, non-string optional) rejects the whole link to avoid showing
+      // a half-built TrainType.
+      const trainTypeResult = parseTrainTypeOverride({
+        name: ttname,
+        color: ttcolor,
+        kind: ttkind,
+        nameRoman: ttnameroman,
+        nameKatakana: ttnamekatakana,
+        nameChinese: ttnamechinese,
+        nameKorean: ttnamekorean,
+        nameIpa: ttnameipa,
+        nameRomanIpa: ttnameromanipa,
+      });
+      if (trainTypeResult.status === 'invalid') {
+        return;
+      }
+      const trainTypeOverride =
+        trainTypeResult.status === 'valid' ? trainTypeResult.trainType : null;
 
       // New `sids` form takes precedence and ignores sgid/lid/lgid/dir
       // entirely — station order alone encodes the intended direction.
@@ -411,6 +510,7 @@ export const useDeepLink = () => {
         await openRouteByStationIds({
           stationIds,
           skipIndices,
+          trainTypeOverride,
           autoMode,
           theme: parsedTheme,
         });
@@ -454,6 +554,7 @@ export const useDeepLink = () => {
         direction,
         lineGroupId,
         lineId,
+        trainTypeOverride,
         autoMode,
         theme: parsedTheme,
       });

--- a/src/lib/deepLinkTrainType.test.ts
+++ b/src/lib/deepLinkTrainType.test.ts
@@ -1,0 +1,232 @@
+import { TrainDirection, TrainTypeKind } from '~/@types/graphql';
+import { parseTrainTypeOverride } from './deepLinkTrainType';
+
+describe('parseTrainTypeOverride', () => {
+  it('全フィールドが未指定なら absent', () => {
+    expect(parseTrainTypeOverride({})).toEqual({ status: 'absent' });
+    expect(
+      parseTrainTypeOverride({
+        name: undefined,
+        color: undefined,
+        kind: undefined,
+      })
+    ).toEqual({ status: 'absent' });
+  });
+
+  it('name + color が揃っていれば valid', () => {
+    const result = parseTrainTypeOverride({
+      name: '快速',
+      color: '#ff0000',
+    });
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.trainType).toMatchObject({
+      __typename: 'TrainTypeNested',
+      name: '快速',
+      color: '#ff0000',
+      kind: null,
+      direction: null,
+      id: null,
+      typeId: null,
+      groupId: null,
+      line: null,
+      lines: null,
+      nameTtsSegments: null,
+    });
+  });
+
+  it('color は大文字でも受理し小文字に正規化する', () => {
+    const result = parseTrainTypeOverride({
+      name: '快速',
+      color: '#FF0000',
+    });
+    expect(result.status).toBe('valid');
+    if (result.status === 'valid') {
+      expect(result.trainType.color).toBe('#ff0000');
+    }
+  });
+
+  it('受理されない id / typeId / groupId / line / lines / nameTtsSegments は無視される', () => {
+    // TrainTypeOverrideInput only declares whitelisted keys; foreign keys are
+    // passed through an `unknown` cast so the validator can prove it ignores
+    // them without TS rejecting the test input.
+    const foreignFields: Record<string, unknown> = {
+      id: 999,
+      typeId: 'should-be-ignored',
+      groupId: 1,
+      line: { id: 1 },
+      lines: [],
+      nameTtsSegments: [],
+    };
+    const result = parseTrainTypeOverride({
+      name: '快速',
+      color: '#ff0000',
+      ...foreignFields,
+    });
+    expect(result.status).toBe('valid');
+    if (result.status === 'valid') {
+      expect(result.trainType.id).toBeNull();
+      expect(result.trainType.typeId).toBeNull();
+      expect(result.trainType.groupId).toBeNull();
+      expect(result.trainType.line).toBeNull();
+      expect(result.trainType.lines).toBeNull();
+      expect(result.trainType.nameTtsSegments).toBeNull();
+    }
+  });
+
+  describe('必須フィールド欠落', () => {
+    it.each([
+      ['name のみ', { name: '快速' }],
+      ['color のみ', { color: '#ff0000' }],
+      ['kind のみ', { kind: TrainTypeKind.Rapid }],
+      ['nameRoman のみ', { nameRoman: 'Rapid' }],
+      [
+        'name なしで他フィールド指定',
+        { color: '#ff0000', kind: TrainTypeKind.Rapid },
+      ],
+      [
+        'color なしで他フィールド指定',
+        { name: '快速', kind: TrainTypeKind.Rapid },
+      ],
+    ])('%s は invalid', (_label, input) => {
+      expect(parseTrainTypeOverride(input).status).toBe('invalid');
+    });
+
+    it('name が空文字は invalid', () => {
+      expect(
+        parseTrainTypeOverride({ name: '', color: '#ff0000' }).status
+      ).toBe('invalid');
+    });
+  });
+
+  describe('color バリデーション', () => {
+    it.each([
+      ['#fff (3桁)', '#fff'],
+      ['rgb形式', 'rgb(255,0,0)'],
+      ['# なし', 'ff0000'],
+      ['7桁', '#ff00000'],
+      ['HEX 外文字', '#gg0000'],
+      ['空文字', ''],
+      ['前後空白', ' #ff0000'],
+    ])('%s は invalid', (_label, color) => {
+      expect(parseTrainTypeOverride({ name: '快速', color }).status).toBe(
+        'invalid'
+      );
+    });
+
+    it('非文字列の color は invalid', () => {
+      expect(
+        parseTrainTypeOverride({
+          name: '快速',
+          color: 0xff0000,
+        }).status
+      ).toBe('invalid');
+    });
+  });
+
+  describe('kind バリデーション', () => {
+    it.each(Object.values(TrainTypeKind))('%s は受理', (kind) => {
+      const result = parseTrainTypeOverride({
+        name: '快速',
+        color: '#ff0000',
+        kind,
+      });
+      expect(result.status).toBe('valid');
+      if (result.status === 'valid') {
+        expect(result.trainType.kind).toBe(kind);
+      }
+    });
+
+    it.each([
+      ['enum 外文字列', 'Unknown'],
+      ['小文字', 'rapid'],
+      ['空文字', ''],
+      ['数値', 1],
+    ])('%s は invalid', (_label, kind) => {
+      expect(
+        parseTrainTypeOverride({
+          name: '快速',
+          color: '#ff0000',
+          kind,
+        }).status
+      ).toBe('invalid');
+    });
+  });
+
+  describe('direction バリデーション', () => {
+    it.each(Object.values(TrainDirection))('%s は受理', (direction) => {
+      const result = parseTrainTypeOverride({
+        name: '快速',
+        color: '#ff0000',
+        direction,
+      });
+      expect(result.status).toBe('valid');
+      if (result.status === 'valid') {
+        expect(result.trainType.direction).toBe(direction);
+      }
+    });
+
+    it.each([
+      ['enum 外文字列', 'Reverse'],
+      ['小文字', 'inbound'],
+      ['空文字', ''],
+      ['数値', 0],
+    ])('%s は invalid', (_label, direction) => {
+      expect(
+        parseTrainTypeOverride({
+          name: '快速',
+          color: '#ff0000',
+          direction,
+        }).status
+      ).toBe('invalid');
+    });
+  });
+
+  describe('任意 name* フィールド', () => {
+    it('指定された文字列が反映される', () => {
+      const result = parseTrainTypeOverride({
+        name: '快速',
+        color: '#ff0000',
+        nameRoman: 'Rapid',
+        nameKatakana: 'カイソク',
+        nameChinese: '快速',
+        nameKorean: '쾌속',
+        nameIpa: 'kaisoku',
+        nameRomanIpa: 'ɾæpɪd',
+      });
+      expect(result.status).toBe('valid');
+      if (result.status === 'valid') {
+        expect(result.trainType).toMatchObject({
+          nameRoman: 'Rapid',
+          nameKatakana: 'カイソク',
+          nameChinese: '快速',
+          nameKorean: '쾌속',
+          nameIpa: 'kaisoku',
+          nameRomanIpa: 'ɾæpɪd',
+        });
+      }
+    });
+
+    it('空文字は null として保持される', () => {
+      const result = parseTrainTypeOverride({
+        name: '快速',
+        color: '#ff0000',
+        nameRoman: '',
+      });
+      expect(result.status).toBe('valid');
+      if (result.status === 'valid') {
+        expect(result.trainType.nameRoman).toBeNull();
+      }
+    });
+
+    it('非文字列の任意フィールドは invalid', () => {
+      expect(
+        parseTrainTypeOverride({
+          name: '快速',
+          color: '#ff0000',
+          nameRoman: 123,
+        }).status
+      ).toBe('invalid');
+    });
+  });
+});

--- a/src/lib/deepLinkTrainType.ts
+++ b/src/lib/deepLinkTrainType.ts
@@ -1,0 +1,175 @@
+import {
+  TrainDirection,
+  TrainTypeKind,
+  type TrainTypeNested,
+} from '~/@types/graphql';
+
+// Subset of TrainType fields a deep link / route resolver short code is
+// allowed to carry. Rejected fields (`id` / `typeId` / `groupId` / `line` /
+// `lines` / `nameTtsSegments`) deliberately do not appear here — they are
+// server-owned identity / structural data that must never be injected from
+// shared URLs. See issue #6018 for the rationale.
+export type TrainTypeOverrideInput = {
+  name?: unknown;
+  color?: unknown;
+  kind?: unknown;
+  direction?: unknown;
+  nameRoman?: unknown;
+  nameKatakana?: unknown;
+  nameChinese?: unknown;
+  nameKorean?: unknown;
+  nameIpa?: unknown;
+  nameRomanIpa?: unknown;
+};
+
+export type TrainTypeOverrideResult =
+  | { status: 'absent' }
+  | { status: 'invalid' }
+  | { status: 'valid'; trainType: TrainTypeNested };
+
+const COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const TRAIN_TYPE_KIND_VALUES = new Set<string>(
+  Object.values(TrainTypeKind) as string[]
+);
+const TRAIN_DIRECTION_VALUES = new Set<string>(
+  Object.values(TrainDirection) as string[]
+);
+
+// `present` means the input attempted to specify the field (so even an empty
+// string is `present`, not `absent`). The caller decides whether emptiness is
+// acceptable per-field — `name` / `color` reject empty, optional name* fields
+// allow it.
+type FieldState =
+  | { state: 'absent' }
+  | { state: 'invalid' }
+  | { state: 'present'; value: string };
+
+const readStringField = (raw: unknown): FieldState => {
+  if (raw === undefined || raw === null) {
+    return { state: 'absent' };
+  }
+  if (typeof raw !== 'string') {
+    return { state: 'invalid' };
+  }
+  return { state: 'present', value: raw };
+};
+
+const hasAnyField = (raw: TrainTypeOverrideInput): boolean => {
+  for (const value of Object.values(raw)) {
+    if (value !== undefined && value !== null) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Normalize lowercase. The Route Builder spec normalizes outgoing color to
+// lowercase, but accept either case so a hand-written link still works.
+const normalizeColor = (raw: string): string => raw.toLowerCase();
+
+export const parseTrainTypeOverride = (
+  raw: TrainTypeOverrideInput
+): TrainTypeOverrideResult => {
+  if (!hasAnyField(raw)) {
+    return { status: 'absent' };
+  }
+
+  // name: required, non-empty string.
+  const nameField = readStringField(raw.name);
+  if (nameField.state !== 'present' || nameField.value.length === 0) {
+    return { status: 'invalid' };
+  }
+
+  // color: required, #RRGGBB (case-insensitive).
+  const colorField = readStringField(raw.color);
+  if (colorField.state !== 'present' || !COLOR_PATTERN.test(colorField.value)) {
+    return { status: 'invalid' };
+  }
+
+  // kind: optional, TrainTypeKind enum.
+  let kind: TrainTypeKind | null = null;
+  const kindField = readStringField(raw.kind);
+  if (kindField.state === 'invalid') {
+    return { status: 'invalid' };
+  }
+  if (kindField.state === 'present') {
+    if (!TRAIN_TYPE_KIND_VALUES.has(kindField.value)) {
+      return { status: 'invalid' };
+    }
+    kind = kindField.value as TrainTypeKind;
+  }
+
+  // direction: optional, TrainDirection enum. URL form (sids / sgid+lid) never
+  // supplies this — the spec reserves it for the route resolver payload —
+  // but the validator does not need to enforce origin; just that, when
+  // provided, the value is in the enum.
+  let direction: TrainDirection | null = null;
+  const directionField = readStringField(raw.direction);
+  if (directionField.state === 'invalid') {
+    return { status: 'invalid' };
+  }
+  if (directionField.state === 'present') {
+    if (!TRAIN_DIRECTION_VALUES.has(directionField.value)) {
+      return { status: 'invalid' };
+    }
+    direction = directionField.value as TrainDirection;
+  }
+
+  // Optional name* fields: when explicitly typed as non-string we reject the
+  // whole link, but empty/absent strings simply leave the field null so a
+  // stray `&ttnameroman=` doesn't break the URL.
+  const optionalName = (
+    field: unknown
+  ): { ok: true; value: string | null } | { ok: false } => {
+    const parsed = readStringField(field);
+    if (parsed.state === 'invalid') {
+      return { ok: false };
+    }
+    if (parsed.state === 'absent' || parsed.value.length === 0) {
+      return { ok: true, value: null };
+    }
+    return { ok: true, value: parsed.value };
+  };
+
+  const nameRoman = optionalName(raw.nameRoman);
+  const nameKatakana = optionalName(raw.nameKatakana);
+  const nameChinese = optionalName(raw.nameChinese);
+  const nameKorean = optionalName(raw.nameKorean);
+  const nameIpa = optionalName(raw.nameIpa);
+  const nameRomanIpa = optionalName(raw.nameRomanIpa);
+
+  if (
+    !nameRoman.ok ||
+    !nameKatakana.ok ||
+    !nameChinese.ok ||
+    !nameKorean.ok ||
+    !nameIpa.ok ||
+    !nameRomanIpa.ok
+  ) {
+    return { status: 'invalid' };
+  }
+
+  const trainType: TrainTypeNested = {
+    __typename: 'TrainTypeNested',
+    name: nameField.value,
+    color: normalizeColor(colorField.value),
+    kind,
+    direction,
+    nameRoman: nameRoman.value,
+    nameKatakana: nameKatakana.value,
+    nameChinese: nameChinese.value,
+    nameKorean: nameKorean.value,
+    nameIpa: nameIpa.value,
+    nameRomanIpa: nameRomanIpa.value,
+    // Server-owned identity / structural fields are explicitly null so the
+    // override never carries stale or fabricated lineGroupId / typeId.
+    id: null,
+    typeId: null,
+    groupId: null,
+    line: null,
+    lines: null,
+    nameTtsSegments: null,
+  };
+
+  return { status: 'valid', trainType };
+};

--- a/src/lib/routeResolver.test.ts
+++ b/src/lib/routeResolver.test.ts
@@ -43,6 +43,7 @@ describe('resolveSidsFromShortId', () => {
 
     expect(result.stationIds).toEqual([1131211, 1131310, 2800217]);
     expect(result.skipIndices).toBeNull();
+    expect(result.trainType).toBeNull();
     expect(mockFetch).toHaveBeenCalledWith(
       `${TEST_HOST}/api/routes/abc123`,
       expect.objectContaining({
@@ -276,5 +277,134 @@ describe('resolveSidsFromShortId', () => {
       resolveSidsFromShortId(id, new AbortController().signal, TEST_HOST)
     ).rejects.toThrow(/invalid route resolver id/);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  describe('trainType フィールド', () => {
+    it('trainType が返れば TrainType として展開する', async () => {
+      setupFetch(
+        async () =>
+          new Response(
+            JSON.stringify({
+              sids: [1131211, 1131310],
+              trainType: {
+                name: '快速',
+                color: '#ff0000',
+                kind: 'Rapid',
+                direction: 'Inbound',
+                nameRoman: 'Rapid',
+              },
+            }),
+            { status: 200 }
+          )
+      );
+
+      const result = await resolveSidsFromShortId(
+        'tt',
+        new AbortController().signal,
+        TEST_HOST
+      );
+
+      expect(result.trainType).toMatchObject({
+        __typename: 'TrainTypeNested',
+        name: '快速',
+        color: '#ff0000',
+        kind: 'Rapid',
+        direction: 'Inbound',
+        nameRoman: 'Rapid',
+        id: null,
+        typeId: null,
+        groupId: null,
+        line: null,
+        lines: null,
+        nameTtsSegments: null,
+      });
+    });
+
+    it.each([
+      ['trainType フィールドなし', { sids: [1, 2] }],
+      ['trainType が null', { sids: [1, 2], trainType: null }],
+    ])('%s の場合は trainType が null', async (_label, payload) => {
+      setupFetch(
+        async () => new Response(JSON.stringify(payload), { status: 200 })
+      );
+
+      const result = await resolveSidsFromShortId(
+        'tt',
+        new AbortController().signal,
+        TEST_HOST
+      );
+
+      expect(result.trainType).toBeNull();
+    });
+
+    it.each([
+      ['trainType が配列', { sids: [1, 2], trainType: [] }],
+      ['trainType が文字列', { sids: [1, 2], trainType: 'Rapid' }],
+      ['name 欠落', { sids: [1, 2], trainType: { color: '#ff0000' } }],
+      ['color 欠落', { sids: [1, 2], trainType: { name: '快速' } }],
+      [
+        'color が #RRGGBB 形式外',
+        { sids: [1, 2], trainType: { name: '快速', color: 'red' } },
+      ],
+      [
+        'kind が enum 外',
+        {
+          sids: [1, 2],
+          trainType: { name: '快速', color: '#ff0000', kind: 'Unknown' },
+        },
+      ],
+      [
+        'direction が enum 外',
+        {
+          sids: [1, 2],
+          trainType: { name: '快速', color: '#ff0000', direction: 'Reverse' },
+        },
+      ],
+    ])('%s の場合はエラーを投げる', async (_label, payload) => {
+      setupFetch(
+        async () => new Response(JSON.stringify(payload), { status: 200 })
+      );
+
+      await expect(
+        resolveSidsFromShortId('tt', new AbortController().signal, TEST_HOST)
+      ).rejects.toThrow(/malformed trainType/);
+    });
+
+    it('受理されない id / typeId / groupId / line / lines / nameTtsSegments は無視される', async () => {
+      setupFetch(
+        async () =>
+          new Response(
+            JSON.stringify({
+              sids: [1, 2],
+              trainType: {
+                name: '快速',
+                color: '#ff0000',
+                id: 999,
+                typeId: 1,
+                groupId: 1,
+                line: { id: 1 },
+                lines: [],
+                nameTtsSegments: [],
+              },
+            }),
+            { status: 200 }
+          )
+      );
+
+      const result = await resolveSidsFromShortId(
+        'tt',
+        new AbortController().signal,
+        TEST_HOST
+      );
+
+      expect(result.trainType).toMatchObject({
+        id: null,
+        typeId: null,
+        groupId: null,
+        line: null,
+        lines: null,
+        nameTtsSegments: null,
+      });
+    });
   });
 });

--- a/src/lib/routeResolver.test.ts
+++ b/src/lib/routeResolver.test.ts
@@ -340,6 +340,14 @@ describe('resolveSidsFromShortId', () => {
     it.each([
       ['trainType が配列', { sids: [1, 2], trainType: [] }],
       ['trainType が文字列', { sids: [1, 2], trainType: 'Rapid' }],
+      ['trainType が空オブジェクト', { sids: [1, 2], trainType: {} }],
+      [
+        'trainType の全フィールドが null',
+        {
+          sids: [1, 2],
+          trainType: { name: null, color: null, kind: null },
+        },
+      ],
       ['name 欠落', { sids: [1, 2], trainType: { color: '#ff0000' } }],
       ['color 欠落', { sids: [1, 2], trainType: { name: '快速' } }],
       [

--- a/src/lib/routeResolver.ts
+++ b/src/lib/routeResolver.ts
@@ -2,7 +2,9 @@ import {
   DEV_ROUTE_RESOLVER_API_URL,
   PRODUCTION_ROUTE_RESOLVER_API_URL,
 } from 'react-native-dotenv';
+import type { TrainTypeNested } from '~/@types/graphql';
 import { isDevApp } from '~/utils/isDevApp';
+import { parseTrainTypeOverride } from './deepLinkTrainType';
 
 export const ROUTE_RESOLVER_ID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 export const ROUTE_RESOLVER_TIMEOUT_MS = 10_000;
@@ -10,11 +12,13 @@ export const ROUTE_RESOLVER_TIMEOUT_MS = 10_000;
 type ResolverResponse = {
   sids: unknown;
   skips?: unknown;
+  trainType?: unknown;
 };
 
 export type ResolvedRoute = {
   stationIds: number[];
   skipIndices: ReadonlySet<number> | null;
+  trainType: TrainTypeNested | null;
 };
 
 export const getRouteResolverHost = (): string => {
@@ -98,6 +102,27 @@ const parseSkipIndices = (
   return new Set(parsed);
 };
 
+// Mirrors the URL-form tt* validation: same field whitelist, same `name` +
+// `color` requirement, same enum / HEX constraints. A malformed payload
+// throws so useDeepLink turns the entire link into a no-op rather than
+// reflecting a partially-trusted TrainType in navigation state.
+const parseResolverTrainType = (raw: unknown): TrainTypeNested | null => {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('route resolver returned malformed trainType');
+  }
+  const result = parseTrainTypeOverride(raw as Record<string, unknown>);
+  if (result.status === 'absent') {
+    return null;
+  }
+  if (result.status === 'invalid') {
+    throw new Error('route resolver returned malformed trainType');
+  }
+  return result.trainType;
+};
+
 // `host` is exposed for testability — production callers should omit it so the
 // env-derived value is used.
 export const resolveSidsFromShortId = async (
@@ -125,5 +150,6 @@ export const resolveSidsFromShortId = async (
   }
   const stationIds = payload.sids.map(coerceStationId);
   const skipIndices = parseSkipIndices(payload.skips, stationIds.length);
-  return { stationIds, skipIndices };
+  const trainType = parseResolverTrainType(payload.trainType);
+  return { stationIds, skipIndices, trainType };
 };

--- a/src/lib/routeResolver.ts
+++ b/src/lib/routeResolver.ts
@@ -106,6 +106,11 @@ const parseSkipIndices = (
 // `color` requirement, same enum / HEX constraints. A malformed payload
 // throws so useDeepLink turns the entire link into a no-op rather than
 // reflecting a partially-trusted TrainType in navigation state.
+//
+// `null` / `undefined` is the absence signal (field omitted by the server);
+// an empty object — or one whose accepted fields are all null — is a contract
+// violation (the server sent the field but with no usable content), so it is
+// thrown rather than silently treated as absent.
 const parseResolverTrainType = (raw: unknown): TrainTypeNested | null => {
   if (raw === undefined || raw === null) {
     return null;
@@ -114,10 +119,7 @@ const parseResolverTrainType = (raw: unknown): TrainTypeNested | null => {
     throw new Error('route resolver returned malformed trainType');
   }
   const result = parseTrainTypeOverride(raw as Record<string, unknown>);
-  if (result.status === 'absent') {
-    return null;
-  }
-  if (result.status === 'invalid') {
+  if (result.status === 'absent' || result.status === 'invalid') {
     throw new Error('route resolver returned malformed trainType');
   }
   return result.trainType;


### PR DESCRIPTION
## 概要

ディープリンクで列車種別 (`TrainType`) をカスタム指定できるようにする。`sids` / `sgid`+`lid` / `?id=` の 3 形式すべてで動作し、head 駅にひもづくサーバ由来の `trainType` ではなくリンクに埋め込まれた値が反映されるようになる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/deepLinkTrainType.ts` を新設し、URL の `tt*` パラメータと resolver の JSON ペイロード両方で同じバリデーション規則を共有する。
  - 必須: `name` (非空)、`color` (`#RRGGBB`、大文字も受理して小文字へ正規化)
  - 任意: `kind` (`TrainTypeKind` enum)、`direction` (`TrainDirection` enum)、`nameRoman` / `nameKatakana` / `nameChinese` / `nameKorean` / `nameIpa` / `nameRomanIpa`
  - 受理しない `id` / `typeId` / `groupId` / `line` / `lines` / `nameTtsSegments` は構築結果で `null` に固定
  - 制約違反は `{ status: 'invalid' }` を返してリンク全体を no-op
- `useDeepLink` で `sids` / `sgid`+`lid` 形式の `tt*` クエリパラメータをパースし、`navigationState.trainType` と `stations[].trainType` の両方に override を反映。`stations[].trainType` も置換することで `useCurrentTrainType` の路線跨ぎ時の挙動でも override が剥がれないようにする。
- `?id=` 形式では URL の `tt*` を無視し、resolver の返却 JSON に含まれる `trainType` を採用する (`resolveSidsFromShortId` の `ResolvedRoute.trainType` に追加。不正値は throw)。
- 既存挙動への影響を回避するため override の `TrainType` は `typeId` / `groupId` を `null` のまま渡し、`useCurrentTrainType` / `useTypeWillChange` / `TypeChangeNotify` が依存する `typeId` 比較が安全に動くことを確認。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加したユニットテスト:

- `src/lib/deepLinkTrainType.test.ts`: 必須欠落・color/kind/direction バリデーション・任意 name* フィールド・受理しないフィールドの除外を網羅。
- `src/lib/routeResolver.test.ts`: resolver レスポンスに含まれる `trainType` の正常解析・null 経路・配列/文字列/必須欠落/enum 外/不正 color の throw を追加。
- `src/hooks/useDeepLink.test.tsx`: sids / sgid+lid の `tt*` 反映、無効な `tt*` 組合せ・形式違反でのリンク no-op、`?id=` 経路での URL `tt*` 無視、resolver 由来の `trainType` 反映を追加。

## 関連Issue

Closes #6018

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ディープリンクのURLパラメータ（列車種別指定）を受け取り、指定が有効な場合はルート内の全駅表示に反映されます。
* **挙動改善 / 安全性**
  * 無効な列車種別指定や不整合な組み合わせはリンクを無効化（no-op）し、既存のサーバ由来情報を保護するようになりました。特定短縮ID形式ではURL指定よりサーバ値を優先します。
* **テスト**
  * 列車種別上書きとパースの網羅的なテスト群を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->