### PR TITLE
最大許容精度を1.5kmに戻し精度超過時は走行中扱いにする

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,7 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 10;
 export const LOCATION_TIME_INTERVAL = 5000;
 
-export const MAX_PERMIT_ACCURACY = 2000;
+export const MAX_PERMIT_ACCURACY = 1500;
 
 export const LOCATION_START_MAX_RETRIES = 3;
 export const LOCATION_START_RETRY_BASE_DELAY_MS = 1000;

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -73,7 +73,7 @@ describe('useRefreshStation', () => {
   });
 
   it('runs without crashing with basic mocks', () => {
-    // locationAtom, notifyStateの順で呼ばれる
+    // locationAtom, locationAccuracyOutlierAtom, notifyStateの順で呼ばれる
     mockUseAtomValue
       .mockReturnValueOnce({
         coords: {
@@ -81,6 +81,7 @@ describe('useRefreshStation', () => {
           longitude: 135.0,
         },
       }) // locationAtom
+      .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     jest
@@ -109,7 +110,8 @@ describe('useRefreshStation', () => {
   });
 
   it('実際の精度がMAX_PERMIT_ACCURACYを超える場合はarrivedを強制的にfalseにする', () => {
-    // 最寄り駅と完全に同一座標でも、精度が許容上限を超えていれば到着とみなさない
+    // ワンショット取得などフィルタを経由せず粗い精度の測位がlocationAtomに入った場合、
+    // 最寄り駅と完全に同一座標でも到着とみなさない
     mockUseAtomValue
       .mockReturnValueOnce({
         coords: {
@@ -118,10 +120,56 @@ describe('useRefreshStation', () => {
           accuracy: MAX_PERMIT_ACCURACY + 1,
         },
       }) // locationAtom
+      .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     // useRefreshStation内のuseSetAtom呼び出し順:
     // 1回目=setStation(stationState), 2回目=setNavigation(navigationState)
+    const setStation = jest.fn();
+    mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
+
+    jest
+      .spyOn(useNearestStationModule, 'useNearestStation')
+      .mockReturnValue(mockStation);
+    jest
+      .spyOn(useNextStationModule, 'useNextStation')
+      .mockReturnValue(mockStation);
+    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
+    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
+      arrivedThreshold: 100,
+      approachingThreshold: 300,
+    });
+    jest
+      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
+      .mockReturnValue({
+        isWrongDirection: false,
+        isLoopLineWrongDirection: false,
+      });
+
+    renderHook(() => useRefreshStation(), {
+      wrapper: ({ children }) => <Provider>{children}</Provider>,
+    });
+
+    expect(setStation).toHaveBeenCalled();
+    const updater = setStation.mock.calls[0][0] as (prev: any) => any;
+    const nextState = updater({});
+    expect(nextState.arrived).toBe(false);
+  });
+
+  it('外れ値フラグが立っている場合は精度が良好でもarrivedを強制的にfalseにする', () => {
+    // 継続測位ではMAX_PERMIT_ACCURACY超の測位は棄却され座標が前回値で凍結するため、
+    // locationAtomの精度は良好なまま。棄却の事実は外れ値フラグから判定する
+    mockUseAtomValue
+      .mockReturnValueOnce({
+        coords: {
+          latitude: 35.0,
+          longitude: 135.0,
+          accuracy: 10,
+        },
+      }) // locationAtom
+      .mockReturnValueOnce(true) // locationAccuracyOutlierAtom
+      .mockReturnValue({ targetStationIds: [] }); // notifyState
+
     const setStation = jest.fn();
     mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
 

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -1,7 +1,8 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
 import { renderHook } from '@testing-library/react-native';
-import { Provider, useAtomValue } from 'jotai';
+import { Provider, useAtomValue, useSetAtom } from 'jotai';
 import { OperationStatus, type Station, StopCondition } from '~/@types/graphql';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import * as useCanGoForwardModule from '~/hooks/useCanGoForward';
 import * as useNearestStationModule from '~/hooks/useNearestStation';
 import * as useNextStationModule from '~/hooks/useNextStation';
@@ -26,6 +27,8 @@ jest.mock('~/store/atoms/notify', () => ({
 const mockUseAtomValue = useAtomValue as jest.MockedFunction<
   typeof useAtomValue
 >;
+
+const mockUseSetAtom = useSetAtom as jest.MockedFunction<typeof useSetAtom>;
 
 const mockStation: Station = {
   __typename: 'Station',
@@ -103,5 +106,50 @@ describe('useRefreshStation', () => {
     });
 
     expect(result).toBeTruthy();
+  });
+
+  it('実際の精度がMAX_PERMIT_ACCURACYを超える場合はarrivedを強制的にfalseにする', () => {
+    // 最寄り駅と完全に同一座標でも、精度が許容上限を超えていれば到着とみなさない
+    mockUseAtomValue
+      .mockReturnValueOnce({
+        coords: {
+          latitude: 35.0,
+          longitude: 135.0,
+          accuracy: MAX_PERMIT_ACCURACY + 1,
+        },
+      }) // locationAtom
+      .mockReturnValue({ targetStationIds: [] }); // notifyState
+
+    // useRefreshStation内のuseSetAtom呼び出し順:
+    // 1回目=setStation(stationState), 2回目=setNavigation(navigationState)
+    const setStation = jest.fn();
+    mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
+
+    jest
+      .spyOn(useNearestStationModule, 'useNearestStation')
+      .mockReturnValue(mockStation);
+    jest
+      .spyOn(useNextStationModule, 'useNextStation')
+      .mockReturnValue(mockStation);
+    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
+    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
+      arrivedThreshold: 100,
+      approachingThreshold: 300,
+    });
+    jest
+      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
+      .mockReturnValue({
+        isWrongDirection: false,
+        isLoopLineWrongDirection: false,
+      });
+
+    renderHook(() => useRefreshStation(), {
+      wrapper: ({ children }) => <Provider>{children}</Provider>,
+    });
+
+    expect(setStation).toHaveBeenCalled();
+    const updater = setStation.mock.calls[0][0] as (prev: any) => any;
+    const nextState = updater({});
+    expect(nextState.arrived).toBe(false);
   });
 });

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -5,7 +5,10 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Station } from '~/@types/graphql';
 import { ARRIVED_GRACE_PERIOD_MS } from '~/constants';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { locationAtom } from '~/store/atoms/location';
+import {
+  locationAccuracyOutlierAtom,
+  locationAtom,
+} from '~/store/atoms/location';
 import navigationState from '../store/atoms/navigation';
 import notifyState from '../store/atoms/notify';
 import stationState from '../store/atoms/station';
@@ -38,6 +41,7 @@ export const useRefreshStation = (): void => {
   const setStation = useSetAtom(stationState);
   const setNavigation = useSetAtom(navigationState);
   const location = useAtomValue(locationAtom);
+  const isAccuracyOutlier = useAtomValue(locationAccuracyOutlierAtom);
   const latitude = location?.coords.latitude;
   const longitude = location?.coords.longitude;
   const accuracy = location?.coords.accuracy;
@@ -78,11 +82,17 @@ export const useRefreshStation = (): void => {
       return true;
     }
 
-    // 実際のGPS精度が許容上限(MAX_PERMIT_ACCURACY=1.5km)を超える測位では到着判定の
-    // 信頼性が担保できないため、強制的に未到着とみなす。
-    // 継続測位はhandleTrackingLocationで弾かれるが、ワンショット取得や手動選択など
-    // フィルタを経由しない経路で粗い精度の測位が紛れ込みうるため、ここでも防御的に検査する。
-    if (accuracy != null && accuracy > MAX_PERMIT_ACCURACY) {
+    // 現在位置を信用できない状況では到着判定の信頼性が担保できないため、
+    // 強制的に未到着(=走行中)とみなす。次の2系統を区別して検査する:
+    //   1. 継続測位: handleTrackingLocationがMAX_PERMIT_ACCURACY超の測位を棄却して
+    //      座標を凍結するため、精度悪化はlocationAtom側には現れない。棄却の事実は
+    //      外れ値フラグ(isAccuracyOutlier)から判定する。
+    //   2. ワンショット取得・手動選択: フィルタを経由せず粗い精度の測位がlocationAtomに
+    //      入りうるため、保持している精度を直接検査する。
+    if (
+      isAccuracyOutlier ||
+      (accuracy != null && accuracy > MAX_PERMIT_ACCURACY)
+    ) {
       return false;
     }
 
@@ -117,6 +127,7 @@ export const useRefreshStation = (): void => {
     return arrived;
   }, [
     accuracy,
+    isAccuracyOutlier,
     effectiveArrivedThreshold,
     latitude,
     longitude,

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -4,6 +4,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Station } from '~/@types/graphql';
 import { ARRIVED_GRACE_PERIOD_MS } from '~/constants';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import { locationAtom } from '~/store/atoms/location';
 import navigationState from '../store/atoms/navigation';
 import notifyState from '../store/atoms/notify';
@@ -77,6 +78,14 @@ export const useRefreshStation = (): void => {
       return true;
     }
 
+    // 実際のGPS精度が許容上限(MAX_PERMIT_ACCURACY=1.5km)を超える測位では到着判定の
+    // 信頼性が担保できないため、強制的に未到着とみなす。
+    // 継続測位はhandleTrackingLocationで弾かれるが、ワンショット取得や手動選択など
+    // フィルタを経由しない経路で粗い精度の測位が紛れ込みうるため、ここでも防御的に検査する。
+    if (accuracy != null && accuracy > MAX_PERMIT_ACCURACY) {
+      return false;
+    }
+
     // グレース期間は到着を引き起こした駅にのみ適用する
     // 別の駅に対してtrueを返すと誤って駅が進んでしまう
     const inGracePeriod =
@@ -106,7 +115,13 @@ export const useRefreshStation = (): void => {
       lastArrivedStationIdRef.current = nearestStation.id ?? null;
     }
     return arrived;
-  }, [effectiveArrivedThreshold, latitude, longitude, nearestStation]);
+  }, [
+    accuracy,
+    effectiveArrivedThreshold,
+    latitude,
+    longitude,
+    nearestStation,
+  ]);
 
   const isApproaching = useMemo((): boolean => {
     if (

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -3,6 +3,7 @@ import { LineType, type Station } from '~/@types/graphql';
 import { store } from '..';
 import {
   accuracyHistoryAtom,
+  locationAccuracyOutlierAtom,
   locationAtom,
   rawLocationAtom,
   resetLocationState,
@@ -68,6 +69,35 @@ describe('setLocation', () => {
       // watchPositionAsync経路ではlocationAtomが生の精度を持つため、rawLocationは触らない
       expect(store.get(rawLocationAtom)).toBeNull();
       expect(store.get(locationAtom)?.coords.accuracy).toBe(30);
+    });
+  });
+
+  describe('外れ値フラグの解除', () => {
+    it('受理した測位を反映する際に外れ値フラグを解除する', () => {
+      // 継続測位で一度立ったフラグが、direct setLocation経由の良好な測位で解除されること
+      store.set(locationAccuracyOutlierAtom, true);
+
+      const loc = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(loc);
+
+      expect(store.get(locationAccuracyOutlierAtom)).toBe(false);
+      expect(store.get(locationAtom)?.coords.accuracy).toBe(30);
+    });
+
+    it('speedフィルタで座標が棄却される場合でも外れ値フラグは解除される', () => {
+      // フィルタ基準となる前回値を用意する
+      const first = makeLocation(35.0, 139.0, 30, 1000);
+      setLocation(first);
+
+      store.set(locationAccuracyOutlierAtom, true);
+
+      // 1秒で遠方へジャンプ → MAX_PLAUSIBLE_SPEED超過で座標は棄却される
+      const jump = makeLocation(36.0, 140.0, 30, 2000);
+      setLocation(jump);
+
+      // 座標は前回値のまま（棄却）だが、精度自体は良好なので外れ値フラグは解除される
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+      expect(store.get(locationAccuracyOutlierAtom)).toBe(false);
     });
   });
 

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -84,9 +84,9 @@ export const setRawLocation = (location: Location.LocationObject) => {
   store.set(rawLocationAtom, location);
 };
 
+// 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
+// 手動選択(StationSearchModal/useInitialNearbyStation/Privacy等)もここを通る。
 export const setLocation = (location: Location.LocationObject) => {
-  // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
-  // 手動選択(StationSearchModal/useInitialNearbyStation/Privacy等)もここを通る。
   // 新しい測位を受け取った時点で「直近の測位が精度外れ値だった」状態は解消されるため、
   // ここで外れ値フラグを解除する。解除をhandleTrackingLocationだけに置くと、継続測位で
   // 一度立ったフラグがdirect setLocation経由の良好な測位では解除されず、arrivedがfalseに

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -51,6 +51,12 @@ export const rawLocationAtom = atom<Location.LocationObject | null>(null);
 export const accuracyHistoryAtom = atom<number[]>([]);
 export const backgroundLocationTrackingAtom = atom(false);
 
+// 直近の継続測位がMAX_PERMIT_ACCURACYを超え、ワープ対策フィルタで棄却されたかを表す。
+// 棄却時は座標を捨てる（=locationAtomが前回値で凍結する）ため、精度の悪化は
+// locationAtom側の精度には現れない。この事実を別フラグとして残すことで、到着判定など
+// 下流の処理が「現在位置を信用できない＝走行中」と扱えるようにする。
+export const locationAccuracyOutlierAtom = atom(false);
+
 // 速度フィルタ・EMAスムージングの基準として使う「最後にフィルタ処理を通過した位置」
 // 地下鉄モード中は更新しないため、モード復帰後にノイジーなprevで誤棄却されるのを防ぐ
 const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
@@ -61,6 +67,13 @@ export const resetLocationState = () => {
   store.set(rawLocationAtom, null);
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
+  store.set(locationAccuracyOutlierAtom, false);
+};
+
+// ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
+// フィルタ判定の都度呼び出すこと。
+export const setLocationAccuracyOutlier = (isOutlier: boolean) => {
+  store.set(locationAccuracyOutlierAtom, isOutlier);
 };
 
 // MAX_PERMIT_ACCURACYフィルタで棄却される測位も含め、生の測位値を記録する。

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -85,6 +85,15 @@ export const setRawLocation = (location: Location.LocationObject) => {
 };
 
 export const setLocation = (location: Location.LocationObject) => {
+  // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
+  // 手動選択(StationSearchModal/useInitialNearbyStation/Privacy等)もここを通る。
+  // 新しい測位を受け取った時点で「直近の測位が精度外れ値だった」状態は解消されるため、
+  // ここで外れ値フラグを解除する。解除をhandleTrackingLocationだけに置くと、継続測位で
+  // 一度立ったフラグがdirect setLocation経由の良好な測位では解除されず、arrivedがfalseに
+  // 張り付く。座標棄却(speedフィルタ)で早期returnする経路でも精度自体は良好なため、
+  // フィルタ判定より前で解除する。
+  store.set(locationAccuracyOutlierAtom, false);
+
   const filteredPrev = store.get(lastFilteredLocationAtom);
   const currentHistory = store.get(accuracyHistoryAtom);
   const newAccuracy = location.coords.accuracy;

--- a/src/utils/handleTrackingLocation.test.ts
+++ b/src/utils/handleTrackingLocation.test.ts
@@ -43,12 +43,13 @@ describe('handleTrackingLocation', () => {
     mockIsDevApp = false;
   });
 
-  it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡し外れ値フラグを下ろす', () => {
+  it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡す（外れ値フラグの解除はsetLocationに委譲）', () => {
     const loc = makeLocation(MAX_PERMIT_ACCURACY);
     handleTrackingLocation(loc);
 
     expect(mockSetLocation).toHaveBeenCalledWith(loc);
-    expect(mockSetLocationAccuracyOutlier).toHaveBeenCalledWith(false);
+    // 解除はsetLocation側に集約したため、本関数からは外れ値フラグを操作しない
+    expect(mockSetLocationAccuracyOutlier).not.toHaveBeenCalled();
   });
 
   it('精度がMAX_PERMIT_ACCURACYを超える測位はsetLocationに渡さず外れ値フラグを立てる', () => {

--- a/src/utils/handleTrackingLocation.test.ts
+++ b/src/utils/handleTrackingLocation.test.ts
@@ -1,11 +1,16 @@
 import type * as Location from 'expo-location';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { setLocation, setRawLocation } from '~/store/atoms/location';
+import {
+  setLocation,
+  setLocationAccuracyOutlier,
+  setRawLocation,
+} from '~/store/atoms/location';
 import { handleTrackingLocation } from './handleTrackingLocation';
 
 jest.mock('~/store/atoms/location', () => ({
   setLocation: jest.fn(),
   setRawLocation: jest.fn(),
+  setLocationAccuracyOutlier: jest.fn(),
 }));
 
 let mockIsDevApp = false;
@@ -17,6 +22,7 @@ jest.mock('./isDevApp', () => ({
 
 const mockSetLocation = setLocation as jest.Mock;
 const mockSetRawLocation = setRawLocation as jest.Mock;
+const mockSetLocationAccuracyOutlier = setLocationAccuracyOutlier as jest.Mock;
 
 const makeLocation = (accuracy: number | null): Location.LocationObject => ({
   coords: {
@@ -37,18 +43,20 @@ describe('handleTrackingLocation', () => {
     mockIsDevApp = false;
   });
 
-  it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡す', () => {
+  it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡し外れ値フラグを下ろす', () => {
     const loc = makeLocation(MAX_PERMIT_ACCURACY);
     handleTrackingLocation(loc);
 
     expect(mockSetLocation).toHaveBeenCalledWith(loc);
+    expect(mockSetLocationAccuracyOutlier).toHaveBeenCalledWith(false);
   });
 
-  it('精度がMAX_PERMIT_ACCURACYを超える測位はsetLocationに渡さない', () => {
+  it('精度がMAX_PERMIT_ACCURACYを超える測位はsetLocationに渡さず外れ値フラグを立てる', () => {
     const loc = makeLocation(MAX_PERMIT_ACCURACY + 1);
     handleTrackingLocation(loc);
 
     expect(mockSetLocation).not.toHaveBeenCalled();
+    expect(mockSetLocationAccuracyOutlier).toHaveBeenCalledWith(true);
   });
 
   it('精度がnullの測位はフィルタせずsetLocationに渡す', () => {

--- a/src/utils/handleTrackingLocation.ts
+++ b/src/utils/handleTrackingLocation.ts
@@ -22,10 +22,11 @@ export const handleTrackingLocation = (location: Location.LocationObject) => {
     // ワープ対策として座標自体は破棄するが、棄却が起きたことは記録する。
     // 座標を捨てるとlocationAtomが前回値で凍結し精度悪化が下流から見えなくなるため、
     // この外れ値フラグを介して到着判定に「位置を信用できない」状態を伝える。
+    // フラグの解除は受理側のsetLocationに集約している（ワンショット取得・手動選択など
+    // 本関数を経由しない経路でも確実に解除するため）。
     setLocationAccuracyOutlier(true);
     return;
   }
 
-  setLocationAccuracyOutlier(false);
   setLocation(location);
 };

--- a/src/utils/handleTrackingLocation.ts
+++ b/src/utils/handleTrackingLocation.ts
@@ -1,6 +1,10 @@
 import type * as Location from 'expo-location';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { setLocation, setRawLocation } from '~/store/atoms/location';
+import {
+  setLocation,
+  setLocationAccuracyOutlier,
+  setRawLocation,
+} from '~/store/atoms/location';
 import { isDevApp } from './isDevApp';
 
 // watchPositionAsync / startLocationUpdatesAsync 双方の継続測位の共通入口。
@@ -15,8 +19,13 @@ export const handleTrackingLocation = (location: Location.LocationObject) => {
 
   const { accuracy } = location.coords;
   if (accuracy != null && accuracy > MAX_PERMIT_ACCURACY) {
+    // ワープ対策として座標自体は破棄するが、棄却が起きたことは記録する。
+    // 座標を捨てるとlocationAtomが前回値で凍結し精度悪化が下流から見えなくなるため、
+    // この外れ値フラグを介して到着判定に「位置を信用できない」状態を伝える。
+    setLocationAccuracyOutlier(true);
     return;
   }
 
+  setLocationAccuracyOutlier(false);
   setLocation(location);
 };


### PR DESCRIPTION
## 概要

地下鉄路線における位置情報の信頼度に応じて到着判定を出し分けるための改修。GPS精度が1.5km以内に収まる路線（例: 都営大江戸線）では従来どおり位置情報を信用してそのまま使い、精度1.5km超が観測される路線（例: 東京メトロ副都心線）では位置情報を信用せず走行中として扱う。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `MAX_PERMIT_ACCURACY` を 2000 から 1.5km(1500) に戻す（#6116 の緩和を取り消し）
- `handleTrackingLocation` でワープ対策フィルタが棄却した測位を `locationAccuracyOutlierAtom`（外れ値フラグ）に記録する。棄却時は座標を破棄して位置が前回値で凍結し、精度悪化が `locationAtom` に現れないことへの対処
- `useRefreshStation` の到着判定で外れ値フラグが立っている場合は座標が良好でも `arrived=false`（走行中）に強制する。フィルタを経由しないワンショット取得・手動選択向けに、保持している精度の直接チェックも併用
- 外れ値フラグの解除を受理側の `setLocation` に集約し、ワンショット取得・手動選択など `handleTrackingLocation` を経由しない経路の良好な測位でも確実に解除されるようにする（フラグが残り `arrived` が `false` に張り付く問題への対処）
- 上記の到着判定ガード・フラグ連携・フラグ解除のユニットテストを追加

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue



## スクリーンショット（任意）



---
_Generated by [Claude Code](https://claude.ai/code/session_01FAkc4wwF8YGJueJYYp5Jzq)_


## Summary by CodeRabbit

* **Bug Fixes**
  * GPS精度の許容閾値を見直し、許容精度をより厳しくしました。
  * 精度が基準を超える（不安定な測位）場合に「到着」判定を取り消すよう到着判定を改善しました。
  * 不正確な測位を下流へ通知するフラグを導入し、誤検知を減らします。