### PR TITLE
StrictModeでPortal経由のモーダルが表示されない問題を修正

### DIFF
--- a/patches/@gorhom+portal+1.0.14.patch
+++ b/patches/@gorhom+portal+1.0.14.patch
@@ -1,0 +1,53 @@
+diff --git a/node_modules/@gorhom/portal/lib/commonjs/components/portal/Portal.js b/node_modules/@gorhom/portal/lib/commonjs/components/portal/Portal.js
+index 5a4872e..5bc32b0 100644
+--- a/node_modules/@gorhom/portal/lib/commonjs/components/portal/Portal.js
++++ b/node_modules/@gorhom/portal/lib/commonjs/components/portal/Portal.js
+@@ -70,11 +70,7 @@ const PortalComponent = ({
+     return () => {
+       var _handleOnUnmountRef$c;
+ 
+-      (_handleOnUnmountRef$c = handleOnUnmountRef.current) === null || _handleOnUnmountRef$c === void 0 ? void 0 : _handleOnUnmountRef$c.call(handleOnUnmountRef); // remove callbacks refs
+-
+-      handleOnMountRef.current = undefined;
+-      handleOnUnmountRef.current = undefined;
+-      handleOnUpdateRef.current = undefined;
++      (_handleOnUnmountRef$c = handleOnUnmountRef.current) === null || _handleOnUnmountRef$c === void 0 ? void 0 : _handleOnUnmountRef$c.call(handleOnUnmountRef); // NOTE: StrictMode の mount→unmount→remount に耐えるため ref はクリアしない
+     };
+   }, []);
+   (0, _react.useEffect)(() => {
+diff --git a/node_modules/@gorhom/portal/lib/module/components/portal/Portal.js b/node_modules/@gorhom/portal/lib/module/components/portal/Portal.js
+index 2e4c868..d2f3978 100644
+--- a/node_modules/@gorhom/portal/lib/module/components/portal/Portal.js
++++ b/node_modules/@gorhom/portal/lib/module/components/portal/Portal.js
+@@ -61,11 +61,7 @@ const PortalComponent = ({
+     return () => {
+       var _handleOnUnmountRef$c;
+ 
+-      (_handleOnUnmountRef$c = handleOnUnmountRef.current) === null || _handleOnUnmountRef$c === void 0 ? void 0 : _handleOnUnmountRef$c.call(handleOnUnmountRef); // remove callbacks refs
+-
+-      handleOnMountRef.current = undefined;
+-      handleOnUnmountRef.current = undefined;
+-      handleOnUpdateRef.current = undefined;
++      (_handleOnUnmountRef$c = handleOnUnmountRef.current) === null || _handleOnUnmountRef$c === void 0 ? void 0 : _handleOnUnmountRef$c.call(handleOnUnmountRef); // NOTE: StrictMode の mount→unmount→remount に耐えるため ref はクリアしない
+     };
+   }, []);
+   useEffect(() => {
+diff --git a/node_modules/@gorhom/portal/src/components/portal/Portal.tsx b/node_modules/@gorhom/portal/src/components/portal/Portal.tsx
+index d03811a..85d0958 100644
+--- a/node_modules/@gorhom/portal/src/components/portal/Portal.tsx
++++ b/node_modules/@gorhom/portal/src/components/portal/Portal.tsx
+@@ -63,10 +63,10 @@ const PortalComponent = ({
+     return () => {
+       handleOnUnmountRef.current?.();
+ 
+-      // remove callbacks refs
+-      handleOnMountRef.current = undefined;
+-      handleOnUnmountRef.current = undefined;
+-      handleOnUpdateRef.current = undefined;
++      // NOTE: StrictMode (React 19) は初回マウントを mount→unmount→remount で
++      // シミュレートする。ここで ref を undefined に潰すと remount 時の
++      // handleOnMountRef.current?.() が no-op になり、Portal がホストへ再登録されず
++      // モーダルが表示されなくなる。再マウントに耐えるため ref はクリアしない。
+     };
+   }, []);
+   useEffect(() => {


### PR DESCRIPTION
## 概要

React Compiler 導入（#6095）でルートに `<StrictMode>` を追加して以降、開発ビルドで長押しメニューの「設定」など Portal 経由のモーダルが表示されなくなっていた問題を、`@gorhom/portal` への patch-package パッチで修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/@gorhom+portal+1.0.14.patch` を追加。
- `@gorhom/portal@1.0.14` の `Portal` コンポーネントは mount effect の cleanup で `handleOnMountRef` / `handleOnUnmountRef` / `handleOnUpdateRef` を `undefined` に潰していた。
- StrictMode（React 19）は初回マウントを `mount → unmount → remount` でシミュレートするため、unmount で ref が破棄され、remount 時の `handleOnMountRef.current?.()` が no-op 化 → Portal がホストへ再登録されず、モーダルが描画されなかった。
- cleanup での ref 破棄 3 行を削除し、再マウントに耐えるよう修正。`src`（Metro が読む `react-native`/`source` エントリ）と `lib/module` / `lib/commonjs` の 3 経路すべてをパッチ。
- `CustomModal`（= Portal）経由で開く全モーダル（設定・種別選択・テーマ・フィードバック等）が StrictMode 有効のまま表示されるようになる。本番ビルドは StrictMode 無効のため元々非発生。

## テスト

<!-- 省略: アプリ本体（src 等）のコード変更は無く、依存パッチの追加のみ。検証は開発ビルドでの長押し→設定モーダル表示確認で実施。 -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * React StrictMode での再マウント時の参照処理を改善し、安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->