### PR TITLE
最大許容精度を1.5kmから2kmに緩和

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 10;
 export const LOCATION_TIME_INTERVAL = 5000;
 
-export const MAX_PERMIT_ACCURACY = 1500;
+export const MAX_PERMIT_ACCURACY = 2000;
 
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;

--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -156,7 +156,7 @@ describe('generateAccuracyChart', () => {
 
   describe('color coding', () => {
     it('should use red color for accuracy > MAX_PERMIT_ACCURACY', () => {
-      const result = generateAccuracyChart([1501, 2000, 3000]);
+      const result = generateAccuracyChart([2001, 2500, 3000]);
       expect(result).toHaveLength(3);
       for (const block of result) {
         expect(block.color).toBe('#ff0000');
@@ -181,14 +181,14 @@ describe('generateAccuracyChart', () => {
 
     it('should handle mixed accuracy values with different colors', () => {
       // Test with values in all three ranges
-      const result = generateAccuracyChart([50, 500, 2000]);
+      const result = generateAccuracyChart([50, 500, 2500]);
       expect(result).toHaveLength(3);
 
       // 50m should be white
       expect(result[0].color).toBe('#ffffff');
       // 500m should be yellow
       expect(result[1].color).toBe('#ffff00');
-      // 2000m (over MAX_PERMIT_ACCURACY) should be red
+      // 2500m (over MAX_PERMIT_ACCURACY) should be red
       expect(result[2].color).toBe('#ff0000');
     });
   });


### PR DESCRIPTION
## 概要

位置情報の最大許容精度（`MAX_PERMIT_ACCURACY`）を 1.5km（1500m）から 2km（2000m）に緩和しました。これにより、従来は破棄されていた精度 1500m〜2000m の位置情報も許容範囲として扱われるようになります。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `src/constants/location.ts`: `MAX_PERMIT_ACCURACY` を `1500` から `2000` に変更。この定数はトラッキングのフィルタリング（`handleTrackingLocation.ts`）、精度チャートの色分け（`accuracyChart.ts`）、開発オーバーレイ（`DevOverlay.tsx`）で共有されているため、一箇所の変更で全利用箇所へ反映される。
- `src/utils/accuracyChart.test.ts`: 新しい閾値（2000m）に合わせてテスト値を更新。
  - 赤色判定: `[1501, 2000, 3000]` → `[2001, 2500, 3000]`（2000m は閾値以下になったため）
  - 混合判定: 赤想定の `2000` → `2500` に修正

## テスト

`npm test`（`accuracyChart` / `handleTrackingLocation` / `DevOverlay` の 3 スイート、54 件）が全てパス。`npm run typecheck` と `biome ci`（変更ファイル）も指摘なし。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01LveC1KjDx6oNFkiaGY6cXA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Changes**
  * 位置情報の許容精度上限を1500メートルから2000メートルに引き上げました。これにより、より広い範囲での位置情報処理に対応します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->