### PR TITLE
警告パネルをPiP表示の背面に配置

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -68,6 +68,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setSpeech = useSetAtom(speechState);
   const setNotify = useSetAtom(notifyState);
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
+  const { active: pictureInPictureActive } = useAtomValue(pictureInPictureAtom);
   const setTuning = useSetAtom(tuningState);
   const [themePreference, setThemePreference] = useAtom(themePreferenceAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
@@ -622,6 +623,16 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     ]
   );
 
+  const warningPanel =
+    warningInfo?.text && warningInfo?.level ? (
+      <WarningPanel
+        behindContent={pictureInPictureActive}
+        onPress={clearWarningInfo}
+        text={warningInfo.text}
+        warningLevel={warningInfo.level}
+      />
+    ) : null;
+
   return (
     <ViewShot ref={viewShotRef} options={{ format: 'png' }}>
       <LongPressGestureHandler
@@ -629,14 +640,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.container}>
+          {pictureInPictureActive && warningPanel}
           {children}
-          {warningInfo?.text && warningInfo?.level && (
-            <WarningPanel
-              onPress={clearWarningInfo}
-              text={warningInfo.text}
-              warningLevel={warningInfo.level}
-            />
-          )}
+          {!pictureInPictureActive && warningPanel}
         </View>
       </LongPressGestureHandler>
       <SelectBoundSettingListModal

--- a/src/components/WarningPanel.tsx
+++ b/src/components/WarningPanel.tsx
@@ -14,12 +14,14 @@ import { RFValue } from '~/utils/rfValue';
 import Typography from './Typography';
 
 interface Props {
+  behindContent?: boolean;
   onPress: (event: GestureResponderEvent) => void;
   text: string;
   warningLevel: 'URGENT' | 'WARNING' | 'INFO';
 }
 
 const WarningPanel: React.FC<Props> = ({
+  behindContent = false,
   text,
   onPress,
   warningLevel,
@@ -46,7 +48,7 @@ const WarningPanel: React.FC<Props> = ({
       right: 24,
       bottom: 24,
       padding: 16,
-      zIndex: 9999,
+      zIndex: behindContent ? 0 : 9999,
       opacity: 0.9,
     },
     message: {


### PR DESCRIPTION
## 概要

Android の Picture in Picture 表示中に、警告パネルが PiP 表示より前面に出ないように配置順と zIndex を調整しました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `Permitted` で PiP 有効時のみ `WarningPanel` を `children` より先に描画するようにしました。
- `WarningPanel` に `behindContent` prop を追加し、PiP 有効時のみ前面用の高い `zIndex` を外しました。
- 通常表示時は従来通り `WarningPanel` が前面に表示されます。

回帰リスク: 警告パネルの重なり順に限定した変更で、通常時の表示順は維持しています。PiP 有効時の警告パネル操作性は背面配置になるため、PiP 表示中は前面タップ対象になりません。

## テスト

- [x] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint`: 成功
- `npm run typecheck`: 成功
- `npm test`: Windows PowerShell では npm script 内の `TZ=UTC` が解釈できず起動前に失敗
- `$env:TZ='UTC'; npx jest`: 成功（158 suites / 1722 tests passed）

## 関連Issue

なし

## スクリーンショット（任意）

未取得（Android PiP 環境での表示順調整のみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ピクチャー・イン・ピクチャー機能の有効時に、警告パネルの表示順序を最適化しました
  * 警告パネルのレイヤー制御を強化し、表示位置の柔軟性が向上しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/MobileApp/pull/6090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->