### PR TITLE
乗り換え案内/種別変更通知画面に表示言語設定を反映

### DIFF
--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -5,6 +5,7 @@ import type { Line, Station } from '~/@types/graphql';
 import { NUMBERING_ICON_SIZE, parenthesisRegexp } from '../constants';
 import { useGetLineMark, useTransferLines } from '../hooks';
 import type { AppTheme } from '../models/Theme';
+import navigationState from '../store/atoms/navigation';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
@@ -68,6 +69,12 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
   const lines = useTransferLines();
   const getLineMarkFunc = useGetLineMark();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const { enabledLanguages } = useAtomValue(navigationState);
+
+  const isJaEnabled = enabledLanguages.includes('JA');
+  const isEnEnabled = enabledLanguages.includes('EN');
+  const isZhEnabled = enabledLanguages.includes('ZH');
+  const isKoEnabled = enabledLanguages.includes('KO');
 
   const stationNumbers = useMemo(
     () =>
@@ -122,6 +129,26 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
       const includesNumberedStation = stationNumbers.some(
         (sn) => !!sn?.stationNumber
       );
+
+      const cjkLineName = [
+        isZhEnabled ? line.nameChinese : null,
+        isKoEnabled ? line.nameKorean : null,
+      ]
+        .filter((s): s is string => !!s?.length)
+        .map((s) => s.replace(parenthesisRegexp, ''))
+        .join(' / ');
+
+      const cjkStationName = [
+        isZhEnabled && line.station?.nameChinese
+          ? `${line.station.nameChinese.replace(parenthesisRegexp, '')}站`
+          : null,
+        isKoEnabled && line.station?.nameKorean
+          ? `${line.station.nameKorean.replace(parenthesisRegexp, '')}역`
+          : null,
+      ]
+        .filter((s): s is string => !!s?.length)
+        .join(' / ');
+
       return (
         <View style={styles.transferLine} key={line.id}>
           <View style={styles.transferLineInnerLeft}>
@@ -164,20 +191,21 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
                   } as Station);
                 }}
               >
-                <Typography style={styles.lineName}>
-                  {line.nameShort?.replace(parenthesisRegexp, '')}
-                </Typography>
-                {line.nameRoman ? (
-                  <Typography style={styles.lineNameEn}>
+                {isJaEnabled && line.nameShort ? (
+                  <Typography style={styles.lineName}>
+                    {line.nameShort.replace(parenthesisRegexp, '')}
+                  </Typography>
+                ) : null}
+                {isEnEnabled && line.nameRoman ? (
+                  <Typography
+                    style={isJaEnabled ? styles.lineNameEn : styles.lineName}
+                  >
                     {line.nameRoman.replace(parenthesisRegexp, '')}
                   </Typography>
                 ) : null}
-                {!!line.nameChinese?.length && !!line.nameKorean?.length ? (
+                {cjkLineName ? (
                   <Typography style={styles.lineNameEn}>
-                    {`${line.nameChinese.replace(
-                      parenthesisRegexp,
-                      ''
-                    )} / ${line.nameKorean.replace(parenthesisRegexp, '')}`}
+                    {cjkLineName}
                   </Typography>
                 ) : null}
               </TouchableOpacity>
@@ -228,24 +256,26 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
                     } as Station);
                   }}
                 >
-                  <Typography style={styles.lineName}>
-                    {`${line.station?.name?.replace(parenthesisRegexp, '')}駅`}
-                  </Typography>
-                  <Typography style={styles.lineNameEn}>
-                    {`${(line.station?.nameRoman ?? '').replace(
-                      parenthesisRegexp,
-                      ''
-                    )} Sta.`}
-                  </Typography>
-                  <Typography style={styles.lineNameEn}>
-                    {`${(line.station?.nameChinese ?? '').replace(
-                      parenthesisRegexp,
-                      ''
-                    )}站 / ${(line.station?.nameKorean ?? '').replace(
-                      parenthesisRegexp,
-                      ''
-                    )}역`}
-                  </Typography>
+                  {isJaEnabled && line.station?.name ? (
+                    <Typography style={styles.lineName}>
+                      {`${line.station.name.replace(parenthesisRegexp, '')}駅`}
+                    </Typography>
+                  ) : null}
+                  {isEnEnabled && line.station?.nameRoman ? (
+                    <Typography
+                      style={isJaEnabled ? styles.lineNameEn : styles.lineName}
+                    >
+                      {`${line.station.nameRoman.replace(
+                        parenthesisRegexp,
+                        ''
+                      )} Sta.`}
+                    </Typography>
+                  ) : null}
+                  {cjkStationName ? (
+                    <Typography style={styles.lineNameEn}>
+                      {cjkStationName}
+                    </Typography>
+                  ) : null}
                 </TouchableOpacity>
               )}
             </View>
