### PR TITLE
MainActivity: PiP の遅延投稿を削除し直接呼び出して例外をハンドル

### DIFF
--- a/android/app/src/main/java/me/tinykitten/trainlcd/MainActivity.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/MainActivity.kt
@@ -5,8 +5,6 @@ import android.app.PictureInPictureParams
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.util.Rational
 
 import com.facebook.react.ReactActivity
@@ -17,7 +15,6 @@ import com.facebook.react.defaults.DefaultReactActivityDelegate
 import expo.modules.ReactActivityDelegateWrapper
 
 class MainActivity : ReactActivity() {
-  private val pictureInPictureHandler = Handler(Looper.getMainLooper())
 
   override fun onCreate(savedInstanceState: Bundle?) {
     // Set the theme to AppTheme BEFORE onCreate to support
@@ -74,19 +71,17 @@ class MainActivity : ReactActivity() {
       }
       .build()
 
-    pictureInPictureHandler.postDelayed({
-      try {
-        val result = enterPictureInPictureMode(params)
-        if (result) {
-          PictureInPictureModule.emitPictureInPictureModeChanged(true)
-        } else {
-          PictureInPictureModule.emitPictureInPictureModeChanged(false)
-        }
-      } catch (_: IllegalStateException) {
+    try {
+      val result = enterPictureInPictureMode(params)
+      if (result) {
+        PictureInPictureModule.emitPictureInPictureModeChanged(true)
+      } else {
         PictureInPictureModule.emitPictureInPictureModeChanged(false)
-        // PiP can be rejected by device policy or transient lifecycle state.
       }
-    }, 120)
+    } catch (_: IllegalStateException) {
+      PictureInPictureModule.emitPictureInPictureModeChanged(false)
+      // PiP can be rejected by device policy or transient lifecycle state.
+    }
   }
 
   override fun onPictureInPictureModeChanged(


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `android/app/src/main/java/me/tinykitten/trainlcd/MainActivity.kt` で PiP の遅延投稿を削除し、`enterPictureInPictureMode` 呼び出しを直接行って `IllegalStateException` をハンドルするよう変更

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

#6035

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
