### PR TITLE
最大許容精度と精度超過時の到着強制をFirebase Remote Config参照に変更し従来値をフォールバックに使用

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,21 @@ import * as TaskManager from 'expo-task-manager';
 import { SENTRY_DSN } from 'react-native-dotenv';
 import App from './src';
 import { LOCATION_TASK_NAME } from './src/constants';
+import { setupRemoteConfig } from './src/lib/remoteConfig';
 import { handleTrackingLocation } from './src/utils/handleTrackingLocation';
 
 Sentry.init({
   dsn: SENTRY_DSN,
   tracesSampleRate: 0.1,
   profilesSampleRate: 0.02,
+});
+
+// Remote Config の既定値登録とフェッチを起動時に一度だけ走らせる。
+// フォアグラウンド・ヘッドレス（バックグラウンド測位タスク）双方の起動経路を
+// 単一のエントリポイントでカバーする。失敗してもアプリは既定値で動作するため、
+// Sentry へ報告するに留めて起動はブロックしない。
+setupRemoteConfig().catch((error) => {
+  Sentry.captureException(error);
 });
 
 if (!TaskManager.isTaskDefined(LOCATION_TASK_NAME)) {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,3 +51,28 @@ jest.mock("~/utils/isTablet", () => ({
 jest.mock("react-native-localize", () => ({
   findBestLanguageTag: jest.fn(() => "ja"),
 }));
+
+// Remote Config はネイティブモジュール依存のためモックする。
+// setDefaults で登録した既定値を getValue から読み出せるようにし、未設定キーは
+// asNumber が 0 を返すことで getMaxPermitAccuracy 側のフォールバックを発火させる。
+jest.mock("@react-native-firebase/remote-config", () => {
+  const store = {};
+  return {
+    getRemoteConfig: jest.fn(() => ({})),
+    setConfigSettings: jest.fn(() => Promise.resolve()),
+    setDefaults: jest.fn((_remoteConfig, defaults) => {
+      Object.assign(store, defaults);
+      return Promise.resolve();
+    }),
+    fetchAndActivate: jest.fn(() => Promise.resolve(true)),
+    getValue: jest.fn((_remoteConfig, key) => {
+      const value = store[key];
+      return {
+        asNumber: () => (typeof value === "number" ? value : Number(value) || 0),
+        asString: () => (value == null ? "" : String(value)),
+        asBoolean: () => Boolean(value),
+        getSource: () => (key in store ? "default" : "static"),
+      };
+    }),
+  };
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -55,24 +55,32 @@ jest.mock("react-native-localize", () => ({
 // Remote Config はネイティブモジュール依存のためモックする。
 // setDefaults で登録した既定値を getValue から読み出せるようにし、未設定キーは
 // asNumber が 0 を返すことで getMaxPermitAccuracy 側のフォールバックを発火させる。
+// store はモジュールスコープで保持されるため、テスト間で値がリークしないよう
+// 各テスト前にリセットする（jest.mock のファクトリ外から参照するため mock 接頭辞が必要）。
+const mockRemoteConfigStore = {};
 jest.mock("@react-native-firebase/remote-config", () => {
-  const store = {};
   return {
     getRemoteConfig: jest.fn(() => ({})),
     setConfigSettings: jest.fn(() => Promise.resolve()),
     setDefaults: jest.fn((_remoteConfig, defaults) => {
-      Object.assign(store, defaults);
+      Object.assign(mockRemoteConfigStore, defaults);
       return Promise.resolve();
     }),
     fetchAndActivate: jest.fn(() => Promise.resolve(true)),
     getValue: jest.fn((_remoteConfig, key) => {
-      const value = store[key];
+      const value = mockRemoteConfigStore[key];
       return {
         asNumber: () => (typeof value === "number" ? value : Number(value) || 0),
         asString: () => (value == null ? "" : String(value)),
         asBoolean: () => Boolean(value),
-        getSource: () => (key in store ? "default" : "static"),
+        getSource: () => (key in mockRemoteConfigStore ? "default" : "static"),
       };
     }),
   };
+});
+
+beforeEach(() => {
+  for (const key of Object.keys(mockRemoteConfigStore)) {
+    delete mockRemoteConfigStore[key];
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-native-firebase/app": "^23.7.0",
         "@react-native-firebase/auth": "^23.7.0",
         "@react-native-firebase/firestore": "^23.7.0",
+        "@react-native-firebase/remote-config": "^23.7.0",
         "@react-native-firebase/storage": "^23.7.0",
         "@react-native-masked-view/masked-view": "0.3.2",
         "@react-navigation/native": "^7.0.14",
@@ -5839,6 +5840,35 @@
       },
       "peerDependencies": {
         "@react-native-firebase/app": "23.8.8"
+      }
+    },
+    "node_modules/@react-native-firebase/remote-config": {
+      "version": "23.8.8",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/remote-config/-/remote-config-23.8.8.tgz",
+      "integrity": "sha512-xyo2d+m/7JPO7TeVjBZwIeg1Q4O26MLv8Y8QIzXTFRBgjp/MijPtx87/PweCQsVB4D/crDHrFh+FYs1XyZB2yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "react-native-fetch-api": "^3.0.0",
+        "text-encoding": "^0.7.0",
+        "web-streams-polyfill": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@react-native-firebase/analytics": "23.8.8",
+        "@react-native-firebase/app": "23.8.8"
+      }
+    },
+    "node_modules/@react-native-firebase/remote-config/node_modules/web-streams-polyfill": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.3.0.tgz",
+      "integrity": "sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@react-native-firebase/storage": {
@@ -15137,6 +15167,15 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16368,6 +16407,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/react-native-gesture-handler": {
@@ -18175,6 +18223,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained",
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/text-segmentation": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-native-firebase/app": "^23.7.0",
     "@react-native-firebase/auth": "^23.7.0",
     "@react-native-firebase/firestore": "^23.7.0",
+    "@react-native-firebase/remote-config": "^23.7.0",
     "@react-native-firebase/storage": "^23.7.0",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-navigation/native": "^7.0.14",

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -13,7 +13,6 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
-import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import {
   useDistanceToNextStation,
@@ -21,6 +20,7 @@ import {
   useNextStation,
 } from '~/hooks';
 import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
+import { getMaxPermitAccuracy } from '~/lib/remoteConfig';
 import {
   backgroundLocationTrackingAtom,
   rawLocationAtom,
@@ -342,15 +342,16 @@ const DevOverlay: React.FC = () => {
   const coordsSpeed = ((speed ?? 0) < 0 ? 0 : speed) ?? 0;
   const accuracyMeters =
     accuracy != null ? Math.max(0, Math.floor(accuracy)) : null;
-  // MAX_PERMIT_ACCURACYのフィルタに関係なく生の精度を判定し、許容値を超えたら赤字で警告する
-  const isAccuracyOverLimit =
-    accuracy != null && accuracy > MAX_PERMIT_ACCURACY;
+  // 最大許容精度のフィルタに関係なく生の精度を判定し、許容値を超えたら赤字で警告する。
+  // 許容値は Remote Config 由来のため、フィルタ本体と同じ実効値で判定をそろえる。
+  const maxPermitAccuracy = getMaxPermitAccuracy();
+  const isAccuracyOverLimit = accuracy != null && accuracy > maxPermitAccuracy;
   // チャートが黄色になる精度域（BAD_ACCURACY_THRESHOLD以上・許容値以下）では
   // m表示も黄色文字にして、精度悪化を数値とチャートの双方で示す
   const isAccuracyWarning =
     accuracy != null &&
     accuracy >= BAD_ACCURACY_THRESHOLD &&
-    accuracy <= MAX_PERMIT_ACCURACY;
+    accuracy <= maxPermitAccuracy;
 
   const speedKMH = useMemo(
     () =>

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,6 +5,9 @@ export const LOCATION_ACCURACY = Location.Accuracy.Highest;
 export const LOCATION_DISTANCE_INTERVAL = 10;
 export const LOCATION_TIME_INTERVAL = 5000;
 
+// 最大許容精度(m)のフォールバック既定値。実効値は Firebase Remote Config の
+// max_permit_accuracy を参照する（src/lib/remoteConfig.ts の getMaxPermitAccuracy）。
+// リモート値が未取得・不正な場合はこの値にフォールバックする。
 export const MAX_PERMIT_ACCURACY = 1500;
 
 export const LOCATION_START_MAX_RETRIES = 3;

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -9,6 +9,7 @@ import * as useNextStationModule from '~/hooks/useNextStation';
 import { useRefreshStation } from '~/hooks/useRefreshStation';
 import * as useThresholdModule from '~/hooks/useThreshold';
 import * as useWrongDirectionDetectorModule from '~/hooks/useWrongDirectionDetector';
+import * as remoteConfigModule from '~/lib/remoteConfig';
 
 jest.mock('jotai', () => {
   const actual = jest.requireActual('jotai');
@@ -199,5 +200,54 @@ describe('useRefreshStation', () => {
     const updater = setStation.mock.calls[0][0] as (prev: any) => any;
     const nextState = updater({});
     expect(nextState.arrived).toBe(false);
+  });
+
+  it('強制未到着トグルが無効なら精度超過・外れ値でも通常の到着判定を行う', () => {
+    // Remote Configのフィーチャートグルで無効化された場合、精度に依らず
+    // 最寄り駅と同一座標なら到着とみなす
+    jest
+      .spyOn(remoteConfigModule, 'isForceNotArrivedOnLowAccuracyEnabled')
+      .mockReturnValue(false);
+
+    mockUseAtomValue
+      .mockReturnValueOnce({
+        coords: {
+          latitude: 35.0,
+          longitude: 135.0,
+          accuracy: MAX_PERMIT_ACCURACY + 1,
+        },
+      }) // locationAtom
+      .mockReturnValueOnce(true) // locationAccuracyOutlierAtom
+      .mockReturnValue({ targetStationIds: [] }); // notifyState
+
+    const setStation = jest.fn();
+    mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
+
+    jest
+      .spyOn(useNearestStationModule, 'useNearestStation')
+      .mockReturnValue(mockStation);
+    jest
+      .spyOn(useNextStationModule, 'useNextStation')
+      .mockReturnValue(mockStation);
+    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
+    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
+      arrivedThreshold: 100,
+      approachingThreshold: 300,
+    });
+    jest
+      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
+      .mockReturnValue({
+        isWrongDirection: false,
+        isLoopLineWrongDirection: false,
+      });
+
+    renderHook(() => useRefreshStation(), {
+      wrapper: ({ children }) => <Provider>{children}</Provider>,
+    });
+
+    expect(setStation).toHaveBeenCalled();
+    const updater = setStation.mock.calls[0][0] as (prev: any) => any;
+    const nextState = updater({});
+    expect(nextState.arrived).toBe(true);
   });
 });

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -4,7 +4,10 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Station } from '~/@types/graphql';
 import { ARRIVED_GRACE_PERIOD_MS } from '~/constants';
-import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import {
+  getMaxPermitAccuracy,
+  isForceNotArrivedOnLowAccuracyEnabled,
+} from '~/lib/remoteConfig';
 import {
   locationAccuracyOutlierAtom,
   locationAtom,
@@ -84,14 +87,17 @@ export const useRefreshStation = (): void => {
 
     // 現在位置を信用できない状況では到着判定の信頼性が担保できないため、
     // 強制的に未到着(=走行中)とみなす。次の2系統を区別して検査する:
-    //   1. 継続測位: handleTrackingLocationがMAX_PERMIT_ACCURACY超の測位を棄却して
+    //   1. 継続測位: handleTrackingLocationが最大許容精度超の測位を棄却して
     //      座標を凍結するため、精度悪化はlocationAtom側には現れない。棄却の事実は
     //      外れ値フラグ(isAccuracyOutlier)から判定する。
     //   2. ワンショット取得・手動選択: フィルタを経由せず粗い精度の測位がlocationAtomに
     //      入りうるため、保持している精度を直接検査する。
+    // この強制未到着はRemote Configのフィーチャートグルで無効化でき、無効時は
+    // 精度に依らず通常の到着判定を行う。
     if (
-      isAccuracyOutlier ||
-      (accuracy != null && accuracy > MAX_PERMIT_ACCURACY)
+      isForceNotArrivedOnLowAccuracyEnabled() &&
+      (isAccuracyOutlier ||
+        (accuracy != null && accuracy > getMaxPermitAccuracy()))
     ) {
       return false;
     }

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -1,0 +1,115 @@
+import {
+  fetchAndActivate,
+  getValue,
+  setConfigSettings,
+  setDefaults,
+} from '@react-native-firebase/remote-config';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import {
+  getMaxPermitAccuracy,
+  isForceNotArrivedOnLowAccuracyEnabled,
+  REMOTE_CONFIG_KEYS,
+  setupRemoteConfig,
+} from './remoteConfig';
+
+const mockedGetValue = getValue as jest.Mock;
+
+describe('getMaxPermitAccuracy', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the remote value when it is a valid positive number', () => {
+    mockedGetValue.mockReturnValueOnce({ asNumber: () => 2000 });
+    expect(getMaxPermitAccuracy()).toBe(2000);
+  });
+
+  it('falls back to MAX_PERMIT_ACCURACY when the remote value is zero', () => {
+    mockedGetValue.mockReturnValueOnce({ asNumber: () => 0 });
+    expect(getMaxPermitAccuracy()).toBe(MAX_PERMIT_ACCURACY);
+  });
+
+  it('falls back to MAX_PERMIT_ACCURACY for negative or non-finite values', () => {
+    mockedGetValue.mockReturnValueOnce({ asNumber: () => -100 });
+    expect(getMaxPermitAccuracy()).toBe(MAX_PERMIT_ACCURACY);
+
+    mockedGetValue.mockReturnValueOnce({ asNumber: () => Number.NaN });
+    expect(getMaxPermitAccuracy()).toBe(MAX_PERMIT_ACCURACY);
+  });
+
+  it('falls back to MAX_PERMIT_ACCURACY when remote config throws', () => {
+    mockedGetValue.mockImplementationOnce(() => {
+      throw new Error('not initialized');
+    });
+    expect(getMaxPermitAccuracy()).toBe(MAX_PERMIT_ACCURACY);
+  });
+
+  it('reads the max_permit_accuracy key', () => {
+    mockedGetValue.mockReturnValueOnce({ asNumber: () => 1234 });
+    getMaxPermitAccuracy();
+    expect(mockedGetValue).toHaveBeenCalledWith(
+      expect.anything(),
+      REMOTE_CONFIG_KEYS.MAX_PERMIT_ACCURACY
+    );
+  });
+});
+
+describe('isForceNotArrivedOnLowAccuracyEnabled', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the remote boolean when the value is set', () => {
+    mockedGetValue.mockReturnValueOnce({
+      getSource: () => 'remote',
+      asBoolean: () => false,
+    });
+    expect(isForceNotArrivedOnLowAccuracyEnabled()).toBe(false);
+  });
+
+  it('falls back to true when the value is unset (static source)', () => {
+    mockedGetValue.mockReturnValueOnce({
+      getSource: () => 'static',
+      asBoolean: () => false,
+    });
+    expect(isForceNotArrivedOnLowAccuracyEnabled()).toBe(true);
+  });
+
+  it('falls back to true when remote config throws', () => {
+    mockedGetValue.mockImplementationOnce(() => {
+      throw new Error('not initialized');
+    });
+    expect(isForceNotArrivedOnLowAccuracyEnabled()).toBe(true);
+  });
+
+  it('reads the force_not_arrived_on_low_accuracy key', () => {
+    mockedGetValue.mockReturnValueOnce({
+      getSource: () => 'remote',
+      asBoolean: () => true,
+    });
+    isForceNotArrivedOnLowAccuracyEnabled();
+    expect(mockedGetValue).toHaveBeenCalledWith(
+      expect.anything(),
+      REMOTE_CONFIG_KEYS.FORCE_NOT_ARRIVED_ON_LOW_ACCURACY
+    );
+  });
+});
+
+describe('setupRemoteConfig', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers defaults and fetches/activates remote config', async () => {
+    await setupRemoteConfig();
+    expect(setConfigSettings).toHaveBeenCalledTimes(1);
+    expect(setDefaults).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        [REMOTE_CONFIG_KEYS.MAX_PERMIT_ACCURACY]: MAX_PERMIT_ACCURACY,
+        [REMOTE_CONFIG_KEYS.FORCE_NOT_ARRIVED_ON_LOW_ACCURACY]: true,
+      })
+    );
+    expect(fetchAndActivate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -1,0 +1,79 @@
+import {
+  fetchAndActivate,
+  getRemoteConfig,
+  getValue,
+  setConfigSettings,
+  setDefaults,
+} from '@react-native-firebase/remote-config';
+import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+
+// Firebase Remote Config のパラメータキー。コンソール側のキー名と一致させる。
+export const REMOTE_CONFIG_KEYS = {
+  // 継続測位で受理する測位精度の上限(m)。これを超える測位はワープ対策で棄却される。
+  MAX_PERMIT_ACCURACY: 'max_permit_accuracy',
+  // 精度が最大許容精度を超えた際に到着判定を強制的に未到着へ倒す機能の有効/無効。
+  FORCE_NOT_ARRIVED_ON_LOW_ACCURACY: 'force_not_arrived_on_low_accuracy',
+} as const;
+
+// 精度超過時に到着判定を未到着へ強制する機能のフォールバック既定値。
+// 既存挙動（常時有効）を維持するため true をフォールバックとする。
+const FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK = true;
+
+// フェッチ前・取得失敗時に参照する既定値。フォールバックは従来の挙動を流用する。
+const REMOTE_CONFIG_DEFAULTS = {
+  [REMOTE_CONFIG_KEYS.MAX_PERMIT_ACCURACY]: MAX_PERMIT_ACCURACY,
+  [REMOTE_CONFIG_KEYS.FORCE_NOT_ARRIVED_ON_LOW_ACCURACY]:
+    FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK,
+} as const;
+
+// 過度なフェッチを避けつつ当日中の値更新を取り込める間隔。
+const MINIMUM_FETCH_INTERVAL_MILLIS = 60 * 60 * 1000; // 1時間
+
+// 起動時に一度だけ既定値を登録し、リモート値をフェッチ＆有効化する。
+// フェッチに失敗してもアプリは既定値で動作を継続するため、呼び出し側で握り潰さず
+// 例外を素通しし、ロギングはエントリポイント側（index.js）に委ねる。
+export const setupRemoteConfig = async (): Promise<void> => {
+  const remoteConfig = getRemoteConfig();
+  await setConfigSettings(remoteConfig, {
+    minimumFetchIntervalMillis: MINIMUM_FETCH_INTERVAL_MILLIS,
+  });
+  await setDefaults(remoteConfig, REMOTE_CONFIG_DEFAULTS);
+  await fetchAndActivate(remoteConfig);
+};
+
+// 最大許容精度(m)を同期的に取得する。setupRemoteConfig 完了後は有効化済みの
+// リモート値を、未完了・未設定・取得失敗時は MAX_PERMIT_ACCURACY をフォールバックとして返す。
+// 0 や負値・非数といった不正値もフォールバックへ倒し、フィルタが無効化されるのを防ぐ。
+export const getMaxPermitAccuracy = (): number => {
+  try {
+    const value = getValue(
+      getRemoteConfig(),
+      REMOTE_CONFIG_KEYS.MAX_PERMIT_ACCURACY
+    ).asNumber();
+    if (Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  } catch {
+    // Remote Config 未初期化などのケースはフォールバックへ倒す。
+  }
+  return MAX_PERMIT_ACCURACY;
+};
+
+// 精度超過時に到着判定を未到着へ強制する機能の有効/無効を同期的に取得する。
+// setupRemoteConfig 完了後はリモート値（既定値含む）を、未設定・取得失敗時は
+// フォールバック(true=既存挙動)を返す。false は明示的な無効化と区別できないため、
+// 値が未設定(source==='static')かどうかで真にフォールバックすべきかを判定する。
+export const isForceNotArrivedOnLowAccuracyEnabled = (): boolean => {
+  try {
+    const configValue = getValue(
+      getRemoteConfig(),
+      REMOTE_CONFIG_KEYS.FORCE_NOT_ARRIVED_ON_LOW_ACCURACY
+    );
+    if (configValue.getSource() === 'static') {
+      return FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK;
+    }
+    return configValue.asBoolean();
+  } catch {
+    return FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK;
+  }
+};

--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -1,11 +1,15 @@
 import {
-  ACCURACY_CHART_CEILING_M,
   ACCURACY_CHART_COLORS,
   ACCURACY_CHART_FLOOR_M,
   buildAccuracyChartSeries,
+  getAccuracyChartCeiling,
   getAccuracyColor,
   normalizeAccuracy,
 } from './accuracyChart';
+
+// Remote Config 未設定時はフォールバック(1500m)が返るため、固定スケールの
+// 上限はその値で評価される。
+const ACCURACY_CHART_CEILING_M = getAccuracyChartCeiling();
 
 describe('normalizeAccuracy (fixed log scale)', () => {
   it('maps the floor and below to 0', () => {

--- a/src/utils/accuracyChart.test.ts
+++ b/src/utils/accuracyChart.test.ts
@@ -1,3 +1,4 @@
+import * as remoteConfigModule from '../lib/remoteConfig';
 import {
   ACCURACY_CHART_COLORS,
   ACCURACY_CHART_FLOOR_M,
@@ -42,6 +43,22 @@ describe('normalizeAccuracy (fixed log scale)', () => {
   it('spreads good-range jitter visibly (5m vs 60m differ clearly)', () => {
     // 相対スケールを廃したログ固定軸では良好域の変化も読み取れる
     expect(normalizeAccuracy(60) - normalizeAccuracy(5)).toBeGreaterThan(0.3);
+  });
+
+  it('degrades gracefully when the ceiling is at or below the floor', () => {
+    // Remote Config で床値以下が設定された退化スケールでも NaN を出さず、
+    // 床超えは上端(1)、床以下は下端(0)へ倒す
+    const spy = jest
+      .spyOn(remoteConfigModule, 'getMaxPermitAccuracy')
+      .mockReturnValue(ACCURACY_CHART_FLOOR_M - 2);
+    try {
+      expect(normalizeAccuracy(ACCURACY_CHART_FLOOR_M + 100)).toBe(1);
+      expect(normalizeAccuracy(ACCURACY_CHART_FLOOR_M)).toBe(0);
+      expect(normalizeAccuracy(1)).toBe(0);
+      expect(Number.isNaN(normalizeAccuracy(50))).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/src/utils/accuracyChart.ts
+++ b/src/utils/accuracyChart.ts
@@ -1,5 +1,5 @@
-import { MAX_PERMIT_ACCURACY } from '../constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '../constants/threshold';
+import { getMaxPermitAccuracy } from '../lib/remoteConfig';
 
 /** 折れ線グラフ上の 1 サンプルを表す点。 */
 export type AccuracyChartPoint = {
@@ -23,10 +23,11 @@ export type AccuracyChartPoint = {
 export const ACCURACY_CHART_FLOOR_M = 5;
 /**
  * 縦軸固定スケールの上限(m)。これ以上は上端(1)にクランプする。
- * 許容上限(MAX_PERMIT_ACCURACY)を超えた測位はフィルタで棄却される域なので、
+ * 許容上限(最大許容精度)を超えた測位はフィルタで棄却される域なので、
  * それ以降を区別する意味は薄く、上端に張り付かせて「振り切れ」を示す。
+ * 上限は Remote Config 由来の最大許容精度に追従させ、フィルタ本体と軸をそろえる。
  */
-export const ACCURACY_CHART_CEILING_M = MAX_PERMIT_ACCURACY;
+export const getAccuracyChartCeiling = (): number => getMaxPermitAccuracy();
 
 /**
  * 精度帯ごとの折れ線・点の表示色。DevOverlay のメトリクスカード配色と揃え、
@@ -34,8 +35,8 @@ export const ACCURACY_CHART_CEILING_M = MAX_PERMIT_ACCURACY;
  */
 export const ACCURACY_CHART_COLORS = {
   good: '#38bdf8', // sky: BAD_ACCURACY_THRESHOLD 未満の良好域
-  warning: '#facc15', // yellow: BAD_ACCURACY_THRESHOLD 以上・MAX_PERMIT_ACCURACY 以下
-  danger: '#f87171', // red: MAX_PERMIT_ACCURACY 超過(フィルタで棄却される域)
+  warning: '#facc15', // yellow: BAD_ACCURACY_THRESHOLD 以上・最大許容精度 以下
+  danger: '#f87171', // red: 最大許容精度 超過(フィルタで棄却される域)
 } as const;
 
 /**
@@ -44,9 +45,10 @@ export const ACCURACY_CHART_COLORS = {
  * @returns Color string for the point
  */
 export const getAccuracyColor = (accuracy: number): string => {
-  // 最大許容精度(MAX_PERMIT_ACCURACY)を超えた測位値はフィルタで棄却されるため、
-  // DevOverlayのメトリクスカード(isAccuracyOverLimit)と揃えて赤で警告する。
-  if (accuracy > MAX_PERMIT_ACCURACY) {
+  // 最大許容精度を超えた測位値はフィルタで棄却されるため、DevOverlayの
+  // メトリクスカード(isAccuracyOverLimit)と揃えて赤で警告する。許容値は
+  // Remote Config 由来のため、フィルタ本体と同じ実効値で判定をそろえる。
+  if (accuracy > getMaxPermitAccuracy()) {
     return ACCURACY_CHART_COLORS.danger;
   }
   if (accuracy >= BAD_ACCURACY_THRESHOLD) {
@@ -56,7 +58,6 @@ export const getAccuracyColor = (accuracy: number): string => {
 };
 
 const LOG_FLOOR = Math.log(ACCURACY_CHART_FLOOR_M);
-const LOG_SPAN = Math.log(ACCURACY_CHART_CEILING_M) - LOG_FLOOR;
 
 /**
  * Maps an accuracy value (m) to a fixed 0..1 position on a logarithmic scale.
@@ -70,11 +71,11 @@ const LOG_SPAN = Math.log(ACCURACY_CHART_CEILING_M) - LOG_FLOOR;
  * @returns Normalized position clamped to [0, 1]
  */
 export const normalizeAccuracy = (accuracy: number): number => {
-  const clamped = Math.min(
-    ACCURACY_CHART_CEILING_M,
-    Math.max(ACCURACY_CHART_FLOOR_M, accuracy)
-  );
-  return (Math.log(clamped) - LOG_FLOOR) / LOG_SPAN;
+  // 上限は Remote Config 由来の最大許容精度に追従するため、対数スパンも都度算出する。
+  const ceiling = getAccuracyChartCeiling();
+  const logSpan = Math.log(ceiling) - LOG_FLOOR;
+  const clamped = Math.min(ceiling, Math.max(ACCURACY_CHART_FLOOR_M, accuracy));
+  return (Math.log(clamped) - LOG_FLOOR) / logSpan;
 };
 
 /**

--- a/src/utils/accuracyChart.ts
+++ b/src/utils/accuracyChart.ts
@@ -73,6 +73,11 @@ const LOG_FLOOR = Math.log(ACCURACY_CHART_FLOOR_M);
 export const normalizeAccuracy = (accuracy: number): number => {
   // 上限は Remote Config 由来の最大許容精度に追従するため、対数スパンも都度算出する。
   const ceiling = getAccuracyChartCeiling();
+  // Remote Config で床値以下が設定されるとスケールが潰れて logSpan が 0 以下になり、
+  // 除算で NaN/不正値が生じる。退化したスケールでは床超えを上端(1)、床以下を下端(0)に倒す。
+  if (ceiling <= ACCURACY_CHART_FLOOR_M) {
+    return accuracy > ACCURACY_CHART_FLOOR_M ? 1 : 0;
+  }
   const logSpan = Math.log(ceiling) - LOG_FLOOR;
   const clamped = Math.min(ceiling, Math.max(ACCURACY_CHART_FLOOR_M, accuracy));
   return (Math.log(clamped) - LOG_FLOOR) / logSpan;

--- a/src/utils/handleTrackingLocation.ts
+++ b/src/utils/handleTrackingLocation.ts
@@ -1,5 +1,5 @@
 import type * as Location from 'expo-location';
-import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { getMaxPermitAccuracy } from '~/lib/remoteConfig';
 import {
   setLocation,
   setLocationAccuracyOutlier,
@@ -18,7 +18,7 @@ export const handleTrackingLocation = (location: Location.LocationObject) => {
   }
 
   const { accuracy } = location.coords;
-  if (accuracy != null && accuracy > MAX_PERMIT_ACCURACY) {
+  if (accuracy != null && accuracy > getMaxPermitAccuracy()) {
     // ワープ対策として座標自体は破棄するが、棄却が起きたことは記録する。
     // 座標を捨てるとlocationAtomが前回値で凍結し精度悪化が下流から見えなくなるため、
     // この外れ値フラグを介して到着判定に「位置を信用できない」状態を伝える。


### PR DESCRIPTION
## 概要

最大許容精度（継続測位で受理する測位精度の上限）と、精度超過時に到着判定を強制的に未到着へ倒す挙動を Firebase Remote Config から参照するように変更しました。リモート値が未取得・不正な場合は従来挙動（最大許容精度 1.5km / 強制未到着は有効）にフォールバックします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/remoteConfig.ts` を新設し、`setupRemoteConfig()`（起動時に既定値登録＋`fetchAndActivate`）と同期 getter `getMaxPermitAccuracy()` / `isForceNotArrivedOnLowAccuracyEnabled()` を実装
- Remote Config キー `max_permit_accuracy`（数値, フォールバック 1500m）と `force_not_arrived_on_low_accuracy`（真偽, フォールバック `true`）を追加。`MAX_PERMIT_ACCURACY` 定数はフォールバック既定値として残置
- 最大許容精度の参照箇所を全て getter 経由に統一（`handleTrackingLocation` の測位棄却フィルタ、`useRefreshStation` の到着判定、`accuracyChart` / `DevOverlay` の診断表示の色・スケール）
- `useRefreshStation` の精度超過時 `arrived: false` 強制をフィーチャートグルで切り替え可能化（無効時は精度に依らず通常の到着判定を行う）
- `index.js` の起動時に `setupRemoteConfig()` を実行（フォアグラウンド／ヘッドレスのバックグラウンド測位タスク両経路をカバー、失敗時は Sentry 報告のみでアプリ起動はブロックしない）
- `@react-native-firebase/remote-config` を依存追加、`jest.setup.js` に Remote Config のモックを追加、`src/lib/remoteConfig.test.ts` 新設および関連テストを追加・更新

### 回帰リスクと緩和

- 全参照箇所がフォールバックを持つため、Remote Config 未登録・フェッチ失敗時も従来値（1.5km / 強制未到着有効）で従来どおり動作する。
- boolean トグルは `false` を正規値と区別できないため、未設定（`getSource() === 'static'`）判定でフォールバックを発火させ、誤って無効化されないようにしている。
- 新規ネイティブモジュール追加のため、実機ビルド時は `pod install`（iOS）等のネイティブ依存再取得が必要。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 162 suites / 1766 tests 全パス。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3ik6x7uoffHN5B2Kfdaph)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Firebase Remote Config を導入し、GPS精度関連の閾値や挙動をサーバー側で動的に制御可能に。
  * 精度表示や到着判定、可視化（精度グラフ）の閾値がリモート値に連動。

* **テスト**
  * Remote Config 動作と各種精度処理のユニットテスト・モックを追加。

* **雑務**
  * Remote Config ライブラリを依存に追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->