### PR TITLE
DevOverlayの精度履歴をreact-native-svgの折れ線グラフで再実装

### DIFF
--- a/src/components/AccuracyHistoryChart.test.tsx
+++ b/src/components/AccuracyHistoryChart.test.tsx
@@ -1,0 +1,87 @@
+import { render } from '@testing-library/react-native';
+import { processColor } from 'react-native';
+import { ACCURACY_CHART_COLORS } from '~/utils/accuracyChart';
+import AccuracyHistoryChart from './AccuracyHistoryChart';
+
+describe('AccuracyHistoryChart', () => {
+  it('renders one point per valid sample', () => {
+    const { getAllByTestId } = render(
+      <AccuracyHistoryChart
+        history={[10, 20, 30, 40]}
+        width={120}
+        height={40}
+      />
+    );
+    expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(4);
+  });
+
+  it('renders a single point for a single sample', () => {
+    const { getAllByTestId } = render(
+      <AccuracyHistoryChart history={[15]} width={120} height={40} />
+    );
+    expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(1);
+  });
+
+  it('drops invalid samples before plotting', () => {
+    const { getAllByTestId } = render(
+      <AccuracyHistoryChart
+        history={[10, Number.NaN, 50, -5]}
+        width={120}
+        height={40}
+      />
+    );
+    expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(2);
+  });
+
+  it('shows a placeholder when there are no valid samples', () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <AccuracyHistoryChart
+        history={[Number.NaN, Number.POSITIVE_INFINITY]}
+        width={120}
+        height={40}
+      />
+    );
+    expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
+      '---'
+    );
+    expect(queryAllByTestId('dev-overlay-accuracy-point')).toHaveLength(0);
+  });
+
+  it('shows a placeholder for empty history', () => {
+    const { getByTestId } = render(
+      <AccuracyHistoryChart history={[]} width={120} height={40} />
+    );
+    expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
+      '---'
+    );
+  });
+
+  it('plots worse (higher) accuracy nearer the top', () => {
+    const { getAllByTestId } = render(
+      <AccuracyHistoryChart history={[10, 100]} width={120} height={40} />
+    );
+    const [best, worst] = getAllByTestId('dev-overlay-accuracy-point');
+    // 値が大きい(精度が悪い)100m の点ほど y 座標が小さい(=上端側)になる
+    expect(Number(worst.props.cy)).toBeLessThan(Number(best.props.cy));
+  });
+
+  it('colors points by accuracy band', () => {
+    const { getAllByTestId } = render(
+      <AccuracyHistoryChart history={[50, 500, 2500]} width={120} height={40} />
+    );
+    const [good, warning, danger] = getAllByTestId(
+      'dev-overlay-accuracy-point'
+    );
+    // react-native-svg は fill 文字列を内部の Brush({ type, payload }) へ変換するため
+    // payload(processColor 相当の数値)で突き合わせる
+    expect(good.props.fill.payload).toBe(
+      processColor(ACCURACY_CHART_COLORS.good)
+    );
+    expect(warning.props.fill.payload).toBe(
+      processColor(ACCURACY_CHART_COLORS.warning)
+    );
+    expect(danger.props.fill.payload).toBe(
+      processColor(ACCURACY_CHART_COLORS.danger)
+    );
+  });
+});

