### PR TITLE
Headerの長い駅名はフォント縮小ではなく文字幅を圧縮して表示するように変更

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -4,7 +4,7 @@ import { useClock } from '../hooks';
 import { translate } from '../translation';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBox from './TrainTypeBoxE231';
@@ -242,14 +242,21 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
             ) : null}
             <View style={styles.stationNameWrapper}>
               <Typography
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(
-                  stationText,
-                  0.5,
-                  styles.stationName.fontSize
-                )}
                 numberOfLines={1}
-                style={styles.stationName}
+                style={[
+                  styles.stationName,
+                  {
+                    transform: [
+                      {
+                        scaleX: calcStationNameScaleX(
+                          stationText,
+                          0.5,
+                          styles.stationName.fontSize
+                        ),
+                      },
+                    ],
+                  },
+                ]}
               >
                 {stationText}
               </Typography>

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -5,7 +5,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useLoopLine } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { HeaderE235Props } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -38,15 +38,20 @@ const styles = StyleSheet.create({
     color: '#fff',
     textAlign: 'right',
   },
+  // 駅名 Text は自然な幅でレンダリングさせ、横方向の縮みは transform: scaleX で行う。
+  // flex: 1 を Text 自身に持たせると幅が拘束されて先に切り詰められてしまうため、
+  // 隣接アイコンの右側の余白を埋める役割は stationNameSlot 側に持たせる。
   stationName: {
     fontWeight: 'bold',
     color: '#fff',
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    flex: 1,
     textAlign: 'center',
     fontSize: STATION_NAME_FONT_SIZE,
+  },
+  stationNameSlot: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
   },
   left: {
     flex: 0.3,
@@ -225,14 +230,21 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
               transformOrigin="bottom"
             />
           ) : null}
-          <Typography
-            style={styles.stationName}
-            adjustsFontSizeToFit
-            minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
-            numberOfLines={1}
-          >
-            {stationText}
-          </Typography>
+          <View style={styles.stationNameSlot}>
+            <Typography
+              style={[
+                styles.stationName,
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.5) },
+                  ],
+                },
+              ]}
+              numberOfLines={1}
+            >
+              {stationText}
+            </Typography>
+          </View>
         </View>
       </View>
       <Clock white style={styles.clockOverride} />

--- a/src/components/HeaderEast/HeaderEast.tsx
+++ b/src/components/HeaderEast/HeaderEast.tsx
@@ -5,7 +5,7 @@ import { MARK_SHAPE, STATION_NAME_FONT_SIZE } from '../../constants';
 import { useHeaderAnimation, useLandscapeWindowDimensions } from '../../hooks';
 import isTablet from '../../utils/isTablet';
 import { RFValue } from '../../utils/rfValue';
-import { calcStationNameMinScale } from '../../utils/stationNameScale';
+import { calcStationNameScaleX } from '../../utils/stationNameScale';
 import type { CommonHeaderProps } from '../Header.types';
 import NumberingIcon from '../NumberingIcon';
 import TrainTypeBox from '../TrainTypeBox';
@@ -289,11 +289,17 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 config.stationNameContainerAlignItems
                   ? { alignItems: config.stationNameContainerAlignItems }
                   : undefined,
+                // 文字サイズは縮めず、Text 自体は自然な幅で描画させ、
+                // 折返し進入アニメーション（scaleY）と独立した横方向圧縮を
+                // ラッパー View 側の transform で行う。
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.55) },
+                  ],
+                },
               ]}
             >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   styles.stationName,
@@ -315,14 +321,19 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 config.stationNameContainerAlignItems
                   ? { alignItems: config.stationNameContainerAlignItems }
                   : undefined,
