### PR TITLE
useDeepLink のテストを flaky から安定化

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -157,8 +157,31 @@ describe('useDeepLink', () => {
     return { mockFetchByGroup, mockFetchByLine, mockFetchByIds };
   };
 
+  beforeEach(() => {
+    // jest.clearAllMocks (afterEach) clears call history but not
+    // mockReturnValue / mockReturnValueOnce settings — those leak across
+    // tests and cause order-dependent flakes (e.g. an isReady queue from
+    // a previous test resuming on the next render). Reset and re-seed the
+    // module-level mocks here so every test starts from the same baseline.
+    mockGetInitialURL.mockReset().mockResolvedValue(null);
+    mockParse.mockReset();
+    mockAddEventListener.mockReset().mockReturnValue({ remove: jest.fn() });
+    (navigationRef.isReady as jest.Mock).mockReset().mockReturnValue(false);
+    (navigationRef.dispatch as jest.Mock).mockReset();
+    (
+      resolveSidsFromShortId as jest.MockedFunction<
+        typeof resolveSidsFromShortId
+      >
+    ).mockReset();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+    // Belt-and-suspenders: if a test forgot to call useRealTimers, leaked
+    // fake timers would silently change the behavior of every subsequent
+    // test. Force-restore real timers and drop any pending fake timers.
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('初回URLがある場合にstateを設定する', async () => {
@@ -439,13 +462,18 @@ describe('useDeepLink', () => {
   });
 
   it('初回URL処理完了前はinitialUrlProcessedがfalse', () => {
+    // The pending Promise from getInitialURL never resolves, so the
+    // initialUrlProcessed effect stays awaiting forever. Unmounting at the
+    // end releases React's hold on the resolver, otherwise the dangling
+    // microtask lingers past the test and contributes to Jest's
+    // "did not exit one second after" warning.
     mockGetInitialURL.mockReturnValue(new Promise(() => {}));
 
     setupAtoms();
     setupQueries();
 
     const hookRef: { current: HookResult } = { current: null };
-    render(
+    const { unmount } = render(
       <HookBridge
         onReady={(value) => {
           hookRef.current = value;
@@ -454,6 +482,7 @@ describe('useDeepLink', () => {
     );
 
     expect(hookRef.current?.initialUrlProcessed).toBe(false);
+    unmount();
   });
 
   it('初回URL処理完了後にinitialUrlProcessedがtrue', async () => {
@@ -640,21 +669,16 @@ describe('useDeepLink', () => {
       />
     );
 
-    // Flush the async chain: getInitialURL → handleUrl → openLink → fetchByLine → navigateToMain → waitForNavReady
+    // advanceTimersByTimeAsync interleaves timer firing with microtask
+    // flushing, so the whole chain (getInitialURL → handleUrl → openLink →
+    // fetchByLine → navigateToMain → waitForNavReady retry loop → warn)
+    // progresses deterministically. The manual `for` + `Promise.resolve()`
+    // pattern relied on a fixed number of microtask drains that could fall
+    // short under load and leave `warnSpy` un-invoked.
+    // Retry delays: 100 + 200 + 400 + 800 = 1500ms — 2000ms covers the
+    // whole sequence plus the final reject microtask.
     await act(async () => {
-      for (let i = 0; i < 10; i++) {
-        await Promise.resolve();
-      }
-    });
-
-    // Advance past all retry delays (100 + 200 + 400 + 800 = 1500ms)
-    await act(async () => {
-      jest.advanceTimersByTime(1500);
-    });
-
-    // Flush the promise resolution after retries exhaust
-    await act(async () => {
-      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(2000);
     });
 
     expect(mockDispatch).not.toHaveBeenCalled();
@@ -663,7 +687,6 @@ describe('useDeepLink', () => {
     );
 
     warnSpy.mockRestore();
-    jest.useRealTimers();
   });
 
   it('sidsが指定された場合はstations(ids)で取得し順序を保つ', async () => {
@@ -1297,10 +1320,6 @@ describe('useDeepLink', () => {
       typeof resolveSidsFromShortId
     >;
 
-    afterEach(() => {
-      mockResolveSids.mockReset();
-    });
-
     it('idが指定された場合はresolverからsidsを取得しstations(ids)で解決する', async () => {
       const stationA = createStation(1131211, {
         line: { id: 11302 },
@@ -1844,10 +1863,6 @@ describe('useDeepLink', () => {
       typeof resolveSidsFromShortId
     >;
 
-    afterEach(() => {
-      mockResolveSids.mockReset();
-    });
-
     const buildTwoStations = () => [
       createStation(1131211, {
         line: { id: 11302 },
@@ -2176,6 +2191,11 @@ describe('useDeepLink', () => {
   });
 
   it('ナビゲーターがリトライ中に準備完了した場合はナビゲートする', async () => {
+    // The previous version used real timers and waited up to 5s for the
+    // 100ms retry to fire — under CI load that real-time wait was the
+    // primary flake. Fake timers make the retry deterministic.
+    jest.useFakeTimers();
+
     const mockDispatch = navigationRef.dispatch as jest.Mock;
     const mockIsReady = navigationRef.isReady as jest.Mock;
     // First two calls return false (navigateToMain check + waitForNavReady first check),
@@ -2218,17 +2238,17 @@ describe('useDeepLink', () => {
       />
     );
 
-    // Wait for the retry to succeed and dispatch to be called (~100ms for first retry)
-    await waitFor(
-      () => {
-        expect(mockDispatch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: 'NAVIGATE',
-            payload: { name: 'MainStack', params: { screen: 'Main' } },
-          })
-        );
-      },
-      { timeout: 5000 }
+    // First retry fires at 100ms. 200ms gives a comfortable margin for the
+    // async chain + microtasks that follow the timer callback.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(200);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'NAVIGATE',
+        payload: { name: 'MainStack', params: { screen: 'Main' } },
+      })
     );
   });
 });


### PR DESCRIPTION
## 概要

`src/hooks/useDeepLink.test.tsx` が flaky だったので、テスト間のモック・タイマー漏れを断ち切り、実時間依存を fake timer 化して安定化させた。アプリ本体 (`src/hooks/useDeepLink.ts` 等) の挙動には変更なし。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

flaky の根本原因は次の 4 点だった:

1. **モック設定の漏れ** — `jest.clearAllMocks()` は `.mock.calls` のみクリアし、`mockReturnValue` / `mockReturnValueOnce` キューは保持される。`navigationRef.isReady` の戻り値が前テストの設定を引き継いでいた。
2. **保留タイマーの漏れ** — `waitForNavReady` が仕込む `setTimeout` (最大 1500ms) がテスト境界を越えて生き残り得た。
3. **fake timer テストの手動 flushing** — `for + Promise.resolve()` ループが microtask の解決順に依存して脆かった。
4. **実時間 100ms 待ち** — `ナビゲーターがリトライ中に準備完了した場合はナビゲートする` テストが実時間で `waitFor({ timeout: 5000 })` していたため、CI 負荷で 100ms の `setTimeout` が遅延すると失敗し得た。

対応:

- グローバル `beforeEach` を追加し、`Linking.*` / `navigationRef.*` / `resolveSidsFromShortId` のモックを `mockReset()` + デフォルト再シードする
- グローバル `afterEach` に `jest.clearAllTimers()` + `jest.useRealTimers()` を追加し、fake timer 漏れに対する防御を入れる
- `describe('id ...')` / `describe('tt* ...')` 内の重複した `mockResolveSids.mockReset()` afterEach を削除 (グローバル beforeEach で一括処理されるため)
- `ナビゲーターが未準備の場合はリトライ後にナビゲートしない` を `jest.advanceTimersByTimeAsync(2000)` で書き換え (手動 flushing を排除)
- `ナビゲーターがリトライ中に準備完了した場合はナビゲートする` を fake timer 化し、`jest.advanceTimersByTimeAsync(200)` で 100ms リトライを決定的に進める
- `初回URL処理完了前はinitialUrlProcessedがfalse` で `render()` の戻り値の `unmount()` を呼び、永遠 pending な `getInitialURL` Promise が次のテストへ漏れないようにする

ローカルで 10 連続実行・並列実行 (hooks 配下 56 ファイル 640 件) とも全件パスを確認した。

なお `Jest did not exit one second after the test run has completed` 警告は依然残るが、これは本テスト固有ではなく `jest-expo` / Apollo Client の global teardown 起因と推測される。本 flaky の直接原因ではないため本 PR のスコープ外。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストの安定性を向上させました。モック状態とタイマー管理を改善し、テストの一貫性が向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->