### PR TITLE
フォアグラウンド測位にも精度フィルタを適用し、DevOverlayに生の精度を表示する

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ import { registerRootComponent } from 'expo';
 import * as TaskManager from 'expo-task-manager';
 import { SENTRY_DSN } from 'react-native-dotenv';
 import App from './src';
-import { LOCATION_TASK_NAME, MAX_PERMIT_ACCURACY } from './src/constants';
-import { setLocation } from './src/store/atoms/location';
+import { LOCATION_TASK_NAME } from './src/constants';
+import { handleTrackingLocation } from './src/utils/handleTrackingLocation';
 
 Sentry.init({
   dsn: SENTRY_DSN,
@@ -21,10 +21,7 @@ if (!TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {
 
     const latestLocation = data.locations[data.locations.length - 1];
     if (latestLocation) {
-      if (latestLocation.coords.accuracy > MAX_PERMIT_ACCURACY) {
-        return;
-      }
-      setLocation(latestLocation);
+      handleTrackingLocation(latestLocation);
     }
   });
 }

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -1,11 +1,13 @@
 import { act, render } from '@testing-library/react-native';
 import * as Application from 'expo-application';
 import { useAtomValue } from 'jotai';
-import { Dimensions } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import type { Station } from '~/@types/graphql';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
+  rawLocationAtom,
 } from '~/store/atoms/location';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import DevOverlay, { getDevOverlayDragTranslation } from './DevOverlay';
@@ -80,14 +82,22 @@ describe('DevOverlay', () => {
         accuracy: 15,
       },
     },
