### PR TITLE
DevOverlayのドラッグ操作で端末向きを考慮する

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -8,7 +8,7 @@ import {
   locationAtom,
 } from '~/store/atoms/location';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
-import DevOverlay from './DevOverlay';
+import DevOverlay, { getDevOverlayDragTranslation } from './DevOverlay';
 
 jest.mock('jotai', () => {
   const actual = jest.requireActual('jotai');
@@ -172,6 +172,22 @@ describe('DevOverlay', () => {
 
       const { getByTestId } = render(<DevOverlay />);
       expect(getByTestId('dev-overlay-landscape')).toBeTruthy();
+    });
+  });
+
+  describe('D&D座標変換', () => {
+    it('物理横向きではドラッグ量をright/top基準の移動量に変換する', () => {
+      expect(getDevOverlayDragTranslation(24, 10, false)).toEqual({
+        x: -24,
+        y: 10,
+      });
+    });
+
+    it('物理縦向きで90度回転表示している場合はドラッグ量をローカル座標へ変換する', () => {
+      expect(getDevOverlayDragTranslation(24, 10, true)).toEqual({
+        x: -10,
+        y: -24,
+      });
     });
   });
 

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -10,6 +10,7 @@ import {
   StyleSheet,
   Text,
   type TextStyle,
+  useWindowDimensions,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -42,6 +43,24 @@ const AURORA_COLORS = [
   'rgba(56, 189, 248, 0.28)',
   'rgba(217, 70, 239, 0.2)',
 ] as const;
+
+export const getDevOverlayDragTranslation = (
+  dx: number,
+  dy: number,
+  isRotatedToLandscape: boolean
+) => {
+  if (isRotatedToLandscape) {
+    return {
+      x: -dy,
+      y: -dx,
+    };
+  }
+
+  return {
+    x: -dx,
+    y: dy,
+  };
+};
 
 const styles = StyleSheet.create({
   root: {
@@ -361,8 +380,10 @@ const DevOverlay: React.FC = () => {
     .join(' / ');
 
   const dim = useLandscapeWindowDimensions();
+  const physicalDim = useWindowDimensions();
   const [basePosition, setBasePosition] = useState({ x: 0, y: 0 });
   const isLandscape = dim.width > dim.height;
+  const isRotatedToLandscape = physicalDim.height > physicalDim.width;
   const panelWidth = isLandscape
     ? Math.min(Math.max(dim.width * 0.29, 360), 520)
     : Math.min(Math.max(dim.width * 0.34, 280), 430);
@@ -526,11 +547,13 @@ const DevOverlay: React.FC = () => {
             isDraggingRef.current = true;
           }
           if (isDraggingRef.current) {
-            // right基準なのでdxを反転
-            dragTranslation.setValue({
-              x: -gestureState.dx,
-              y: gestureState.dy,
-            });
+            dragTranslation.setValue(
+              getDevOverlayDragTranslation(
+                gestureState.dx,
+                gestureState.dy,
+                isRotatedToLandscape
+              )
+            );
           }
         },
         onPanResponderRelease: () => {
@@ -579,6 +602,7 @@ const DevOverlay: React.FC = () => {
       panelWidth,
       isExpanded,
       resolvedExpandedHeight,
+      isRotatedToLandscape,
     ]
   );
 


### PR DESCRIPTION
## 概要

DevOverlay のドラッグ操作が、物理 portrait 端末を 90 度回転表示している状態でも見た目の向きに沿って動くように修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- DevOverlay の D&D 移動量を、端末が物理 portrait で横向き表示に回転されている場合のローカル座標へ変換
- 物理横向き時と回転表示時の座標変換をテストで検証

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

Windows `cmd` では `npm test` 内の `TZ=UTC` が解釈されないため、ローカルでは `set TZ=UTC&& npx jest --runInBand` で同等のフル Jest を実行しました。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * デバイスの物理的な回転（縦向き・横向き）に対応して、ドラッグ操作の座標変換ロジックを改善しました。

* **Tests**
  * デバイス回転時のドラッグ座標変換動作を検証するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->