### PR TITLE
Headerの極端に長い駅名がscaleX圧縮されず…で省略される問題を修正

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -165,8 +165,11 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onStationTextLayout, scaleX: stationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onStationTextLayout,
+    scaleX: stationNameScaleX,
+    naturalTextWidth: stationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
 
   const boundSuffixText = useMemo(() => {
     switch (headerLangState) {
@@ -271,8 +274,15 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
               </Typography>
               <Typography
                 numberOfLines={1}
+                ellipsizeMode="clip"
                 style={[
                   styles.stationName,
+                  // 自然幅を width に渡してスロット幅で ellipsize されないようにし、
+                  // 視覚的な収まりは scaleX に任せる。ellipsizeMode="clip" は scaleX が下限
+                  // に到達してなお収まらない場合の「…」表示を抑止する。
+                  stationNaturalTextWidth > 0
+                    ? { width: stationNaturalTextWidth }
+                    : null,
                   { transform: [{ scaleX: stationNameScaleX }] },
                 ]}
               >

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -122,8 +122,11 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onStationTextLayout, scaleX: stationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onStationTextLayout,
+    scaleX: stationNameScaleX,
+    naturalTextWidth: stationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
 
   const boundPrefix = useMemo(() => {
     switch (headerLangState) {
@@ -264,9 +267,15 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
             <Typography
               style={[
                 styles.stationName,
+                // 自然幅を明示的に width に渡してスロット幅で ellipsize されないようにする。
+                // 視覚的な収まりは scaleX に任せ、ellipsizeMode="clip" で「…」を抑止する。
+                stationNaturalTextWidth > 0
+                  ? { width: stationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: stationNameScaleX }] },
               ]}
               numberOfLines={1}
+              ellipsizeMode="clip"
             >
               {stationText}
             </Typography>

--- a/src/components/HeaderEast/HeaderEast.tsx
+++ b/src/components/HeaderEast/HeaderEast.tsx
@@ -340,6 +340,8 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                // scaleX が下限に達してなお収まらない場合の「…」表示を抑止する。
+                ellipsizeMode="clip"
                 style={[
                   styles.stationName,
                   animation.topNameAnimatedStyles,
@@ -365,6 +367,7 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                ellipsizeMode="clip"
                 style={[
                   styles.stationName,
                   animation.bottomNameAnimatedStyles,

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -134,8 +134,11 @@ const HeaderJL: React.FC<CommonHeaderProps> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onStationTextLayout, scaleX: stationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onStationTextLayout,
+    scaleX: stationNameScaleX,
+    naturalTextWidth: stationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
 
   const boundPrefix = useMemo(() => {
     switch (headerLangState) {
@@ -266,9 +269,16 @@ const HeaderJL: React.FC<CommonHeaderProps> = (props) => {
             <Typography
               style={[
                 styles.stationName,
+                // 自然幅を width に渡してスロット幅で ellipsize されないようにし、
+                // 視覚的な収まりは scaleX に任せる。ellipsizeMode="clip" は scaleX が下限
+                // に到達してなお収まらない場合の「…」表示を抑止する。
+                stationNaturalTextWidth > 0
+                  ? { width: stationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: stationNameScaleX }] },
               ]}
               numberOfLines={1}
+              ellipsizeMode="clip"
             >
               {stationText}
             </Typography>

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -267,6 +267,8 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                // scaleX が下限に達してなお収まらない場合の「…」表示を抑止する。
+                ellipsizeMode="clip"
                 style={[
                   animation.topNameAnimatedStyles,
                   styles.stationName,
@@ -288,6 +290,7 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                ellipsizeMode="clip"
                 style={[
                   animation.bottomNameAnimatedStyles,
                   styles.stationName,

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -119,8 +119,11 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onStationTextLayout, scaleX: stationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onStationTextLayout,
+    scaleX: stationNameScaleX,
+    naturalTextWidth: stationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
 
   const fetchJRWLocalLogo = useCallback((): number => {
     switch (headerLangState) {
@@ -559,8 +562,17 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
             </Typography>
             <Typography
               numberOfLines={1}
+              ellipsizeMode="clip"
               style={[
                 styles.stationName,
+                // 自然幅を明示的に width に渡してスロット幅で ellipsize されないようにし、
+                // 視覚的な収まりは scaleX に任せる。未計測時は width 指定なし
+                // （= スロット幅にフォールバック）で初期描画の見た目を維持する。
+                // ellipsizeMode="clip" は scaleX が下限に到達してなお収まらない極端な
+                // ケースで「…」が表示されるのを防ぐためのフォールバック。
+                stationNaturalTextWidth > 0
+                  ? { width: stationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: stationNameScaleX }] },
               ]}
             >

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -290,6 +290,8 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                // scaleX が下限に達してなお収まらない場合の「…」表示を抑止する。
+                ellipsizeMode="clip"
                 style={[
                   animation.topNameAnimatedStyles,
                   styles.stationName,
@@ -312,6 +314,7 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             >
               <RNAnimated.Text
                 numberOfLines={1}
+                ellipsizeMode="clip"
                 style={[
                   animation.bottomNameAnimatedStyles,
                   styles.stationName,

--- a/src/hooks/useStationNameScaleX.test.ts
+++ b/src/hooks/useStationNameScaleX.test.ts
@@ -109,12 +109,21 @@ describe('useStationNameScaleX', () => {
     expect(result.current.scaleX).toBeCloseTo(200 / 300, 5);
   });
 
-  it('過度に長い駅名でも下限 0.5 にクランプされる', () => {
+  it('過度に長い駅名でも下限 0.3 にクランプされる', () => {
     const { result } = renderHook(() => useStationNameScaleX('長い駅名', 100));
     act(() => {
       result.current.onTextLayout(textLayoutEvent([1000]));
     });
-    expect(result.current.scaleX).toBe(0.5);
+    expect(result.current.scaleX).toBe(0.3);
+  });
+
+  it('onTextLayout で計測した自然幅を返す', () => {
+    const { result } = renderHook(() => useStationNameScaleX('長い駅名', 200));
+    expect(result.current.naturalTextWidth).toBe(0);
+    act(() => {
+      result.current.onTextLayout(textLayoutEvent([320]));
+    });
+    expect(result.current.naturalTextWidth).toBe(320);
   });
 
   it('text が変わったら計測値はリセットされ、再計測前は 1 に戻る', () => {
@@ -126,6 +135,7 @@ describe('useStationNameScaleX', () => {
       result.current.onTextLayout(textLayoutEvent([400]));
     });
     expect(result.current.scaleX).toBe(0.5);
+    // 自然幅 400 / 200 = 0.5 でクランプを超えないため、下限変更の影響を受けない
 
     rerender({ text: '駅' });
     expect(result.current.scaleX).toBe(1);

--- a/src/hooks/useStationNameScaleX.ts
+++ b/src/hooks/useStationNameScaleX.ts
@@ -6,8 +6,10 @@ import type {
 } from 'react-native';
 
 // 実機の駅名 LCD（JR 東日本 E235 系など）は長い駅名をおよそ 50% 程度まで字幅を詰めて
-// 表示するため、その下限に合わせて 0.5 を採用する。これより下げると視認性が著しく落ちる。
-const MIN_SCALE_FLOOR = 0.5;
+// 表示するが、「長者ヶ浜潮騒はまなす公園前」のような極端に長い駅名は 0.5 では
+// 1 行スロットに収まらず ellipsize される。視認性下限と全文字表示の折衷として
+// 0.3 を採用する（これより下げると判読が著しく困難になる）。
+const MIN_SCALE_FLOOR = 0.3;
 
 // onLayout が報告する幅のジッターを無視するための閾値（px）。
 const MEASUREMENT_EPSILON = 0.5;
@@ -82,5 +84,8 @@ export const useStationNameScaleX = (text: string, containerWidth: number) => {
     return Math.max(MIN_SCALE_FLOOR, containerWidth / naturalTextWidth);
   }, [text, containerWidth, naturalTextWidth]);
 
-  return { onTextLayout, scaleX };
+  // 可視 Text 側で width を `naturalTextWidth` に固定するために露出する。
+  // numberOfLines={1} だけだとスロット幅で ellipsize されてしまい、transform: scaleX
+  // が掛かる前に末尾が「…」に置き換わるため、レイアウト段階で自然幅を確保する必要がある。
+  return { onTextLayout, scaleX, naturalTextWidth };
 };


### PR DESCRIPTION
## 概要

長者ヶ浜潮騒はまなす公園前のような極端に長い駅名で、Header の `scaleX` 圧縮が効かず末尾が `…` で省略される問題を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 可視 `Typography` 側に `numberOfLines={1}` のみが指定されていたため、`transform: scaleX` 適用前の layout 段階で React Native がスロット幅に合わせて末尾を ellipsize していた。`useStationNameScaleX` から `naturalTextWidth` を返し、`HeaderE231` / `HeaderE235` / `HeaderJL` / `HeaderJRWest` の可視 Text に `width: naturalTextWidth` を明示することで layout 段階の ellipsize を回避する。
- `MIN_SCALE_FLOOR` を `0.5` から `0.3` に緩和。23 文字級の駅名（例: ちょうじゃがはましおさいはまなすこうえんまえ）でも 1 行スロットに収まるようにする。視認性下限と全文字表示の折衷値で、これより下げると判読が著しく困難になるためコメントに意図を明記。
- 全 7 Header（E231 / E235 / JL / JRWest / JRKyushu / Saikyo / East）の可視 Text に `ellipsizeMode="clip"` を付与。`scaleX` が下限に達してなお収まらない極端ケースでも `…` が表示されないようにする安全弁。
- `useStationNameScaleX.test.ts` の下限値テストを 0.3 に更新し、`naturalTextWidth` を返すことを検証するテストを追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0164RvhmUUmXeF9eHmRnCtks)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 駅名表示の横方向圧縮時に不要な省略記号（…）が表示される問題を修正しました
* 駅名の自然幅計測機能を拡張し、さまざまな画面サイズでの表示精度を向上させました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->