### PR TITLE
LineBoardと駅接近通知の現在駅をヘッダーのまもなく表示に揃えて全表示面で一致させる

### DIFF
--- a/src/components/LineBoard.test.tsx
+++ b/src/components/LineBoard.test.tsx
@@ -13,7 +13,7 @@ jest.mock('jotai', () => ({
 
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
-  useCurrentStation: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
 }));
 
 const mockUseAtomValue = useAtomValue as jest.MockedFunction<
@@ -66,7 +66,7 @@ jest.mock('./LineBoardJRKyushu', () => ({
 }));
 
 describe('LineBoard', () => {
-  const { useCurrentStation } = require('~/hooks');
+  const { useDisplayCurrentStation } = require('~/hooks');
   const LineBoardEast = require('./LineBoardEast').default;
   const LineBoardToei = require('./LineBoardToei').default;
   const LineBoardWest = require('./LineBoardWest').default;
@@ -83,7 +83,7 @@ describe('LineBoard', () => {
     mockUseAtomValue
       .mockReturnValueOnce(theme) // themeAtom
       .mockReturnValueOnce({ leftStations }); // navigationState
-    useCurrentStation.mockReturnValue({
+    useDisplayCurrentStation.mockReturnValue({
       id: 1,
       groupId: 1,
       name: '東京',

--- a/src/components/LineBoard.tsx
+++ b/src/components/LineBoard.tsx
@@ -2,7 +2,7 @@ import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { parenthesisRegexp } from '~/constants';
-import { useCurrentStation } from '../hooks';
+import { useDisplayCurrentStation } from '../hooks';
 import { APP_THEME } from '../models/Theme';
 import navigationState from '../store/atoms/navigation';
 import { themeAtom } from '../store/atoms/theme';
@@ -36,7 +36,8 @@ const styles = StyleSheet.create({
 const LineBoard: React.FC<Props> = ({ hasTerminus = false }: Props) => {
   const theme = useAtomValue(themeAtom);
   const { leftStations } = useAtomValue(navigationState);
-  const station = useCurrentStation();
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const station = useDisplayCurrentStation();
   const isBus = isBusLine(station?.line);
 
   const slicedLeftStations = useMemo(() => {

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -4,6 +4,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useDisplayCurrentStation,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
 } from '~/hooks';
@@ -112,7 +113,9 @@ const useStationCellState = (
   index: number,
   stations: Station[]
 ) => {
-  const { station: currentStation, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const currentStation = useDisplayCurrentStation();
   const transferLines = useTransferLinesFromStation(station, {
     omitJR: true,
     omitRepeatingLine: true,

--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -13,6 +13,7 @@ jest.mock('jotai', () => ({
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));
@@ -65,7 +66,7 @@ jest.mock('./ChevronTY', () => ({
 
 describe('LineBoardEast', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -95,6 +96,7 @@ describe('LineBoardEast', () => {
       arrived: true,
     });
     useCurrentLine.mockReturnValue(mockLine);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -5,6 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useDisplayCurrentStation,
   useInterval,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
@@ -305,7 +306,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   chevronColor,
   isOdakyu,
 }: StationNameCellProps) => {
-  const { station: currentStation, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const currentStation = useDisplayCurrentStation();
   const isEn = useAtomValue(isEnAtom);
 
   const currentStationIndex = useMemo(

--- a/src/components/LineBoardJO.test.tsx
+++ b/src/components/LineBoardJO.test.tsx
@@ -13,7 +13,7 @@ jest.mock('jotai', () => ({
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
-  useCurrentStation: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useIsPassing: jest.fn(() => false),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
   useTransferLinesFromStation: jest.fn(() => []),
@@ -81,7 +81,7 @@ jest.mock('./LineBoard/shared/components', () => ({
 
 describe('LineBoardJO', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine, useCurrentStation } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -111,7 +111,7 @@ describe('LineBoardJO', () => {
       selectedLine: mockLine,
     });
     useCurrentLine.mockReturnValue(mockLine);
-    useCurrentStation.mockReturnValue(mockStations[0]);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -4,7 +4,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import type { Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
-  useCurrentStation,
+  useDisplayCurrentStation,
   useIsPassing,
   useLandscapeWindowDimensions,
   useStationNumberIndexFunc,
@@ -229,7 +229,8 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
   const { arrived } = useAtomValue(stationState);
   const { selectedLine } = useAtomValue(lineState);
   const isPassing = useIsPassing();
-  const station = useCurrentStation();
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const station = useDisplayCurrentStation();
   const currentLine = useCurrentLine();
   const barWidth = useBarWidth();
 

--- a/src/components/LineBoardJRKyushu.test.tsx
+++ b/src/components/LineBoardJRKyushu.test.tsx
@@ -13,6 +13,7 @@ jest.mock('jotai', () => ({
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));
@@ -62,7 +63,7 @@ jest.mock('./NumberingIcon', () => ({
 
 describe('LineBoardJRKyushu', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -108,6 +109,7 @@ describe('LineBoardJRKyushu', () => {
       arrived: true,
     });
     useCurrentLine.mockReturnValue(mockLine);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -5,6 +5,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useDisplayCurrentStation,
   useInterval,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
@@ -111,7 +112,9 @@ const useStationRenderState = (
   index: number,
   stations: Station[]
 ) => {
-  const { station: currentStation, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const currentStation = useDisplayCurrentStation();
   const isEn = useAtomValue(isEnAtom);
 
   const currentStationIndex = useMemo(

--- a/src/components/LineBoardLED.test.tsx
+++ b/src/components/LineBoardLED.test.tsx
@@ -17,6 +17,7 @@ jest.mock('~/hooks', () => ({
   useBounds: jest.fn(() => ({ directionalStops: [] })),
   useCurrentLine: jest.fn(),
   useCurrentTrainType: jest.fn(() => ({ name: '普通', nameRoman: 'Local' })),
+  useDisplayNextStation: jest.fn(),
   useLoopLine: jest.fn(() => ({
     isLoopLine: false,
     isPartiallyLoopLine: false,
@@ -41,7 +42,7 @@ describe('LineBoardLED', () => {
   const { useAtomValue } = require('jotai');
   const {
     useCurrentLine,
-    useNextStation,
+    useDisplayNextStation,
     useAfterNextStation,
     useTransferLines,
     useNumbering,
@@ -80,7 +81,7 @@ describe('LineBoardLED', () => {
       return { headerState: 'NEXT' };
     });
     useCurrentLine.mockReturnValue(mockLine);
-    useNextStation.mockReturnValue(mockNextStation);
+    useDisplayNextStation.mockReturnValue(mockNextStation);
     useAfterNextStation.mockReturnValue(mockAfterNextStation);
     useTransferLines.mockReturnValue([]);
     useNumbering.mockReturnValue([null]);
@@ -157,7 +158,7 @@ describe('LineBoardLED', () => {
   });
 
   it('一部列車が通過する駅の場合、注意喚起が表示される', () => {
-    useNextStation.mockReturnValue({
+    useDisplayNextStation.mockReturnValue({
       ...mockNextStation,
       stopCondition: StopCondition.Partial,
     });

--- a/src/components/LineBoardLED.tsx
+++ b/src/components/LineBoardLED.tsx
@@ -8,8 +8,9 @@ import {
   useBounds,
   useCurrentLine,
   useCurrentTrainType,
+  useDisplayNextStation,
   useLoopLine,
-  useNextStation,
+  type useNextStation,
   useNumbering,
   useTransferLines,
 } from '../hooks';
@@ -287,7 +288,8 @@ const LineBoardLED = () => {
     [headerState]
   );
 
-  const nextStation = useNextStation();
+  // ヘッダーの「まもなく」と一致させるため現在地基準の次駅を使う
+  const nextStation = useDisplayNextStation();
   const trainType = useCurrentTrainType();
   const { directionalStops } = useBounds(stations);
   const transferLines = useTransferLines();

--- a/src/components/LineBoardSaikyo.test.tsx
+++ b/src/components/LineBoardSaikyo.test.tsx
@@ -13,6 +13,7 @@ jest.mock('jotai', () => ({
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));
@@ -57,7 +58,7 @@ jest.mock('./LineBoard/shared/hooks/useBarStyles', () => ({
 
 describe('LineBoardSaikyo', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -87,6 +88,7 @@ describe('LineBoardSaikyo', () => {
       arrived: true,
     });
     useCurrentLine.mockReturnValue(mockLine);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -5,6 +5,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useDisplayCurrentStation,
   useInterval,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
@@ -81,7 +82,9 @@ const useStationCellState = (
   index: number,
   stations: Station[]
 ) => {
-  const { station: currentStation, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const currentStation = useDisplayCurrentStation();
   const transferLines = useTransferLinesFromStation(station, {
     omitJR: true,
     omitRepeatingLine: true,

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -13,6 +13,7 @@ jest.mock('jotai', () => ({
 jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useInterval: jest.fn(),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
   useTransferLinesFromStation: jest.fn(() => []),
@@ -75,7 +76,7 @@ jest.mock('./Typography', () => {
 
 describe('LineBoardToei', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -141,6 +142,7 @@ describe('LineBoardToei', () => {
   beforeEach(() => {
     useAtomValue.mockImplementation(createUseAtomValueMock());
     useCurrentLine.mockReturnValue(mockLine);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -5,6 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import type { Line, Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useDisplayCurrentStation,
   useInterval,
   useLandscapeWindowDimensions,
   useStationNumberIndexFunc,
@@ -336,7 +337,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   hasTerminus,
   chevronColor,
 }: StationNameCellProps) => {
-  const { station: currentStation, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const currentStation = useDisplayCurrentStation();
   const isEn = useAtomValue(isEnAtom);
   const { enabledLanguages } = useAtomValue(navigationState);
   const isKoEnabled = enabledLanguages.includes('KO');

--- a/src/components/LineBoardWest.test.tsx
+++ b/src/components/LineBoardWest.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useCurrentStation: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
   useHasPassStationInRegion: jest.fn(() => false),
   useIsPassing: jest.fn(() => false),
   useNextStation: jest.fn(() => null),

--- a/src/components/LineBoardWest.test.tsx
+++ b/src/components/LineBoardWest.test.tsx
@@ -67,7 +67,8 @@ jest.mock('./LineBoard/shared/components', () => ({
 
 describe('LineBoardWest', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine } = require('~/hooks');
+  const { useCurrentLine, useCurrentStation, useDisplayCurrentStation } =
+    require('~/hooks');
 
   const mockLine: Line = {
     __typename: 'Line',
@@ -100,6 +101,10 @@ describe('LineBoardWest', () => {
       selectedLine: mockLine,
     });
     useCurrentLine.mockReturnValue(mockLine);
+    // 現在駅と表示用現在駅を同一駅に固定し、isHealed=false(前方補正なし)の
+    // 通常運行パスを決定論的に検証する。
+    useCurrentStation.mockReturnValue(mockStations[0]);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardWest.tsx
+++ b/src/components/LineBoardWest.tsx
@@ -5,6 +5,7 @@ import type { Line, Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
   useCurrentStation,
+  useDisplayCurrentStation,
   useHasPassStationInRegion,
   useIsPassing,
   useLandscapeWindowDimensions,
@@ -165,14 +166,23 @@ const useStationProgress = (
 ) => {
   const { leftStations } = useAtomValue(navigationState);
   const station = useCurrentStation();
+  // 現在地基準の現在駅。到着取りこぼしで記録上の現在駅が古いとき、ヘッダーの
+  // 「まもなく」と一致する側へ前方補正された駅が返る。
+  const displayStation = useDisplayCurrentStation();
   const prevStation = usePreviousStation(false);
+  // 前方補正が効いている(displayStation が記録上の現在駅より進んでいる)ときだけ
+  // 走行中アンカーを補正後の駅へ切り替える。通常運行では従来どおり prevStation を使い、
+  // 既存の currentStationIndex === -1 フォールバック挙動を完全に維持する。
+  const isHealed = displayStation?.groupId !== station?.groupId;
 
   const currentStationIndex = useMemo(
     () =>
       leftStations.findIndex(
-        (s) => s.groupId === (arrived ? station : prevStation)?.groupId
+        (s) =>
+          s.groupId ===
+          (arrived ? station : isHealed ? displayStation : prevStation)?.groupId
       ),
-    [arrived, station, leftStations, prevStation]
+    [arrived, station, displayStation, isHealed, leftStations, prevStation]
   );
 
   const passed = useMemo(

--- a/src/components/LineBoardYamanotePad.test.tsx
+++ b/src/components/LineBoardYamanotePad.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useCurrentTrainType: jest.fn(() => null),
+  useDisplayCurrentStation: jest.fn(),
   useGetLineMark: jest.fn(() => jest.fn(() => null)),
   useNextStation: jest.fn(() => null),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
@@ -39,7 +40,8 @@ jest.mock('./PadArch', () => {
 
 describe('LineBoardYamanotePad', () => {
   const { useAtomValue } = require('jotai');
-  const { useCurrentLine, useNextStation } = require('~/hooks');
+  const { useCurrentLine, useDisplayCurrentStation, useNextStation } =
+    require('~/hooks');
   const PadArch = require('./PadArch').default;
 
   const mockLine: Line = {
@@ -99,6 +101,7 @@ describe('LineBoardYamanotePad', () => {
     });
     useCurrentLine.mockReturnValue(mockLine);
     useNextStation.mockReturnValue(mockStations[1]);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
   });
 
   afterEach(() => {

--- a/src/components/LineBoardYamanotePad.tsx
+++ b/src/components/LineBoardYamanotePad.tsx
@@ -4,6 +4,7 @@ import type { Station } from '~/@types/graphql';
 import {
   useCurrentLine,
   useCurrentTrainType,
+  useDisplayCurrentStation,
   useGetLineMark,
   useNextStation,
   useTransferLines,
@@ -19,7 +20,9 @@ interface Props {
 }
 
 const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
-  const { station, arrived } = useAtomValue(stationState);
+  const { arrived } = useAtomValue(stationState);
+  // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
+  const station = useDisplayCurrentStation();
   const { selectedLine } = useAtomValue(lineState);
   const isEn = useAtomValue(isEnAtom);
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,6 +18,7 @@ export { useCurrentLine } from './useCurrentLine';
 export { useCurrentStation } from './useCurrentStation';
 export { useCurrentTrainType } from './useCurrentTrainType';
 export { useDeepLink } from './useDeepLink';
+export { useDisplayCurrentStation } from './useDisplayCurrentStation';
 export { useDisplayNextStation } from './useDisplayNextStation';
 export { useDistanceToNextStation } from './useDistanceToNextStation';
 export { useFeedback } from './useFeedback';

--- a/src/hooks/useDisplayCurrentStation.test.tsx
+++ b/src/hooks/useDisplayCurrentStation.test.tsx
@@ -1,0 +1,185 @@
+import { render } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import { Text } from 'react-native';
+import { StopCondition } from '~/@types/graphql';
+import { createStation } from '~/utils/test/factories';
+import getIsPass from '../utils/isPass';
+import { useApproachingStation } from './useApproachingStation';
+import { useCurrentStation } from './useCurrentStation';
+import { useDisplayCurrentStation } from './useDisplayCurrentStation';
+import { useLoopLine } from './useLoopLine';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  useAtomValue: jest.fn(),
+  atom: jest.fn(),
+}));
+
+jest.mock('../store/atoms/station', () => ({
+  __esModule: true,
+  default: 'STATION_ATOM',
+}));
+
+jest.mock('../utils/dropJunctionStation', () => ({
+  __esModule: true,
+  // ジャンクション除去はここでは検証対象外なので素通しする
+  default: (stations: unknown) => stations,
+}));
+
+jest.mock('../utils/isPass', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./useApproachingStation', () => ({
+  __esModule: true,
+  useApproachingStation: jest.fn(),
+}));
+
+jest.mock('./useCurrentStation', () => ({
+  __esModule: true,
+  useCurrentStation: jest.fn(),
+}));
+
+jest.mock('./useLoopLine', () => ({
+  __esModule: true,
+  useLoopLine: jest.fn(),
+}));
+
+const TestComponent: React.FC = () => {
+  const station = useDisplayCurrentStation();
+  return <Text testID="station">{JSON.stringify(station)}</Text>;
+};
+
+describe('useDisplayCurrentStation', () => {
+  const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+    typeof useAtomValue
+  >;
+  const mockUseApproachingStation =
+    useApproachingStation as jest.MockedFunction<typeof useApproachingStation>;
+  const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
+    typeof useCurrentStation
+  >;
+  const mockUseLoopLine = useLoopLine as jest.MockedFunction<
+    typeof useLoopLine
+  >;
+  const mockGetIsPass = getIsPass as jest.MockedFunction<typeof getIsPass>;
+
+  const setStationState = (state: {
+    approaching: boolean;
+    stations: ReturnType<typeof createStation>[];
+    selectedDirection?: 'INBOUND' | 'OUTBOUND';
+  }) => {
+    mockUseAtomValue.mockImplementation(() => ({
+      selectedDirection: 'INBOUND',
+      ...state,
+    }));
+  };
+
+  beforeEach(() => {
+    mockGetIsPass.mockReturnValue(false);
+    mockUseLoopLine.mockReturnValue({ isLoopLine: false } as ReturnType<
+      typeof useLoopLine
+    >);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('非接近時は useCurrentStation をそのまま返す', () => {
+    const a = createStation(1);
+    const b = createStation(2);
+    setStationState({ approaching: false, stations: [a, b] });
+    mockUseCurrentStation.mockReturnValue(a);
+    mockUseApproachingStation.mockReturnValue(b);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(1);
+  });
+
+  it('通常運行(接近駅の1つ手前が現在駅)では前方補正せず現在駅を返す', () => {
+    const a = createStation(1);
+    const b = createStation(2);
+    const c = createStation(3);
+    setStationState({ approaching: true, stations: [a, b, c] });
+    // 現在駅A・接近駅B(=次の停車駅)。Bの手前はAで現在駅と一致するため補正不要
+    mockUseCurrentStation.mockReturnValue(a);
+    mockUseApproachingStation.mockReturnValue(b);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(1);
+  });
+
+  it('到着取りこぼしで現在駅が古いときは接近駅の1つ手前の停車駅へ前方補正する', () => {
+    const a = createStation(1);
+    const b = createStation(2);
+    const c = createStation(3);
+    setStationState({ approaching: true, stations: [a, b, c] });
+    // 記録上の現在駅はA(古い)だが、GPSの接近駅はC。Cの手前の停車駅Bへ補正する
+    mockUseCurrentStation.mockReturnValue(a);
+    mockUseApproachingStation.mockReturnValue(c);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(2);
+  });
+
+  it('前方補正時は通過駅をスキップして手前の停車駅を返す', () => {
+    const a = createStation(1, { stopCondition: StopCondition.All });
+    const b = createStation(2, { stopCondition: StopCondition.All });
+    const pass = createStation(3, { stopCondition: StopCondition.Not });
+    const d = createStation(4, { stopCondition: StopCondition.All });
+    setStationState({ approaching: true, stations: [a, b, pass, d] });
+    mockGetIsPass.mockImplementation(
+      (s) => s?.stopCondition === StopCondition.Not
+    );
+    // 現在駅A(古い)・接近駅D。Dの手前は通過駅passだがスキップして停車駅Bを返す
+    mockUseCurrentStation.mockReturnValue(a);
+    mockUseApproachingStation.mockReturnValue(d);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(2);
+  });
+
+  it('ループ線では補正せず useCurrentStation を返す', () => {
+    const a = createStation(1);
+    const b = createStation(2);
+    const c = createStation(3);
+    setStationState({ approaching: true, stations: [a, b, c] });
+    mockUseLoopLine.mockReturnValue({ isLoopLine: true } as ReturnType<
+      typeof useLoopLine
+    >);
+    mockUseCurrentStation.mockReturnValue(a);
+    mockUseApproachingStation.mockReturnValue(c);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    // 補正されず現在駅Aのまま
+    expect(result.id).toBe(1);
+  });
+
+  it('OUTBOUND でも取りこぼし時に接近駅の1つ手前の停車駅へ補正する', () => {
+    const a = createStation(1);
+    const b = createStation(2);
+    const c = createStation(3);
+    const d = createStation(4);
+    // 配列は [A,B,C,D]、OUTBOUND は逆順 [D,C,B,A] で進む
+    setStationState({
+      approaching: true,
+      stations: [a, b, c, d],
+      selectedDirection: 'OUTBOUND',
+    });
+    // 記録上の現在駅はD(古い)、接近駅はB。Bの手前(進行方向)はCへ補正する
+    mockUseCurrentStation.mockReturnValue(d);
+    mockUseApproachingStation.mockReturnValue(b);
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    expect(result.id).toBe(3);
+  });
+});

--- a/src/hooks/useDisplayCurrentStation.ts
+++ b/src/hooks/useDisplayCurrentStation.ts
@@ -1,0 +1,102 @@
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import type { Station } from '~/@types/graphql';
+import stationState from '../store/atoms/station';
+import dropEitherJunctionStation from '../utils/dropJunctionStation';
+import getIsPass from '../utils/isPass';
+import { useApproachingStation } from './useApproachingStation';
+import { useCurrentStation } from './useCurrentStation';
+import { useLoopLine } from './useLoopLine';
+
+/**
+ * LineBoard など「現在駅」を起点に描画する表示面で使う、現在地基準の現在駅アクセサ。
+ *
+ * ヘッダーの「まもなく」は useDisplayNextStation → useApproachingStation(GPS基準)で
+ * 次の停車駅を出すため、到着取りこぼし(arrived検知漏れ)で stationState.station が古く
+ * なると、ヘッダーは正しい次駅へ自己修復するのに LineBoard は記録上の現在駅基準のまま
+ * 1駅遅れ、「ヘッダーのまもなく駅 ≠ LineBoard の次駅」という不整合が起きる。
+ *
+ * 本フックは接近中のみ、接近駅(=次の停車駅)の1つ手前の停車駅を現在駅として返し、
+ * LineBoard をヘッダーと同じ GPS 基準に追従させる。これにより
+ * useNextStation(true, useDisplayCurrentStation()) === useApproachingStation()
+ * が成り立ち、両者が常に一致する。
+ *
+ * 重要(デグレ防止): 前方への補正が必要なとき(取りこぼし時)だけ healed 値を返し、
+ * それ以外(非接近・GPS無し・通常運行・ループ線)は useCurrentStation() をそのまま返す。
+ * 通常運行・通過駅・発車直後では従来の挙動と完全に一致する。
+ */
+export const useDisplayCurrentStation = (): Station | undefined => {
+  const {
+    approaching,
+    stations: stationsFromState,
+    selectedDirection,
+  } = useAtomValue(stationState);
+  const currentStation = useCurrentStation();
+  const approachingStation = useApproachingStation();
+  // ループ線は環状スライスのインデックス折返しが複雑なため、現状の挙動を維持する
+  // (補正対象外。両者とも非補正の同一アンカーになるため新たな不整合は生まない)。
+  const { isLoopLine } = useLoopLine();
+
+  const healedStation = useMemo<Station | undefined>(() => {
+    if (!approaching || !approachingStation || isLoopLine) {
+      return undefined;
+    }
+
+    const ordered = dropEitherJunctionStation(
+      stationsFromState,
+      selectedDirection
+    );
+    const directional =
+      selectedDirection === 'INBOUND' ? ordered : ordered.slice().reverse();
+
+    const findIndexByIdentity = (target: Station | undefined): number => {
+      if (!target) {
+        return -1;
+      }
+      const byId = directional.findIndex((s) => s.id === target.id);
+      return byId !== -1
+        ? byId
+        : directional.findIndex((s) => s.groupId === target.groupId);
+    };
+
+    const approachingIndex = findIndexByIdentity(approachingStation);
+    if (approachingIndex <= 0) {
+      return undefined;
+    }
+
+    // 接近駅(次の停車駅)の1つ手前の停車駅(通過駅はスキップ)を現在駅とみなす
+    let predecessor: Station | undefined;
+    for (let i = approachingIndex - 1; i >= 0; i--) {
+      const s = directional[i];
+      if (s && !getIsPass(s)) {
+        predecessor = s;
+        break;
+      }
+    }
+    if (!predecessor) {
+      return undefined;
+    }
+
+    // 前方への補正のときだけ healed 値を採用する。
+    // 通常運行では predecessor は現在駅と一致(または手前)になるため undefined を返し、
+    // useCurrentStation() のフォールバックで従来挙動を完全維持する。
+    const currentIndex = findIndexByIdentity(currentStation);
+    const predecessorIndex = directional.findIndex(
+      (s) => s.groupId === predecessor?.groupId
+    );
+    if (currentIndex !== -1 && predecessorIndex <= currentIndex) {
+      return undefined;
+    }
+
+    return predecessor;
+  }, [
+    approaching,
+    approachingStation,
+    currentStation,
+    isLoopLine,
+    selectedDirection,
+    stationsFromState,
+  ]);
+
+  return healedStation ?? currentStation;
+};

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -11,6 +11,7 @@ import { useRefreshStation } from '~/hooks/useRefreshStation';
 import * as useThresholdModule from '~/hooks/useThreshold';
 import * as useWrongDirectionDetectorModule from '~/hooks/useWrongDirectionDetector';
 import * as remoteConfigModule from '~/lib/remoteConfig';
+import sendNotificationAsync from '~/utils/native/ios/sensitiveNotificationMoudle';
 
 jest.mock('jotai', () => {
   const actual = jest.requireActual('jotai');
@@ -25,6 +26,15 @@ jest.mock('~/store/atoms/notify', () => ({
   __esModule: true,
   default: {},
 }));
+
+jest.mock('~/utils/native/ios/sensitiveNotificationMoudle', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockSendNotification = sendNotificationAsync as jest.MockedFunction<
+  typeof sendNotificationAsync
+>;
 
 const mockUseAtomValue = useAtomValue as jest.MockedFunction<
   typeof useAtomValue
@@ -389,5 +399,67 @@ describe('useRefreshStation', () => {
     const nextState = updater({});
     expect(nextState.arrived).toBe(false);
     expect(nextState.approaching).toBe(false);
+  });
+
+  it('駅接近ローカル通知は最寄り駅ではなく現在地基準の接近駅を通知する', () => {
+    // 最寄り駅(発車直後の駅など)は遠方かつ別駅。接近駅は現在地と同一座標の通知対象駅。
+    // 通知される駅名がヘッダーの「まもなく」と同じ接近駅になることを担保する。
+    const approachingTarget = {
+      ...mockStation,
+      id: 2,
+      groupId: 2,
+      name: 'Approaching Station',
+      nameRoman: 'Approaching Station',
+      latitude: 35.0,
+      longitude: 135.0,
+    };
+    const farNearestStation = {
+      ...mockStation,
+      id: 1,
+      groupId: 1,
+      name: 'Nearest Station',
+      nameRoman: 'Nearest Station',
+      latitude: 35.5,
+      longitude: 135.0,
+    };
+
+    mockUseAtomValue
+      .mockReturnValueOnce({
+        coords: { latitude: 35.0, longitude: 135.0 },
+      }) // locationAtom
+      .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
+      .mockReturnValue({ targetStationIds: [2] }); // notifyState(接近駅id=2が通知対象)
+
+    mockUseSetAtom.mockReturnValue(jest.fn());
+
+    jest
+      .spyOn(useApproachingStationModule, 'useApproachingStation')
+      .mockReturnValue(approachingTarget);
+    jest
+      .spyOn(useNearestStationModule, 'useNearestStation')
+      .mockReturnValue(farNearestStation);
+    jest
+      .spyOn(useNextStationModule, 'useNextStation')
+      .mockReturnValue(approachingTarget);
+    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
+    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
+      arrivedThreshold: 100,
+      approachingThreshold: 300,
+    });
+    jest
+      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
+      .mockReturnValue({
+        isWrongDirection: false,
+        isLoopLineWrongDirection: false,
+      });
+
+    renderHook(() => useRefreshStation(), {
+      wrapper: ({ children }) => <Provider>{children}</Provider>,
+    });
+
+    expect(mockSendNotification).toHaveBeenCalled();
+    const body = mockSendNotification.mock.calls[0][0].body;
+    expect(body).toContain('Approaching Station');
+    expect(body).not.toContain('Nearest Station');
   });
 });

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -189,36 +189,38 @@ export const useRefreshStation = (): void => {
   );
 
   useEffect(() => {
-    if (!nearestStation || !canGoForward) {
+    if (!canGoForward) {
       return;
     }
 
-    const isNearestStationNotifyTarget = !!targetStationIds.find(
-      (id) => id === nearestStation.id
-    );
+    // 接近通知はヘッダーの「まもなく」と同じく現在地基準の接近駅(次に到着する停車駅)を
+    // 基準にする。通知される駅名・発火対象がヘッダー表示と一致し、発車直後の駅や通過駅で
+    // 誤って鳴らない。到着判定の取りこぼし時も接近駅側へ自己修復する。
+    if (
+      isApproaching &&
+      approachingStation?.id != null &&
+      targetStationIds.includes(approachingStation.id) &&
+      approachingStation.id !== approachingNotifiedIdRef.current
+    ) {
+      sendApproachingNotification(approachingStation, 'APPROACHING');
+      approachingNotifiedIdRef.current = approachingStation.id;
+    }
 
-    if (isNearestStationNotifyTarget) {
-      if (
-        isApproaching &&
-        nearestStation.id !== undefined &&
-        nearestStation.id !== approachingNotifiedIdRef.current
-      ) {
-        sendApproachingNotification(nearestStation, 'APPROACHING');
-        approachingNotifiedIdRef.current = nearestStation.id ?? null;
-      }
-      if (
-        isArrived &&
-        nearestStation.id !== undefined &&
-        nearestStation.id !== arrivedNotifiedIdRef.current
-      ) {
-        sendApproachingNotification(nearestStation, 'ARRIVED');
-        arrivedNotifiedIdRef.current = nearestStation.id ?? null;
-      }
+    // 到着通知は実際に到着した最寄り駅を基準にする
+    if (
+      isArrived &&
+      nearestStation?.id != null &&
+      targetStationIds.includes(nearestStation.id) &&
+      nearestStation.id !== arrivedNotifiedIdRef.current
+    ) {
+      sendApproachingNotification(nearestStation, 'ARRIVED');
+      arrivedNotifiedIdRef.current = nearestStation.id;
     }
   }, [
     canGoForward,
     isApproaching,
     isArrived,
+    approachingStation,
     nearestStation,
     sendApproachingNotification,
     targetStationIds,

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -202,7 +202,9 @@ export const useRefreshStation = (): void => {
       targetStationIds.includes(approachingStation.id) &&
       approachingStation.id !== approachingNotifiedIdRef.current
     ) {
-      sendApproachingNotification(approachingStation, 'APPROACHING');
+      void sendApproachingNotification(approachingStation, 'APPROACHING').catch(
+        () => {}
+      );
       approachingNotifiedIdRef.current = approachingStation.id;
     }
 
@@ -213,7 +215,9 @@ export const useRefreshStation = (): void => {
       targetStationIds.includes(nearestStation.id) &&
       nearestStation.id !== arrivedNotifiedIdRef.current
     ) {
-      sendApproachingNotification(nearestStation, 'ARRIVED');
+      void sendApproachingNotification(nearestStation, 'ARRIVED').catch(
+        () => {}
+      );
       arrivedNotifiedIdRef.current = nearestStation.id;
     }
   }, [


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ヘッダーの「まもなく」は現在地基準（`useApproachingStation`）で次の停車駅を出す一方、LineBoard と駅接近ローカル通知は記録上の現在駅（`stationState.station`）基準のままでした。このため到着取りこぼし（GPS精度劣化で `arrived` 検知が漏れる等）時に、ヘッダーの「まもなく」駅と LineBoard の次駅・通知駅が食い違う不整合がありました。

本PRで LineBoard と駅接近通知も現在地基準に揃え、全表示面（ヘッダー / LineBoard / ライブアクティビティ・Android Live Update / Apple Watch / TTS / 駅接近通知）が常に同じ駅を指すようにします。**通常運行・通過駅が間にあるケース・発車直後・ループ線では従来挙動を完全維持**し、変わるのは「取りこぼし時に header と一緒に自己修復する」点のみです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 表示専用の現在地基準アクセサ `useDisplayCurrentStation` を追加。接近中のみ「接近駅（次の停車駅）の1つ手前の停車駅」を現在駅として返し、到着取りこぼし時に header と一緒に自己修復する。非接近・GPS無し・通常運行・ループ線では `useCurrentStation()` に完全フォールバックし従来挙動を維持（前方への補正が必要なときだけ healed 値を返す不変条件）
- LineBoard 全テーマ（East / Toei / Saikyo / E231 / JRKyushu / JO / YamanotePad / West / LED）とルータ `LineBoard` の現在駅ソースを `useDisplayCurrentStation` に統一。West は既存の `prevStation` / `currentStationIndex === -1` フォールバック挙動を保ち、前方補正時のみ追従。LED の「まもなく」テキストも `useDisplayNextStation` に統一
- 駅接近ローカル通知（`useRefreshStation`）の接近（APPROACHING）通知の通知駅名・ターゲット判定を `nearestStation` → `approachingStation`（ヘッダーの「まもなく」と同一）に変更。発車駅除外・自己修復も反映。到着（ARRIVED）通知は「最寄り駅に到着」が正しいため `nearestStation` 基準のまま
- ユニットテスト追加：`useDisplayCurrentStation`（非接近フォールバック / 通常運行 / 取りこぼし前方補正 / 通過駅スキップ / ループ線 / OUTBOUND）、接近通知が接近駅を通知すること、および各 LineBoard テーマのモック追従更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（165 suites / 1785 tests 全パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_014jsjmE1khPmdyz7S9N2Pbd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 表示基準の現在駅判定ロジックを導入し、表示の一貫性を向上しました
* **Bug Fixes**
  * 到着取りこぼし時に駅表示がヘッダー表示と一致するよう自動修正されるようになりました
  * 駅接近通知が現在地基準の接近駅を正確に通知するようになりました（通知送信の失敗時の安全処理を追加）
  * 各路線の駅進捗表示がヘッダー表示と連動するようになりました
* **Tests**
  * 表示基準ロジックと通知挙動をカバーするテストを追加・更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->