### PR TITLE
iPhoneでフィードバックモーダルが一瞬で消える問題を修正

### DIFF
--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -115,6 +115,12 @@ const NewReportModal: React.FC<Props> = ({
     onSubmit(textRef.current);
   }, [onSubmit]);
 
+  const handleShow = useCallback(() => {
+    if (Platform.OS === 'ios') {
+      textInputRef.current?.focus();
+    }
+  }, []);
+
   const handleClose = useCallback(() => {
     const hasInput = textRef.current.trim().length > 0;
 
@@ -145,6 +151,7 @@ const NewReportModal: React.FC<Props> = ({
     <CustomModal
       visible={visible}
       onClose={handleClose}
+      onShow={handleShow}
       backdropStyle={styles.backdrop}
       contentContainerStyle={[
         styles.modalView,
@@ -171,7 +178,7 @@ const NewReportModal: React.FC<Props> = ({
 
             <TextInput
               ref={textInputRef}
-              autoFocus={Platform.OS === 'ios'}
+              autoFocus={Platform.OS !== 'ios'}
               defaultValue=""
               onChangeText={handleChangeText}
               multiline


### PR DESCRIPTION
## 概要

iPhone でフィードバックモーダルを開いた直後、モーダル本体だけが一瞬で消えてしまう不具合を修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- iOS では `TextInput` の `autoFocus` を無効化し、`CustomModal` の `onShow` コールバック経由でアニメーション完了後にフォーカスを当てるよう変更
- これにより、モーダルの開閉アニメーション(180ms)中にキーボード起動による `KeyboardAvoidingView` のレイアウト再計算が走らないようにする

### 背景

#6036 でフィードバックモーダルがハーフモーダルからセンタリング表示(`maxHeight: '75%'`)に変更されたことで、`autoFocus={Platform.OS === 'ios'}` によってモーダル開閉アニメーションと同時にキーボードが立ち上がり、`KeyboardAvoidingView` のリフロー → `Animated.View` の opacity/scale 推移と競合してモーダルが一瞬で消えていました。以前の flex-end 配置では maxHeight 制約が効きにくく競合しなかったため顕在化していませんでした。

`SavePresetNameModal` で既に同様の問題を `onShow` 方式で解決済み(PR #5575)のため、同じパターンに揃えています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レポート作成モーダルを表示する際のテキスト入力フィールドのフォーカス動作を改善しました。異なるプラットフォーム環境に対応した自動フォーカス処理を実装することで、各デバイスでの入力体験を最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->