+                {
+                  transform: [
+                    {
+                      scaleX: calcStationNameScaleX(
+                        animation.prevStationText,
+                        0.55
+                      ),
+                    },
+                  ],
+                },
               ]}
             >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(
-                  animation.prevStationText,
-                  0.55
-                )}
                 numberOfLines={1}
                 style={[
                   styles.stationName,

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -6,7 +6,7 @@ import { useLoopLine } from '~/hooks';
 import { STATION_NAME_FONT_SIZE } from '../constants';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -38,16 +38,21 @@ const styles = StyleSheet.create({
     textAlign: 'right',
     fontSize: RFValue(14),
   },
+  // 駅名 Text は自然な幅で描画し、収まらないぶんは transform: scaleX で字詰めする。
+  // flex: 1 を Text に持たせると先に幅で切り詰められてしまうので、
+  // 縦横方向の領域確保は stationNameSlot 側に分離する。
   stationName: {
     fontWeight: 'bold',
     color: '#fff',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: 32,
-    flexWrap: 'wrap',
-    flex: 1,
     textAlign: 'center',
     fontSize: STATION_NAME_FONT_SIZE,
+  },
+  stationNameSlot: {
+    flex: 1,
+    marginTop: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
   },
   left: {
     flex: 0.2,
@@ -228,14 +233,21 @@ const HeaderJL: React.FC<CommonHeaderProps> = (props) => {
               transformOrigin="bottom"
             />
           ) : null}
-          <Typography
-            style={styles.stationName}
-            adjustsFontSizeToFit
-            minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
-            numberOfLines={1}
-          >
-            {stationText}
-          </Typography>
+          <View style={styles.stationNameSlot}>
+            <Typography
+              style={[
+                styles.stationName,
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.5) },
+                  ],
+                },
+              ]}
+              numberOfLines={1}
+            >
+              {stationText}
+            </Typography>
+          </View>
         </View>
       </View>
       <View style={styles.clockContainer}>

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -5,7 +5,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useHeaderAnimation } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TrainTypeBoxJRKyushu from './TrainTypeBoxJRKyushu';
@@ -215,10 +215,20 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
           </View>
 
           <View style={styles.stationNameWrapper}>
-            <View style={styles.stationNameContainer}>
+            <View
+              style={[
+                styles.stationNameContainer,
+                // 文字サイズは縮めず、Text 自体は自然な幅で描画させて、
+                // 切替アニメーション（scaleY）と独立した横方向圧縮を
+                // ラッパー View 側の transform で行う。
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.55) },
+                  ],
+                },
+              ]}
+            >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   animation.topNameAnimatedStyles,
@@ -233,13 +243,22 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
                 {stationText}
               </RNAnimated.Text>
             </View>
-            <View style={styles.stationNameContainer}>
+            <View
+              style={[
+                styles.stationNameContainer,
+                {
+                  transform: [
+                    {
+                      scaleX: calcStationNameScaleX(
+                        animation.prevStationText,
+                        0.55
+                      ),
+                    },
+                  ],
+                },
+              ]}
+            >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(
-                  animation.prevStationText,
-                  0.55
-                )}
                 numberOfLines={1}
                 style={[
                   animation.bottomNameAnimatedStyles,

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -12,7 +12,7 @@ import {
 } from '../constants';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
 import TransferLineMark from './TransferLineMark';
@@ -530,10 +530,15 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
           ) : null}
           <View style={styles.stationNameContainer}>
             <Typography
-              adjustsFontSizeToFit
-              minimumFontScale={calcStationNameMinScale(stationText, 0.5)}
               numberOfLines={1}
-              style={styles.stationName}
+              style={[
+                styles.stationName,
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.5) },
+                  ],
+                },
+              ]}
             >
               {stationText}
             </Typography>

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -12,7 +12,7 @@ import { STATION_NAME_FONT_SIZE } from '../constants';
 import { useHeaderAnimation } from '../hooks';
 import isTablet from '../utils/isTablet';
 import { RFValue } from '../utils/rfValue';
-import { calcStationNameMinScale } from '../utils/stationNameScale';
+import { calcStationNameScaleX } from '../utils/stationNameScale';
 import Clock from './Clock';
 import type { CommonHeaderProps } from './Header.types';
 import NumberingIcon from './NumberingIcon';
@@ -238,10 +238,20 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             />
           ) : null}
           <View style={styles.stationNameWrapper}>
