### PR TITLE
DevOverlayの精度履歴グラフの縦軸を固定ログスケールに変更し値の変化を読み取りやすくする

### DIFF
--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -1,8 +1,45 @@
 import {
+  ACCURACY_CHART_CEILING_M,
   ACCURACY_CHART_COLORS,
+  ACCURACY_CHART_FLOOR_M,
   buildAccuracyChartSeries,
   getAccuracyColor,
+  normalizeAccuracy,
 } from './accuracyChart';
+
+describe('normalizeAccuracy (fixed log scale)', () => {
+  it('maps the floor and below to 0', () => {
+    expect(normalizeAccuracy(ACCURACY_CHART_FLOOR_M)).toBe(0);
+    expect(normalizeAccuracy(0)).toBe(0);
+    expect(normalizeAccuracy(ACCURACY_CHART_FLOOR_M - 1)).toBe(0);
+  });
+
+  it('maps the ceiling and above to 1', () => {
+    expect(normalizeAccuracy(ACCURACY_CHART_CEILING_M)).toBe(1);
+    expect(normalizeAccuracy(ACCURACY_CHART_CEILING_M + 500)).toBe(1);
+  });
+
+  it('is monotonically increasing with accuracy across the range', () => {
+    const samples = [5, 10, 50, 200, 700, 1500];
+    const normalized = samples.map(normalizeAccuracy);
+    for (let i = 0; i < normalized.length - 1; i++) {
+      expect(normalized[i]).toBeLessThan(normalized[i + 1]);
+    }
+  });
+
+  it('keeps every result within [0, 1]', () => {
+    for (const v of [0, 1, 5, 60, 199, 200, 1499, 1500, 5000]) {
+      const n = normalizeAccuracy(v);
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('spreads good-range jitter visibly (5m vs 60m differ clearly)', () => {
+    // 相対スケールを廃したログ固定軸では良好域の変化も読み取れる
+    expect(normalizeAccuracy(60) - normalizeAccuracy(5)).toBeGreaterThan(0.3);
+  });
+});
 
 describe('buildAccuracyChartSeries', () => {
   it('should return empty array for empty history', () => {
@@ -15,26 +52,34 @@ describe('buildAccuracyChartSeries', () => {
     expect(result.map((point) => point.value)).toEqual([10, 20, 30, 40]);
   });
 
-  it('should normalize worst (highest) accuracy to 1 and best to 0', () => {
-    const result = buildAccuracyChartSeries([10, 100, 55]);
-    // 10m が最良(0)、100m が最悪(1)
-    expect(result[0].normalized).toBe(0);
-    expect(result[1].normalized).toBe(1);
-    // 中間値は 0..1 の範囲に収まる
-    expect(result[2].normalized).toBeGreaterThan(0);
-    expect(result[2].normalized).toBeLessThan(1);
+  it('positions each sample on the fixed scale, independent of the window', () => {
+    // 同じ精度値は他のサンプルに依らず常に同じ高さに来る(可変スケールの撤廃)
+    const alone = buildAccuracyChartSeries([50]);
+    const withOthers = buildAccuracyChartSeries([10, 50, 1500]);
+    expect(alone[0].normalized).toBe(normalizeAccuracy(50));
+    expect(withOthers[1].normalized).toBe(normalizeAccuracy(50));
+    expect(alone[0].normalized).toBe(withOthers[1].normalized);
   });
 
-  it('should return middle (0.5) normalization for identical values', () => {
+  it('does not collapse identical values to the middle', () => {
+    // 旧実装は全同値で 0.5 を返していたが、固定スケールでは実際の位置を返す
     const result = buildAccuracyChartSeries([100, 100, 100, 100]);
     expect(result).toHaveLength(4);
-    expect(result.every((point) => point.normalized === 0.5)).toBe(true);
+    const expected = normalizeAccuracy(100);
+    expect(result.every((point) => point.normalized === expected)).toBe(true);
+    expect(result[0].normalized).not.toBe(0.5);
+  });
+
+  it('orders worse (higher) accuracy above better accuracy', () => {
+    const result = buildAccuracyChartSeries([10, 100, 1000]);
+    expect(result[0].normalized).toBeLessThan(result[1].normalized);
+    expect(result[1].normalized).toBeLessThan(result[2].normalized);
   });
 
   it('should handle single value', () => {
     const result = buildAccuracyChartSeries([50]);
     expect(result).toHaveLength(1);
-    expect(result[0].normalized).toBe(0.5);
+    expect(result[0].normalized).toBe(normalizeAccuracy(50));
     expect(result[0].value).toBe(50);
   });
 
@@ -75,9 +120,10 @@ describe('buildAccuracyChartSeries', () => {
     const values = [10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100];
     const result = buildAccuracyChartSeries(values);
     expect(result).toHaveLength(12);
-    // 最初(10m)が最良で 0、最後(100m)が最悪で 1
-    expect(result[0].normalized).toBe(0);
-    expect(result[11].normalized).toBe(1);
+    // 単調増加の入力は単調増加の正規化位置になる
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(result[i].normalized).toBeLessThan(result[i + 1].normalized);
+    }
   });
 
   describe('color coding', () => {

--- a/src/utils/accuracyChart.ts
+++ b/src/utils/accuracyChart.ts
@@ -6,14 +6,27 @@ export type AccuracyChartPoint = {
   /** 測位精度(m)。小さいほど高精度。 */
   value: number;
   /**
-   * 系列内の相対位置を 0..1 に正規化した値。
-   * 1 が系列中で最も精度が悪い(値が大きい)サンプル、0 が最も精度が良い(値が小さい)サンプル。
-   * 全サンプルが同値の場合は中央の 0.5 を返す。
+   * 精度を 0..1 の固定スケール上の位置へ変換した値。
+   * 履歴ウィンドウの min/max には依存せず、同じ精度値は常に同じ位置に来る。
+   * 1 が最も精度が悪い(上端)、0 が最も精度が良い(下端)。
+   * @see normalizeAccuracy
    */
   normalized: number;
   /** 精度帯に応じた線・点の表示色。 */
   color: string;
 };
+
+/**
+ * 縦軸固定スケールの下限(m)。これ以下の高精度は下端(0)に張り付く。
+ * GPS の実用的な最良精度域(数 m)を踏まえた値。
+ */
+export const ACCURACY_CHART_FLOOR_M = 5;
+/**
+ * 縦軸固定スケールの上限(m)。これ以上は上端(1)にクランプする。
+ * 許容上限(MAX_PERMIT_ACCURACY)を超えた測位はフィルタで棄却される域なので、
+ * それ以降を区別する意味は薄く、上端に張り付かせて「振り切れ」を示す。
+ */
+export const ACCURACY_CHART_CEILING_M = MAX_PERMIT_ACCURACY;
 
 /**
  * 精度帯ごとの折れ線・点の表示色。DevOverlay のメトリクスカード配色と揃え、
@@ -42,12 +55,35 @@ export const getAccuracyColor = (accuracy: number): string => {
   return ACCURACY_CHART_COLORS.good;
 };
 
+const LOG_FLOOR = Math.log(ACCURACY_CHART_FLOOR_M);
+const LOG_SPAN = Math.log(ACCURACY_CHART_CEILING_M) - LOG_FLOOR;
+
+/**
+ * Maps an accuracy value (m) to a fixed 0..1 position on a logarithmic scale.
+ * The scale is anchored to constant floor/ceiling bounds (not the history
+ * window) so the same accuracy always lands at the same height and the
+ * magnitude of a change is directly readable. A log axis keeps both
+ * good-range jitter (e.g. 5m↔60m) and large degradations (hundreds of m)
+ * legible despite GPS accuracy spanning several orders of magnitude.
+ * 1 = worst (ceiling and above), 0 = best (floor and below).
+ * @param accuracy Accuracy value in meters
+ * @returns Normalized position clamped to [0, 1]
+ */
+export const normalizeAccuracy = (accuracy: number): number => {
+  const clamped = Math.min(
+    ACCURACY_CHART_CEILING_M,
+    Math.max(ACCURACY_CHART_FLOOR_M, accuracy)
+  );
+  return (Math.log(clamped) - LOG_FLOOR) / LOG_SPAN;
+};
+
 /**
  * Builds a normalized series for the accuracy history line chart.
  * Invalid samples (NaN, Infinity, negative numbers) are dropped so that a
  * stalled GPS makes the line visibly thin out instead of drawing bogus points.
- * The series is normalization-only and rendering-size agnostic; callers map the
- * 0..1 `normalized` value onto pixel coordinates.
+ * Each sample is positioned on a fixed logarithmic scale (see normalizeAccuracy)
+ * independently of the others, so the chart is both window- and
+ * rendering-size agnostic; callers map the 0..1 `normalized` value onto pixels.
  * @param accuracyHistory Array of accuracy values in meters
  * @returns Array of chart points with normalized position and color
  */
@@ -59,26 +95,9 @@ export const buildAccuracyChartSeries = (
     (val) => Number.isFinite(val) && val >= 0
   );
 
-  if (validHistory.length === 0) {
-    return [];
-  }
-
-  // Find min and max for normalization using reduce to avoid stack overflow
-  const minAccuracy = validHistory.reduce(
-    (min, val) => (val < min ? val : min),
-    validHistory[0]
-  );
-  const maxAccuracy = validHistory.reduce(
-    (max, val) => (val > max ? val : max),
-    validHistory[0]
-  );
-  const range = maxAccuracy - minAccuracy;
-
-  // normalized: 値が大きい(精度が悪い)ほど 1 に近づける。
-  // 全サンプルが同値で range が 0 のときは中央(0.5)に揃える。
   return validHistory.map((value) => ({
     value,
-    normalized: range > 0 ? (value - minAccuracy) / range : 0.5,
+    normalized: normalizeAccuracy(value),
     color: getAccuracyColor(value),
   }));
 };


### PR DESCRIPTION
## 概要

DevOverlay の精度履歴グラフの縦軸スケールが履歴ウィンドウの min/max に依存する相対スケールだったため、平常時のわずかな揺れでもグラフが全高に広がり、逆に値の変化量が読み取りづらかった。実機フィードバックを受け、縦軸を**固定ログスケール**に変更する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 縦軸を、履歴ウィンドウの min/max に依存する相対スケールから、下限 `5m`〜上限 `MAX_PERMIT_ACCURACY`(1500m) を対数で割り当てる**固定スケール**に変更。同じ精度値は常に同じ高さに描画され、値の変化量を直接読み取れる。
- 対数軸により、良好域の微小な変化（例: 5m↔60m）と数百m級の悪化の双方を判読可能に。GPS 精度のように桁が広い量に適した割り当て。
- `5m` 以下は下端(0)、`MAX_PERMIT_ACCURACY` 以上は上端(1)にクランプ（許容上限超過＝棄却域は「振り切れ」として上端に張り付かせる）。
- `buildAccuracyChartSeries` の相対正規化（min/max・range・全同値時 0.5）を撤去し、`normalizeAccuracy` で各サンプルを独立に固定変換する実装へ簡素化。
- 関連テストを固定ログスケール向けに更新（`accuracyChart.test.ts`）。ウィンドウ非依存・クランプ・単調性・良好域の判読性を検証。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_017Lz6naTZHtiWnKXRu3ZGFE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 精度チャートの正規化ロジックを改善し、グラフの軸スケーリングをより一貫性のあるものに変更しました。

* **Tests**
  * 精度チャート関連のテストを拡充し、固定スケールでの正規化が正しく動作することを検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->