### PR TITLE
React Compilerを導入

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,14 @@ This handbook defines how automation agents collaborate safely and effectively o
 - Co-locate style modules or constants near their consumers; share cross-cutting utilities through `src/utils/`.
 - Keep comments purposeful: explain intent or non-obvious constraints, not obvious mechanics.
 
+### React Native side effects under StrictMode
+
+- React StrictMode intentionally re-runs effect setup/cleanup in development. Treat mount-time effects as repeatable, and never rely on an empty dependency array to mean "runs exactly once" for visible side effects.
+- Do not call `Alert.alert` directly from `useEffect` or from async functions launched by `useEffect`. StrictMode can evaluate the same persisted condition twice before the first alert is dismissed, which may stack duplicate native alerts.
+- For automatic alerts, use the shared alert presentation guard in `src/utils/alertPresentation.ts` or an equivalent keyed presentation layer. The guard should prevent duplicate alerts only while the same logical alert is already being presented, and should release the key when the user presses a button or dismisses the alert.
+- User-initiated alerts from event handlers such as `onPress` may call `Alert.alert` directly when they are not triggered by mount-time or subscription effects.
+- If an effect writes shared app state during cleanup, confirm that the cleanup represents a real lifecycle event such as a navigation `beforeRemove`, not only StrictMode's development-only unmount check.
+
 ### Markdown documentation (docs/, README, .claude/skills/\*\*/SKILL.md)
 
 `markdownlint-cli2` 準拠。CodeRabbit も同ルールで指摘するため、執筆時点で以下を守る:

--- a/app.config.ts
+++ b/app.config.ts
@@ -73,4 +73,7 @@ export default ({ config }: ConfigContext) => ({
     versionCode: 100000443,
   },
   owner: 'trainlcd',
+  experiments: {
+    reactCompiler: true,
+  },
 });

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -1,5 +1,4 @@
-import { Portal } from '@gorhom/portal';
-import React, { useEffect, useId, useMemo, useRef } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   Platform,
   Pressable,
