### PR TITLE
フィードバックモーダルを縦方向いっぱいに広げる

### DIFF
--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -33,11 +33,17 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
   },
   modalView: {
+    flex: 1,
+    maxHeight: '100%',
     borderRadius: 16,
   },
   scrollContent: {
+    flexGrow: 1,
     paddingHorizontal: 32,
     paddingVertical: 32,
+  },
+  pressableContent: {
+    flex: 1,
   },
   textInput: {
     borderWidth: 1,
@@ -45,6 +51,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     width: '100%',
+    height: 128,
     fontSize: RFValue(14),
     marginTop: 8,
     textAlignVertical: 'top',
@@ -77,6 +84,7 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
   modalContent: {
+    flex: 1,
     marginTop: 21,
   },
   subtitle: {
@@ -166,7 +174,7 @@ const NewReportModal: React.FC<Props> = ({
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <Pressable onPress={Keyboard.dismiss}>
+        <Pressable onPress={Keyboard.dismiss} style={styles.pressableContent}>
           <Heading style={styles.title}>
             {translate('reportModalTitle')}
           </Heading>


### PR DESCRIPTION
## 概要

フィードバックモーダル内側に発生していた余白を減らすため、モーダル本体を縦方向いっぱいに展開する。あわせて本文入力欄 (TextInput) を固定高さにし、入力中もキーボード開閉時もサイズが変動しないようにした。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `NewReportModal` のモーダル本体に `flex: 1` / `maxHeight: '100%'` を当てて常に縦方向いっぱいに表示するように変更
- 本文入力欄 (TextInput) を `height: 128` の固定サイズに変更し、入力前後・キーボード開閉に関わらず大きさが変わらないようにした
- 上記に伴い、`ScrollView` / `Pressable` / 本文ラッパー View に `flex` 系プロパティを追加して縦方向の領域を吸収

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * レポート作成モーダルのレイアウトを改善しました。スクロール領域の伸長、入力フィールドのサイズ制御、キーボード操作時の使いやすさが向上しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->