### PR TITLE
DevOverlayの精度チャートとm表示の配色を最大許容精度に応じて調整

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from 'jotai';
 import { Dimensions, StyleSheet } from 'react-native';
 import type { Station } from '~/@types/graphql';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
@@ -256,6 +257,51 @@ describe('DevOverlay', () => {
         getByTestId('dev-overlay-accuracy-value').props.style
       );
       expect(valueStyle.color).not.toBe('#f87171');
+    });
+
+    it('生の精度がBAD_ACCURACY_THRESHOLD以上・MAX_PERMIT_ACCURACY以下の場合は黄字で表示する', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { speed: 10, accuracy: BAD_ACCURACY_THRESHOLD },
+        },
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueStyle = StyleSheet.flatten(
+        getByTestId('dev-overlay-accuracy-value').props.style
+      );
+      expect(valueStyle.color).toBe('#facc15');
+    });
+
+    it('生の精度がMAX_PERMIT_ACCURACYを超える場合は黄字ではなく赤字で表示する', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { speed: 10, accuracy: MAX_PERMIT_ACCURACY + 100 },
+        },
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueStyle = StyleSheet.flatten(
+        getByTestId('dev-overlay-accuracy-value').props.style
+      );
+      expect(valueStyle.color).toBe('#f87171');
+    });
+
+    it('生の精度がBAD_ACCURACY_THRESHOLD未満の場合は黄字にしない', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { speed: 10, accuracy: BAD_ACCURACY_THRESHOLD - 1 },
+        },
+        backgroundLocationTracking: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      const valueStyle = StyleSheet.flatten(
+        getByTestId('dev-overlay-accuracy-value').props.style
+      );
+      expect(valueStyle.color).not.toBe('#facc15');
     });
 
     it('継続測位の生の値（rawLocation）が無い場合は精度を表示しない', () => {

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -15,6 +15,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import {
   useDistanceToNextStation,
   useLandscapeWindowDimensions,
@@ -42,6 +43,7 @@ const PANEL_BG = 'rgba(7, 11, 24, 0.78)';
 const LABEL_COLOR = 'rgba(199, 210, 254, 0.72)';
 const VALUE_COLOR = '#f8fafc';
 const DANGER_COLOR = '#f87171';
+const WARNING_COLOR = '#facc15';
 const AURORA_COLORS = [
   'rgba(56, 189, 248, 0.28)',
   'rgba(217, 70, 239, 0.2)',
@@ -196,6 +198,9 @@ const styles = StyleSheet.create({
   metricValueDanger: {
     color: DANGER_COLOR,
   },
+  metricValueWarning: {
+    color: WARNING_COLOR,
+  },
   metricSuffix: {
     color: 'rgba(191, 219, 254, 0.78)',
     fontSize: 11,
@@ -347,6 +352,12 @@ const DevOverlay: React.FC = () => {
   // MAX_PERMIT_ACCURACYのフィルタに関係なく生の精度を判定し、許容値を超えたら赤字で警告する
   const isAccuracyOverLimit =
     accuracy != null && accuracy > MAX_PERMIT_ACCURACY;
+  // チャートが黄色になる精度域（BAD_ACCURACY_THRESHOLD以上・許容値以下）では
+  // m表示も黄色文字にして、精度悪化を数値とチャートの双方で示す
+  const isAccuracyWarning =
+    accuracy != null &&
+    accuracy >= BAD_ACCURACY_THRESHOLD &&
+    accuracy <= MAX_PERMIT_ACCURACY;
 
   const speedKMH = useMemo(
     () =>
@@ -760,10 +771,15 @@ const DevOverlay: React.FC = () => {
                     labelStyle={metricLabelStyle}
                     valueStyle={[
                       metricValueStyle,
+                      isAccuracyWarning && styles.metricValueWarning,
                       isAccuracyOverLimit && styles.metricValueDanger,
                     ]}
                     suffixStyle={
-                      isAccuracyOverLimit ? styles.metricValueDanger : null
+                      isAccuracyOverLimit
+                        ? styles.metricValueDanger
+                        : isAccuracyWarning
+                          ? styles.metricValueWarning
+                          : null
                     }
                     metaStyle={metricMetaStyle}
                   />
@@ -820,10 +836,15 @@ const DevOverlay: React.FC = () => {
                     labelStyle={metricLabelStyle}
                     valueStyle={[
                       metricValueStyle,
+                      isAccuracyWarning && styles.metricValueWarning,
                       isAccuracyOverLimit && styles.metricValueDanger,
                     ]}
                     suffixStyle={
-                      isAccuracyOverLimit ? styles.metricValueDanger : null
+                      isAccuracyOverLimit
+                        ? styles.metricValueDanger
+                        : isAccuracyWarning
+                          ? styles.metricValueWarning
+                          : null
                     }
                     metaStyle={metricMetaStyle}
                   />

--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -155,24 +155,24 @@ describe('generateAccuracyChart', () => {
   });
 
   describe('color coding', () => {
-    it('should use red color for accuracy >= BAD_ACCURACY_THRESHOLD', () => {
-      const result = generateAccuracyChart([200, 250, 300]);
+    it('should use red color for accuracy > MAX_PERMIT_ACCURACY', () => {
+      const result = generateAccuracyChart([1501, 2000, 3000]);
       expect(result).toHaveLength(3);
       for (const block of result) {
         expect(block.color).toBe('#ff0000');
       }
     });
 
-    it('should use yellow color for accuracy >= BAD_ACCURACY_THRESHOLD / 2 and < BAD_ACCURACY_THRESHOLD', () => {
-      const result = generateAccuracyChart([100, 150, 199]);
+    it('should use yellow color for accuracy >= BAD_ACCURACY_THRESHOLD and <= MAX_PERMIT_ACCURACY', () => {
+      const result = generateAccuracyChart([200, 750, 1500]);
       expect(result).toHaveLength(3);
       for (const block of result) {
         expect(block.color).toBe('#ffff00');
       }
     });
 
-    it('should use white color for accuracy < BAD_ACCURACY_THRESHOLD / 2', () => {
-      const result = generateAccuracyChart([10, 50, 99]);
+    it('should use white color for accuracy < BAD_ACCURACY_THRESHOLD', () => {
+      const result = generateAccuracyChart([10, 100, 199]);
       expect(result).toHaveLength(3);
       for (const block of result) {
         expect(block.color).toBe('#ffffff');
@@ -181,14 +181,14 @@ describe('generateAccuracyChart', () => {
 
     it('should handle mixed accuracy values with different colors', () => {
       // Test with values in all three ranges
-      const result = generateAccuracyChart([50, 150, 250]);
+      const result = generateAccuracyChart([50, 500, 2000]);
       expect(result).toHaveLength(3);
 
       // 50m should be white
       expect(result[0].color).toBe('#ffffff');
-      // 150m should be yellow
+      // 500m should be yellow
       expect(result[1].color).toBe('#ffff00');
-      // 250m should be red
+      // 2000m (over MAX_PERMIT_ACCURACY) should be red
       expect(result[2].color).toBe('#ff0000');
     });
   });

--- a/src/utils/accuracyChart.ts
+++ b/src/utils/accuracyChart.ts
@@ -1,3 +1,4 @@
+import { MAX_PERMIT_ACCURACY } from '../constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '../constants/threshold';
 
 export type AccuracyBlock = {
@@ -11,10 +12,12 @@ export type AccuracyBlock = {
  * @returns Color string for the block
  */
 const getAccuracyColor = (accuracy: number): string => {
-  if (accuracy >= BAD_ACCURACY_THRESHOLD) {
+  // 最大許容精度(MAX_PERMIT_ACCURACY)を超えた測位値はフィルタで棄却されるため、
+  // DevOverlayのメトリクスカード(isAccuracyOverLimit)と揃えて赤で警告する。
+  if (accuracy > MAX_PERMIT_ACCURACY) {
     return '#ff0000'; // red
   }
-  if (accuracy >= BAD_ACCURACY_THRESHOLD / 2) {
+  if (accuracy >= BAD_ACCURACY_THRESHOLD) {
     return '#ffff00'; // yellow
   }
   return '#ffffff'; // white


### PR DESCRIPTION
## 概要

DevOverlay の測位精度ビジュアライズの配色を見直し、「最大許容精度（`MAX_PERMIT_ACCURACY` = 1500m）を超えると赤」になるよう統一しました。あわせて、精度チャートが黄色になる精度域では LOCATION ACCURACY の m 表示も黄字にして、数値とチャートの双方で精度悪化を示します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- 精度チャート（`src/utils/accuracyChart.ts`）の赤色判定を `BAD_ACCURACY_THRESHOLD`(200m) 以上から、最大許容精度 `MAX_PERMIT_ACCURACY`(1500m) 超過に変更し、メトリクスカードの `isAccuracyOverLimit` 警告と整合させた。
- 中間域（`BAD_ACCURACY_THRESHOLD`(200m) 以上・`MAX_PERMIT_ACCURACY`(1500m) 以下）を黄色に変更。
- `src/components/DevOverlay.tsx` の LOCATION ACCURACY の m 表示を、チャートが黄色になる精度域では黄字（`#facc15`）、許容精度を超えた場合は従来どおり赤字（`#f87171`）で表示するよう調整。
- 上記に合わせて `accuracyChart.test.ts` の色判定テストを更新し、`DevOverlay.test.tsx` に黄字表示・赤字優先・閾値未満は黄字にしないケースを追加。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01KbgHvpJ3J7TTbSqrvzeEcY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロケーション精度メトリクスの表示状態を拡張しました。精度値に応じて正常（白）、注意（黄）、危険（赤）の3段階で視覚的にフィードバックを提供するようになりました。

* **改善**
  * 精度に関する閾値条件をより詳細に定義し直し、ユーザーが精度レベルをより正確に把握できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->