+    rawLocation,
     backgroundLocationTracking = false,
   }: {
     location?: unknown;
+    rawLocation?: unknown;
     backgroundLocationTracking?: boolean;
   } = {}) => {
+    // 精度はrawLocationAtomから読むため、未指定時はlocationと同じ値にフォールバックさせる
+    const resolvedRawLocation =
+      rawLocation === undefined ? location : rawLocation;
     mockUseAtomValue.mockImplementation((atom) => {
       if (atom === locationAtom) {
         return location as never;
+      }
+      if (atom === rawLocationAtom) {
+        return resolvedRawLocation as never;
       }
       if (atom === backgroundLocationTrackingAtom) {
         return backgroundLocationTracking as never;
@@ -212,6 +222,71 @@ describe('DevOverlay', () => {
       expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent(
         '15m'
       );
+    });
+
+    it('生の精度がMAX_PERMIT_ACCURACYを超える場合は赤字で表示する', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { speed: 10, accuracy: MAX_PERMIT_ACCURACY + 100 },
+        },
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueStyle = StyleSheet.flatten(
+        getByTestId('dev-overlay-accuracy-value').props.style
+      );
+      expect(valueStyle.color).toBe('#f87171');
+    });
+
+    it('生の精度がMAX_PERMIT_ACCURACY以下の場合は赤字にしない', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { speed: 10, accuracy: MAX_PERMIT_ACCURACY },
+        },
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueStyle = StyleSheet.flatten(
+        getByTestId('dev-overlay-accuracy-value').props.style
+      );
+      expect(valueStyle.color).not.toBe('#f87171');
+    });
+
+    it('継続測位の生の値（rawLocation）が無い場合は精度を表示しない', () => {
+      // 継続測位（watch/background）はhandleTrackingLocation経由でrawLocationを記録する。
+      // ワンショット取得や手動選択のみでrawLocationが無い状態では精度を出さない。
+      setupAtomValues({
+        location: {
+          coords: { speed: 10, accuracy: 42 },
+        },
+        rawLocation: null,
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent('--');
+    });
+
+    it('startLocationUpdatesAsync経路でlocationAtomがフィルタ後の値でも生の精度を表示する', () => {
+      // バックグラウンドタスクはMAX_PERMIT_ACCURACY超過を棄却するため、
+      // locationAtomには直近のフィルタ通過値が残り、rawLocationAtomに生の値が入る
+      setupAtomValues({
+        location: {
+          coords: { speed: 10, accuracy: 15 },
+        },
+        rawLocation: {
+          coords: { speed: 10, accuracy: MAX_PERMIT_ACCURACY + 500 },
+        },
+        backgroundLocationTracking: true,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueNode = getByTestId('dev-overlay-accuracy-value');
+      // フィルタ後の15mではなく生の精度を表示し、赤字で警告する
+      expect(valueNode).toHaveTextContent(`${MAX_PERMIT_ACCURACY + 500}m`);
+      expect(StyleSheet.flatten(valueNode.props.style).color).toBe('#f87171');
     });
 
     it('速度情報をkm/hで表示する', () => {

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -76,28 +76,32 @@ describe('DevOverlay', () => {
   const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
 
   const setupAtomValues = ({
+    // locationAtomはフィルタ・スムージング後の値で、速度や次駅距離の表示元
     location = {
       coords: {
         speed: 10,
         accuracy: 15,
       },
     },
-    rawLocation,
+    // rawLocationAtomは継続測位の生の値で、精度表示はlocationAtomではなくここから読む。
+    // 既定は精度15mの測位が継続取得できている状態を表す（locationAtomとは独立した別物）。
+    rawLocation = {
+      coords: {
+        accuracy: 15,
+      },
+    },
     backgroundLocationTracking = false,
   }: {
     location?: unknown;
     rawLocation?: unknown;
     backgroundLocationTracking?: boolean;
   } = {}) => {
-    // 精度はrawLocationAtomから読むため、未指定時はlocationと同じ値にフォールバックさせる
-    const resolvedRawLocation =
-      rawLocation === undefined ? location : rawLocation;
     mockUseAtomValue.mockImplementation((atom) => {
       if (atom === locationAtom) {
         return location as never;
       }
       if (atom === rawLocationAtom) {
-        return resolvedRawLocation as never;
+        return rawLocation as never;
       }
       if (atom === backgroundLocationTrackingAtom) {
         return backgroundLocationTracking as never;
@@ -212,8 +216,8 @@ describe('DevOverlay', () => {
 
     it('精度情報の小数点を切り捨てて表示する', () => {
       setupAtomValues({
-        location: {
-          coords: { speed: 10, accuracy: 15.9 },
+        rawLocation: {
+          coords: { accuracy: 15.9 },
         },
         backgroundLocationTracking: false,
       });
@@ -339,6 +343,7 @@ describe('DevOverlay', () => {
     it('位置情報が取得できない状態で精度チャートが空のまま維持される', () => {
       setupAtomValues({
         location: null,
+        rawLocation: null,
         backgroundLocationTracking: false,
       });
       jest.useFakeTimers();
@@ -395,8 +400,8 @@ describe('DevOverlay', () => {
 
     it('精度がnullの場合に空文字を表示する', () => {
       setupAtomValues({
-        location: {
-          coords: { speed: 10, accuracy: null },
+        rawLocation: {
+          coords: { accuracy: null },
         },
         backgroundLocationTracking: false,
       });

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -14,6 +14,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import {
   useDistanceToNextStation,
   useLandscapeWindowDimensions,
@@ -23,6 +24,7 @@ import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
+  rawLocationAtom,
 } from '~/store/atoms/location';
 import { generateAccuracyChart } from '~/utils/accuracyChart';
 import Typography from './Typography';
@@ -39,6 +41,7 @@ const PANEL_BORDER = 'rgba(255,255,255,0.18)';
 const PANEL_BG = 'rgba(7, 11, 24, 0.78)';
 const LABEL_COLOR = 'rgba(199, 210, 254, 0.72)';
 const VALUE_COLOR = '#f8fafc';
+const DANGER_COLOR = '#f87171';
 const AURORA_COLORS = [
   'rgba(56, 189, 248, 0.28)',
   'rgba(217, 70, 239, 0.2)',
@@ -190,6 +193,9 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     lineHeight: 22,
   },
+  metricValueDanger: {
+    color: DANGER_COLOR,
+  },
   metricSuffix: {
     color: 'rgba(191, 219, 254, 0.78)',
     fontSize: 11,
@@ -256,6 +262,7 @@ type MetricCardProps = {
   style?: StyleProp<ViewStyle>;
   labelStyle?: StyleProp<TextStyle>;
   valueStyle?: StyleProp<TextStyle>;
+  suffixStyle?: StyleProp<TextStyle>;
   metaStyle?: StyleProp<TextStyle>;
 };
 
@@ -294,6 +301,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
   style,
   labelStyle,
   valueStyle,
+  suffixStyle,
   metaStyle,
 }) => (
   <View style={[styles.metricCard, style]}>
@@ -302,7 +310,9 @@ const MetricCard: React.FC<MetricCardProps> = ({
       <Typography style={[styles.metricValue, valueStyle]} testID={valueTestID}>
         {value}
         {suffix && value !== '--' ? (
-          <Typography style={styles.metricSuffix}>{suffix}</Typography>
+          <Typography style={[styles.metricSuffix, suffixStyle]}>
+            {suffix}
+          </Typography>
         ) : null}
       </Typography>
     </View>
@@ -318,8 +328,12 @@ const DevOverlay: React.FC = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedHeight, setExpandedHeight] = useState(0);
   const location = useAtomValue(locationAtom);
+  // 精度はMAX_PERMIT_ACCURACYフィルタを通らない生の測位値から取得する。
+  // 継続測位（watch/background両経路）はhandleTrackingLocation経由でフィルタ前に
+  // rawLocationAtomへ生の値を記録するため、棄却された精度もここから観測できる。
+  const rawLocation = useAtomValue(rawLocationAtom);
   const speed = location?.coords?.speed;
-  const accuracy = location?.coords?.accuracy;
+  const accuracy = rawLocation?.coords?.accuracy;
   const distanceToNextStation = useDistanceToNextStation();
   const nextStation = useNextStation(false);
   const isTelemetryEnabled = useTelemetryEnabled();
@@ -330,6 +344,9 @@ const DevOverlay: React.FC = () => {
   const coordsSpeed = ((speed ?? 0) < 0 ? 0 : speed) ?? 0;
   const accuracyMeters =
     accuracy != null ? Math.max(0, Math.floor(accuracy)) : null;
+  // MAX_PERMIT_ACCURACYのフィルタに関係なく生の精度を判定し、許容値を超えたら赤字で警告する
+  const isAccuracyOverLimit =
+    accuracy != null && accuracy > MAX_PERMIT_ACCURACY;
 
   const speedKMH = useMemo(
     () =>
@@ -741,7 +758,13 @@ const DevOverlay: React.FC = () => {
                     style={[{ width: leftMetricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-accuracy-value"
                     labelStyle={metricLabelStyle}
-                    valueStyle={metricValueStyle}
+                    valueStyle={[
+                      metricValueStyle,
+                      isAccuracyOverLimit && styles.metricValueDanger,
+                    ]}
+                    suffixStyle={
+                      isAccuracyOverLimit ? styles.metricValueDanger : null
+                    }
                     metaStyle={metricMetaStyle}
                   />
                   <MetricCard
@@ -795,7 +818,13 @@ const DevOverlay: React.FC = () => {
                     style={[{ width: metricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-accuracy-value"
                     labelStyle={metricLabelStyle}
-                    valueStyle={metricValueStyle}
+                    valueStyle={[
+                      metricValueStyle,
+                      isAccuracyOverLimit && styles.metricValueDanger,
+                    ]}
+                    suffixStyle={
+                      isAccuracyOverLimit ? styles.metricValueDanger : null
+                    }
                     metaStyle={metricMetaStyle}
                   />
                   <MetricCard

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -23,7 +23,9 @@ jest.mock('~/store', () => ({
 }));
 jest.mock('~/store/atoms/location', () => ({
   backgroundLocationTrackingAtom: {},
-  setLocation: jest.fn(),
+}));
+jest.mock('~/utils/handleTrackingLocation', () => ({
+  handleTrackingLocation: jest.fn(),
 }));
 jest.mock('~/store/atoms/navigation', () => ({
   __esModule: true,

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -2,11 +2,9 @@ import * as Location from 'expo-location';
 import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
 import { store } from '~/store';
-import {
-  backgroundLocationTrackingAtom,
-  setLocation,
-} from '~/store/atoms/location';
+import { backgroundLocationTrackingAtom } from '~/store/atoms/location';
 import navigationState from '~/store/atoms/navigation';
+import { handleTrackingLocation } from '~/utils/handleTrackingLocation';
 import {
   LOCATION_START_MAX_RETRIES,
   LOCATION_START_RETRY_BASE_DELAY_MS,
@@ -99,7 +97,7 @@ export const useStartBackgroundLocationUpdates = () => {
               try {
                 const sub = await Location.watchPositionAsync(
                   LOCATION_WATCH_OPTIONS,
-                  setLocation
+                  handleTrackingLocation
                 );
                 if (cancelled) {
                   sub.remove();
@@ -158,7 +156,7 @@ export const useStartBackgroundLocationUpdates = () => {
       try {
         const sub = await Location.watchPositionAsync(
           LOCATION_WATCH_OPTIONS,
-          setLocation
+          handleTrackingLocation
         );
         if (cancelled) {
           sub.remove();

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -4,8 +4,10 @@ import { store } from '..';
 import {
   accuracyHistoryAtom,
   locationAtom,
+  rawLocationAtom,
   resetLocationState,
   setLocation,
+  setRawLocation,
 } from './location';
 import stationState from './station';
 
@@ -46,6 +48,27 @@ describe('setLocation', () => {
   beforeEach(() => {
     resetLocationState();
     setStationLineType(null);
+  });
+
+  describe('生の測位値の記録', () => {
+    it('setRawLocationはlocationAtomを更新せずrawLocationAtomへ生の値を記録する', () => {
+      const loc = makeLocation(35.0, 139.0, 5000, 1000);
+      setRawLocation(loc);
+
+      // フィルタで棄却される想定の値でもrawLocationAtomには記録される
+      expect(store.get(rawLocationAtom)?.coords.accuracy).toBe(5000);
+      // locationAtomは更新しない（フィルタ後の値はsetLocation側が管理する）
+      expect(store.get(locationAtom)).toBeNull();
+    });
+
+    it('setLocationはrawLocationAtomを更新しない（background経路のみが記録責務を持つ）', () => {
+      const loc = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(loc);
+
+      // watchPositionAsync経路ではlocationAtomが生の精度を持つため、rawLocationは触らない
+      expect(store.get(rawLocationAtom)).toBeNull();
+      expect(store.get(locationAtom)?.coords.accuracy).toBe(30);
+    });
   });
 
   describe('非地下鉄路線', () => {

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -43,6 +43,11 @@ const isAccuracyStable = (history: number[]): boolean => {
 };
 
 export const locationAtom = atom<Location.LocationObject | null>(null);
+// MAX_PERMIT_ACCURACYフィルタで棄却される測位も含めた、継続測位の生の値。
+// handleTrackingLocation経由でwatch/background双方が更新し、DevOverlayの診断表示で
+// 「フィルタで棄却された精度」も確認できるようにする。
+// DevOverlayはisDevApp時しか描画されないので、更新もそのとき（isDevApp）だけ行えば十分。
+export const rawLocationAtom = atom<Location.LocationObject | null>(null);
 export const accuracyHistoryAtom = atom<number[]>([]);
 export const backgroundLocationTrackingAtom = atom(false);
 
@@ -53,8 +58,17 @@ const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
   store.set(locationAtom, null);
+  store.set(rawLocationAtom, null);
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
+};
+
+// MAX_PERMIT_ACCURACYフィルタで棄却される測位も含め、生の測位値を記録する。
+// startLocationUpdatesAsync経路ではフィルタがsetLocation到達前に値を捨てるため、
+// フィルタ前に本関数を呼ぶことで生の精度をDevOverlayから観測できるようにする。
+// 呼び出し側でisDevApp判定を行い、本番ビルドでは更新しないこと。
+export const setRawLocation = (location: Location.LocationObject) => {
+  store.set(rawLocationAtom, location);
 };
 
 export const setLocation = (location: Location.LocationObject) => {

--- a/src/utils/handleTrackingLocation.test.ts
+++ b/src/utils/handleTrackingLocation.test.ts
@@ -1,0 +1,79 @@
+import type * as Location from 'expo-location';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { setLocation, setRawLocation } from '~/store/atoms/location';
+import { handleTrackingLocation } from './handleTrackingLocation';
+
+jest.mock('~/store/atoms/location', () => ({
+  setLocation: jest.fn(),
+  setRawLocation: jest.fn(),
+}));
+
+let mockIsDevApp = false;
+jest.mock('./isDevApp', () => ({
+  get isDevApp() {
+    return mockIsDevApp;
+  },
+}));
+
+const mockSetLocation = setLocation as jest.Mock;
+const mockSetRawLocation = setRawLocation as jest.Mock;
+
+const makeLocation = (accuracy: number | null): Location.LocationObject => ({
+  coords: {
+    latitude: 35.0,
+    longitude: 139.0,
+    accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: 0,
+  },
+  timestamp: 1000,
+});
+
+describe('handleTrackingLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDevApp = false;
+  });
+
+  it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡す', () => {
+    const loc = makeLocation(MAX_PERMIT_ACCURACY);
+    handleTrackingLocation(loc);
+
+    expect(mockSetLocation).toHaveBeenCalledWith(loc);
+  });
+
+  it('精度がMAX_PERMIT_ACCURACYを超える測位はsetLocationに渡さない', () => {
+    const loc = makeLocation(MAX_PERMIT_ACCURACY + 1);
+    handleTrackingLocation(loc);
+
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('精度がnullの測位はフィルタせずsetLocationに渡す', () => {
+    const loc = makeLocation(null);
+    handleTrackingLocation(loc);
+
+    expect(mockSetLocation).toHaveBeenCalledWith(loc);
+  });
+
+  it('isDevApp時はフィルタで棄却される測位も生の値として記録する', () => {
+    mockIsDevApp = true;
+    const loc = makeLocation(MAX_PERMIT_ACCURACY + 500);
+    handleTrackingLocation(loc);
+
+    // 生の値は記録するが、フィルタにより通常の位置情報としては採用しない
+    expect(mockSetRawLocation).toHaveBeenCalledWith(loc);
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('本番ビルド（isDevApp=false）では生の値を記録しない', () => {
+    mockIsDevApp = false;
+    const loc = makeLocation(30);
+    handleTrackingLocation(loc);
+
+    expect(mockSetRawLocation).not.toHaveBeenCalled();
+    expect(mockSetLocation).toHaveBeenCalledWith(loc);
+  });
+});

--- a/src/utils/handleTrackingLocation.ts
+++ b/src/utils/handleTrackingLocation.ts
@@ -1,0 +1,22 @@
+import type * as Location from 'expo-location';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { setLocation, setRawLocation } from '~/store/atoms/location';
+import { isDevApp } from './isDevApp';
+
+// watchPositionAsync / startLocationUpdatesAsync 双方の継続測位の共通入口。
+// 経路ごとにMAX_PERMIT_ACCURACYの適用漏れが起きないよう、精度フィルタをここへ集約する。
+// （getCurrentPositionAsyncによるワンショット取得や手動選択はsetLocationを直接呼ぶため対象外）
+export const handleTrackingLocation = (location: Location.LocationObject) => {
+  // DevOverlayの診断表示用に、フィルタで棄却される測位も生の値として記録する。
+  // DevOverlayはisDevApp時しか描画されないため、本番ビルドでは記録しない。
+  if (isDevApp) {
+    setRawLocation(location);
+  }
+
+  const { accuracy } = location.coords;
+  if (accuracy != null && accuracy > MAX_PERMIT_ACCURACY) {
+    return;
+  }
+
+  setLocation(location);
+};


### PR DESCRIPTION
## 概要

DevOverlay の `LOCATION ACCURACY` を `MAX_PERMIT_ACCURACY` フィルタに影響されない生の測位精度で表示し、許容値を超えた場合は赤字で警告するようにしました。あわせて、`watchPositionAsync`（フォアグラウンド監視）経路に `MAX_PERMIT_ACCURACY` フィルタが適用されていなかった考慮漏れを修正し、継続測位の2経路で精度フィルタを一貫させました。

## 変更の種類

- [x] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `watchPositionAsync` 経路でも `MAX_PERMIT_ACCURACY` フィルタが効くよう修正。これまで `startLocationUpdatesAsync`（background）経路でしかフィルタしておらず、フォアグラウンド監視では許容精度を超える測位もそのまま採用していた。
- 継続測位の共通入口 `handleTrackingLocation` を新設し、watch / background 双方の精度フィルタをここへ集約。経路ごとの適用漏れが構造的に起きないようにした（`getCurrentPositionAsync` のワンショット取得・手動選択は従来どおり `setLocation` 直呼びでフィルタ対象外）。
- DevOverlay の精度表示元を、フィルタ前の生の測位値を保持する `rawLocationAtom` に変更。`MAX_PERMIT_ACCURACY` で棄却された測位の精度も診断表示できるようにした。
- 生の精度が `MAX_PERMIT_ACCURACY` を超える場合、数値・単位を赤字（`#f87171`）で表示する警告を追加。
- `rawLocationAtom` の更新は `handleTrackingLocation` 内で `isDevApp` のときだけ行う。DevOverlay は `isDevApp` 時しか描画されないため、本番ビルドでは余計な atom 更新を発生させない。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DevOverlayで生の測位精度を基に許容値超過時に警告（赤表示）するよう強化。
  * バックグラウンド/フォアグラウンドの位置更新で共通処理を導入し、生の測位データを保存できるように。

* **Tests**
  * 生データ保存と精度フィルタリング挙動、表示の色分岐などに関するテストを拡充。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->