--- a/src/components/AccuracyHistoryChart.tsx
+++ b/src/components/AccuracyHistoryChart.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Circle, Line, Svg } from 'react-native-svg';
+import { buildAccuracyChartSeries } from '~/utils/accuracyChart';
+import Typography from './Typography';
+
+type Props = {
+  /** 1Hzでサンプリングした測位精度履歴(m)。無効値はNaNで積まれる想定。 */
+  history: number[];
+  /** 描画領域の幅(px)。 */
+  width: number;
+  /** 描画領域の高さ(px)。 */
+  height: number;
+};
+
+// 線・点が描画領域の縁で切れないように内側に余白を取る
+const HORIZONTAL_PADDING = 4;
+const VERTICAL_PADDING = 6;
+const DOT_RADIUS = 2.5;
+const LINE_WIDTH = 1.75;
+
+const styles = StyleSheet.create({
+  placeholder: {
+    color: 'rgba(148, 163, 184, 0.9)',
+    fontSize: 12,
+    letterSpacing: 2,
+  },
+  placeholderContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+/**
+ * DevOverlay の精度履歴を折れ線グラフで描画する。
+ * 縦軸は測位精度で、値が大きい(精度が悪い)サンプルほど上端側に描く。
+ * 各点・線分は精度帯に応じて色分けし、悪化区間を一目で把握できるようにする。
+ */
+const AccuracyHistoryChart: React.FC<Props> = ({ history, width, height }) => {
+  const series = useMemo(() => buildAccuracyChartSeries(history), [history]);
+
+  const points = useMemo(() => {
+    if (series.length === 0 || width <= 0 || height <= 0) {
+      return [];
+    }
+    const innerWidth = Math.max(0, width - HORIZONTAL_PADDING * 2);
+    const innerHeight = Math.max(0, height - VERTICAL_PADDING * 2);
+    return series.map((point, index) => ({
+      // サンプルは等間隔に配置。1点のみのときは中央に置く
+      x:
+        HORIZONTAL_PADDING +
+        (series.length === 1
+          ? innerWidth / 2
+          : (index / (series.length - 1)) * innerWidth),
+      // normalized=1(最も精度が悪い)を上端、0(最も良い)を下端へマッピングする
+      y: VERTICAL_PADDING + (1 - point.normalized) * innerHeight,
+      value: point.value,
+      color: point.color,
+    }));
+  }, [series, width, height]);
+
+  if (points.length === 0) {
+    return (
+      <View
+        testID="dev-overlay-accuracy-history"
+        style={[styles.placeholderContainer, { width, height }]}
+      >
+        <Typography style={styles.placeholder}>---</Typography>
+      </View>
+    );
+  }
+
+  return (
+    <View testID="dev-overlay-accuracy-history" style={{ width, height }}>
+      <Svg width={width} height={height}>
+        {points.slice(1).map((point, index) => {
+          const prev = points[index];
+          // 線分は両端のうち精度が悪い(値が大きい)側の色で塗り、悪化区間を強調する
+          const segmentColor =
+            point.value >= prev.value ? point.color : prev.color;
+          return (
+            <Line
+              key={`segment-${index}-${point.x}-${point.y}`}
+              x1={prev.x}
+              y1={prev.y}
+              x2={point.x}
+              y2={point.y}
+              stroke={segmentColor}
+              strokeWidth={LINE_WIDTH}
+              strokeLinecap="round"
+            />
+          );
+        })}
+        {points.map((point, index) => (
+          <Circle
+            key={`point-${index}-${point.x}-${point.y}`}
+            testID="dev-overlay-accuracy-point"
+            cx={point.x}
+            cy={point.y}
+            r={DOT_RADIUS}
+            fill={point.color}
+          />
+        ))}
+      </Svg>
+    </View>
+  );
+};
+
+export default React.memo(AccuracyHistoryChart);

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -34,22 +34,6 @@ jest.mock('~/hooks', () => ({
   useNextStation: jest.fn(),
 }));
 
-// Mock utils
-jest.mock('~/utils/accuracyChart', () => ({
-  generateAccuracyChart: jest.fn((history: number[] | null | undefined) => {
-    // Mock implementation that mirrors generateAccuracyChart's invalid-value filter
-    if (!history || history.length === 0) {
-      return [];
-    }
-    return history
-      .filter((value) => Number.isFinite(value) && value >= 0)
-      .map(() => ({
-        char: '▇',
-        color: '#ffffff',
-      }));
-  }),
-}));
-
 jest.mock('~/utils/telemetryConfig', () => ({
   isTelemetryEnabledByBuild: true,
 }));
@@ -358,30 +342,24 @@ describe('DevOverlay', () => {
     });
 
     it('精度チャートをマウント直後に1サンプル分描画する', () => {
-      const { getByTestId } = render(<DevOverlay />);
-      // マウント時の即時サンプリングで1件積まれる
-      expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
-        /^▇$/
-      );
+      const { getAllByTestId } = render(<DevOverlay />);
+      // マウント時の即時サンプリングで折れ線グラフに1点描かれる
+      expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(1);
     });
 
     it('精度チャートが1秒ごとに無条件で更新される', () => {
       jest.useFakeTimers();
       try {
-        const { getByTestId } = render(<DevOverlay />);
+        const { getAllByTestId } = render(<DevOverlay />);
         // 初回サンプル
-        expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
-          /^▇$/
-        );
+        expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(1);
 
         act(() => {
           jest.advanceTimersByTime(3000);
         });
 
         // 位置情報イベントが届かなくても interval 由来で履歴が積み増される
-        expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
-          /^▇{4}$/
-        );
+        expect(getAllByTestId('dev-overlay-accuracy-point')).toHaveLength(4);
       } finally {
         jest.useRealTimers();
       }
@@ -395,14 +373,15 @@ describe('DevOverlay', () => {
       });
       jest.useFakeTimers();
       try {
-        const { getByTestId } = render(<DevOverlay />);
+        const { getByTestId, queryAllByTestId } = render(<DevOverlay />);
         act(() => {
           jest.advanceTimersByTime(5000);
         });
-        // NaN だけが積まれるため generateAccuracyChart 側で全件除外され '---' になる
+        // NaN だけが積まれるため buildAccuracyChartSeries 側で全件除外され '---' になる
         expect(getByTestId('dev-overlay-accuracy-history')).toHaveTextContent(
           '---'
         );
+        expect(queryAllByTestId('dev-overlay-accuracy-point')).toHaveLength(0);
       } finally {
         jest.useRealTimers();
       }

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -8,7 +8,6 @@ import {
   PanResponder,
   type StyleProp,
   StyleSheet,
-  Text,
   type TextStyle,
   useWindowDimensions,
   View,
@@ -26,7 +25,7 @@ import {
   backgroundLocationTrackingAtom,
   rawLocationAtom,
 } from '~/store/atoms/location';
-import { generateAccuracyChart } from '~/utils/accuracyChart';
+import AccuracyHistoryChart from './AccuracyHistoryChart';
 import Typography from './Typography';
 
 const EXPAND_DURATION = 280;
@@ -159,11 +158,6 @@ const styles = StyleSheet.create({
     color: LABEL_COLOR,
     fontSize: 9,
     letterSpacing: 1.6,
-  },
-  chartValue: {
-    color: '#fff',
-    fontSize: 14,
-    lineHeight: 18,
   },
   metricsGrid: {
     flexDirection: 'row',
@@ -391,11 +385,6 @@ const DevOverlay: React.FC = () => {
     return () => clearInterval(id);
   }, []);
 
-  const accuracyChartBlocks = useMemo(
-    () => generateAccuracyChart(chartHistory),
-    [chartHistory]
-  );
-
   const versionLabel = `TrainLCD DO ${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`;
   const telemetryValue = isTelemetryEnabled ? 'ON' : 'OFF';
   const backgroundValue = isBackgroundLocationTracking ? 'ON' : 'OFF';
@@ -432,7 +421,6 @@ const DevOverlay: React.FC = () => {
         minHeight: 64,
       }
     : null;
-  const chartValueStyle = isLandscape ? { fontSize: 12, lineHeight: 15 } : null;
   const metricCardStyle = isLandscape
     ? {
         minHeight: 56,
@@ -463,6 +451,11 @@ const DevOverlay: React.FC = () => {
     : contentWidth;
   const metricWidth = (metricsColumnWidth - metricsGap) / 2;
   const nextCardWidth = metricsColumnWidth;
+  // 折れ線グラフの描画サイズ。chartShellの内側(paddingHorizontal分を差し引いた幅)に収める
+  const accuracyChartWidth = isLandscape
+    ? chartColumnWidth - 20
+    : contentWidth - 24;
+  const accuracyChartHeight = isLandscape ? 30 : 40;
   const leftMetricWidth = metricWidth;
   const nextTargetCardStyle: ViewStyle = {
     justifyContent: 'flex-start',
@@ -721,23 +714,11 @@ const DevOverlay: React.FC = () => {
                         <Typography style={styles.chartLabel}>
                           ACCURACY HISTORY
                         </Typography>
-                        <Typography
-                          style={[styles.chartValue, chartValueStyle]}
-                          testID="dev-overlay-accuracy-history"
-                          numberOfLines={1}
-                          ellipsizeMode="clip"
-                        >
-                          {accuracyChartBlocks.length === 0
-                            ? '---'
-                            : accuracyChartBlocks.map((block, index) => (
-                                <Text
-                                  key={`${index}-${block.char}-${block.color}`}
-                                  style={{ color: block.color }}
-                                >
-                                  {block.char}
-                                </Text>
-                              ))}
-                        </Typography>
+                        <AccuracyHistoryChart
+                          history={chartHistory}
+                          width={accuracyChartWidth}
+                          height={accuracyChartHeight}
+                        />
                       </View>
                     </View>
                   </View>
@@ -805,23 +786,11 @@ const DevOverlay: React.FC = () => {
                     <Typography style={styles.chartLabel}>
                       ACCURACY HISTORY
                     </Typography>
-                    <Typography
-                      style={[styles.chartValue, chartValueStyle]}
-                      testID="dev-overlay-accuracy-history"
-                      numberOfLines={1}
-                      ellipsizeMode="clip"
-                    >
-                      {accuracyChartBlocks.length === 0
-                        ? '---'
-                        : accuracyChartBlocks.map((block, index) => (
-                            <Text
-                              key={`${index}-${block.char}-${block.color}`}
-                              style={{ color: block.color }}
-                            >
-                              {block.char}
-                            </Text>
-                          ))}
-                    </Typography>
+                    <AccuracyHistoryChart
+                      history={chartHistory}
+                      width={accuracyChartWidth}
+                      height={accuracyChartHeight}
+                    />
                   </View>
                 </View>
 

--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -1,133 +1,68 @@
-import { generateAccuracyChart } from './accuracyChart';
+import {
+  ACCURACY_CHART_COLORS,
+  buildAccuracyChartSeries,
+  getAccuracyColor,
+} from './accuracyChart';
 
-describe('generateAccuracyChart', () => {
+describe('buildAccuracyChartSeries', () => {
   it('should return empty array for empty history', () => {
-    expect(generateAccuracyChart([])).toEqual([]);
+    expect(buildAccuracyChartSeries([])).toEqual([]);
   });
 
-  it('should return same block for all identical values', () => {
-    const result = generateAccuracyChart([100, 100, 100, 100]);
+  it('should keep one point per valid sample', () => {
+    const result = buildAccuracyChartSeries([10, 20, 30, 40]);
     expect(result).toHaveLength(4);
-    expect(result.every((block) => block.char === '▄')).toBe(true);
+    expect(result.map((point) => point.value)).toEqual([10, 20, 30, 40]);
   });
 
-  it('should use taller blocks for higher (worse) accuracy values', () => {
-    // Higher accuracy values (worse precision) should get taller blocks
-    const result = generateAccuracyChart([100, 50, 10]);
+  it('should normalize worst (highest) accuracy to 1 and best to 0', () => {
+    const result = buildAccuracyChartSeries([10, 100, 55]);
+    // 10m が最良(0)、100m が最悪(1)
+    expect(result[0].normalized).toBe(0);
+    expect(result[1].normalized).toBe(1);
+    // 中間値は 0..1 の範囲に収まる
+    expect(result[2].normalized).toBeGreaterThan(0);
+    expect(result[2].normalized).toBeLessThan(1);
+  });
 
-    // Should have 3 blocks
-    expect(result).toHaveLength(3);
-
-    // First block (100m accuracy) should be tallest
-    // Last block (10m accuracy) should be shortest
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    const firstChar = result[0].char;
-    const lastChar = result[2].char;
-
-    expect(blocks.indexOf(firstChar)).toBeLessThan(blocks.indexOf(lastChar));
+  it('should return middle (0.5) normalization for identical values', () => {
+    const result = buildAccuracyChartSeries([100, 100, 100, 100]);
+    expect(result).toHaveLength(4);
+    expect(result.every((point) => point.normalized === 0.5)).toBe(true);
   });
 
   it('should handle single value', () => {
-    const result = generateAccuracyChart([50]);
+    const result = buildAccuracyChartSeries([50]);
     expect(result).toHaveLength(1);
-    expect(result[0].char).toBe('▄');
-  });
-
-  it('should handle two values', () => {
-    const result = generateAccuracyChart([100, 10]);
-    expect(result).toHaveLength(2);
-
-    // Higher value should have taller block
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    expect(blocks.indexOf(result[0].char)).toBeLessThan(
-      blocks.indexOf(result[1].char)
-    );
-  });
-
-  it('should handle typical accuracy progression', () => {
-    // Simulate getting worse accuracy over time
-    const result = generateAccuracyChart([10, 20, 40, 60, 80, 100]);
-
-    expect(result).toHaveLength(6);
-
-    // Should be an ascending pattern (visually going up since higher accuracy = taller block)
-    // Indices should decrease as blocks get taller
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    for (let i = 0; i < result.length - 1; i++) {
-      const currentIndex = blocks.indexOf(result[i].char);
-      const nextIndex = blocks.indexOf(result[i + 1].char);
-      // Each subsequent value should have a taller or same height block (lower or same index)
-      expect(currentIndex).toBeGreaterThanOrEqual(nextIndex);
-    }
-  });
-
-  it('should handle fluctuating accuracy', () => {
-    const result = generateAccuracyChart([50, 100, 25, 75]);
-
-    expect(result).toHaveLength(4);
-
-    // Should use blocks based on relative values
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-
-    // 100m (worst) should have tallest block
-    const index100 = blocks.indexOf(result[1].char);
-    // 25m (best) should have shortest block
-    const index25 = blocks.indexOf(result[2].char);
-
-    expect(index100).toBeLessThan(index25);
-  });
-
-  it('should handle 12 values (max history)', () => {
-    const values = [10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100];
-    const result = generateAccuracyChart(values);
-
-    expect(result).toHaveLength(12);
-
-    // First value (10) should be shortest
-    // Last value (100) should be tallest
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    expect(blocks.indexOf(result[0].char)).toBeGreaterThan(
-      blocks.indexOf(result[11].char)
-    );
-  });
-
-  it('should only use valid block characters', () => {
-    const validBlocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    const result = generateAccuracyChart([
-      10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
-    ]);
-
-    for (const block of result) {
-      expect(validBlocks).toContain(block.char);
-    }
+    expect(result[0].normalized).toBe(0.5);
+    expect(result[0].value).toBe(50);
   });
 
   it('should filter out NaN values', () => {
-    const result = generateAccuracyChart([10, Number.NaN, 50, 100]);
-    // Should have 3 valid values
+    const result = buildAccuracyChartSeries([10, Number.NaN, 50, 100]);
     expect(result).toHaveLength(3);
+    expect(result.map((point) => point.value)).toEqual([10, 50, 100]);
   });
 
   it('should filter out Infinity values', () => {
-    const result = generateAccuracyChart([
+    const result = buildAccuracyChartSeries([
       10,
       Number.POSITIVE_INFINITY,
       50,
       Number.NEGATIVE_INFINITY,
       100,
     ]);
-    // Should have 3 valid values
     expect(result).toHaveLength(3);
   });
 
   it('should filter out negative values', () => {
-    const result = generateAccuracyChart([10, -5, 50, -100, 100]);
-    // Should have 3 valid values (10, 50, 100)
+    const result = buildAccuracyChartSeries([10, -5, 50, -100, 100]);
     expect(result).toHaveLength(3);
+    expect(result.map((point) => point.value)).toEqual([10, 50, 100]);
   });
 
   it('should return empty array when all values are invalid', () => {
-    const result = generateAccuracyChart([
+    const result = buildAccuracyChartSeries([
       Number.NaN,
       Number.POSITIVE_INFINITY,
       -10,
@@ -136,60 +71,60 @@ describe('generateAccuracyChart', () => {
     expect(result).toEqual([]);
   });
 
-  it('should handle mixed valid and invalid values', () => {
-    const result = generateAccuracyChart([
-      10,
-      Number.NaN,
-      50,
-      Number.POSITIVE_INFINITY,
-      100,
-      -5,
-    ]);
-    // Should have 3 valid values
-    expect(result).toHaveLength(3);
-
-    const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-    for (const block of result) {
-      expect(blocks).toContain(block.char);
-    }
+  it('should handle 12 values (max history)', () => {
+    const values = [10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    const result = buildAccuracyChartSeries(values);
+    expect(result).toHaveLength(12);
+    // 最初(10m)が最良で 0、最後(100m)が最悪で 1
+    expect(result[0].normalized).toBe(0);
+    expect(result[11].normalized).toBe(1);
   });
 
   describe('color coding', () => {
-    it('should use red color for accuracy > MAX_PERMIT_ACCURACY', () => {
-      const result = generateAccuracyChart([2001, 2500, 3000]);
+    it('should use danger color for accuracy > MAX_PERMIT_ACCURACY', () => {
+      const result = buildAccuracyChartSeries([2001, 2500, 3000]);
       expect(result).toHaveLength(3);
-      for (const block of result) {
-        expect(block.color).toBe('#ff0000');
+      for (const point of result) {
+        expect(point.color).toBe(ACCURACY_CHART_COLORS.danger);
       }
     });
 
-    it('should use yellow color for accuracy >= BAD_ACCURACY_THRESHOLD and <= MAX_PERMIT_ACCURACY', () => {
-      const result = generateAccuracyChart([200, 750, 1500]);
+    it('should use warning color for accuracy >= BAD_ACCURACY_THRESHOLD and <= MAX_PERMIT_ACCURACY', () => {
+      const result = buildAccuracyChartSeries([200, 750, 1500]);
       expect(result).toHaveLength(3);
-      for (const block of result) {
-        expect(block.color).toBe('#ffff00');
+      for (const point of result) {
+        expect(point.color).toBe(ACCURACY_CHART_COLORS.warning);
       }
     });
 
-    it('should use white color for accuracy < BAD_ACCURACY_THRESHOLD', () => {
-      const result = generateAccuracyChart([10, 100, 199]);
+    it('should use good color for accuracy < BAD_ACCURACY_THRESHOLD', () => {
+      const result = buildAccuracyChartSeries([10, 100, 199]);
       expect(result).toHaveLength(3);
-      for (const block of result) {
-        expect(block.color).toBe('#ffffff');
+      for (const point of result) {
+        expect(point.color).toBe(ACCURACY_CHART_COLORS.good);
       }
     });
 
     it('should handle mixed accuracy values with different colors', () => {
-      // Test with values in all three ranges
-      const result = generateAccuracyChart([50, 500, 2500]);
+      const result = buildAccuracyChartSeries([50, 500, 2500]);
       expect(result).toHaveLength(3);
-
-      // 50m should be white
-      expect(result[0].color).toBe('#ffffff');
-      // 500m should be yellow
-      expect(result[1].color).toBe('#ffff00');
-      // 2500m (over MAX_PERMIT_ACCURACY) should be red
-      expect(result[2].color).toBe('#ff0000');
+      expect(result[0].color).toBe(ACCURACY_CHART_COLORS.good);
+      expect(result[1].color).toBe(ACCURACY_CHART_COLORS.warning);
+      expect(result[2].color).toBe(ACCURACY_CHART_COLORS.danger);
     });
+  });
+});
+
+describe('getAccuracyColor', () => {
+  it('returns danger over MAX_PERMIT_ACCURACY', () => {
+    expect(getAccuracyColor(2000)).toBe(ACCURACY_CHART_COLORS.danger);
+  });
+
+  it('returns warning at the bad threshold boundary', () => {
+    expect(getAccuracyColor(200)).toBe(ACCURACY_CHART_COLORS.warning);
+  });
+
+  it('returns good below the bad threshold', () => {
+    expect(getAccuracyColor(199)).toBe(ACCURACY_CHART_COLORS.good);
   });
 });

--- a/src/utils/accuracyChart.ts
+++ b/src/utils/accuracyChart.ts
@@ -1,51 +1,64 @@
 import { MAX_PERMIT_ACCURACY } from '../constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '../constants/threshold';
 
-export type AccuracyBlock = {
-  char: string;
+/** 折れ線グラフ上の 1 サンプルを表す点。 */
+export type AccuracyChartPoint = {
+  /** 測位精度(m)。小さいほど高精度。 */
+  value: number;
+  /**
+   * 系列内の相対位置を 0..1 に正規化した値。
+   * 1 が系列中で最も精度が悪い(値が大きい)サンプル、0 が最も精度が良い(値が小さい)サンプル。
+   * 全サンプルが同値の場合は中央の 0.5 を返す。
+   */
+  normalized: number;
+  /** 精度帯に応じた線・点の表示色。 */
   color: string;
 };
 
 /**
- * Determines the color of an accuracy block based on accuracy value
- * @param accuracy Accuracy value in meters
- * @returns Color string for the block
+ * 精度帯ごとの折れ線・点の表示色。DevOverlay のメトリクスカード配色と揃え、
+ * 数値表示とグラフで同じ警告レベルが読み取れるようにする。
  */
-const getAccuracyColor = (accuracy: number): string => {
+export const ACCURACY_CHART_COLORS = {
+  good: '#38bdf8', // sky: BAD_ACCURACY_THRESHOLD 未満の良好域
+  warning: '#facc15', // yellow: BAD_ACCURACY_THRESHOLD 以上・MAX_PERMIT_ACCURACY 以下
+  danger: '#f87171', // red: MAX_PERMIT_ACCURACY 超過(フィルタで棄却される域)
+} as const;
+
+/**
+ * Determines the color of a chart point based on accuracy value
+ * @param accuracy Accuracy value in meters
+ * @returns Color string for the point
+ */
+export const getAccuracyColor = (accuracy: number): string => {
   // 最大許容精度(MAX_PERMIT_ACCURACY)を超えた測位値はフィルタで棄却されるため、
   // DevOverlayのメトリクスカード(isAccuracyOverLimit)と揃えて赤で警告する。
   if (accuracy > MAX_PERMIT_ACCURACY) {
-    return '#ff0000'; // red
+    return ACCURACY_CHART_COLORS.danger;
   }
   if (accuracy >= BAD_ACCURACY_THRESHOLD) {
-    return '#ffff00'; // yellow
+    return ACCURACY_CHART_COLORS.warning;
   }
-  return '#ffffff'; // white
+  return ACCURACY_CHART_COLORS.good;
 };
 
 /**
- * Generates an ASCII bar chart from accuracy values
- * Uses block characters to represent accuracy levels
- * Higher accuracy values (worse) produce taller bars
+ * Builds a normalized series for the accuracy history line chart.
+ * Invalid samples (NaN, Infinity, negative numbers) are dropped so that a
+ * stalled GPS makes the line visibly thin out instead of drawing bogus points.
+ * The series is normalization-only and rendering-size agnostic; callers map the
+ * 0..1 `normalized` value onto pixel coordinates.
  * @param accuracyHistory Array of accuracy values in meters
- * @returns Array of accuracy blocks with color information
+ * @returns Array of chart points with normalized position and color
  */
-export const generateAccuracyChart = (
+export const buildAccuracyChartSeries = (
   accuracyHistory: number[]
-): AccuracyBlock[] => {
-  if (accuracyHistory.length === 0) {
-    return [];
-  }
-
-  // Block characters from tallest to shortest
-  const blocks = ['▇', '▆', '▅', '▄', '▃', '▂', '▁'];
-
+): AccuracyChartPoint[] => {
   // Filter out invalid values (NaN, Infinity, negative numbers)
   const validHistory = accuracyHistory.filter(
     (val) => Number.isFinite(val) && val >= 0
   );
 
-  // Return empty array if no valid values
   if (validHistory.length === 0) {
     return [];
   }
@@ -59,32 +72,13 @@ export const generateAccuracyChart = (
     (max, val) => (val > max ? val : max),
     validHistory[0]
   );
+  const range = maxAccuracy - minAccuracy;
 
-  // If all values are the same, use middle block
-  if (minAccuracy === maxAccuracy) {
-    return validHistory.map((accuracy) => ({
-      char: blocks[3],
-      color: getAccuracyColor(accuracy),
-    }));
-  }
-
-  // Normalize and map to block characters
-  // Higher accuracy values (worse) map to taller blocks (index 0)
-  // Lower accuracy (better) maps to shorter blocks (index 6)
-  return validHistory.map((accuracy) => {
-    // Higher accuracy values should map to lower indices (taller blocks)
-    // So we invert the normalization
-    const denominator = maxAccuracy - minAccuracy;
-    const normalized =
-      denominator > 0
-        ? Math.max(0, Math.min(1, (maxAccuracy - accuracy) / denominator))
-        : 0.5;
-    const blockIndex = Math.floor(normalized * (blocks.length - 1));
-    // Ensure blockIndex is within bounds
-    const safeIndex = Math.max(0, Math.min(blocks.length - 1, blockIndex));
-    return {
-      char: blocks[safeIndex] || blocks[3],
-      color: getAccuracyColor(accuracy),
-    };
-  });
+  // normalized: 値が大きい(精度が悪い)ほど 1 に近づける。
+  // 全サンプルが同値で range が 0 のときは中央(0.5)に揃える。
+  return validHistory.map((value) => ({
+    value,
+    normalized: range > 0 ? (value - minAccuracy) / range : 0.5,
+    color: getAccuracyColor(value),
+  }));
 };


### PR DESCRIPTION
## 概要

DevOverlay の精度履歴表示を、ASCII ブロック文字（`▇▆▅▄▃▂▁`）による擬似バーから `react-native-svg` ベースの折れ線グラフに再実装した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/AccuracyHistoryChart.tsx` を新規追加し、`react-native-svg` の `Svg` / `Line` / `Circle` で精度履歴を折れ線グラフ描画。値が大きい（＝精度が悪い）サンプルほど上端側に配置する。
- 精度帯ごとに線・点を色分け（良好=`#38bdf8` / 警告=`#facc15` / 超過=`#f87171`、DevOverlay のメトリクスカード配色と統一）。線分は両端のうち精度が悪い側の色で塗り、悪化区間を強調する。
- 有効サンプルが無い場合は `---` プレースホルダー、1 サンプルのみの場合は中央に 1 点を表示する。
- `src/utils/accuracyChart.ts` の `generateAccuracyChart`（ブロック文字生成）を、描画サイズ非依存の正規化済み点列を返す `buildAccuracyChartSeries` に置き換え、色定数 `ACCURACY_CHART_COLORS` を公開。
- `src/components/DevOverlay.tsx` の縦・横レイアウト双方のチャート描画を `AccuracyHistoryChart` に差し替え、不要になった `Text` import・`generateAccuracyChart`・`chartValue` 系スタイルを削除。
- 関連テストを更新・追加（`accuracyChart.test.ts` を新 API 向けに刷新、`AccuracyHistoryChart.test.tsx` を新規追加、`DevOverlay.test.tsx` のチャート系アサーションを描画点数ベースへ更新）。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_017Lz6naTZHtiWnKXRu3ZGFE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 精度履歴をテキストベースから折れ線グラフ形式に変更。各データポイントを視覚的に表示し、精度の良悪を色分けで表現します。

* **テスト**
  * 新しい精度チャート表示形式に対応するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->