### PR TITLE
HeaderE231のステート表示がAndroidで下端が見切れる問題を修正

### DIFF
--- a/src/components/HeaderE231.tsx
+++ b/src/components/HeaderE231.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#000',
     textAlign: 'right',
-    lineHeight: Platform.select({ android: RFValue(21) }),
+    lineHeight: Platform.select({ android: RFValue(28) }),
   },
   stationArea: {
     width: '60%',


### PR DESCRIPTION
## 概要

`HeaderE231` のステート表示（「まもなく」「ただいま停車中」等）が Android 端末でフォント下端が見切れる問題を修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `state` スタイルの Android 用 `lineHeight` を `RFValue(21)` から `RFValue(28)` に変更
- `fontSize: RFValue(24)` に対して `lineHeight` が小さく（21 < 24）、行ボックスがグリフ高を下回って下端が見切れていたため、`fontSize` の約 1.2 倍に引き上げて文字全体が収まるようにした
- ステート表示は高さ `BOTTOM_HEIGHT`（非タブレット時 84dp）の領域に `flex: 1` で配置されており、`numberOfLines={2}` でも `28 × 2 = 56dp` で収まるため領域からははみ出さない

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Android デバイスでのテキスト行の高さ表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->