@@ -253,7 +283,16 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
         </View>
       );
     },
-    [getLineMarkFunc, onPress, stationNumbers, lines]
+    [
+      getLineMarkFunc,
+      onPress,
+      stationNumbers,
+      lines,
+      isJaEnabled,
+      isEnEnabled,
+      isZhEnabled,
+      isKoEnabled,
+    ]
   );
 
   if (isLEDTheme) {

--- a/src/components/TransfersYamanote.tsx
+++ b/src/components/TransfersYamanote.tsx
@@ -1,3 +1,4 @@
+import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
 import {
   FlatList,
@@ -14,6 +15,7 @@ import {
   useLandscapeWindowDimensions,
   useTransferLines,
 } from '../hooks';
+import navigationState from '../store/atoms/navigation';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
@@ -70,6 +72,12 @@ const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
   const getLineMarkFunc = useGetLineMark();
   const lines = useTransferLines();
   const dim = useLandscapeWindowDimensions();
+  const { enabledLanguages } = useAtomValue(navigationState);
+
+  const isJaEnabled = enabledLanguages.includes('JA');
+  const isEnEnabled = enabledLanguages.includes('EN');
+  const isZhEnabled = enabledLanguages.includes('ZH');
+  const isKoEnabled = enabledLanguages.includes('KO');
 
   const flexBasis = useMemo(() => dim.width / 3, [dim.width]);
 
@@ -82,6 +90,14 @@ const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
         line,
         stationNumbers: station.stationNumbers,
       });
+
+      const cjkLineName = [
+        isZhEnabled ? line.nameChinese : null,
+        isKoEnabled ? line.nameKorean : null,
+      ]
+        .filter((s): s is string => !!s?.length)
+        .map((s) => s.replace(parenthesisRegexp, ''))
+        .join(' / ');
 
       return (
         <SafeAreaView
@@ -128,12 +144,21 @@ const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
                   } as Station)
                 }
               >
