### PR TITLE
練馬春日町の駅名表示幅に余白を追加

### DIFF
--- a/src/components/HeaderStationName.test.tsx
+++ b/src/components/HeaderStationName.test.tsx
@@ -38,9 +38,9 @@ describe('HeaderStationName', () => {
       'no-hide-descendants'
     );
     expect(textNodes[1].props.ellipsizeMode).toBe('clip');
-    expect(scaledWrapperStyle.width).toBe(240);
+    expect(scaledWrapperStyle.width).toBe(248);
     expect(scaledWrapperStyle.transformOrigin).toBe('center');
-    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 0.5 }]);
+    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 120 / 248 }]);
     expect(StyleSheet.flatten(textNodes[1].props.style).fontSize).toBe(50);
   });
 
@@ -67,8 +67,8 @@ describe('HeaderStationName', () => {
       UNSAFE_getAllByType(View)[2].props.style
     );
 
-    expect(scaledWrapperStyle.width).toBe(360);
-    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 300 / 360 }]);
+    expect(scaledWrapperStyle.width).toBe(368);
+    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 300 / 368 }]);
   });
 
   it('compresses the full station name without clipping the suffix', () => {
@@ -94,9 +94,9 @@ describe('HeaderStationName', () => {
     expect(textNodes[1].props.children).toBe(
       '北野白梅町・きたのはくばいちょう'
     );
-    expect(scaledWrapperStyle.width).toBe(360);
+    expect(scaledWrapperStyle.width).toBe(368);
     expect(scaledWrapperStyle.transformOrigin).toBe('center');
-    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 240 / 360 }]);
+    expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 240 / 368 }]);
   });
 
   it('does not reuse the previous short station width while measuring a changed station name', () => {
@@ -123,5 +123,18 @@ describe('HeaderStationName', () => {
     expect(textNodes[1].props.children).toBe('練馬春日町');
     expect(scaledWrapperStyle.width).toBe(10000);
     expect(scaledWrapperStyle.transform).toEqual([{ scaleX: 1 }]);
+
+    fireEvent(textNodes[0], 'textLayout', {
+      nativeEvent: { lines: [{ width: 240 }] },
+    });
+
+    const measuredScaledWrapperStyle = StyleSheet.flatten(
+      UNSAFE_getAllByType(View)[2].props.style
+    );
+
+    expect(measuredScaledWrapperStyle.width).toBe(248);
+    expect(measuredScaledWrapperStyle.transform).toEqual([
+      { scaleX: 240 / 248 },
+    ]);
   });
 });

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 
 const MEASURE_TEXT_WIDTH = 10000;
+const MEASURED_TEXT_WIDTH_BUFFER = 8;
 
 type Props = {
   text: string;
@@ -58,7 +59,9 @@ const HeaderStationName: React.FC<Props> = ({
 }) => {
   const [containerWidth, setContainerWidth] = useState(0);
   const [measuredText, setMeasuredText] = useState({ text: '', width: 0 });
-  const textWidth = measuredText.text === text ? measuredText.width : 0;
+  const measuredTextWidth = measuredText.text === text ? measuredText.width : 0;
+  const renderTextWidth =
+    measuredTextWidth > 0 ? measuredTextWidth + MEASURED_TEXT_WIDTH_BUFFER : 0;
 
   const handleContainerLayout = useCallback((event: LayoutChangeEvent) => {
     setContainerWidth(event.nativeEvent.layout.width);
@@ -86,11 +89,11 @@ const HeaderStationName: React.FC<Props> = ({
   );
 
   const widthScale = useMemo(() => {
-    if (containerWidth <= 0 || textWidth <= 0) {
+    if (containerWidth <= 0 || renderTextWidth <= 0) {
       return 1;
     }
-    return Math.min(1, containerWidth / textWidth);
-  }, [containerWidth, textWidth]);
+    return Math.min(1, containerWidth / renderTextWidth);
+  }, [containerWidth, renderTextWidth]);
 
   return (
     <View
@@ -121,7 +124,7 @@ const HeaderStationName: React.FC<Props> = ({
           style={[
             styles.scaledText,
             {
-              width: textWidth || MEASURE_TEXT_WIDTH,
+              width: renderTextWidth || MEASURE_TEXT_WIDTH,
               transform: [{ scaleX: widthScale }],
             },
           ]}

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -13,6 +13,9 @@ import {
 } from 'react-native';
 
 const MEASURE_TEXT_WIDTH = 10000;
+// 8px covers small native text-measurement underestimates seen with Japanese
+// glyphs and renderer/font quirks. renderTextWidth adds this to measured width;
+// adjust only if station names still clip or start shrinking too aggressively.
 const MEASURED_TEXT_WIDTH_BUFFER = 8;
 
 type Props = {


### PR DESCRIPTION
## 概要

駅名表示の測定幅に小さな余白を加え、ネイティブの文字幅計測が日本語グリフをわずかに小さく返す場合でも末尾が欠けにくいようにしました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `HeaderStationName` の描画幅と縮小率計算に、測定幅 + 8px の余白を使うようにしました。
- 「練馬春日町」へ表示変更した直後だけでなく、再測定後も余白込みの幅で描画することをテストで確認しました。
- 既存の幅圧縮テストの期待値を、余白込みの計算に合わせて更新しました。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

実行したコマンド:

```bash
npx biome check src/components/HeaderStationName.tsx src/components/HeaderStationName.test.tsx
set TZ=UTC&& node_modules\.bin\jest.cmd HeaderStationName.test.tsx --runInBand
```

補足: Windows `cmd` では package script 内の `TZ=UTC` が解釈されないため、対象 Jest は `TZ` を設定して直接実行しました。

## 関連Issue

Follow-up: #6084

## スクリーンショット（任意）

未取得です。画面上での最終確認は実機または Expo 実行環境で、都営大江戸線の「練馬春日町」表示を確認してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 駅名表示のテキストスケーリング計算を改善し、測定幅にバッファを追加して表示が安定するようにしました。
* **テスト**
  * スケーリング挙動に合わせて期待値と検証手順を更新し、レンダー後の再計測を含むケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->