### PR TITLE
駅名の末尾が圧縮表示で欠ける問題を修正

### DIFF
--- a/src/components/HeaderStationName.test.tsx
+++ b/src/components/HeaderStationName.test.tsx
@@ -26,8 +26,12 @@ describe('HeaderStationName', () => {
     const scaledWrapperStyle = StyleSheet.flatten(
       UNSAFE_getAllByType(View)[2].props.style
     );
+    const viewportStyle = StyleSheet.flatten(
+      UNSAFE_getAllByType(View)[1].props.style
+    );
     const measureTextStyle = StyleSheet.flatten(textNodes[0].props.style);
 
+    expect(viewportStyle.overflow).toBeUndefined();
     expect(measureTextStyle.width).toBe(10000);
     expect(textNodes[0].props.accessible).toBe(false);
     expect(textNodes[0].props.importantForAccessibility).toBe(
@@ -35,6 +39,7 @@ describe('HeaderStationName', () => {
     );
     expect(textNodes[1].props.ellipsizeMode).toBe('clip');
     expect(scaledWrapperStyle.width).toBe(240);
+    expect(scaledWrapperStyle.transformOrigin).toBe('center');
     expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 0.5 }]);
     expect(StyleSheet.flatten(textNodes[1].props.style).fontSize).toBe(50);
   });
@@ -64,5 +69,33 @@ describe('HeaderStationName', () => {
 
     expect(scaledWrapperStyle.width).toBe(360);
     expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 300 / 360 }]);
+  });
+
+  it('compresses the full station name without clipping the suffix', () => {
+    const { UNSAFE_getAllByType } = render(
+      <HeaderStationName
+        text="北野白梅町・きたのはくばいちょう"
+        textStyle={{ fontSize: 50 }}
+      />
+    );
+    const textNodes = UNSAFE_getAllByType(Text);
+
+    fireEvent(UNSAFE_getAllByType(View)[0], 'layout', {
+      nativeEvent: { layout: { width: 240 } },
+    });
+    fireEvent(textNodes[0], 'textLayout', {
+      nativeEvent: { lines: [{ width: 360 }] },
+    });
+
+    const scaledWrapperStyle = StyleSheet.flatten(
+      UNSAFE_getAllByType(View)[2].props.style
+    );
+
+    expect(textNodes[1].props.children).toBe(
+      '北野白梅町・きたのはくばいちょう'
+    );
+    expect(scaledWrapperStyle.width).toBe(360);
+    expect(scaledWrapperStyle.transformOrigin).toBe('center');
+    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 240 / 360 }]);
   });
 });

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -31,7 +31,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     minWidth: 0,
     maxWidth: '100%',
-    overflow: 'hidden',
   },
   measureText: {
     position: 'absolute',
@@ -41,11 +40,11 @@ const styles = StyleSheet.create({
   scaledText: {
     alignItems: 'center',
     justifyContent: 'center',
+    transformOrigin: 'center',
   },
   viewport: {
     alignItems: 'center',
     justifyContent: 'center',
-    overflow: 'hidden',
     maxWidth: '100%',
   },
 });


### PR DESCRIPTION
## 概要

駅名を横圧縮表示する際に、末尾が表示窓で欠ける問題を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 駅名表示コンポーネントの変換前クリップを外し、センタリングを維持したまま全文を圧縮対象に変更
- `北野白梅町・きたのはくばいちょう` が末尾まで圧縮表示対象になる回帰テストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行コマンド:

```bash
set TZ=UTC&& npx jest --runInBand src/components/HeaderStationName.test.tsx src/components/HeaderTY.test.tsx src/components/HeaderEast/HeaderEast.test.tsx src/components/HeaderJRKyushu.test.tsx src/components/HeaderSaikyo.test.tsx
npm run typecheck
npm run lint
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * HeaderStationName コンポーネントのテストケースを強化し、表示スタイルとテキストクリッピング挙動をより厳密に検証

* **スタイル**
  * 駅名の描画範囲制御を調整し、テキストスケーリング時の基準点を中央に統一

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->