-                <Typography style={styles.lineName}>
-                  {line.nameShort?.replace(parenthesisRegexp, '')}
-                </Typography>
-                {line.nameRoman ? (
-                  <Typography style={styles.lineNameEn}>
+                {isJaEnabled && line.nameShort ? (
+                  <Typography style={styles.lineName}>
+                    {line.nameShort.replace(parenthesisRegexp, '')}
+                  </Typography>
+                ) : null}
+                {isEnEnabled && line.nameRoman ? (
+                  <Typography
+                    style={isJaEnabled ? styles.lineNameEn : styles.lineName}
+                  >
                     {line.nameRoman.replace(parenthesisRegexp, '')}
+                  </Typography>
+                ) : null}
+                {cjkLineName ? (
+                  <Typography style={styles.lineNameEn}>
+                    {cjkLineName}
                   </Typography>
                 ) : null}
               </TouchableOpacity>
@@ -142,7 +167,17 @@ const TransfersYamanote: React.FC<Props> = ({ onPress, station }: Props) => {
         </SafeAreaView>
       );
     },
-    [flexBasis, onPress, station, getLineMarkFunc, lines]
+    [
+      flexBasis,
+      onPress,
+      station,
+      getLineMarkFunc,
+      lines,
+      isJaEnabled,
+      isEnEnabled,
+      isZhEnabled,
+      isKoEnabled,
+    ]
   );
 
   return (

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -339,4 +339,115 @@ describe('TypeChangeNotify', () => {
     const odakyuTexts = queryAllByText(/小田急多摩線/);
     expect(odakyuTexts).toHaveLength(0);
   });
+
+  describe('enabledLanguages による表示切替', () => {
+    const setupLanguageScenario = (enabledLanguages: string[]) => {
+      const { useAtomValue } = require('jotai');
+      const {
+        useCurrentLine,
+        useCurrentStation,
+        useCurrentTrainType,
+        useNextTrainType,
+      } = require('~/hooks');
+
+      const odakyuTamaLine = {
+        id: 100,
+        nameShort: '小田急多摩線',
+        nameRoman: 'Odakyu Tama Line',
+        color: '#0D82C7',
+      };
+      const jobanLine = {
+        id: 300,
+        nameShort: '常磐線',
+        nameRoman: 'Joban Line',
+        color: '#00B264',
+      };
+      const stations = [
+        {
+          id: 1,
+          groupId: 1,
+          name: '新百合ヶ丘',
+          nameRoman: 'Shin-Yurigaoka',
+          line: odakyuTamaLine,
+          lines: [odakyuTamaLine],
+          trainType: { typeId: 2, name: '準急', nameRoman: 'Semi Express' },
+          stopCondition: 'STOP',
+        },
+        {
+          id: 2,
+          groupId: 2,
+          name: '綾瀬',
+          nameRoman: 'Ayase',
+          line: jobanLine,
+          lines: [jobanLine],
+          trainType: { typeId: 3, name: '各停', nameRoman: 'Local' },
+          stopCondition: 'STOP',
+        },
+      ];
+
+      useCurrentLine.mockReturnValue(odakyuTamaLine);
+      useCurrentStation.mockReturnValue(stations[0]);
+      useCurrentTrainType.mockReturnValue({
+        typeId: 2,
+        name: '準急',
+        nameRoman: 'Semi Express',
+        color: '#009944',
+        line: odakyuTamaLine,
+      });
+      useNextTrainType.mockReturnValue({
+        typeId: 3,
+        name: '各停',
+        nameRoman: 'Local',
+        color: '#00B264',
+        line: jobanLine,
+      });
+
+      useAtomValue.mockImplementation((atom: unknown) => {
+        if (atom === require('../store/atoms/station').default) {
+          return {
+            selectedDirection: 'INBOUND',
+            stations,
+            selectedBound: { name: '取手', nameRoman: 'Toride' },
+          };
+        }
+        if (atom === require('../store/atoms/theme').themeAtom) {
+          return 'TOKYO_METRO';
+        }
+        if (atom === require('../store/atoms/navigation').default) {
+          return { enabledLanguages };
+        }
+        return {};
+      });
+    };
+
+    it('JAのみ有効時は日本語ラベルだけが表示される', () => {
+      setupLanguageScenario(['JA']);
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/準急/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/各停/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Semi Express/)).toHaveLength(0);
+      expect(queryAllByText(/Local/)).toHaveLength(0);
+    });
+
+    it('ENのみ有効時は英語ラベルだけが表示される', () => {
+      setupLanguageScenario(['EN']);
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/Semi Express/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Local/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/準急/)).toHaveLength(0);
+      expect(queryAllByText(/各停/)).toHaveLength(0);
+    });
+
+    it('JAとEN両方有効時は両言語のラベルが共存する', () => {
+      setupLanguageScenario(['JA', 'EN']);
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/準急/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/各停/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Semi Express/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Local/).length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -14,6 +14,9 @@ jest.mock('jotai', () => ({
     if (atom === require('../store/atoms/theme').themeAtom) {
       return 'TOKYO_METRO';
     }
+    if (atom === require('../store/atoms/navigation').default) {
+      return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
+    }
     return {};
   }),
   atom: jest.fn((initialValue) => initialValue),
@@ -73,6 +76,11 @@ jest.mock('../store/atoms/theme', () => ({
   themeAtom: {},
 }));
 
+jest.mock('../store/atoms/navigation', () => ({
+  __esModule: true,
+  default: {},
+}));
+
 jest.mock('./BarTerminalEast', () => ({
   BarTerminalEast: jest.fn(() => null),
 }));
@@ -126,6 +134,9 @@ describe('TypeChangeNotify', () => {
       if (atom === require('../store/atoms/theme').themeAtom) {
         return 'SAIKYO';
       }
+      if (atom === require('../store/atoms/navigation').default) {
+        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
+      }
       return {};
     });
 
@@ -147,6 +158,9 @@ describe('TypeChangeNotify', () => {
       if (atom === require('../store/atoms/theme').themeAtom) {
         return 'JO';
       }
+      if (atom === require('../store/atoms/navigation').default) {
+        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
+      }
       return {};
     });
 
@@ -167,6 +181,9 @@ describe('TypeChangeNotify', () => {
       }
       if (atom === require('../store/atoms/theme').themeAtom) {
         return 'ODAKYU';
+      }
+      if (atom === require('../store/atoms/navigation').default) {
+        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
       }
       return {};
     });
@@ -305,6 +322,9 @@ describe('TypeChangeNotify', () => {
       }
       if (atom === require('../store/atoms/theme').themeAtom) {
         return 'TOKYO_METRO';
+      }
+      if (atom === require('../store/atoms/navigation').default) {
+        return { enabledLanguages: ['JA', 'EN', 'ZH', 'KO'] };
       }
       return {};
     });

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/hooks';
 import { RFValue } from '~/utils/rfValue';
 import { getIsLocal } from '~/utils/trainTypeString';
