### PR TITLE
位置情報の許容最大精度を引き下げる

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 10;
 export const LOCATION_TIME_INTERVAL = 5000;
 
-export const MAX_PERMIT_ACCURACY = 4000;
+export const MAX_PERMIT_ACCURACY = 1500;
 
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;


### PR DESCRIPTION
## 概要

位置情報の許容最大精度を `4000` から `1500` に引き下げました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `MAX_PERMIT_ACCURACY` を `1500` に変更し、許容する位置情報精度の上限を厳しくしました。
- 位置精度が低い状態で現在地判定が進むリスクを抑えます。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint`: passed (`biome check ./src`, 519 files)
- `npm test`: Windows `cmd` では `TZ=UTC` の解釈で失敗したため、同等条件として `set TZ=UTC&& npx jest` を実行し、159 suites / 1725 tests passed
- `npm run typecheck`: passed (`tsc --noEmit`)

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * バックグラウンド位置情報更新における精度基準を厳格化しました。これにより、より正確な位置データの取得が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->