### PR TITLE
Header駅名のscaleX圧縮が効かない問題を全テーマで根本修正

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -83,12 +83,22 @@ const styles = StyleSheet.create({
   },
   stationNameWrapper: {
     flex: 1,
-    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
-    // 内側 Text の `width: naturalTextWidth` が wrapper 自身を押し広げてしまい、
-    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
     minWidth: 0,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  // 可視 Text を absolute 配置の wrapper でラップしてレイアウトフローから切り離す。
+  // これをやらないと内側 Text の `width: naturalTextWidth` が wrapper や祖先 View まで
+  // 押し広げ、onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+  stationNameVisibleWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
   },
   stationName: {
     fontWeight: 'bold',
@@ -276,22 +286,24 @@ const HeaderE231: React.FC<CommonHeaderProps> = (props) => {
               >
                 {stationText}
               </Typography>
-              <Typography
-                numberOfLines={1}
-                ellipsizeMode="clip"
-                style={[
-                  styles.stationName,
-                  // 自然幅を width に渡してスロット幅で ellipsize されないようにし、
-                  // 視覚的な収まりは scaleX に任せる。ellipsizeMode="clip" は scaleX が下限
-                  // に到達してなお収まらない場合の「…」表示を抑止する。
-                  stationNaturalTextWidth > 0
-                    ? { width: stationNaturalTextWidth }
-                    : null,
-                  { transform: [{ scaleX: stationNameScaleX }] },
-                ]}
+              <View
+                style={styles.stationNameVisibleWrapper}
+                pointerEvents="none"
               >
-                {stationText}
-              </Typography>
+                <Typography
+                  numberOfLines={1}
+                  ellipsizeMode="clip"
+                  style={[
+                    styles.stationName,
+                    stationNaturalTextWidth > 0
+                      ? { width: stationNaturalTextWidth }
+                      : null,
+                    { transform: [{ scaleX: stationNameScaleX }] },
+                  ]}
+                >
+                  {stationText}
+                </Typography>
+              </View>
             </View>
           </View>
           <View style={styles.spacer}>

--- a/src/components/HeaderE235.tsx
+++ b/src/components/HeaderE235.tsx
@@ -62,10 +62,22 @@ const styles = StyleSheet.create({
   },
   stationNameSlot: {
     flex: 1,
-    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
-    // 内側 Text の `width: naturalTextWidth` がスロット自身を押し広げてしまい、
-    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
     minWidth: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
+  },
+  // 可視 Text を absolute 配置の wrapper でラップしてレイアウトフローから切り離す。
+  // これをやらないと内側 Text の `width: naturalTextWidth` がスロットや祖先 View まで
+  // 押し広げ、onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+  // wrapper 自身は left/right/top/bottom: 0 でスロット全体を覆い、その内側で
+  // alignItems/justifyContent: center により Text を視覚的に中央寄せする。
+  stationNameVisibleWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'visible',
@@ -268,21 +280,21 @@ const HeaderE235: React.FC<HeaderE235Props> = (props) => {
             >
               {stationText}
             </Typography>
-            <Typography
-              style={[
-                styles.stationName,
-                // 自然幅を明示的に width に渡してスロット幅で ellipsize されないようにする。
-                // 視覚的な収まりは scaleX に任せ、ellipsizeMode="clip" で「…」を抑止する。
-                stationNaturalTextWidth > 0
-                  ? { width: stationNaturalTextWidth }
-                  : null,
-                { transform: [{ scaleX: stationNameScaleX }] },
-              ]}
-              numberOfLines={1}
-              ellipsizeMode="clip"
-            >
-              {stationText}
-            </Typography>
+            <View style={styles.stationNameVisibleWrapper} pointerEvents="none">
+              <Typography
+                style={[
+                  styles.stationName,
+                  stationNaturalTextWidth > 0
+                    ? { width: stationNaturalTextWidth }
+                    : null,
+                  { transform: [{ scaleX: stationNameScaleX }] },
+                ]}
+                numberOfLines={1}
+                ellipsizeMode="clip"
+              >
+                {stationText}
+              </Typography>
+            </View>
           </View>
         </View>
       </View>

--- a/src/components/HeaderEast/HeaderEast.tsx
+++ b/src/components/HeaderEast/HeaderEast.tsx
@@ -138,10 +138,16 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onTopTextLayout, scaleX: topStationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
-  const { onTextLayout: onBottomTextLayout, scaleX: bottomStationNameScaleX } =
-    useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onTopTextLayout,
+    scaleX: topStationNameScaleX,
+    naturalTextWidth: topStationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onBottomTextLayout,
+    scaleX: bottomStationNameScaleX,
+    naturalTextWidth: bottomStationNaturalTextWidth,
+  } = useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
 
   const stationNameColor = config.stationNameColor ?? config.textColor;
 
@@ -332,6 +338,12 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 config.stationNameContainerAlignItems
                   ? { alignItems: config.stationNameContainerAlignItems }
                   : undefined,
+                // absolute container の幅を自然幅に明示固定する。
+                // 指定しないと Yoga の挙動次第で container が 0 や parent 幅に張り付き、
+                // 結果として scaleX の効きが視認できない（または scaleX=1 と等価）になる。
+                topStationNaturalTextWidth > 0
+                  ? { width: topStationNaturalTextWidth }
+                  : null,
                 // 文字サイズは縮めず、Text 自体は自然な幅で描画させ、
                 // 折返し進入アニメーション（scaleY）と独立した横方向圧縮を
                 // ラッパー View 側の transform で行う。
@@ -362,6 +374,9 @@ const HeaderEast: React.FC<Props> = ({ config, ...props }) => {
                 config.stationNameContainerAlignItems
                   ? { alignItems: config.stationNameContainerAlignItems }
                   : undefined,
+                bottomStationNaturalTextWidth > 0
+                  ? { width: bottomStationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: bottomStationNameScaleX }] },
               ]}
             >

--- a/src/components/HeaderJL.tsx
+++ b/src/components/HeaderJL.tsx
@@ -61,11 +61,21 @@ const styles = StyleSheet.create({
   },
   stationNameSlot: {
     flex: 1,
-    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
-    // 内側 Text の `width: naturalTextWidth` がスロット自身を押し広げてしまい、
-    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
     minWidth: 0,
     marginTop: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
+  },
+  // 可視 Text を absolute 配置の wrapper でラップしてレイアウトフローから切り離す。
+  // これをやらないと内側 Text の `width: naturalTextWidth` がスロットや祖先 View まで
+  // 押し広げ、onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+  stationNameVisibleWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'visible',
@@ -270,22 +280,21 @@ const HeaderJL: React.FC<CommonHeaderProps> = (props) => {
             >
               {stationText}
             </Typography>
-            <Typography
-              style={[
-                styles.stationName,
-                // 自然幅を width に渡してスロット幅で ellipsize されないようにし、
-                // 視覚的な収まりは scaleX に任せる。ellipsizeMode="clip" は scaleX が下限
-                // に到達してなお収まらない場合の「…」表示を抑止する。
-                stationNaturalTextWidth > 0
-                  ? { width: stationNaturalTextWidth }
-                  : null,
-                { transform: [{ scaleX: stationNameScaleX }] },
-              ]}
-              numberOfLines={1}
-              ellipsizeMode="clip"
-            >
-              {stationText}
-            </Typography>
+            <View style={styles.stationNameVisibleWrapper} pointerEvents="none">
+              <Typography
+                style={[
+                  styles.stationName,
+                  stationNaturalTextWidth > 0
+                    ? { width: stationNaturalTextWidth }
+                    : null,
+                  { transform: [{ scaleX: stationNameScaleX }] },
+                ]}
+                numberOfLines={1}
+                ellipsizeMode="clip"
+              >
+                {stationText}
+              </Typography>
+            </View>
           </View>
         </View>
       </View>

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -159,10 +159,16 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onTopTextLayout, scaleX: topStationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
-  const { onTextLayout: onBottomTextLayout, scaleX: bottomStationNameScaleX } =
-    useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onTopTextLayout,
+    scaleX: topStationNameScaleX,
+    naturalTextWidth: topStationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onBottomTextLayout,
+    scaleX: bottomStationNameScaleX,
+    naturalTextWidth: bottomStationNaturalTextWidth,
+  } = useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
 
   return (
     <View style={styles.root}>
@@ -259,6 +265,12 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             <View
               style={[
                 styles.stationNameContainer,
+                // absolute container の幅を自然幅に明示固定する。
+                // 指定しないと Yoga の挙動次第で container が 0 や parent 幅に張り付き、
+                // 結果として scaleX の効きが視認できない（または scaleX=1 と等価）になる。
+                topStationNaturalTextWidth > 0
+                  ? { width: topStationNaturalTextWidth }
+                  : null,
                 // 文字サイズは縮めず、Text 自体は自然な幅で描画させて、
                 // 切替アニメーション（scaleY）と独立した横方向圧縮を
                 // ラッパー View 側の transform で行う。
@@ -285,6 +297,9 @@ const HeaderJRKyushu: React.FC<CommonHeaderProps> = (props) => {
             <View
               style={[
                 styles.stationNameContainer,
+                bottomStationNaturalTextWidth > 0
+                  ? { width: bottomStationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: bottomStationNameScaleX }] },
               ]}
             >

--- a/src/components/HeaderJRWest.tsx
+++ b/src/components/HeaderJRWest.tsx
@@ -44,10 +44,20 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     height: STATION_NAME_FONT_SIZE * 2 - 24,
-    // minWidth: 0 を明示しないと flex 子要素の既定 min-width: auto により、
-    // 内側 Text の `width: naturalTextWidth` がコンテナ自身を押し広げてしまい、
-    // onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
     minWidth: 0,
+  },
+  // 可視 Text を absolute 配置の wrapper でラップしてレイアウトフローから切り離す。
+  // これをやらないと内側 Text の `width: naturalTextWidth` がコンテナや祖先 View まで
+  // 押し広げ、onLayout が natural と同じ値を返して scaleX = 1（圧縮なし）になる。
+  stationNameVisibleWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
   },
   stationName: {
     textAlign: 'center',
@@ -564,24 +574,21 @@ const HeaderJRWest: React.FC<CommonHeaderProps> = (props) => {
             >
               {stationText}
             </Typography>
-            <Typography
-              numberOfLines={1}
-              ellipsizeMode="clip"
-              style={[
-                styles.stationName,
-                // 自然幅を明示的に width に渡してスロット幅で ellipsize されないようにし、
-                // 視覚的な収まりは scaleX に任せる。未計測時は width 指定なし
-                // （= スロット幅にフォールバック）で初期描画の見た目を維持する。
-                // ellipsizeMode="clip" は scaleX が下限に到達してなお収まらない極端な
-                // ケースで「…」が表示されるのを防ぐためのフォールバック。
-                stationNaturalTextWidth > 0
-                  ? { width: stationNaturalTextWidth }
-                  : null,
-                { transform: [{ scaleX: stationNameScaleX }] },
-              ]}
-            >
-              {stationText}
-            </Typography>
+            <View style={styles.stationNameVisibleWrapper} pointerEvents="none">
+              <Typography
+                numberOfLines={1}
+                ellipsizeMode="clip"
+                style={[
+                  styles.stationName,
+                  stationNaturalTextWidth > 0
+                    ? { width: stationNaturalTextWidth }
+                    : null,
+                  { transform: [{ scaleX: stationNameScaleX }] },
+                ]}
+              >
+                {stationText}
+              </Typography>
+            </View>
           </View>
         </View>
       </LinearGradient>

--- a/src/components/HeaderSaikyo.tsx
+++ b/src/components/HeaderSaikyo.tsx
@@ -183,10 +183,16 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
 
   const [stationNameSlotWidth, onStationNameSlotLayout] =
     useStationNameContainerWidth();
-  const { onTextLayout: onTopTextLayout, scaleX: topStationNameScaleX } =
-    useStationNameScaleX(stationText, stationNameSlotWidth);
-  const { onTextLayout: onBottomTextLayout, scaleX: bottomStationNameScaleX } =
-    useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onTopTextLayout,
+    scaleX: topStationNameScaleX,
+    naturalTextWidth: topStationNaturalTextWidth,
+  } = useStationNameScaleX(stationText, stationNameSlotWidth);
+  const {
+    onTextLayout: onBottomTextLayout,
+    scaleX: bottomStationNameScaleX,
+    naturalTextWidth: bottomStationNaturalTextWidth,
+  } = useStationNameScaleX(animation.prevStationText, stationNameSlotWidth);
 
   return (
     <View style={styles.root}>
@@ -282,6 +288,12 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             <View
               style={[
                 styles.stationNameContainer,
+                // absolute container の幅を自然幅に明示固定する。
+                // 指定しないと Yoga の挙動次第で container が 0 や parent 幅に張り付き、
+                // 結果として scaleX の効きが視認できない（または scaleX=1 と等価）になる。
+                topStationNaturalTextWidth > 0
+                  ? { width: topStationNaturalTextWidth }
+                  : null,
                 // 文字サイズは縮めず、Text 自体は自然な幅で描画させて、
                 // 切替アニメーション（scaleY）と独立した横方向圧縮を
                 // ラッパー View 側の transform で行う。
@@ -309,6 +321,9 @@ const HeaderSaikyo: React.FC<CommonHeaderProps> = (props) => {
             <View
               style={[
                 styles.stationNameContainer,
+                bottomStationNaturalTextWidth > 0
+                  ? { width: bottomStationNaturalTextWidth }
+                  : null,
                 { transform: [{ scaleX: bottomStationNameScaleX }] },
               ]}
             >


### PR DESCRIPTION
## 概要

PR #6060 / #6063 でも Header の `scaleX` 圧縮が実機で効いていなかった。ユーザー検証で「向きを変えてもヘッダーがバグったまま」「HeaderEast 系（TokyoMetro / TY / Odakyu）も含めて全部動いていない」と確認されたため、根本から作り直す。

### これまでの失敗の原因

| 試み | 何をしたか | なぜ効かなかったか |
| --- | --- | --- |
| #6060 | 可視 Text に `width: naturalTextWidth` を追加 | Text の自然幅が flex の `min-width: auto` を経由してスロットまで押し広げ、`onLayout` が natural を返して `scaleX = naturalWidth / naturalWidth = 1` になった |
| #6063 | スロットに `minWidth: 0` を追加 | スロットの**親**（`stationNameContainer` 等）にも同じフィードバックが残っていて、結局 flex 配分される幅自体が natural まで膨らんでいた |

### 今回の修正

可視 Text を **絶対配置の wrapper** で完全にレイアウトフローから切り離す。wrapper 自身は `top:0/left:0/right:0/bottom:0` でスロット全体を覆い、内部で `alignItems/justifyContent: center` により Text を中央寄せする。

```jsx
<View style={slot} onLayout={onSlotLayout}>
  <Typography style={measurer} ... />  {/* 計測用、画面外 */}
  <View style={visibleWrapper /* absolute, fills slot */}>
    <Typography style={[stationName, { width: naturalTextWidth, transform: [{ scaleX }] }]}>
      {stationText}
    </Typography>
  </View>
</View>
```

これで可視 Text の `width: naturalTextWidth` がいくら大きくても、wrapper が absolute なのでスロット・祖先 View の幅計算に影響しない。スロットの `onLayout` は flex 配分どおりの値を返し、`scaleX = containerWidth / naturalTextWidth` が想定どおりに計算されて圧縮が効く。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `HeaderE231` / `HeaderE235` / `HeaderJL` / `HeaderJRWest` の可視 Text を新規 `stationNameVisibleWrapper`（absolute、スロット全体に展開）でラップ。Text 自身は `width: naturalTextWidth` で natural 描画し、`scaleX` で視覚的に圧縮する構造に再構成。
- `HeaderEast` / `HeaderJRKyushu` / `HeaderSaikyo` の absolute な `stationNameContainer` に明示的な `width: naturalTextWidth` を追加。Yoga の absolute element はデフォルトの幅挙動が実装依存のため、明示することで確実に container が自然幅で描画され、`scaleX` が全体に効くようにする。`HeaderEast` 系は `HeaderTokyoMetro` / `HeaderTY` / `HeaderOdakyu` のラップ元なので、これら 3 テーマも自動的に直る。
- `useStationNameScaleX` から `naturalTextWidth` を呼び出し側に渡す（前の PR で実装済み）。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（196 件 pass）
- [x] `npm run typecheck` が通ること

実機検証は次の dev マージ後にユーザー側で実施お願いします（特に長い駅名: 長者ヶ浜潮騒はまなす公園前 / Adachi-Odai 等）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0164RvhmUUmXeF9eHmRnCtks)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数のヘッダーコンポーネント（E231、E235、East、JL、JR九州、JR西日本、埼京線）における駅名表示品質を向上させました。表示のずれやテキストのスケーリング動作が改善され、より安定した描画が実現しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->