### PR TITLE
フィードバックモーダルをハーフモーダルからセンタリング表示に変更

### DIFF
--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -5,6 +5,7 @@ import {
   Keyboard,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   TextInput,
   type TextInput as TextInputType,
@@ -13,7 +14,6 @@ import {
 import { FONTS, LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
-import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import Button from './Button';
 import { CustomModal } from './CustomModal';
@@ -29,23 +29,15 @@ type Props = {
 };
 
 const styles = StyleSheet.create({
-  modalContainer: {
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    width: '100%',
-    height: '100%',
-    padding: 0,
-  },
   backdrop: {
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
   },
   modalView: {
+    borderRadius: 16,
+  },
+  scrollContent: {
+    paddingHorizontal: 32,
     paddingVertical: 32,
-    width: '100%',
-    // iPhoneのみ全方位に角丸を設定(KeyboardAvoidingViewでの見栄え関係)
-    borderRadius: !isTablet && Platform.OS === 'ios' ? 16 : 0,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
   },
   textInput: {
     borderWidth: 1,
@@ -153,83 +145,87 @@ const NewReportModal: React.FC<Props> = ({
     <CustomModal
       visible={visible}
       onClose={handleClose}
-      containerStyle={styles.modalContainer}
       backdropStyle={styles.backdrop}
       contentContainerStyle={[
         styles.modalView,
         {
           backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
-          paddingLeft: 32,
-          paddingRight: 32,
         },
       ]}
       dismissOnBackdropPress={!sending}
       avoidKeyboard
     >
-      <Pressable onPress={Keyboard.dismiss}>
-        <Heading style={styles.title}>{translate('reportModalTitle')}</Heading>
-
-        <View style={styles.modalContent}>
-          <Heading style={styles.subtitle}>
-            {translate('reportBodyTitle')}
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Pressable onPress={Keyboard.dismiss}>
+          <Heading style={styles.title}>
+            {translate('reportModalTitle')}
           </Heading>
 
-          <TextInput
-            ref={textInputRef}
-            autoFocus={Platform.OS === 'ios'}
-            defaultValue=""
-            onChangeText={handleChangeText}
-            multiline
+          <View style={styles.modalContent}>
+            <Heading style={styles.subtitle}>
+              {translate('reportBodyTitle')}
+            </Heading>
+
+            <TextInput
+              ref={textInputRef}
+              autoFocus={Platform.OS === 'ios'}
+              defaultValue=""
+              onChangeText={handleChangeText}
+              multiline
+              style={[
+                styles.textInput,
+                {
+                  color: isLEDTheme ? '#fff' : '#000',
+                  fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
+                },
+              ]}
+              placeholder={translate('reportPlaceholder', {
+                lowerLimit: descriptionLowerLimit,
+              })}
+            />
+
+            {needsLeftCount < 0 ? (
+              <Typography style={styles.charCount}>
+                {translate('remainingCharacters', { count: -needsLeftCount })}
+              </Typography>
+            ) : (
+              <Typography style={styles.charCount}>
+                {translate('sendable')}
+              </Typography>
+            )}
+          </View>
+
+          <Typography
             style={[
-              styles.textInput,
+              styles.caution,
               {
                 color: isLEDTheme ? '#fff' : '#000',
-                fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
+                lineHeight: Platform.select({ ios: RFValue(14) }),
               },
             ]}
-            placeholder={translate('reportPlaceholder', {
-              lowerLimit: descriptionLowerLimit,
-            })}
-          />
-
-          {needsLeftCount < 0 ? (
-            <Typography style={styles.charCount}>
-              {translate('remainingCharacters', { count: -needsLeftCount })}
-            </Typography>
-          ) : (
-            <Typography style={styles.charCount}>
-              {translate('sendable')}
-            </Typography>
-          )}
-        </View>
-
-        <Typography
-          style={[
-            styles.caution,
-            {
-              color: isLEDTheme ? '#fff' : '#000',
-              lineHeight: Platform.select({ ios: RFValue(14) }),
-            },
-          ]}
-        >
-          {translate('reportCaution')}
-        </Typography>
-        <View style={styles.buttonContainer}>
-          <Button disabled={sending} onPress={handleClose} outline>
-            {translate('close')}
-          </Button>
-
-          <Button
-            style={styles.sendButton}
-            disabled={charCount < descriptionLowerLimit || sending}
-            onPress={handleSubmit}
           >
-            {sending
-              ? translate('reportSendInProgress')
-              : translate('reportSend')}
-          </Button>
-        </View>
-      </Pressable>
+            {translate('reportCaution')}
+          </Typography>
+          <View style={styles.buttonContainer}>
+            <Button disabled={sending} onPress={handleClose} outline>
+              {translate('close')}
+            </Button>
+
+            <Button
+              style={styles.sendButton}
+              disabled={charCount < descriptionLowerLimit || sending}
+              onPress={handleSubmit}
+            >
+              {sending
+                ? translate('reportSendInProgress')
+                : translate('reportSend')}
+            </Button>
+          </View>
+        </Pressable>
+      </ScrollView>
     </CustomModal>
   );
 };


### PR DESCRIPTION
## 概要

横画面 (landscape) で `NewReportModal` (フィードバック送信モーダル) を開くと、`CustomModal` のデフォルト `maxHeight: 75%` (= 720px 端末で 540px) と `overflow: hidden`、および `justifyContent: 'flex-end'` のボトムシート配置とが重なって、注意書きや送信ボタンが画面外に切れて操作できなくなっていた (#6031)。

そもそも本モーダルが画面下端に貼り付くハーフモーダルである必然性は薄かったため、`CustomModal` のデフォルトであるセンタリング表示に切り替え、内容を `ScrollView` でラップして両画面向き・縦長フォーム両方で安定して表示・操作できるようにする。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正 (既存機能の問題を修正)
- [ ] 新機能 (新しい機能の追加)
- [x] リファクタリング (機能変更を伴わないコードの改善)
- [ ] ドキュメント更新
- [ ] CI/CD関連の変更
- [ ] その他 (詳細を記載):

## 変更内容

- `src/components/NewReportModal.tsx`
  - `containerStyle` の `justifyContent: 'flex-end'` / `padding: 0` 等のボトムシート配置を撤去し、`CustomModal` のデフォルト center 配置 (画面中央・周囲に余白) に乗せる
  - `modalView` を `borderRadius: 16` の全周角丸に統一 (旧: 上端のみ角丸 + iPhone のみ全周という分岐)
  - 中身を `ScrollView` (`keyboardShouldPersistTaps="handled"`) でラップ。`CustomModal` 側の `maxHeight: 75%` に収まらない端末・フォントサイズでも送信ボタンまで到達可能に
  - 横/縦パディング (32 / 32) を `ScrollView` の `contentContainerStyle` へ集約
  - 不要になった `isTablet` import を削除

## テスト

<!-- 動作確認した内容を記載 -->

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run typecheck`

## 関連Issue

<!-- 関連するIssueがあれば記載 -->

Closes #6031

## スクリーンショット (任意)

<!-- UIに関する変更がある場合、スクリーンショットを添付 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * レポート送信モーダルがスクロール対応になり、長いコンテンツの閲覧がより快適になりました。レイアウトとスタイルを最適化し、キーボード操作時の動作をより安定させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->