### PR TITLE
到着判定閾値を狭めて入線前の誤判定を抑止

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -1,8 +1,8 @@
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
 export const APPROACHING_MIN_THRESHOLD = 200;
-export const ARRIVED_MAX_THRESHOLD = 300;
-export const ARRIVED_MIN_THRESHOLD = 100;
+export const ARRIVED_MAX_THRESHOLD = 150;
+export const ARRIVED_MIN_THRESHOLD = 50;
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;

--- a/src/hooks/useThreshold.test.tsx
+++ b/src/hooks/useThreshold.test.tsx
@@ -213,7 +213,8 @@ describe('useThreshold', () => {
   });
 
   it('駅間距離がapproachingThreshold上限付近の場合、正しく判定する', () => {
-    // 約1000mの距離を設定 -> approachingThreshold = 500, arrivedThreshold = 250
+    // 約1000mの距離を設定 -> approachingThreshold = 500 (スケール内),
+    // arrivedThreshold = 250 -> ARRIVED_MAX_THRESHOLD(150) でクランプ
     mockUseCurrentStation.mockReturnValue({
       id: 1,
       groupId: 1,
@@ -231,7 +232,7 @@ describe('useThreshold', () => {
     const result = JSON.parse(getByTestId('thresholds').props.children);
 
     expect(result.approachingThreshold).toBeLessThan(APPROACHING_MAX_THRESHOLD);
-    expect(result.arrivedThreshold).toBeLessThan(ARRIVED_MAX_THRESHOLD);
+    expect(result.arrivedThreshold).toBe(ARRIVED_MAX_THRESHOLD);
   });
 
   it('駅間距離がarrivedThreshold上限付近でapproachingThresholdが最大値の場合', () => {
@@ -257,7 +258,8 @@ describe('useThreshold', () => {
   });
 
   it('駅間距離が非常に短い場合、最小閾値にクランプされる', () => {
-    // 約200mの距離 -> distance/4 = 50 < ARRIVED_MIN_THRESHOLD(100)
+    // 約200mの距離 -> distance/4 ≈ 50 (= ARRIVED_MIN_THRESHOLD),
+    // distance/2 ≈ 100 < APPROACHING_MIN_THRESHOLD(200) で APPROACHING がクランプされる
     mockUseCurrentStation.mockReturnValue({
       id: 1,
       groupId: 1,


### PR DESCRIPTION
## 概要

到着判定の閾値が過大で、列車がプラットフォームに入線していない段階で「到着」判定が出る不具合の報告があったため、`ARRIVED_MAX_THRESHOLD` / `ARRIVED_MIN_THRESHOLD` を狭めて誤判定を抑止する。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/constants/threshold.ts`: `ARRIVED_MAX_THRESHOLD` を 300m → 150m、`ARRIVED_MIN_THRESHOLD` を 100m → 50m に縮小。
- `src/hooks/useThreshold.test.tsx`: 駅間 1000m ケースで `arrivedThreshold` が新 MAX(150m) にクランプされる挙動に合わせて assertion を更新、駅間 200m ケースのコメントを新 MIN(50m) に合わせて修正。
- 動的閾値計算 (`clamp(betweenDistance / 4, MIN, MAX)`) と GPS 精度ボーナス (`MAX_ACCURACY_BONUS=150m`) の構造自体は変更なし。最悪ケースの判定圏が `300m + 150m = 450m` → `150m + 150m = 300m` に縮小し、通常時は `300m → 150m` まで縮まる。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
