### PR TITLE
Header駅名スロットにminWidth: 0を追加して圧縮が効かなくなる回帰を修正

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -83,6 +83,10 @@ const styles = StyleSheet.create({
   },
   stationNameWrapper: {
     flex: 1,
+    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
+    // 内側 Text の `width: naturalTextWidth` が wrapper 自身を押し広げてしまい、
+    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+    minWidth: 0,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -62,6 +62,10 @@ const styles = StyleSheet.create({
   },
   stationNameSlot: {
     flex: 1,
+    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
+    // 内側 Text の `width: naturalTextWidth` がスロット自身を押し広げてしまい、
+    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+    minWidth: 0,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'visible',

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -61,6 +61,10 @@ const styles = StyleSheet.create({
   },
   stationNameSlot: {
     flex: 1,
+    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
+    // 内側 Text の `width: naturalTextWidth` がスロット自身を押し広げてしまい、
+    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+    minWidth: 0,
     marginTop: 32,
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -44,6 +44,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     height: STATION_NAME_FONT_SIZE * 2 - 24,
+    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
+    // 内側 Text の `width: naturalTextWidth` がコンテナ自身を押し広げてしまい、
+    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+    minWidth: 0,
   },
   stationName: {
     textAlign: 'center',


### PR DESCRIPTION
## 概要

PR #6060 で導入した駅名圧縮の修正に回帰があった。可視 Text に `width: naturalTextWidth` を渡しても、スロット側のデフォルト `min-width: auto` により Text の自然幅がスロット自身を押し広げてしまい、`onLayout` が natural と同じ値を返して `scaleX = 1`（圧縮ゼロ）になっていた。実機でも「…」は消えたが文字が画面外へはみ出すだけになっていたので追従修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `HeaderE231` (`stationNameWrapper`) / `HeaderE235` (`stationNameSlot`) / `HeaderJL` (`stationNameSlot`) / `HeaderJRWest` (`stationNameContainer`) に `minWidth: 0` を追加。これにより flex 子要素の既定 `min-width: auto` を上書きし、内側 Text の `width: naturalTextWidth` がスロット／コンテナ自体を押し広げる回帰を抑止する。
- スロットの実測幅が flex 配分で決まる値に戻るため、`scaleX = containerWidth / naturalTextWidth` が想定通りに計算され、極端に長い駅名でも字幅圧縮が機能する。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0164RvhmUUmXeF9eHmRnCtks)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 複数のヘッダーコンポーネントの駅名表示レイアウトを改善しました。テキストのスケーリングと幅計算が正確に動作するように調整されています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->