### PR TITLE
キーボード表示時にフィードバックモーダルを縦方向いっぱいに広げる

### DIFF
--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -118,6 +118,11 @@ const NewReportModal: React.FC<Props> = ({
   }, [visible]);
 
   useEffect(() => {
+    if (!visible) {
+      setIsKeyboardVisible(false);
+      return;
+    }
+
     const showSubscription = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       () => setIsKeyboardVisible(true)
@@ -131,7 +136,7 @@ const NewReportModal: React.FC<Props> = ({
       showSubscription.remove();
       hideSubscription.remove();
     };
-  }, []);
+  }, [visible]);
 
   const handleChangeText = useCallback((text: string) => {
     textRef.current = text;

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -40,8 +40,12 @@ const styles = StyleSheet.create({
     maxHeight: '100%',
   },
   scrollContent: {
+    flexGrow: 1,
     paddingHorizontal: 32,
     paddingVertical: 32,
+  },
+  pressableContent: {
+    flex: 1,
   },
   textInput: {
     borderWidth: 1,
@@ -49,6 +53,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     width: '100%',
+    flex: 1,
     fontSize: RFValue(14),
     marginTop: 8,
     textAlignVertical: 'top',
@@ -81,6 +86,7 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
   modalContent: {
+    flex: 1,
     marginTop: 21,
   },
   subtitle: {
@@ -188,7 +194,7 @@ const NewReportModal: React.FC<Props> = ({
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <Pressable onPress={Keyboard.dismiss}>
+        <Pressable onPress={Keyboard.dismiss} style={styles.pressableContent}>
           <Heading style={styles.title}>
             {translate('reportModalTitle')}
           </Heading>

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -35,6 +35,10 @@ const styles = StyleSheet.create({
   modalView: {
     borderRadius: 16,
   },
+  modalViewExpanded: {
+    flex: 1,
+    maxHeight: '100%',
+  },
   scrollContent: {
     paddingHorizontal: 32,
     paddingVertical: 32,
@@ -96,6 +100,7 @@ const NewReportModal: React.FC<Props> = ({
   const textInputRef = useRef<TextInputType>(null);
   const textRef = useRef('');
   const [charCount, setCharCount] = useState(0);
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
   // モーダルが開かれたときに初期化
   useEffect(() => {
@@ -105,6 +110,22 @@ const NewReportModal: React.FC<Props> = ({
       textInputRef.current?.clear();
     }
   }, [visible]);
+
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
+      () => setIsKeyboardVisible(true)
+    );
+    const hideSubscription = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      () => setIsKeyboardVisible(false)
+    );
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
 
   const handleChangeText = useCallback((text: string) => {
     textRef.current = text;
@@ -158,6 +179,7 @@ const NewReportModal: React.FC<Props> = ({
         {
           backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
         },
+        isKeyboardVisible && styles.modalViewExpanded,
       ]}
       dismissOnBackdropPress={!sending}
       avoidKeyboard


### PR DESCRIPTION
## 概要

入力中（キーボード表示中）に `NewReportModal` を画面いっぱいに縦方向へ広げ、入力欄も伸長させて使いやすくする。あわせて、入力前後で `TextInput` の高さが変動する見た目の不格好さを解消する。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `Keyboard.addListener` でキーボードの表示状態を購読し、`isKeyboardVisible` ステートで保持（iOS は `keyboardWillShow/Hide`、Android は `keyboardDidShow/Hide`）
- キーボード表示中のみ `CustomModal` の `contentContainerStyle` に `flex: 1` / `maxHeight: '100%'` を当てて、`CustomModal` 側の `maxHeight: '75%'` 制約を解除して縦方向にフィルさせる
- `ScrollView` (`flexGrow: 1`) / `Pressable` (`flex: 1`) / `modalContent` (`flex: 1`) / `TextInput` (`flex: 1`) を flex レイアウトにつなぎ、`TextInput` が残スペースをフィルするようにして、入力前後の高さ変動をなくす
- モーダル非表示中はキーボードイベントを購読しないよう `useEffect` を `visible` に連動させる（CodeRabbit nitpick 反映）
- `CustomModal` 側は変更しないため他モーダルへの副作用なし

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レポート作成モーダルがキーボード表示時に自動で拡張し、入力しやすい表示になります。キーボードを閉じると元のサイズに戻ります。

* **バグ修正**
  * モーダルのキーボード表示状態が正しくリセットされるようになり、表示の不整合が改善されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->