### PR TITLE
DevOverlayの速度表示もrawLocationの生の測位値から取得するよう変更

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -77,17 +77,18 @@ describe('DevOverlay', () => {
   const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
 
   const setupAtomValues = ({
-    // locationAtomはフィルタ・スムージング後の値で、速度や次駅距離の表示元
+    // locationAtomはフィルタ・スムージング後の値。DevOverlayの速度・精度表示はここから読まない
     location = {
       coords: {
         speed: 10,
         accuracy: 15,
       },
     },
-    // rawLocationAtomは継続測位の生の値で、精度表示はlocationAtomではなくここから読む。
-    // 既定は精度15mの測位が継続取得できている状態を表す（locationAtomとは独立した別物）。
+    // rawLocationAtomは継続測位の生の値で、速度・精度ともにlocationAtomではなくここから読む。
+    // 既定は速度10m/s・精度15mの測位が継続取得できている状態を表す（locationAtomとは独立した別物）。
     rawLocation = {
       coords: {
+        speed: 10,
         accuracy: 15,
       },
     },
@@ -422,7 +423,7 @@ describe('DevOverlay', () => {
 
     it('速度がnullの場合に0km/hを表示する', () => {
       setupAtomValues({
-        location: {
+        rawLocation: {
           coords: { speed: null, accuracy: 15 },
         },
         backgroundLocationTracking: false,
@@ -434,7 +435,7 @@ describe('DevOverlay', () => {
 
     it('速度が負の値の場合に0km/hを表示する', () => {
       setupAtomValues({
-        location: {
+        rawLocation: {
           coords: { speed: -5, accuracy: 15 },
         },
         backgroundLocationTracking: false,
@@ -483,7 +484,7 @@ describe('DevOverlay', () => {
   describe('速度計算のロジック', () => {
     it('速度が0の場合に0km/hを表示する', () => {
       setupAtomValues({
-        location: {
+        rawLocation: {
           coords: { speed: 0, accuracy: 15 },
         },
         backgroundLocationTracking: false,
@@ -495,7 +496,7 @@ describe('DevOverlay', () => {
 
     it('速度が正の小数値の場合に正しく変換する', () => {
       setupAtomValues({
-        location: {
+        rawLocation: {
           coords: { speed: 13.89, accuracy: 15 },
         },
         backgroundLocationTracking: false,

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -24,7 +24,6 @@ import {
 import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import {
   backgroundLocationTrackingAtom,
-  locationAtom,
   rawLocationAtom,
 } from '~/store/atoms/location';
 import { generateAccuracyChart } from '~/utils/accuracyChart';
@@ -332,12 +331,12 @@ const MetricCard: React.FC<MetricCardProps> = ({
 const DevOverlay: React.FC = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedHeight, setExpandedHeight] = useState(0);
-  const location = useAtomValue(locationAtom);
-  // 精度はMAX_PERMIT_ACCURACYフィルタを通らない生の測位値から取得する。
+  // DevOverlayは診断用途のため、速度・精度ともにEMAスムージングやMAX_PERMIT_ACCURACY
+  // フィルタを通らない生の測位値（rawLocationAtom）から取得する。
   // 継続測位（watch/background両経路）はhandleTrackingLocation経由でフィルタ前に
-  // rawLocationAtomへ生の値を記録するため、棄却された精度もここから観測できる。
+  // rawLocationAtomへ生の値を記録するため、棄却・補正された値もここから観測できる。
   const rawLocation = useAtomValue(rawLocationAtom);
-  const speed = location?.coords?.speed;
+  const speed = rawLocation?.coords?.speed;
   const accuracy = rawLocation?.coords?.accuracy;
   const distanceToNextStation = useDistanceToNextStation();
   const nextStation = useNextStation(false);


### PR DESCRIPTION
## 概要

DevOverlay（開発者向け診断オーバーレイ）の速度表示を、EMA スムージング・速度フィルタ後の `locationAtom` ではなく、フィルタ前の生の測位値である `rawLocationAtom` から取得するように変更しました。これまで生データだったのは精度（accuracy）のみで、速度（CURRENT SPEED）は補正後の値を表示していたため、診断用途に合わせて速度も生の値を常に表示するようにします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `DevOverlay.tsx` の速度参照元を `locationAtom` から `rawLocationAtom` に変更（`rawLocationAtom` は `handleTrackingLocation` がフィルタ前に記録する生の `LocationObject` で、速度を含む）。
- 速度・精度ともに生の測位値から読む旨にコメントを更新。
- 不要になった `locationAtom` の import を削除。
- `DevOverlay.test.tsx` の速度系テストを `rawLocation` 駆動に更新し、既定の `rawLocation` に `speed` を追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest src/components/DevOverlay.test.tsx`（31 件成功）、`npm run typecheck`（エラーなし）、`biome ci`（対象2ファイル・指摘なし）を実行済み。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BSSujuoMp1YpQ9RuFXJu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 速度・精度表示のデータ参照元を変更し、より直接的なセンサーデータを使用するように改善しました。

* **Tests**
  * 表示機能のテストケースをデータ参照元の変更に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->