### PR TITLE
到着判定閾値を200m/75mに緩めて停車後検知ラグを解消

### DIFF
--- a/src/constants/threshold.ts
+++ b/src/constants/threshold.ts
@@ -1,8 +1,8 @@
 // 閾値
 export const APPROACHING_MAX_THRESHOLD = 1000;
 export const APPROACHING_MIN_THRESHOLD = 200;
-export const ARRIVED_MAX_THRESHOLD = 150;
-export const ARRIVED_MIN_THRESHOLD = 50;
+export const ARRIVED_MAX_THRESHOLD = 200;
+export const ARRIVED_MIN_THRESHOLD = 75;
 export const MANY_LINES_THRESHOLD = 7;
 export const OMIT_JR_THRESHOLD = 3; // これ以上JR線があったら「JR線」で省略しよう
 export const JR_LINE_MAX_ID = 6;

--- a/src/hooks/useThreshold.test.tsx
+++ b/src/hooks/useThreshold.test.tsx
@@ -258,8 +258,8 @@ describe('useThreshold', () => {
   });
 
   it('駅間距離が非常に短い場合、最小閾値にクランプされる', () => {
-    // 約200mの距離 -> distance/4 ≈ 50 (= ARRIVED_MIN_THRESHOLD),
-    // distance/2 ≈ 100 < APPROACHING_MIN_THRESHOLD(200) で APPROACHING がクランプされる
+    // 約200mの距離 -> distance/4 ≈ 50 < ARRIVED_MIN_THRESHOLD(75) でクランプ、
+    // distance/2 ≈ 100 < APPROACHING_MIN_THRESHOLD(200) で APPROACHING もクランプされる
     mockUseCurrentStation.mockReturnValue({
       id: 1,
       groupId: 1,

--- a/src/hooks/useThreshold.test.tsx
+++ b/src/hooks/useThreshold.test.tsx
@@ -214,7 +214,7 @@ describe('useThreshold', () => {
 
   it('駅間距離がapproachingThreshold上限付近の場合、正しく判定する', () => {
     // 約1000mの距離を設定 -> approachingThreshold = 500 (スケール内),
-    // arrivedThreshold = 250 -> ARRIVED_MAX_THRESHOLD(150) でクランプ
+    // arrivedThreshold = 250 -> ARRIVED_MAX_THRESHOLD(200) でクランプ
     mockUseCurrentStation.mockReturnValue({
       id: 1,
       groupId: 1,


### PR DESCRIPTION
## 概要

#6022 で `ARRIVED_MAX_THRESHOLD` を 300m → 150m、`ARRIVED_MIN_THRESHOLD` を 100m → 50m まで狭めた結果、停車後に到着判定が走るまでラグが生じるケースが確認できたため、閾値を再調整して中庸を取る。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ARRIVED_MAX_THRESHOLD` を 150m → **200m** に拡大
- `ARRIVED_MIN_THRESHOLD` を 50m → **75m** に拡大
- 動的計算式 `clamp(distance / 4, MIN, MAX)` と GPS 精度ボーナス (最大 +150m) は据え置き
- `useThreshold.test.tsx` の短距離駅テストに付与していた `distance/4 ≈ 50 (= ARRIVED_MIN_THRESHOLD)` コメントを `< ARRIVED_MIN_THRESHOLD(75) でクランプ` に更新（実挙動と一致させるため）

### 駅間距離別の `arrivedThreshold` 想定値

| 駅間距離 | 直前 (#6022) | 本 PR |
| ---- | ---- | ---- |
| 200m（密集都市部） | 50m (MIN) | 75m (MIN) |
| 400m | 100m | 100m |
| 600m | 150m (MAX) | 150m |
| 800m | 150m (MAX) | 200m (MAX) |
| 1000m 以上 | 150m (MAX) | 200m (MAX) |

最悪ケース（MAX + GPS 精度ボーナス）は 350m。#6022 マージ前の元値 (300m + 150m = 450m) よりは依然として厳しい。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`useThreshold.test.tsx` / `useRefreshStation.test.tsx` 計 12 ケースが PASS することを確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01GU53jydgKsRNkVnzZVciFj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 到達検出の閾値を調整し、到達判定の安定性と位置認識の精度を向上させました。

* **テスト**
  * 閾値に関するテスト説明を更新し、期待される判定挙動が正しく表現されるようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->