+import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { themeAtom } from '../store/atoms/theme';
 import isTablet from '../utils/isTablet';
@@ -192,6 +193,24 @@ const defaultBoxGradient: ColorGradientFn = (color) => [
   `${color}aa`,
 ];
 
+type BarsLanguageProps = {
+  isJaEnabled: boolean;
+  isEnEnabled: boolean;
+};
+
+const joinLineText = (
+  isJaEnabled: boolean,
+  isEnEnabled: boolean,
+  nameShort: string | null | undefined,
+  nameRoman: string | null | undefined
+): string =>
+  [
+    isJaEnabled ? (nameShort ?? '').replace(parenthesisRegexp, '') : '',
+    isEnEnabled ? (nameRoman ?? '').replace(parenthesisRegexp, '') : '',
+  ]
+    .filter((s) => s.length > 0)
+    .join(' ');
+
 const EastBars = React.memo(function EastBars({
   currentLine,
   nextLine,
@@ -199,6 +218,8 @@ const EastBars = React.memo(function EastBars({
   nextTrainType,
   getBarGradient = defaultBarGradient,
   getBoxGradient = defaultBoxGradient,
+  isJaEnabled,
+  isEnEnabled,
 }: {
   currentLine: Line;
   nextLine: Line;
@@ -206,7 +227,7 @@ const EastBars = React.memo(function EastBars({
   nextTrainType: TrainType;
   getBarGradient?: ColorGradientFn;
   getBoxGradient?: ColorGradientFn;
-}) {
+} & BarsLanguageProps) {
   const dim = useLandscapeWindowDimensions();
   const barWidth = useBarWidth();
   const rightBarWidth = Math.max(0, barWidth - barTerminalWidth);
@@ -333,28 +354,32 @@ const EastBars = React.memo(function EastBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            style={styles.text}
-            adjustsFontSizeToFit
-            numberOfLines={1}
-          >
-            {(trainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (trainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              style={styles.text}
+              adjustsFontSizeToFit
+              numberOfLines={1}
+            >
+              {(trainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (trainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
-        {nextLine && (
+        {nextLine ? (
           <Typography
             style={[
               styles.lineText,
@@ -363,11 +388,14 @@ const EastBars = React.memo(function EastBars({
               },
             ]}
           >
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            {(currentLine?.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-            {(currentLine?.nameRoman ?? '').replace(parenthesisRegexp, '')}
+            {joinLineText(
+              isJaEnabled,
+              isEnEnabled,
+              currentLine?.nameShort,
+              currentLine?.nameRoman
+            )}
           </Typography>
-        )}
+        ) : null}
       </View>
       <View style={styles.trainTypeRight}>
         <LinearGradient
@@ -381,28 +409,32 @@ const EastBars = React.memo(function EastBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            style={styles.text}
-            adjustsFontSizeToFit
-            numberOfLines={1}
-          >
-            {(nextTrainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (nextTrainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              style={styles.text}
+              adjustsFontSizeToFit
+              numberOfLines={1}
+            >
+              {(nextTrainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (nextTrainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
-        {nextLine && (
+        {nextLine ? (
           <Typography
             style={[
               styles.lineText,
@@ -411,11 +443,14 @@ const EastBars = React.memo(function EastBars({
               },
             ]}
           >
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-            {(nextLine.nameRoman ?? '').replace(parenthesisRegexp, '')}
+            {joinLineText(
+              isJaEnabled,
+              isEnEnabled,
+              nextLine.nameShort,
+              nextLine.nameRoman
+            )}
           </Typography>
-        )}
+        ) : null}
       </View>
     </View>
   );
@@ -440,12 +475,14 @@ const OdakyuBars = React.memo(function OdakyuBars({
   nextLine,
   trainType,
   nextTrainType,
+  isJaEnabled,
+  isEnEnabled,
 }: {
   currentLine: Line;
   nextLine: Line;
   trainType: TrainType;
   nextTrainType: TrainType;
-}) {
+} & BarsLanguageProps) {
   const dim = useLandscapeWindowDimensions();
   const barWidth = useBarWidth();
   const rightBarWidth = Math.max(0, barWidth - odakyuTerminalWidth);
@@ -606,39 +643,46 @@ const OdakyuBars = React.memo(function OdakyuBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            style={styles.text}
-            adjustsFontSizeToFit
-            numberOfLines={1}
-          >
-            {(trainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (trainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              style={styles.text}
+              adjustsFontSizeToFit
+              numberOfLines={1}
+            >
+              {(trainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (trainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
-        {nextLine && (
+        {nextLine ? (
           <Typography
             style={[
               styles.lineText,
               { color: currentLine?.color ?? '#000000' },
             ]}
           >
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            {(currentLine?.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-            {(currentLine?.nameRoman ?? '').replace(parenthesisRegexp, '')}
+            {joinLineText(
+              isJaEnabled,
+              isEnEnabled,
+              currentLine?.nameShort,
+              currentLine?.nameRoman
+            )}
           </Typography>
-        )}
+        ) : null}
       </View>
       <View style={styles.trainTypeRight}>
         <LinearGradient
@@ -669,36 +713,43 @@ const OdakyuBars = React.memo(function OdakyuBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            style={styles.text}
-            adjustsFontSizeToFit
-            numberOfLines={1}
-          >
-            {(nextTrainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (nextTrainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              style={styles.text}
+              adjustsFontSizeToFit
+              numberOfLines={1}
+            >
+              {(nextTrainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (nextTrainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
-        {nextLine && (
+        {nextLine ? (
           <Typography
             style={[styles.lineText, { color: nextLine.color ?? '#000000' }]}
           >
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-            {(nextLine.nameRoman ?? '').replace(parenthesisRegexp, '')}
+            {joinLineText(
+              isJaEnabled,
+              isEnEnabled,
+              nextLine.nameShort,
+              nextLine.nameRoman
+            )}
           </Typography>
-        )}
+        ) : null}
       </View>
     </View>
   );
@@ -709,12 +760,14 @@ const SaikyoBars = React.memo(function SaikyoBars({
   nextLine,
   trainType,
   nextTrainType,
+  isJaEnabled,
+  isEnEnabled,
 }: {
   currentLine: Line;
   nextLine: Line;
   trainType: TrainType;
   nextTrainType: TrainType;
-}) {
+} & BarsLanguageProps) {
   const dim = useLandscapeWindowDimensions();
   const barWidth = useBarWidth();
   const rightBarWidth = Math.max(0, barWidth - barTerminalWidth);
@@ -839,26 +892,30 @@ const SaikyoBars = React.memo(function SaikyoBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            adjustsFontSizeToFit
-            numberOfLines={1}
-            style={styles.text}
-          >
-            {(trainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (trainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              numberOfLines={1}
+              style={styles.text}
+            >
+              {(trainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (trainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
 
         <Typography
@@ -869,9 +926,12 @@ const SaikyoBars = React.memo(function SaikyoBars({
             },
           ]}
         >
-          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          {(currentLine?.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-          {(currentLine?.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          {joinLineText(
+            isJaEnabled,
+            isEnEnabled,
+            currentLine?.nameShort,
+            currentLine?.nameRoman
+          )}
         </Typography>
       </View>
       <View style={styles.trainTypeRight}>
@@ -889,26 +949,30 @@ const SaikyoBars = React.memo(function SaikyoBars({
         />
 
         <View style={styles.textWrapper}>
-          <Typography
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            style={styles.text}
-          >
-            {((nextTrainType ?? trainType)?.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={styles.textEn}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              ((nextTrainType ?? trainType)?.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              style={styles.text}
+            >
+              {((nextTrainType ?? trainType)?.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={styles.textEn}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                ((nextTrainType ?? trainType)?.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
 
         <Typography
@@ -919,9 +983,12 @@ const SaikyoBars = React.memo(function SaikyoBars({
             },
           ]}
         >
-          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-          {(nextLine.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          {joinLineText(
+            isJaEnabled,
+            isEnEnabled,
+            nextLine.nameShort,
+            nextLine.nameRoman
+          )}
         </Typography>
       </View>
     </View>
@@ -933,12 +1000,14 @@ const JOBars = React.memo(function JOBars({
   nextLine,
   trainType,
   nextTrainType,
+  isJaEnabled,
+  isEnEnabled,
 }: {
   currentLine: Line;
   nextLine: Line;
   trainType: TrainType;
   nextTrainType: TrainType;
-}) {
+} & BarsLanguageProps) {
   const dim = useLandscapeWindowDimensions();
   const barWidth = useBarWidth();
   const rightBarWidth = Math.max(0, barWidth - barTerminalWidth);
@@ -1006,26 +1075,30 @@ const JOBars = React.memo(function JOBars({
         ]}
       >
         <View style={styles.textWrapper}>
-          <Typography
-            adjustsFontSizeToFit
-            numberOfLines={1}
-            style={[styles.text, { shadowOpacity: 0 }]}
-          >
-            {(trainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={[styles.textEn, { shadowOpacity: 0 }]}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (trainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              numberOfLines={1}
+              style={[styles.text, { shadowOpacity: 0 }]}
+            >
+              {(trainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={[styles.textEn, { shadowOpacity: 0 }]}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (trainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
 
         <Typography
@@ -1037,9 +1110,12 @@ const JOBars = React.memo(function JOBars({
             },
           ]}
         >
-          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          {(currentLine?.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-          {(currentLine?.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          {joinLineText(
+            isJaEnabled,
+            isEnEnabled,
+            currentLine?.nameShort,
+            currentLine?.nameRoman
+          )}
         </Typography>
       </View>
 
@@ -1056,26 +1132,30 @@ const JOBars = React.memo(function JOBars({
         ]}
       >
         <View style={styles.textWrapper}>
-          <Typography
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            style={[styles.text, { shadowOpacity: 0 }]}
-          >
-            {(nextTrainType.name ?? '')
-              .replace('\n', '')
-              .replace(parenthesisRegexp, '')}
-          </Typography>
-          <Typography
-            adjustsFontSizeToFit
-            style={[styles.textEn, { shadowOpacity: 0 }]}
-            numberOfLines={1}
-          >
-            {truncateTrainType(
-              (nextTrainType.nameRoman ?? '')
+          {isJaEnabled ? (
+            <Typography
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              style={[styles.text, { shadowOpacity: 0 }]}
+            >
+              {(nextTrainType.name ?? '')
                 .replace('\n', '')
-                .replace(parenthesisRegexp, '')
-            )}
-          </Typography>
+                .replace(parenthesisRegexp, '')}
+            </Typography>
+          ) : null}
+          {isEnEnabled ? (
+            <Typography
+              adjustsFontSizeToFit
+              style={[styles.textEn, { shadowOpacity: 0 }]}
+              numberOfLines={1}
+            >
+              {truncateTrainType(
+                (nextTrainType.nameRoman ?? '')
+                  .replace('\n', '')
+                  .replace(parenthesisRegexp, '')
+              )}
+            </Typography>
+          ) : null}
         </View>
 
         <Typography
@@ -1087,9 +1167,12 @@ const JOBars = React.memo(function JOBars({
             },
           ]}
         >
-          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          {(nextLine.nameShort ?? '').replace(parenthesisRegexp, '')}{' '}
-          {(nextLine.nameRoman ?? '').replace(parenthesisRegexp, '')}
+          {joinLineText(
+            isJaEnabled,
+            isEnEnabled,
+            nextLine.nameShort,
+            nextLine.nameRoman
+          )}
         </Typography>
       </View>
     </View>
@@ -1194,10 +1277,14 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
   const { selectedDirection, stations, selectedBound } =
     useAtomValue(stationState);
   const theme = useAtomValue(themeAtom);
+  const { enabledLanguages } = useAtomValue(navigationState);
   const station = useCurrentStation();
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
   const nextTrainType = useNextTrainType();
+
+  const isJaEnabled = enabledLanguages.includes('JA');
+  const isEnEnabled = enabledLanguages.includes('EN');
 
   const nextLine = useMemo(() => nextTrainType?.line, [nextTrainType]);
 
@@ -1378,6 +1465,8 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
+            isJaEnabled={isJaEnabled}
+            isEnEnabled={isEnEnabled}
           />
         );
       case 'YAMANOTE':
@@ -1389,6 +1478,8 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
+            isJaEnabled={isJaEnabled}
+            isEnEnabled={isEnEnabled}
           />
         );
       case 'ODAKYU':
@@ -1398,6 +1489,8 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
             nextLine={nextLine}
             trainType={trainType}
             nextTrainType={nextTrainType}
+            isJaEnabled={isJaEnabled}
+            isEnEnabled={isEnEnabled}
           />
         );
       default:
@@ -1409,6 +1502,8 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
             nextTrainType={nextTrainType}
             getBarGradient={getBarGradient}
             getBoxGradient={getBoxGradient}
+            isJaEnabled={isJaEnabled}
+            isEnEnabled={isEnEnabled}
           />
         );
     }
@@ -1421,21 +1516,27 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     theme,
     getBarGradient,
     getBoxGradient,
+    isJaEnabled,
+    isEnEnabled,
   ]);
 
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.top}>
-        <HeadingJa headingTexts={headingTexts} />
-        <HeadingEn headingTexts={headingTexts} />
+        {isJaEnabled ? <HeadingJa headingTexts={headingTexts} /> : null}
+        {isEnEnabled ? <HeadingEn headingTexts={headingTexts} /> : null}
       </View>
       <View style={styles.bottom}>
-        <Typography style={styles.headingJa}>
-          {currentTypeFinalStation?.name}
-        </Typography>
-        <Typography style={styles.headingEn}>
-          {currentTypeFinalStation?.nameRoman}
-        </Typography>
+        {isJaEnabled && currentTypeFinalStation?.name ? (
+          <Typography style={styles.headingJa}>
+            {currentTypeFinalStation.name}
+          </Typography>
+        ) : null}
+        {isEnEnabled && currentTypeFinalStation?.nameRoman ? (
+          <Typography style={styles.headingEn}>
+            {currentTypeFinalStation.nameRoman}
+          </Typography>
+        ) : null}
         <BarsComponent />
       </View>
     </SafeAreaView>

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -368,7 +368,7 @@ const EastBars = React.memo(function EastBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -423,7 +423,7 @@ const EastBars = React.memo(function EastBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -657,7 +657,7 @@ const OdakyuBars = React.memo(function OdakyuBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -727,7 +727,7 @@ const OdakyuBars = React.memo(function OdakyuBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -906,7 +906,7 @@ const SaikyoBars = React.memo(function SaikyoBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -1089,7 +1089,10 @@ const JOBars = React.memo(function JOBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={[styles.textEn, { shadowOpacity: 0 }]}
+              style={[
+                isJaEnabled ? styles.textEn : styles.text,
+                { shadowOpacity: 0 },
+              ]}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -1146,7 +1149,10 @@ const JOBars = React.memo(function JOBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={[styles.textEn, { shadowOpacity: 0 }]}
+              style={[
+                isJaEnabled ? styles.textEn : styles.text,
+                { shadowOpacity: 0 },
+              ]}
               numberOfLines={1}
             >
               {truncateTrainType(
@@ -1224,6 +1230,7 @@ const HeadingJa = React.memo(
 const HeadingEn = React.memo(
   ({
     headingTexts,
+    isJaEnabled,
   }: {
     headingTexts: {
       jaPrefix: string;
@@ -1231,6 +1238,7 @@ const HeadingEn = React.memo(
       jaSuffix?: string;
       enSuffix?: string;
     } | null;
+    isJaEnabled: boolean;
   }) => {
     const trainType = useCurrentTrainType();
     const nextTrainType = useNextTrainType();
@@ -1239,9 +1247,11 @@ const HeadingEn = React.memo(
       return null;
     }
 
+    const headingStyle = isJaEnabled ? styles.headingEn : styles.headingJa;
+
     if (headingTexts.enSuffix) {
       return (
-        <Typography style={styles.headingEn}>
+        <Typography style={headingStyle}>
           {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
           {headingTexts.enPrefix}{' '}
           <Typography
@@ -1260,7 +1270,7 @@ const HeadingEn = React.memo(
     }
 
     return (
-      <Typography style={styles.headingEn}>{headingTexts.enPrefix}</Typography>
+      <Typography style={headingStyle}>{headingTexts.enPrefix}</Typography>
     );
   }
 );
@@ -1524,7 +1534,9 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     <SafeAreaView style={styles.container}>
       <View style={styles.top}>
         {isJaEnabled ? <HeadingJa headingTexts={headingTexts} /> : null}
-        {isEnEnabled ? <HeadingEn headingTexts={headingTexts} /> : null}
+        {isEnEnabled ? (
+          <HeadingEn headingTexts={headingTexts} isJaEnabled={isJaEnabled} />
+        ) : null}
       </View>
       <View style={styles.bottom}>
         {isJaEnabled && currentTypeFinalStation?.name ? (
@@ -1533,7 +1545,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
           </Typography>
         ) : null}
         {isEnEnabled && currentTypeFinalStation?.nameRoman ? (
-          <Typography style={styles.headingEn}>
+          <Typography style={isJaEnabled ? styles.headingEn : styles.headingJa}>
             {currentTypeFinalStation.nameRoman}
           </Typography>
         ) : null}

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -963,7 +963,7 @@ const SaikyoBars = React.memo(function SaikyoBars({
           {isEnEnabled ? (
             <Typography
               adjustsFontSizeToFit
-              style={styles.textEn}
+              style={isJaEnabled ? styles.textEn : styles.text}
               numberOfLines={1}
             >
               {truncateTrainType(


### PR DESCRIPTION
## 概要

乗り換え案内画面 (Transfers / TransfersYamanote) と種別変更通知画面 (TypeChangeNotify) で「表示する言語」設定が無視され、JA/EN/ZH/KO のすべてが常時表示されていた不具合を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `Transfers.tsx` / `TransfersYamanote.tsx` で `navigationState.enabledLanguages` を購読し、JA/EN/ZH/KO の各言語を有効状態に応じて出し分け
- 路線名・乗り換え駅名ともに、ZH と KO は両方有効なら `" / "` 区切り、片方のみ有効なら単独行で描画
- `TypeChangeNotify.tsx` でも上部 HeadingJa/HeadingEn、種別変更後駅名、各テーマの Bars (East/Odakyu/Saikyo/JO) における種別ボックスと路線名行を enabledLanguages で出し分け
- JA が無効で EN のみ有効な場合は、Transfers / TransfersYamanote / TypeChangeNotify いずれもメイン表記が貧弱にならないよう EN を JA と同じフォントサイズに昇格 (`styles.lineName` / `styles.text` / `styles.headingJa` を流用)
- `TypeChangeNotify.test.tsx` の `useAtomValue` モックに `navigationState` 用の case を追加し、既存テストが新しい依存に追従するようにした

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 利用者の有効言語設定（日本語/英語/中国語/韓国語）に基づき、路線名・駅名・見出し・種別表示を動的に切替え、CJK表記の併記にも対応。

* **Refactor**
  * 表示ロジックを言語フラグ中心に整理し、表示結合の挙動を言語ごとに明確化。

* **Tests**
  * 言語設定パターン（単独／組合せ）を検証するテストを追加・モック整備。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->