### PR TITLE
テーマをJR西日本風/LEDへ切り替えた際にleftStationsから通過駅が除外されないバグを修正

### DIFF
--- a/src/hooks/useRefreshLeftStations.test.tsx
+++ b/src/hooks/useRefreshLeftStations.test.tsx
@@ -1,0 +1,128 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import { StopCondition } from '~/@types/graphql';
+import { createStation } from '~/utils/test/factories';
+import { APP_THEME } from '../models/Theme';
+import navigationState from '../store/atoms/navigation';
+import stationState from '../store/atoms/station';
+import { themePreferenceAtom } from '../store/atoms/theme';
+import { useRefreshLeftStations } from './useRefreshLeftStations';
+
+// 10駅の直線路線。2駅目と4駅目が通過駅。
+// INBOUND(配列順方向)で1駅目に停車中の状態を基本とする。
+const PASS_STATION_IDS = [2, 4];
+const stations = Array.from({ length: 10 }, (_, i) =>
+  createStation(i + 1, {
+    stopCondition: PASS_STATION_IDS.includes(i + 1)
+      ? StopCondition.Not
+      : StopCondition.All,
+  })
+);
+
+const ALL_IDS = stations.map((s) => s.id as number);
+const STOP_IDS = ALL_IDS.filter((id) => !PASS_STATION_IDS.includes(id));
+
+const renderWithStore = (theme: (typeof APP_THEME)[keyof typeof APP_THEME]) => {
+  const store = createStore();
+  store.set(themePreferenceAtom, theme);
+  store.set(stationState, (prev) => ({
+    ...prev,
+    station: stations[0],
+    stations,
+    selectedDirection: 'INBOUND' as const,
+  }));
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const utils = renderHook(() => useRefreshLeftStations(), { wrapper });
+
+  return { store, ...utils };
+};
+
+const getLeftStationIds = (store: ReturnType<typeof createStore>) =>
+  store.get(navigationState).leftStations.map((s) => s.id);
+
+describe('useRefreshLeftStations', () => {
+  it('通常テーマでは通過駅を含む全駅をleftStationsにセットする', () => {
+    const { store } = renderWithStore(APP_THEME.TOKYO_METRO);
+
+    expect(getLeftStationIds(store)).toEqual(ALL_IDS);
+  });
+
+  it.each([APP_THEME.JR_WEST, APP_THEME.LED])(
+    '%sテーマを最初から選択している場合は通過駅を除外したleftStationsをセットする',
+    (theme) => {
+      const { store } = renderWithStore(theme);
+
+      expect(getLeftStationIds(store)).toEqual(STOP_IDS);
+    }
+  );
+
+  it('走行中にテーマをJR西日本風へ切り替えるとleftStationsから通過駅が除外される', () => {
+    const { store } = renderWithStore(APP_THEME.TOKYO_METRO);
+    expect(getLeftStationIds(store)).toEqual(ALL_IDS);
+
+    // 先頭駅(=現在停車駅)は変わらないままテーマだけ切り替わるケース。
+    // 以前は先頭駅のgroupId比較しかしておらず、古い未フィルタのリストが残っていた。
+    act(() => {
+      store.set(themePreferenceAtom, APP_THEME.JR_WEST);
+    });
+
+    expect(getLeftStationIds(store)).toEqual(STOP_IDS);
+  });
+
+  it('テーマをJR西日本風から通常テーマへ戻すと通過駅が復活する', () => {
+    const { store } = renderWithStore(APP_THEME.JR_WEST);
+    expect(getLeftStationIds(store)).toEqual(STOP_IDS);
+
+    act(() => {
+      store.set(themePreferenceAtom, APP_THEME.TOKYO_METRO);
+    });
+
+    expect(getLeftStationIds(store)).toEqual(ALL_IDS);
+  });
+
+  it('リストの中身が変わらない更新ではleftStationsの参照を維持する', () => {
+    const { store } = renderWithStore(APP_THEME.JR_WEST);
+    const before = store.get(navigationState).leftStations;
+
+    // JR_WEST→LEDはどちらも通過駅除外のため内容が同一。
+    // フィルタ配列の参照は変わるが、内容が同じならprevを返して再レンダーを抑制する。
+    act(() => {
+      store.set(themePreferenceAtom, APP_THEME.LED);
+    });
+
+    expect(store.get(navigationState).leftStations).toBe(before);
+  });
+
+  it('JR西日本風テーマでは通過駅を通過中でもleftStationsを更新しない', () => {
+    const { store } = renderWithStore(APP_THEME.JR_WEST);
+    const before = store.get(navigationState).leftStations;
+
+    // 現在駅が通過駅(2駅目)になっても、直前の停車駅(1駅目)基準のまま維持される
+    act(() => {
+      store.set(stationState, (prev) => ({
+        ...prev,
+        station: stations[1],
+      }));
+    });
+
+    expect(store.get(navigationState).leftStations).toBe(before);
+    expect(getLeftStationIds(store)).toEqual(STOP_IDS);
+  });
+
+  it('通常テーマでは次の駅へ進むとleftStationsが先へ進む', () => {
+    const { store } = renderWithStore(APP_THEME.TOKYO_METRO);
+
+    act(() => {
+      store.set(stationState, (prev) => ({
+        ...prev,
+        station: stations[1],
+      }));
+    });
+
+    expect(getLeftStationIds(store)).toEqual(ALL_IDS.slice(1));
+  });
+});