@@ -143,25 +142,41 @@ const WalkthroughOverlay: React.FC<Props> = ({
   const insets = useSafeAreaInsets();
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const maskId = useId();
+  const overlayRef = useRef<View>(null);
+  const [overlayOffset, setOverlayOffset] = useState({ x: 0, y: 0 });
 
   const { spotlightArea, tooltipPosition = 'bottom' } = step;
+  // spotlightArea は measureInWindow() 由来の画面全体を基準にした座標。
+  // WalkthroughOverlay は Alert より手前に出ないよう Portal ではなく通常ツリー内に描画しているため、
+  // SVG とツールチップの座標基準はオーバーレイ自身の左上になる。
+  // そのまま使うとスポットライトがずれるので、オーバーレイの画面上の原点を差し引いてローカル座標へ変換する。
+  const adjustedSpotlightArea = useMemo(() => {
+    if (!spotlightArea) {
+      return undefined;
+    }
+    return {
+      ...spotlightArea,
+      x: spotlightArea.x - overlayOffset.x,
+      y: spotlightArea.y - overlayOffset.y,
+    };
+  }, [overlayOffset.x, overlayOffset.y, spotlightArea]);
 
   // tooltipPosition === 'top' かつ spotlightArea がある場合は bottom で配置
   const useBottomPositioning =
-    tooltipPosition === 'top' && spotlightArea !== undefined;
+    tooltipPosition === 'top' && adjustedSpotlightArea !== undefined;
 
   // ツールチップのY座標を計算（画面上端からの距離）
   const calculateTooltipY = (): number => {
-    if (tooltipPosition === 'top' && !spotlightArea) {
+    if (tooltipPosition === 'top' && !adjustedSpotlightArea) {
       return insets.top + 60;
     }
-    if (tooltipPosition === 'bottom' && spotlightArea) {
-      return spotlightArea.y + spotlightArea.height + 20;
+    if (tooltipPosition === 'bottom' && adjustedSpotlightArea) {
+      return adjustedSpotlightArea.y + adjustedSpotlightArea.height + 20;
     }
-    if (useBottomPositioning && spotlightArea) {
+    if (useBottomPositioning && adjustedSpotlightArea) {
       // bottomからの距離をtopに変換（推定高さ200pxを使用）
       const estimatedModalHeight = 200;
-      return spotlightArea.y - estimatedModalHeight - 20;
+      return adjustedSpotlightArea.y - estimatedModalHeight - 20;
     }
     // デフォルト: 画面下部
     return screenHeight - insets.bottom - 300;
@@ -179,7 +194,17 @@ const WalkthroughOverlay: React.FC<Props> = ({
       duration: ANIMATION_DURATION,
       useNativeDriver: false,
     }).start();
-  }, [currentStepIndex, spotlightArea?.y, screenHeight]);
+  }, [currentStepIndex, adjustedSpotlightArea?.y, screenHeight]);
+
+  // 通常ツリー内に描画したオーバーレイの画面上の原点を測り、
+  // measureInWindow() で取得したスポットライト座標をローカル座標へ補正できるようにする。
+  const handleOverlayLayout = () => {
+    overlayRef.current?.measureInWindow((x, y) => {
+      setOverlayOffset((prev) =>
+        prev.x === x && prev.y === y ? prev : { x, y }
+      );
+    });
+  };
 
   // タブレットで中央揃えになるよう左位置を計算
   const tooltipWidth = Math.min(Math.max(0, screenWidth - 48), 640);
@@ -199,109 +224,108 @@ const WalkthroughOverlay: React.FC<Props> = ({
   }
 
   return (
-    <Portal>
-      <View style={styles.overlay} pointerEvents="box-none">
-        <Pressable style={styles.pressableOverlay} onPress={onNext}>
-          <Svg width={screenWidth} height={screenHeight}>
-            <Defs>
-              <Mask id={maskId}>
+    <View
+      ref={overlayRef}
+      style={styles.overlay}
+      pointerEvents="box-none"
+      onLayout={handleOverlayLayout}
+    >
+      <Pressable style={styles.pressableOverlay} onPress={onNext}>
+        <Svg width={screenWidth} height={screenHeight}>
+          <Defs>
+            <Mask id={maskId}>
+              <Rect
+                x="0"
+                y="0"
+                width={screenWidth}
+                height={screenHeight}
+                fill="white"
+              />
+              {adjustedSpotlightArea && (
                 <Rect
-                  x="0"
-                  y="0"
-                  width={screenWidth}
-                  height={screenHeight}
-                  fill="white"
+                  x={adjustedSpotlightArea.x}
+                  y={adjustedSpotlightArea.y}
+                  width={adjustedSpotlightArea.width}
+                  height={adjustedSpotlightArea.height}
+                  rx={adjustedSpotlightArea.borderRadius ?? 8}
+                  ry={adjustedSpotlightArea.borderRadius ?? 8}
+                  fill="black"
                 />
-                {spotlightArea && (
-                  <Rect
-                    x={spotlightArea.x}
-                    y={spotlightArea.y}
-                    width={spotlightArea.width}
-                    height={spotlightArea.height}
-                    rx={spotlightArea.borderRadius ?? 8}
-                    ry={spotlightArea.borderRadius ?? 8}
-                    fill="black"
-                  />
-                )}
-              </Mask>
-            </Defs>
-            <Rect
-              x="0"
-              y="0"
-              width={screenWidth}
-              height={screenHeight}
-              fill="rgba(0, 0, 0, 0.7)"
-              mask={`url(#${maskId})`}
-            />
-          </Svg>
-        </Pressable>
+              )}
+            </Mask>
+          </Defs>
+          <Rect
+            x="0"
+            y="0"
+            width={screenWidth}
+            height={screenHeight}
+            fill="rgba(0, 0, 0, 0.7)"
+            mask={`url(#${maskId})`}
+          />
+        </Svg>
+      </Pressable>
 
-        <RNAnimated.View
-          style={[styles.tooltipContainer, animatedTooltipStyle]}
-        >
-          <Typography style={styles.title}>
-            {translate(step.titleKey)}
-          </Typography>
-          <Typography style={styles.description}>
-            {translate(step.descriptionKey)}
-          </Typography>
+      <RNAnimated.View style={[styles.tooltipContainer, animatedTooltipStyle]}>
+        <Typography style={styles.title}>{translate(step.titleKey)}</Typography>
+        <Typography style={styles.description}>
+          {translate(step.descriptionKey)}
+        </Typography>
 
-          <View style={styles.footer}>
-            <Pressable
-              onPress={onSkip}
-              accessibilityRole="button"
-              accessibilityLabel={translate('walkthroughSkip')}
-              accessibilityHint={translate('walkthroughSkipHint')}
-            >
-              <Typography style={styles.skipText}>
-                {translate('walkthroughSkip')}
-              </Typography>
-            </Pressable>
+        <View style={styles.footer}>
+          <Pressable
+            onPress={onSkip}
+            accessibilityRole="button"
+            accessibilityLabel={translate('walkthroughSkip')}
+            accessibilityHint={translate('walkthroughSkipHint')}
+          >
+            <Typography style={styles.skipText}>
+              {translate('walkthroughSkip')}
+            </Typography>
+          </Pressable>
 
-            <View style={styles.pagination}>
-              {Array.from({ length: totalSteps }).map((_, index) => (
-                <Pressable
-                  key={`dot-${
-                    // biome-ignore lint/suspicious/noArrayIndexKey: stable array
-                    index
-                  }`}
-                  onPress={() => onGoToStep(index)}
-                  hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-                  accessibilityRole="button"
-                  accessibilityLabel={`${index + 1} / ${totalSteps}`}
-                  accessibilityHint={translate('walkthroughGoToStepHint')}
-                >
-                  <View
-                    style={[
-                      styles.dot,
-                      index === currentStepIndex && styles.dotActive,
-                    ]}
-                  />
-                </Pressable>
-              ))}
-            </View>
-
-            <Pressable
-              style={styles.nextButton}
-              onPress={onNext}
-              accessibilityRole="button"
-              accessibilityLabel={
-                currentStepIndex === totalSteps - 1
-                  ? translate('walkthroughStart')
-                  : translate('walkthroughNext')
-              }
-              accessibilityHint={translate('walkthroughNextHint')}
-            >
-              <Typography style={styles.nextButtonText}>
-                {currentStepIndex === totalSteps - 1
-                  ? translate('walkthroughStart')
-                  : translate('walkthroughNext')}
-              </Typography>
-            </Pressable>
+          <View style={styles.pagination}>
+            {Array.from({ length: totalSteps }).map((_, index) => (
+              <Pressable
+                key={`dot-${
+                  // biome-ignore lint/suspicious/noArrayIndexKey: stable array
+                  index
+                }`}
+                onPress={() => onGoToStep(index)}
+                hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+                accessibilityRole="button"
+                accessibilityLabel={`${index + 1} / ${totalSteps}`}
+                accessibilityHint={translate('walkthroughGoToStepHint')}
+              >
+                <View
+                  style={[
+                    styles.dot,
+                    index === currentStepIndex && styles.dotActive,
+                  ]}
+                />
+              </Pressable>
+            ))}
           </View>
-        </RNAnimated.View>
-      </View>
-    </Portal>
+
+          <Pressable
+            style={styles.nextButton}
+            onPress={onNext}
+            accessibilityRole="button"
+            accessibilityLabel={
+              currentStepIndex === totalSteps - 1
+                ? translate('walkthroughStart')
+                : translate('walkthroughNext')
+            }
+            accessibilityHint={translate('walkthroughNextHint')}
+          >
+            <Typography style={styles.nextButtonText}>
+              {currentStepIndex === totalSteps - 1
+                ? translate('walkthroughStart')
+                : translate('walkthroughNext')}
+            </Typography>
+          </Pressable>
+        </View>
+      </RNAnimated.View>
+    </View>
   );
 };
 

--- a/src/hooks/useCheckStoreVersion.ts
+++ b/src/hooks/useCheckStoreVersion.ts
@@ -1,16 +1,18 @@
 import { useSetAtom } from 'jotai';
 import { useCallback, useEffect } from 'react';
-import { Alert, Linking, Platform } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import VersionCheck from 'react-native-version-check';
 import { APP_STORE_URL, GOOGLE_PLAY_URL } from '~/constants';
 import navigationState from '~/store/atoms/navigation';
 import { translate } from '../translation';
+import { showAlertWhilePresenting } from '../utils/alertPresentation';
 
 export const useCheckStoreVersion = (): void => {
   const setNavigationState = useSetAtom(navigationState);
 
   const showUpdateRequestDialog = useCallback((storeURL: string) => {
-    Alert.alert(
+    showAlertWhilePresenting(
+      'storeVersionUpdateRequest',
       translate('announcementTitle'),
       translate('newVersionAvailableText'),
       [

--- a/src/hooks/useInitialNearbyStation.test.tsx
+++ b/src/hooks/useInitialNearbyStation.test.tsx
@@ -157,7 +157,8 @@ describe('useInitialNearbyStation', () => {
     expect(Alert.alert).toHaveBeenCalledWith(
       'notice',
       'firstAlertText',
-      expect.any(Array)
+      expect.any(Array),
+      expect.objectContaining({ onDismiss: expect.any(Function) })
     );
   });
 });

--- a/src/hooks/useInitialNearbyStation.ts
+++ b/src/hooks/useInitialNearbyStation.ts
@@ -2,13 +2,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Location from 'expo-location';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Alert } from 'react-native';
 import type { Station } from '~/@types/graphql';
 import { ASYNC_STORAGE_KEYS, LOCATION_TASK_NAME } from '../constants';
 import { locationAtom, setLocation } from '../store/atoms/location';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { translate } from '../translation';
+import { showAlertWhilePresenting } from '../utils/alertPresentation';
 import { useFetchCurrentLocationOnce } from './useFetchCurrentLocationOnce';
 import { useFetchNearbyStation } from './useFetchNearbyStation';
 
@@ -128,17 +128,22 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
         ASYNC_STORAGE_KEYS.FIRST_LAUNCH_PASSED
       );
       if (firstLaunchPassed === null) {
-        Alert.alert(translate('notice'), translate('firstAlertText'), [
-          {
-            text: 'OK',
-            onPress: (): void => {
-              AsyncStorage.setItem(
-                ASYNC_STORAGE_KEYS.FIRST_LAUNCH_PASSED,
-                'true'
-              );
+        showAlertWhilePresenting(
+          ASYNC_STORAGE_KEYS.FIRST_LAUNCH_PASSED,
+          translate('notice'),
+          translate('firstAlertText'),
+          [
+            {
+              text: 'OK',
+              onPress: (): void => {
+                AsyncStorage.setItem(
+                  ASYNC_STORAGE_KEYS.FIRST_LAUNCH_PASSED,
+                  'true'
+                );
+              },
             },
-          },
-        ]);
+          ]
+        );
       }
     };
     checkFirstLaunch();
@@ -148,7 +153,11 @@ export const useInitialNearbyStation = (): UseInitialNearbyStationResult => {
   useEffect(() => {
     if (nearbyStationFetchError) {
       console.error(nearbyStationFetchError);
-      Alert.alert(translate('errorTitle'), translate('apiErrorText'));
+      showAlertWhilePresenting(
+        'initialNearbyStationFetchError',
+        translate('errorTitle'),
+        translate('apiErrorText')
+      );
     }
   }, [nearbyStationFetchError]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ const options: NativeStackNavigationOptions = {
   },
 };
 
-const App: React.FC = () => {
+const AppContent: React.FC = () => {
   useEffect(() => {
     type TextProps = {
       defaultProps: {
@@ -72,61 +72,63 @@ const App: React.FC = () => {
   }, [fontsLoadError, fontsLoaded]);
 
   return (
-    <StrictMode>
+    <>
       {Platform.OS === 'ios' ? (
         <StatusBar hidden translucent backgroundColor="transparent" />
       ) : (
         <SystemBars hidden style="auto" />
       )}
 
-      <CustomErrorBoundary>
-        <GestureHandlerRootView>
-          <ApolloProvider client={gqlClient}>
-            <ActionSheetProvider>
-              <Provider store={store}>
-                <NavigationContainer ref={navigationRef}>
-                  <DeepLinkProvider>
-                    <QuickActionsProvider>
-                      <PortalProvider>
-                        <Stack.Navigator screenOptions={screenOptions}>
-                          {!permStatus?.granted ? (
-                            <Stack.Screen
-                              options={options}
-                              name="Privacy"
-                              component={PrivacyScreen}
-                            />
-                          ) : null}
+      <Stack.Navigator screenOptions={screenOptions}>
+        {!permStatus?.granted ? (
+          <Stack.Screen
+            options={options}
+            name="Privacy"
+            component={PrivacyScreen}
+          />
+        ) : null}
 
-                          <Stack.Screen
-                            options={options}
-                            name="MainStack"
-                            component={MainStack}
-                          />
+        <Stack.Screen
+          options={options}
+          name="MainStack"
+          component={MainStack}
+        />
 
-                          <Stack.Screen
-                            options={options}
-                            name="TuningSettings"
-                            component={TuningSettings}
-                          />
-                        </Stack.Navigator>
-                      </PortalProvider>
-                    </QuickActionsProvider>
-                    <GlobalToast />
-                  </DeepLinkProvider>
-                </NavigationContainer>
-              </Provider>
-            </ActionSheetProvider>
-          </ApolloProvider>
-        </GestureHandlerRootView>
-      </CustomErrorBoundary>
-    </StrictMode>
+        <Stack.Screen
+          options={options}
+          name="TuningSettings"
+          component={TuningSettings}
+        />
+      </Stack.Navigator>
+    </>
   );
 };
 
-const AppWithStrictMode: React.FC = () => (
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+const App: React.FC = () => {
+  return (
+    <CustomErrorBoundary>
+      <GestureHandlerRootView>
+        <ApolloProvider client={gqlClient}>
+          <ActionSheetProvider>
+            <Provider store={store}>
+              <NavigationContainer ref={navigationRef}>
+                <DeepLinkProvider>
+                  <QuickActionsProvider>
+                    <PortalProvider>
+                      <StrictMode>
+                        <AppContent />
+                      </StrictMode>
+                    </PortalProvider>
+                  </QuickActionsProvider>
+                  <GlobalToast />
+                </DeepLinkProvider>
+              </NavigationContainer>
+            </Provider>
+          </ActionSheetProvider>
+        </ApolloProvider>
+      </GestureHandlerRootView>
+    </CustomErrorBoundary>
+  );
+};
 
-export default React.memo(AppWithStrictMode);
+export default React.memo(App);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import * as Location from 'expo-location';
 import * as SplashScreen from 'expo-splash-screen';
 import { Provider } from 'jotai';
 import React, { StrictMode, useEffect } from 'react';
-import { Alert, Platform, StatusBar, Text } from 'react-native';
+import { Platform, StatusBar, Text } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import CustomErrorBoundary from './components/CustomErrorBoundary';
@@ -26,6 +26,7 @@ import MainStack from './stacks/MainStack';
 import { navigationRef } from './stacks/rootNavigation';
 import { store } from './store';
 import { setI18nConfig } from './translation';
+import { showAlertWhilePresenting } from './utils/alertPresentation';
 
 SplashScreen.preventAutoHideAsync();
 setI18nConfig();
@@ -65,7 +66,11 @@ const AppContent: React.FC = () => {
   useEffect(() => {
     if (fontsLoaded || fontsLoadError) {
       if (fontsLoadError) {
-        Alert.alert('Font Load Error', 'Failed to load fonts.');
+        showAlertWhilePresenting(
+          'fontLoadError',
+          'Font Load Error',
+          'Failed to load fonts.'
+        );
       }
       SplashScreen.hideAsync();
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { useFonts } from 'expo-font';
 import * as Location from 'expo-location';
 import * as SplashScreen from 'expo-splash-screen';
 import { Provider } from 'jotai';
-import React, { useEffect } from 'react';
+import React, { StrictMode, useEffect } from 'react';
 import { Alert, Platform, StatusBar, Text } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -72,7 +72,7 @@ const App: React.FC = () => {
   }, [fontsLoadError, fontsLoaded]);
 
   return (
-    <>
+    <StrictMode>
       {Platform.OS === 'ios' ? (
         <StatusBar hidden translucent backgroundColor="transparent" />
       ) : (
@@ -119,7 +119,7 @@ const App: React.FC = () => {
           </ApolloProvider>
         </GestureHandlerRootView>
       </CustomErrorBoundary>
-    </>
+    </StrictMode>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,4 +123,10 @@ const App: React.FC = () => {
   );
 };
 
-export default React.memo(App);
+const AppWithStrictMode: React.FC = () => (
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+
+export default React.memo(AppWithStrictMode);

--- a/src/providers/DeepLinkProvider.tsx
+++ b/src/providers/DeepLinkProvider.tsx
@@ -1,7 +1,7 @@
 import { memo, type ReactNode, useEffect } from 'react';
-import { Alert } from 'react-native';
 import { useDeepLink } from '../hooks/useDeepLink';
 import { translate } from '../translation';
+import { showAlertWhilePresenting } from '../utils/alertPresentation';
 
 type Props = {
   children: ReactNode;
@@ -12,7 +12,11 @@ const DeepLinkProvider = ({ children }: Props) => {
   useEffect(() => {
     if (error) {
       console.error(error);
-      Alert.alert(translate('errorTitle'), translate('failedToFetchStation'));
+      showAlertWhilePresenting(
+        'deepLinkFetchStationError',
+        translate('errorTitle'),
+        translate('failedToFetchStation')
+      );
     }
   }, [error]);
   if (!initialUrlProcessed || (isLoading && !error)) {

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -1,5 +1,6 @@
 import { useLazyQuery } from '@apollo/client/react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
 import * as Location from 'expo-location';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import React, {
@@ -179,6 +180,7 @@ const MainScreen: React.FC = () => {
 
   const currentStationRef = useRef(currentStation);
   const stationsRef = useRef(stations);
+  const navigation = useNavigation();
 
   const handleCloseSelectBoundModal = useCallback(() => {
     setIsSelectBoundModalOpen(false);
@@ -443,12 +445,9 @@ const MainScreen: React.FC = () => {
     transferLines.length,
   ]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 確実にアンマウント時に動かしたい
   useEffect(() => {
-    return () => {
-      resetMainState();
-    };
-  }, []);
+    return navigation.addListener('beforeRemove', resetMainState);
+  }, [navigation, resetMainState]);
 
   useEffect(() => {
     const f = async (): Promise<void> => {

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -77,6 +77,7 @@ import TypeChangeNotify from '../components/TypeChangeNotify';
 import navigationState from '../store/atoms/navigation';
 import { pictureInPictureAtom } from '../store/atoms/pictureInPicture';
 import stationState from '../store/atoms/station';
+import { showAlertWhilePresenting } from '../utils/alertPresentation';
 import getCurrentStationIndex from '../utils/currentStationIndex';
 import getIsPass from '../utils/isPass';
 
@@ -287,7 +288,8 @@ const MainScreen: React.FC = () => {
         );
 
         if (subwayAlertDismissed !== 'true') {
-          Alert.alert(
+          showAlertWhilePresenting(
+            ASYNC_STORAGE_KEYS.SUBWAY_ALERT_DISMISSED,
             translate('subwayAlertTitle'),
             translate('subwayAlertText'),
             [
@@ -326,19 +328,24 @@ const MainScreen: React.FC = () => {
         isHoliday &&
         holidayNoticeDismissed !== 'true'
       ) {
-        Alert.alert(translate('notice'), translate('holidayNotice'), [
-          {
-            text: translate('doNotShowAgain'),
-            style: 'cancel',
-            onPress: async (): Promise<void> => {
-              await AsyncStorage.setItem(
-                ASYNC_STORAGE_KEYS.HOLIDAY_ALERT_DISMISSED,
-                'true'
-              );
+        showAlertWhilePresenting(
+          ASYNC_STORAGE_KEYS.HOLIDAY_ALERT_DISMISSED,
+          translate('notice'),
+          translate('holidayNotice'),
+          [
+            {
+              text: translate('doNotShowAgain'),
+              style: 'cancel',
+              onPress: async (): Promise<void> => {
+                await AsyncStorage.setItem(
+                  ASYNC_STORAGE_KEYS.HOLIDAY_ALERT_DISMISSED,
+                  'true'
+                );
+              },
             },
-          },
-          { text: 'OK' },
-        ]);
+            { text: 'OK' },
+          ]
+        );
       }
 
       // 平日通過
@@ -353,19 +360,24 @@ const MainScreen: React.FC = () => {
         !isHoliday &&
         weekdayNoticeDismissed !== 'true'
       ) {
-        Alert.alert(translate('notice'), translate('weekdayNotice'), [
-          {
-            text: translate('doNotShowAgain'),
-            style: 'cancel',
-            onPress: async (): Promise<void> => {
-              await AsyncStorage.setItem(
-                ASYNC_STORAGE_KEYS.WEEKDAY_ALERT_DISMISSED,
-                'true'
-              );
+        showAlertWhilePresenting(
+          ASYNC_STORAGE_KEYS.WEEKDAY_ALERT_DISMISSED,
+          translate('notice'),
+          translate('weekdayNotice'),
+          [
+            {
+              text: translate('doNotShowAgain'),
+              style: 'cancel',
+              onPress: async (): Promise<void> => {
+                await AsyncStorage.setItem(
+                  ASYNC_STORAGE_KEYS.WEEKDAY_ALERT_DISMISSED,
+                  'true'
+                );
+              },
             },
-          },
-          { text: 'OK' },
-        ]);
+            { text: 'OK' },
+          ]
+        );
       }
 
       // 一部通過
@@ -378,19 +390,24 @@ const MainScreen: React.FC = () => {
         ) !== -1 &&
         partiallyPassNoticeDismissed !== 'true'
       ) {
-        Alert.alert(translate('notice'), translate('partiallyPassNotice'), [
-          {
-            text: translate('doNotShowAgain'),
-            style: 'cancel',
-            onPress: async (): Promise<void> => {
-              await AsyncStorage.setItem(
-                ASYNC_STORAGE_KEYS.PARTIALLY_PASS_ALERT_DISMISSED,
-                'true'
-              );
+        showAlertWhilePresenting(
+          ASYNC_STORAGE_KEYS.PARTIALLY_PASS_ALERT_DISMISSED,
+          translate('notice'),
+          translate('partiallyPassNotice'),
+          [
+            {
+              text: translate('doNotShowAgain'),
+              style: 'cancel',
+              onPress: async (): Promise<void> => {
+                await AsyncStorage.setItem(
+                  ASYNC_STORAGE_KEYS.PARTIALLY_PASS_ALERT_DISMISSED,
+                  'true'
+                );
+              },
             },
-          },
-          { text: 'OK' },
-        ]);
+            { text: 'OK' },
+          ]
+        );
       }
     };
     alertAsync();
@@ -462,7 +479,8 @@ const MainScreen: React.FC = () => {
 
       const bgPermStatus = await Location.getBackgroundPermissionsAsync();
       if (warningDismissed !== 'true' && !bgPermStatus?.granted && !isClip()) {
-        Alert.alert(
+        showAlertWhilePresenting(
+          ASYNC_STORAGE_KEYS.ALWAYS_PERMISSION_NOT_GRANTED_WARNING_DISMISSED,
           translate('announcementTitle'),
           translate('alwaysPermissionNotGrantedAlertText'),
           [
@@ -505,7 +523,8 @@ const MainScreen: React.FC = () => {
           ASYNC_STORAGE_KEYS.DOZE_CONFIRMED
         );
         if (bgStatus === 'granted' && dozeAlertDismissed !== 'true') {
-          Alert.alert(
+          showAlertWhilePresenting(
+            ASYNC_STORAGE_KEYS.DOZE_CONFIRMED,
             translate('announcementTitle'),
             translate('dozeAlertText'),
             [

--- a/src/utils/alertPresentation.test.ts
+++ b/src/utils/alertPresentation.test.ts
@@ -1,0 +1,43 @@
+import { Alert } from 'react-native';
+import { showAlertWhilePresenting } from './alertPresentation';
+
+jest.mock('react-native', () => ({
+  Alert: {
+    alert: jest.fn(),
+  },
+}));
+
+describe('showAlertWhilePresenting', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('同じキーのアラートが表示中なら二重表示しない', () => {
+    expect(showAlertWhilePresenting('notice', 'title')).toBe(true);
+    expect(showAlertWhilePresenting('notice', 'title')).toBe(false);
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('ボタン押下後は同じキーを再表示できる', () => {
+    showAlertWhilePresenting('retryableNotice', 'title', undefined, [
+      { text: 'OK' },
+    ]);
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    buttons[0].onPress();
+
+    expect(showAlertWhilePresenting('retryableNotice', 'title')).toBe(true);
+    expect(Alert.alert).toHaveBeenCalledTimes(2);
+  });
+
+  it('dismiss後は同じキーを再表示できる', () => {
+    showAlertWhilePresenting('dismissedNotice', 'title');
+
+    const options = (Alert.alert as jest.Mock).mock.calls[0][3];
+    options.onDismiss();
+
+    expect(showAlertWhilePresenting('dismissedNotice', 'title')).toBe(true);
+    expect(Alert.alert).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/alertPresentation.ts
+++ b/src/utils/alertPresentation.ts
@@ -1,0 +1,56 @@
+import { Alert, type AlertButton, type AlertOptions } from 'react-native';
+
+const presentingAlertKeys = new Set<string>();
+
+/**
+ * 同じ論理キーの native alert が表示中でない場合だけ表示する。
+ *
+ * React StrictMode の開発時検査では、mount 時の effect が 2 回実行される。
+ * effect 内で AsyncStorage の永続フラグを確認してから Alert.alert を呼ぶと、
+ * 最初の alert が閉じられる前に 2 回目の effect も同じ条件を通過し、
+ * native alert が二重に積まれることがある。
+ *
+ * この helper は「同じ alert が表示中」の間だけ再入を防ぐ。ユーザーがボタンを
+ * 押す、または alert を dismiss するとキーを解放するため、各 alert 自身の
+ * 「今後表示しない」永続フラグが立っていない限り、次回以降の表示は妨げない。
+ */
+export const showAlertWhilePresenting = (
+  key: string,
+  title: string,
+  message?: string,
+  buttons?: AlertButton[],
+  options?: AlertOptions
+): boolean => {
+  if (presentingAlertKeys.has(key)) {
+    return false;
+  }
+
+  presentingAlertKeys.add(key);
+
+  const release = () => {
+    presentingAlertKeys.delete(key);
+  };
+
+  const sourceButtons = buttons ?? [{ text: 'OK' }];
+  const wrappedButtons = sourceButtons.map((button) => ({
+    ...button,
+    onPress: (value?: string) => {
+      try {
+        button.onPress?.(value as never);
+      } finally {
+        release();
+      }
+    },
+  }));
+
+  const wrappedOptions = {
+    ...options,
+    onDismiss: () => {
+      options?.onDismiss?.();
+      release();
+    },
+  };
+
+  Alert.alert(title, message, wrappedButtons, wrappedOptions);
+  return true;
+};


### PR DESCRIPTION
## 概要

React Compiler を導入し、導入に伴って StrictMode 下で露出した副作用の不具合を修正します。

## 変更の種類

- [x] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `app.config.ts` で React Compiler を有効化しました。
- StrictMode 適用範囲を整理し、アプリ本体の StrictMode 検査を維持しつつ PortalProvider 由来の重複影響を避ける構成にしました。
- `Main` 画面の状態リセットを mount cleanup ではなく navigation の `beforeRemove` に寄せ、StrictMode の開発時 cleanup で駅数が 0 になる問題を防ぎました。
- effect 起点の自動 `Alert.alert` が StrictMode で二重表示されないよう、表示中キーで抑止する `showAlertWhilePresenting` を追加しました。
- ウォークスルーを通常ツリー内で表示し、Native Alert より前面に重ならないようにしました。あわせて `measureInWindow()` 由来の画面座標をオーバーレイのローカル座標へ補正し、スポットライト位置のずれを修正しました。
- StrictMode 下の React Native 副作用、特に自動 Alert の扱いを `AGENTS.md` に明文化しました。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加で以下の対象 Jest が通ることを確認しました。

```bash
set TZ=UTC&& npx jest --runInBand src/utils/alertPresentation.test.ts src/hooks/useInitialNearbyStation.test.tsx src/hooks/useResetMainState.test.ts src/components/LineBoard.test.tsx src/hooks/useWalkthroughCompleted.test.tsx src/hooks/useSelectLineWalkthrough.test.tsx src/screens/SelectLineScreen.render.test.tsx
```

`npm test` 全体は未実行です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
