### PR TITLE
ヘッダーの「まもなく」が接近解除後や発車直後に実際とずれた駅を指す不具合を修正する

### DIFF
--- a/src/hooks/useApproachingStation.test.tsx
+++ b/src/hooks/useApproachingStation.test.tsx
@@ -162,6 +162,36 @@ describe('useApproachingStation', () => {
     expect(result.id).toBe(2);
   });
 
+  it('発車駅を出た直後、手前の区間が短くても発車駅を接近駅に再選択しない', () => {
+    // W—X—Y で X を発車直後(現在地は X 付近)。
+    // W–X が X–Y より短いと findNearest が手前の W を最寄りに選び、
+    // useNextStation(true, W)=X となって「まもなくX(発車済み駅)」に化ける。
+    const stationW = createStation(1, { latitude: 35.0, longitude: 135.0 });
+    const stationX = createStation(2, { latitude: 35.1, longitude: 135.0 });
+    const stationY = createStation(3, { latitude: 35.4, longitude: 135.0 });
+    stations = [stationW, stationX, stationY];
+
+    // 発車駅(到着済みの現在駅)は X。現在地は X 直近。
+    setLocation({ latitude: 35.1, longitude: 135.0 }, stationX);
+    // 起点ごとの次の停車駅: W→X, X→Y
+    mockUseNextStation.mockImplementation(
+      (_ignorePass?: boolean, origin?: ReturnType<typeof createStation>) => {
+        if (origin?.id === stationW.id) {
+          return stationX;
+        }
+        if (origin?.id === stationX.id) {
+          return stationY;
+        }
+        return undefined;
+      }
+    );
+
+    const { getByTestId } = render(<TestComponent />);
+    const result = JSON.parse(getByTestId('station').props.children as string);
+    // 発車済みの X ではなく、次の停車駅 Y を接近駅として返す
+    expect(result.id).toBe(3);
+  });
+
   it('次の停車駅が存在しない(終点)場合は最寄り停車駅を返す', () => {
     const stationA = createStation(1, { latitude: 35.0, longitude: 135.0 });
     const stationB = createStation(2, { latitude: 35.2, longitude: 135.0 });

--- a/src/hooks/useApproachingStation.ts
+++ b/src/hooks/useApproachingStation.ts
@@ -1,7 +1,7 @@
 import findNearest from 'geolib/es/findNearest';
 import getDistance from 'geolib/es/getPreciseDistance';
 import { useAtomValue } from 'jotai';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { Station } from '~/@types/graphql';
 import { locationAtom } from '~/store/atoms/location';
 import stationState from '../store/atoms/station';
@@ -71,6 +71,20 @@ export const useApproachingStation = (): Station | undefined => {
 
   // 最寄り停車駅を起点とした進行方向側の次の停車駅
   const nextOfNearestStop = useNextStation(true, nearestStop);
+  // 発車駅を起点とした次の停車駅。発車直後に発車駅自身が接近駅へ再選択された
+  // ときのフォールバック先(=本来向かっている次の停車駅)に使う。
+  const nextOfDepartedStation = useNextStation(
+    true,
+    departedStation ?? undefined
+  );
+
+  const isDepartedStation = useCallback(
+    (s: Station | undefined): boolean =>
+      !!s &&
+      !!departedStation &&
+      (s.id === departedStation.id || s.groupId === departedStation.groupId),
+    [departedStation]
+  );
 
   return useMemo<Station | undefined>(() => {
     if (!nearestStop) {
@@ -106,8 +120,23 @@ export const useApproachingStation = (): Station | undefined => {
 
     // 最寄り停車駅よりも次の停車駅へ近づいている場合は、
     // 既に最寄り停車駅を通過したとみなして次の停車駅を接近駅として扱う。
-    return distanceToNext < distanceBetweenStops
-      ? nextOfNearestStop
-      : nearestStop;
-  }, [latitude, longitude, nearestStop, nextOfNearestStop]);
+    const resolved =
+      distanceToNext < distanceBetweenStops ? nextOfNearestStop : nearestStop;
+
+    // 発車直後、手前の区間(W–X)が次の区間(X–Y)より短いと findNearest が手前の
+    // 停車駅 W を最寄りに選び、その次駅(=発車駅 X)が接近駅へ再選択されて
+    // 「まもなくX(発車済み駅)」と誤表示される。発車駅へ collapse したときは
+    // 本来向かっている次の停車駅(発車駅の次)へ進める。
+    if (isDepartedStation(resolved)) {
+      return nextOfDepartedStation ?? resolved;
+    }
+    return resolved;
+  }, [
+    latitude,
+    longitude,
+    nearestStop,
+    nextOfNearestStop,
+    nextOfDepartedStation,
+    isDepartedStation,
+  ]);
 };

--- a/src/hooks/useTransitionHeaderState.test.tsx
+++ b/src/hooks/useTransitionHeaderState.test.tsx
@@ -215,6 +215,35 @@ describe('useTransitionHeaderState', () => {
     expect(navigationAtomValue.headerState).toBe('CURRENT');
   });
 
+  it('未到着のまま approaching が解除されたら ARRIVING から NEXT へ戻る', () => {
+    // 到着を挟まず接近が解除されるケース(到着検知の取りこぼし・GPS補正・接近駅切替)。
+    // arrived のリセット useEffect が効かないため、interval 側で ARRIVING を抜ける。
+    navigationAtomValue.enabledLanguages = ['JA'];
+    navigationAtomValue.headerState = 'ARRIVING';
+    stationAtomValue.arrived = false;
+    stationAtomValue.approaching = false;
+
+    render(<TestComponent />);
+
+    tick();
+
+    expect(navigationAtomValue.headerState).toBe('NEXT');
+  });
+
+  it('到着中は ARRIVING から interval では NEXT に戻さない（arrived の useEffect に委ねる）', () => {
+    navigationAtomValue.enabledLanguages = ['JA'];
+    navigationAtomValue.headerState = 'ARRIVING';
+    stationAtomValue.arrived = true;
+    stationAtomValue.approaching = false;
+
+    render(<TestComponent />);
+
+    tick();
+
+    // interval は NEXT へ遷移させない（言語循環のみ）。CURRENT への復帰は別 useEffect の責務。
+    expect(navigationAtomValue.headerState).not.toBe('NEXT');
+  });
+
   it('日本語無効かつ次言語が見つからない場合は JA に戻らない', () => {
     navigationAtomValue.enabledLanguages = ['EN', 'KO'];
     navigationAtomValue.headerState = 'NEXT_KO';

--- a/src/hooks/useTransitionHeaderState.ts
+++ b/src/hooks/useTransitionHeaderState.ts
@@ -261,6 +261,26 @@ export const useTransitionHeaderState = (): void => {
         targetStation
       );
 
+      // 接近が解除されたのに ARRIVING のまま貼り付くのを防ぐ。
+      // ARRIVING からの離脱は本来 arrived のリセット useEffect でしか起きないため、
+      // 到着を挟まず approaching が true→false に戻るケース(到着検知の取りこぼし・
+      // GPS補正・接近駅の切替など)では「まもなく」が解除されず、displayNextStation が
+      // 記録基準の次駅へフォールバックして「まもなく(遠い駅)」と誤表示され続ける。
+      // 未到着で接近も解除されたら NEXT/CURRENT へ明示的に戻す。
+      if (!approaching && !arrived && currentHeaderState === 'ARRIVING') {
+        const fallbackState = showNextExpression ? 'NEXT' : 'CURRENT';
+        setHeaderStateIfChanged(
+          isJapaneseEnabled
+            ? fallbackState
+            : getFallbackStateWithoutJapanese(
+                fallbackState,
+                currentHeaderStateLang,
+                enabledLanguages
+              )
+        );
+        return;
+      }
+
       switch (currentHeaderState) {
         case 'ARRIVING': {
           switch (currentHeaderStateLang) {
@@ -433,6 +453,7 @@ export const useTransitionHeaderState = (): void => {
       }
     }, [
       approaching,
+      arrived,
       enabledLanguages,
       headerStateRef,
       isJapaneseEnabled,


### PR DESCRIPTION
## 概要

ヘッダーの「まもなく」表示が、実際には接近していない駅を指してしまう 2 つの遷移バグを修正します。どちらも `approaching`(接近) まわりの遷移で、表示が現在地に追従しきれていなかったのが原因です。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 接近解除後にヘッダーが「まもなく」に貼り付く問題を修正（`useTransitionHeaderState`）
  - `ARRIVING`(「まもなく」) からの離脱は `arrived` 時のリセット `useEffect` でしか起きず、到着を挟まず `approaching` が `true`→`false` に戻るケース（到着検知の取りこぼし・GPS補正・接近駅の切替）で解除されなかった。`displayNextStation` が記録基準の次駅へフォールバックし「まもなく(遠い駅)」と表示され続ける。
  - 未到着で接近も解除されたら interval 側で `NEXT`/`CURRENT` へ明示的に戻すようにした（到着時の挙動は従来どおり `arrived` の `useEffect` に委譲）。
- 発車直後に発車駅を「まもなく」と誤表示する問題を修正（`useApproachingStation`）
  - 発車駅は最寄り探索の候補から除外されるが、手前の区間が次の区間より短いと `findNearest` が手前の停車駅を最寄りに選び、その次駅(=発車駅)が接近駅へ再選択される。結果 `approaching` が `true` になり「まもなく(今出た駅)」となる（オートモードで動き出した瞬間に再現）。
  - 接近駅が発車駅へ collapse したら、発車駅の次の停車駅へ進めるフォールバックを追加。
- 各修正に対する回帰テストを追加。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 発車駅出発直後の接近駅選択ロジックを改善し、不正な再選択を防止しました。
  * 接近状態がキャンセルされた際のヘッダー状態遷移を修正し、適切に状態が戻るようになりました。

* **テスト**
  * 駅接近判定ロジックの境界ケースをカバーするテストを追加しました。
  * ヘッダー状態遷移の複数シナリオをカバーするテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->