--- a/src/hooks/useRefreshLeftStations.ts
+++ b/src/hooks/useRefreshLeftStations.ts
@@ -206,13 +206,17 @@ export const useRefreshLeftStations = (): void => {
       loopLine && getIsLocal(trainType)
         ? getStationsForLoopLine(currentIndex)
         : getStations(currentIndex);
-    setNavigation((prev) => ({
-      ...prev,
-      leftStations:
-        leftStations[0]?.groupId !== prev.leftStations[0]?.groupId
-          ? leftStations
-          : prev.leftStations,
-    }));
+    setNavigation((prev) => {
+      // 先頭駅が同じでもリストの中身が変わることがある
+      // (例: テーマをJR西日本風/LEDへ切り替えると通過駅が除外される)ため、
+      // 全要素を比較して差分があるときだけ置き換える。
+      const isSameList =
+        leftStations.length === prev.leftStations.length &&
+        leftStations.every(
+          (s, i) => s.groupId === prev.leftStations[i]?.groupId
+        );
+      return isSameList ? prev : { ...prev, leftStations };
+    });
   }, [
     getStations,
     getStationsForLoopLine,


### PR DESCRIPTION
## 概要

走行中に設定画面からテーマを JR西日本風 / LED へ切り替えても、LineBoard の `leftStations` から通過駅が除外されず表示され続けるバグを修正しました。最初から JR西日本風 / LED テーマが選ばれている場合は発症しません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useRefreshLeftStations` の `leftStations` 更新ガードが先頭駅の `groupId` しか比較していなかったため、テーマ切替で通過駅フィルタ済みの新リストが生成されても「先頭駅が同じ」という理由で破棄され、切り替え前の未フィルタのリストが残り続けていた
- 長さ + 全要素の `groupId` 比較に変更し、リストの中身に差分があるときだけ置き換えるよう修正(内容が同一なら `prev` を返すため、元のガードが意図していた再レンダー抑制は維持)
- `useRefreshLeftStations` のテストを新規追加(実 jotai ストア + `Provider` の統合スタイル、全 8 件)
  - テーマ切替で通過駅が除外される回帰テストを含む(修正前のガードでは 2 件が失敗することを確認済み)
  - 内容が同じ更新では参照を維持すること、JR西日本風テーマで通過駅通過中は更新しないこと等も検証

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テストケースを追加し、駅情報表示機能の動作を検証。

* **Bug Fixes**
  * テーマ切り替え時や駅更新時の駅情報リスト更新ロジックを改善し、より正確に変更を検出するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->