### PR TITLE
HeaderE231 の駅名フォントを白枠に収まる固定サイズにする

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -15,6 +15,15 @@ const BOTTOM_HEIGHT = isTablet ? 128 : 84;
 const DIVIDER_HEIGHT = isTablet ? 4 : 2;
 const ROOT_HEIGHT = BOUND_AREA_HEIGHT + BOTTOM_HEIGHT + DIVIDER_HEIGHT;
 
+// 白枠は固定 dp 高さなので、駅名も RFValue で画面スケールさせず枠高に連動した
+// 固定サイズにする。枠の内寸(高さ - 上下ボーダー)に行の高さが収まるよう 0.7 を掛け、
+// HeaderStationName の縦方向はスケールしない前提でも枠からはみ出さないようにしている。
+const STATION_AREA_HEIGHT = isTablet ? 128 : 80;
+const STATION_AREA_BORDER_WIDTH = isTablet ? 4 : 2;
+const STATION_NAME_FONT_SIZE = Math.floor(
+  (STATION_AREA_HEIGHT - STATION_AREA_BORDER_WIDTH * 2) * 0.7
+);
+
 const styles = StyleSheet.create({
   root: {
     zIndex: 9999,
@@ -67,13 +76,13 @@ const styles = StyleSheet.create({
   },
   stationArea: {
     width: '60%',
-    height: isTablet ? 128 : 80,
+    height: STATION_AREA_HEIGHT,
     flexShrink: 0,
     flexGrow: 0,
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: '#fff',
-    borderWidth: isTablet ? 4 : 2,
+    borderWidth: STATION_AREA_BORDER_WIDTH,
     borderColor: '#666',
     borderRadius: isTablet ? 4 : 2,
     paddingHorizontal: isTablet ? 8 : 4,
@@ -87,7 +96,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     color: '#1B432B',
-    fontSize: RFValue(64),
+    fontSize: STATION_NAME_FONT_SIZE,
   },
   headerTexts: {
     flexDirection: 'row',

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -98,6 +98,11 @@ const HeaderStationName: React.FC<Props> = ({
     return Math.min(1, containerWidth / renderTextWidth);
   }, [containerWidth, renderTextWidth]);
 
+  // 計測（コンテナ幅・現在の text の文字幅）が揃うまでは widthScale が 1 のままで、
+  // そのまま見せると縮小前の等倍テキストが 1 フレーム見えてしまう（scaleX が
+  // 一瞬効かない）。計測完了までは表示用テキストを隠し、スケール確定後に出す。
+  const isScaleReady = containerWidth > 0 && renderTextWidth > 0;
+
   return (
     <View
       onLayout={handleContainerLayout}
@@ -120,6 +125,7 @@ const HeaderStationName: React.FC<Props> = ({
           styles.viewport,
           {
             width: containerWidth || '100%',
+            opacity: isScaleReady ? 1 : 0,
           },
         ]}
       >

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -98,11 +98,6 @@ const HeaderStationName: React.FC<Props> = ({
     return Math.min(1, containerWidth / renderTextWidth);
   }, [containerWidth, renderTextWidth]);
 
-  // 計測（コンテナ幅・現在の text の文字幅）が揃うまでは widthScale が 1 のままで、
-  // そのまま見せると縮小前の等倍テキストが 1 フレーム見えてしまう（scaleX が
-  // 一瞬効かない）。計測完了までは表示用テキストを隠し、スケール確定後に出す。
-  const isScaleReady = containerWidth > 0 && renderTextWidth > 0;
-
   return (
     <View
       onLayout={handleContainerLayout}
@@ -125,7 +120,6 @@ const HeaderStationName: React.FC<Props> = ({
           styles.viewport,
           {
             width: containerWidth || '100%',
-            opacity: isScaleReady ? 1 : 0,
           },
         ]}
       >
@@ -133,7 +127,11 @@ const HeaderStationName: React.FC<Props> = ({
           style={[
             styles.scaledText,
             {
-              width: renderTextWidth || MEASURE_TEXT_WIDTH,
+              // 計測前は文字幅が未確定で widthScale が 1 のまま。ここでコンテナ幅
+              // （未確定なら '100%'）にクランプしておくと、計測完了までの間も
+              // 等倍テキストが枠からはみ出さず、かつ空白にもならない。計測が返れば
+              // renderTextWidth が入り、自然幅 + scaleX で正確に圧縮される。
+              width: renderTextWidth || containerWidth || '100%',
               transform: [{ scaleX: widthScale }],
             },
           ]}

--- a/src/components/HeaderStationName.tsx
+++ b/src/components/HeaderStationName.tsx
@@ -127,11 +127,7 @@ const HeaderStationName: React.FC<Props> = ({
           style={[
             styles.scaledText,
             {
-              // 計測前は文字幅が未確定で widthScale が 1 のまま。ここでコンテナ幅
-              // （未確定なら '100%'）にクランプしておくと、計測完了までの間も
-              // 等倍テキストが枠からはみ出さず、かつ空白にもならない。計測が返れば
-              // renderTextWidth が入り、自然幅 + scaleX で正確に圧縮される。
-              width: renderTextWidth || containerWidth || '100%',
+              width: renderTextWidth || MEASURE_TEXT_WIDTH,
               transform: [{ scaleX: widthScale }],
             },
           ]}


### PR DESCRIPTION
## 概要

HeaderE231 の駅名表示が白枠からはみ出していた問題を修正します。白枠は固定 dp 高さなのに駅名フォントだけ `RFValue` で画面高に応じてスケールしていたため、縦長端末ほどフォントが枠の高さを超えてはみ出していました。枠の内寸に連動した固定サイズに変更し、どのデバイスでも白枠内に収まるようにします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 白枠の寸法を定数化（`STATION_AREA_HEIGHT` / `STATION_AREA_BORDER_WIDTH`）し、`stationArea` スタイルから参照するように統一
- 駅名フォントサイズを `RFValue(64)` から、枠の内寸（高さ - 上下ボーダー）× 0.7 の固定サイズ `STATION_NAME_FONT_SIZE` に変更
  - スマホ: `(80 - 4) × 0.7 = 53`
  - タブレット: `(128 - 8) × 0.7 = 84`
- `HeaderStationName` は横方向のみ `scaleX` で縮小し縦方向は縮まないため、フォントサイズ自体を枠高に連動させて縦のはみ出しを防止

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