-            <View style={styles.stationNameContainer}>
+            <View
+              style={[
+                styles.stationNameContainer,
+                // 文字サイズは縮めず、Text 自体は自然な幅で描画させて、
+                // 切替アニメーション（scaleY）と独立した横方向圧縮を
+                // ラッパー View 側の transform で行う。
+                {
+                  transform: [
+                    { scaleX: calcStationNameScaleX(stationText, 0.55) },
+                  ],
+                },
+              ]}
+            >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(stationText, 0.55)}
                 numberOfLines={1}
                 style={[
                   animation.topNameAnimatedStyles,
@@ -257,13 +267,22 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
               </RNAnimated.Text>
             </View>
 
-            <View style={styles.stationNameContainer}>
+            <View
+              style={[
+                styles.stationNameContainer,
+                {
+                  transform: [
+                    {
+                      scaleX: calcStationNameScaleX(
+                        animation.prevStationText,
+                        0.55
+                      ),
+                    },
+                  ],
+                },
+              ]}
+            >
               <RNAnimated.Text
-                adjustsFontSizeToFit
-                minimumFontScale={calcStationNameMinScale(
-                  animation.prevStationText,
-                  0.55
-                )}
                 numberOfLines={1}
                 style={[
                   animation.bottomNameAnimatedStyles,

--- a/src/utils/stationNameScale.test.ts
+++ b/src/utils/stationNameScale.test.ts
@@ -1,7 +1,7 @@
 import { Dimensions } from 'react-native';
-import { calcStationNameMinScale } from './stationNameScale';
+import { calcStationNameScaleX } from './stationNameScale';
 
-describe('calcStationNameMinScale', () => {
+describe('calcStationNameScaleX', () => {
   const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
 
   beforeEach(() => {
@@ -19,36 +19,32 @@ describe('calcStationNameMinScale', () => {
   });
 
   it('空文字は早期 return で 1 を返す', () => {
-    expect(calcStationNameMinScale('', 0.6, 50)).toBe(1);
+    expect(calcStationNameScaleX('', 0.6, 50)).toBe(1);
   });
 
-  it('短い駅名は上限 1 にクランプされる', () => {
-    expect(calcStationNameMinScale('あ', 0.6, 50)).toBe(1);
+  it('短い駅名は上限 1 にクランプされる（圧縮しない）', () => {
+    expect(calcStationNameScaleX('あ', 0.6, 50)).toBe(1);
   });
 
-  it('極端に長い駅名はフロア値 0.1 にクランプされる', () => {
-    expect(calcStationNameMinScale('あ'.repeat(1000), 0.6, 50)).toBe(0.1);
+  it('極端に長い駅名はフロア値 0.5 にクランプされる', () => {
+    expect(calcStationNameScaleX('あ'.repeat(1000), 0.6, 50)).toBe(0.5);
   });
 
-  it('中間長の駅名は (0.1, 1) の範囲内のスケールを返す', () => {
-    const scale = calcStationNameMinScale(
-      'はねだくうこうだいさんたーみなる',
-      0.55,
-      45
-    );
-    expect(scale).toBeGreaterThan(0.1);
-    expect(scale).toBeLessThan(1);
+  it('中間長の駅名は (0.5, 1) の範囲内の圧縮率を返す', () => {
+    const scaleX = calcStationNameScaleX('はねだくうこうだい', 0.55, 45);
+    expect(scaleX).toBeGreaterThan(0.5);
+    expect(scaleX).toBeLessThan(1);
   });
 
-  it('文字数に応じて単調にスケールが減少する', () => {
-    const shortScale = calcStationNameMinScale('みと', 0.55, 45);
-    const midScale = calcStationNameMinScale('はねだくうこう', 0.55, 45);
-    const longScale = calcStationNameMinScale(
+  it('文字数に応じて単調に圧縮率が減少する', () => {
+    const shortScaleX = calcStationNameScaleX('みと', 0.55, 45);
+    const midScaleX = calcStationNameScaleX('はねだくうこう', 0.55, 45);
+    const longScaleX = calcStationNameScaleX(
       'ちょうじゃがはまましおさいはまなすこうえんまえ',
       0.55,
       45
     );
-    expect(shortScale).toBeGreaterThanOrEqual(midScale);
-    expect(midScale).toBeGreaterThan(longScale);
+    expect(shortScaleX).toBeGreaterThanOrEqual(midScaleX);
+    expect(midScaleX).toBeGreaterThan(longScaleX);
   });
 });

--- a/src/utils/stationNameScale.ts
+++ b/src/utils/stationNameScale.ts
@@ -1,16 +1,21 @@
 import { Dimensions } from 'react-native';
 import { STATION_NAME_FONT_SIZE } from '../constants';
 
-const MIN_SCALE_FLOOR = 0.1;
+// 横方向圧縮の下限。実機の駅名 LCD（JR 東日本 E235 系など）は長い駅名を
+// およそ 50% 程度まで字幅を詰めて表示するため、その下限に合わせて 0.5 を採用する。
+// これより下げると視認性が著しく落ちるので、これ以上は文字幅を縮めない。
+const MIN_SCALE_FLOOR = 0.5;
 // 実フォントの 1 文字あたりの幅は fontSize より狭い（Roboto Bold + CJK でおよそ 0.65〜0.75）。
 // 1.0 寄りで見積もると KANA や長い英字駅名で「画面幅にはまだ余裕があるのにスケールが下がる」
 // 状態になるため、実描画に近い値まで下げる。
 const CHAR_WIDTH_RATIO = 0.7;
 
-// adjustsFontSizeToFit は minimumFontScale 未指定だと 0.01 倍まで縮むため、
-// 「はねだくうこうだいさんたーみなる」のような長文駅名で文字が潰れる。
-// 画面幅にぎりぎり収まるスケールをフロアにして、それ以下の縮小を防ぐ。
-export const calcStationNameMinScale = (
+// Header の駅名 Text に `transform: [{ scaleX }]` として渡す横方向圧縮率を返す。
+// 駅名がコンテナ幅に収まる場合は 1（無加工）を返し、はみ出す場合のみ
+// 1 文字分の幅を狭めて全文を画面内に収める。フォントサイズ自体は変えず、
+// 実車内 LCD のように「字を縦に長く・横に詰めて」表示することで、長い駅名でも
+// 高さを保ったまま読ませる演出を実現する。
+export const calcStationNameScaleX = (
   text: string,
   widthRatio = 0.6,
   baseFontSize: number = STATION_NAME_FONT_SIZE
@@ -20,6 +25,6 @@ export const calcStationNameMinScale = (
   }
   const availableWidth = Dimensions.get('window').width * widthRatio;
   const requiredFontSize = availableWidth / (text.length * CHAR_WIDTH_RATIO);
-  const scale = requiredFontSize / baseFontSize;
-  return Math.min(1, Math.max(scale, MIN_SCALE_FLOOR));
+  const scaleX = requiredFontSize / baseFontSize;
+  return Math.min(1, Math.max(scaleX, MIN_SCALE_FLOOR));
 };


### PR DESCRIPTION
## 概要

Header コンポーネントで長い駅名を表示する際、これまでは `adjustsFontSizeToFit` でフォント自体を縮小していましたが、実車内 LCD（JR 東日本 E235 系など）の見た目に合わせて「フォントサイズは保ったまま 1 文字あたりの幅を圧縮する」方式に切り替えました。リアリティ向上のための表示方法の差し替えです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/stationNameScale.ts`: 関数を `calcStationNameMinScale` → `calcStationNameScaleX` にリネームし、用途を `minimumFontScale` から `transform: scaleX` 向けに変更。下限を 0.1 → 0.5（実機 LCD 相当、半分以下には潰さない）に引き上げ。
- アニメーションを伴う Header（`HeaderEast` / `HeaderSaikyo` / `HeaderJRKyushu`）: 駅名 Text の `scaleY` アニメーションを壊さないよう、ラッパー `View` 側に `transform: [{ scaleX }]` を適用。`adjustsFontSizeToFit` / `minimumFontScale` は除去。
- `HeaderE235` / `HeaderJL`: Text の `flex: 1` を新設の `stationNameSlot` View に逃がし、Text 自身は自然幅で描画 → `scaleX` で圧縮。
- `HeaderE231` / `HeaderJRWest`: 駅名 Text の style に直接 `transform: [{ scaleX }]` を追加。
- `src/utils/stationNameScale.test.ts`: 新しい関数名・下限値（0.5）に合わせてテストを更新。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZdU7aPgdHcgxPagNLeRp1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 複数のヘッダーコンポーネントにおいて、駅名の表示スケーリング方式を改善しました。長い駅名の圧縮時の表現方法を見直し、より適切な表示品質と統一性を実現しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->