### PR TITLE
直近で発車した駅を接近判定の対象から除外して発車直後の「まもなく当該駅」誤表示を防ぐ

### DIFF
--- a/src/hooks/useApproachingStation.test.tsx
+++ b/src/hooks/useApproachingStation.test.tsx
@@ -49,13 +49,14 @@ describe('useApproachingStation', () => {
   const mockGetIsPass = getIsPass as jest.MockedFunction<typeof getIsPass>;
 
   const setLocation = (
-    coords: { latitude: number; longitude: number } | null
+    coords: { latitude: number; longitude: number } | null,
+    currentStation?: ReturnType<typeof createStation>
   ) => {
     mockUseAtomValue.mockImplementation((atom: unknown) => {
       if (atom === 'LOCATION_ATOM') {
         return coords ? { coords } : null;
       }
-      return { stations };
+      return { stations, station: currentStation };
     });
   };
 
@@ -142,6 +143,23 @@ describe('useApproachingStation', () => {
     const result = JSON.parse(getByTestId('station').props.children as string);
     // 通過駅Bは除外され、A→Cの区間でCへ接近しているためC
     expect(result.id).toBe(3);
+  });
+
+  it('直近で発車した(到着済みの)駅は接近判定の対象から除外する', () => {
+    const stationA = createStation(1, { latitude: 35.0, longitude: 135.0 });
+    const stationB = createStation(2, { latitude: 35.2, longitude: 135.0 });
+    const stationC = createStation(3, { latitude: 35.4, longitude: 135.0 });
+    stations = [stationA, stationB, stationC];
+
+    // 直近の到着駅(=発車駅)はA。Aの直近に留まっていても、Aを除外して
+    // 次の停車駅Bを接近駅として返す(「まもなくA」の誤表示を防ぐ)。
+    setLocation({ latitude: 35.0, longitude: 135.0 }, stationA);
+    // Aを除外した最寄り停車駅はB。Bを起点とした次駅はC。
+    mockUseNextStation.mockReturnValue(stationC);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(2);
   });
 
   it('次の停車駅が存在しない(終点)場合は最寄り停車駅を返す', () => {

--- a/src/hooks/useApproachingStation.ts
+++ b/src/hooks/useApproachingStation.ts
@@ -18,17 +18,27 @@ import { useNextStation } from './useNextStation';
  */
 export const useApproachingStation = (): Station | undefined => {
   const location = useAtomValue(locationAtom);
-  const { stations } = useAtomValue(stationState);
+  const { stations, station: departedStation } = useAtomValue(stationState);
   const latitude = location?.coords.latitude;
   const longitude = location?.coords.longitude;
 
-  // 通過駅を除いた停車駅のうち座標が有効なものだけを接近判定の対象にする
+  // 通過駅を除いた停車駅のうち座標が有効なものだけを接近判定の対象にする。
+  // さらに直近で発車した(=到着済みの現在)駅を除外する。これを残すと、発車直後で
+  // まだ当該駅の接近圏内に留まっている間に「まもなく(発車した駅)」と誤表示される
+  // (例: 五反田を発車直後に「まもなく五反田」)。除外することで次の停車駅(高輪台)を
+  // 正しく接近駅として扱える。stationState.station は到着時に確定する現在駅のため、
+  // 値が古い場合でも除外対象は進行方向の後方に限られ、前方の接近対象を消すことはない。
   const validStops = useMemo(
     () =>
       stations.filter(
-        (s) => !getIsPass(s) && s.latitude != null && s.longitude != null
+        (s) =>
+          !getIsPass(s) &&
+          s.latitude != null &&
+          s.longitude != null &&
+          s.id !== departedStation?.id &&
+          s.groupId !== departedStation?.groupId
       ),
-    [stations]
+    [stations, departedStation?.id, departedStation?.groupId]
   );
 
   const stopCoordinates = useMemo(


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

GPS現在地基準で接近駅を算出する `useApproachingStation` で、直近に発車した（到着済みの現在）駅が接近候補に残っていたため、発車直後にまだ当該駅の接近圏内にいる間「まもなく（発車した駅）」と誤表示されていた問題を修正します。例: 浅草線で泉岳寺方面選択時、五反田を発車した直後に「まもなく五反田」と表示されていたものを、正しく次の停車駅「まもなく高輪台」と表示します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useApproachingStation` の接近候補(停車駅)から、直近で発車した現在駅(`stationState.station`)を `id` / `groupId` で除外
- これにより発車直後でも次の停車駅を接近駅として扱い、「まもなく(発車した駅)」の誤表示を防止
- 除外対象は常に進行方向の後方に限られるため、これから接近する前方の駅が消えることはない（`station` の値が古い場合でも安全）。既存の「最寄り停車駅を通過したら次駅へ」距離比較による自己修復も従来どおり機能する
- `useApproachingStation.test.tsx` に「直近で発車した駅は接近判定の対象から除外する」ケースを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（164 suites / 1778 tests 全パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_014jsjmE1khPmdyz7S9N2Pbd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 発車直後に前の駅が「接近中」と表示される問題を修正しました。到着済みの駅を接近判定から除外し、次の停車駅を正しく表示するようになりました。

## テスト
* 発車済み駅の除外処理に関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->