### PR TITLE
オートモード中はDevOverlayの速度・精度をシミュレーション由来のlocationAtomから表示するよう修正

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -485,6 +485,7 @@ describe('DevOverlay', () => {
       expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
         '90km/h'
       );
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent('0m');
     });
 
     it('オートモード中はrawLocationが無くてもシミュレーション速度を表示する', () => {
@@ -500,6 +501,7 @@ describe('DevOverlay', () => {
       expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
         '50km/h'
       );
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent('0m');
     });
 
     it('オートモードが無効の場合はrawLocationAtomの速度を表示する', () => {
@@ -516,6 +518,9 @@ describe('DevOverlay', () => {
       const { getByTestId } = render(<DevOverlay />);
       expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
         '36km/h'
+      );
+      expect(getByTestId('dev-overlay-accuracy-value')).toHaveTextContent(
+        '15m'
       );
     });
   });

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -10,6 +10,7 @@ import {
   locationAtom,
   rawLocationAtom,
 } from '~/store/atoms/location';
+import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import DevOverlay, { getDevOverlayDragTranslation } from './DevOverlay';
 
@@ -61,14 +62,15 @@ describe('DevOverlay', () => {
   const mockDimensionsGet = jest.spyOn(Dimensions, 'get');
 
   const setupAtomValues = ({
-    // locationAtomはフィルタ・スムージング後の値。DevOverlayの速度・精度表示はここから読まない
+    // locationAtomはフィルタ・スムージング後の値。通常モードの速度・精度表示はここから読まないが、
+    // オートモード中はuseSimulationModeがここへ書き込むため、参照元がこちらへ切り替わる
     location = {
       coords: {
         speed: 10,
         accuracy: 15,
       },
     },
-    // rawLocationAtomは継続測位の生の値で、速度・精度ともにlocationAtomではなくここから読む。
+    // rawLocationAtomは継続測位の生の値で、通常モードでは速度・精度ともにここから読む。
     // 既定は速度10m/s・精度15mの測位が継続取得できている状態を表す（locationAtomとは独立した別物）。
     rawLocation = {
       coords: {
@@ -77,10 +79,12 @@ describe('DevOverlay', () => {
       },
     },
     backgroundLocationTracking = false,
+    autoModeEnabled = false,
   }: {
     location?: unknown;
     rawLocation?: unknown;
     backgroundLocationTracking?: boolean;
+    autoModeEnabled?: boolean;
   } = {}) => {
     mockUseAtomValue.mockImplementation((atom) => {
       if (atom === locationAtom) {
@@ -91,6 +95,9 @@ describe('DevOverlay', () => {
       }
       if (atom === backgroundLocationTrackingAtom) {
         return backgroundLocationTracking as never;
+      }
+      if (atom === autoModeEnabledAtom) {
+        return autoModeEnabled as never;
       }
       if (atom === isLEDThemeAtom) {
         return false as never;
@@ -457,6 +464,59 @@ describe('DevOverlay', () => {
 
       const { getByTestId } = render(<DevOverlay />);
       expect(getByTestId('dev-overlay-next-value')).toHaveTextContent('--');
+    });
+  });
+
+  describe('オートモード時の表示', () => {
+    it('オートモード中はlocationAtomのシミュレーション速度を表示する', () => {
+      // オートモード中はGPS測位が停止しrawLocationAtomが更新されないため、
+      // useSimulationModeが書き込むlocationAtom側の速度を表示する
+      setupAtomValues({
+        location: {
+          coords: { speed: 25, accuracy: 0 },
+        },
+        rawLocation: {
+          coords: { speed: 0, accuracy: 15 },
+        },
+        autoModeEnabled: true,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+        '90km/h'
+      );
+    });
+
+    it('オートモード中はrawLocationが無くてもシミュレーション速度を表示する', () => {
+      setupAtomValues({
+        location: {
+          coords: { speed: 13.89, accuracy: 0 },
+        },
+        rawLocation: null,
+        autoModeEnabled: true,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+        '50km/h'
+      );
+    });
+
+    it('オートモードが無効の場合はrawLocationAtomの速度を表示する', () => {
+      setupAtomValues({
+        location: {
+          coords: { speed: 25, accuracy: 0 },
+        },
+        rawLocation: {
+          coords: { speed: 10, accuracy: 15 },
+        },
+        autoModeEnabled: false,
+      });
+
+      const { getByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+        '36km/h'
+      );
     });
   });
 

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -23,8 +23,10 @@ import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import { getMaxPermitAccuracy } from '~/lib/remoteConfig';
 import {
   backgroundLocationTrackingAtom,
+  locationAtom,
   rawLocationAtom,
 } from '~/store/atoms/location';
+import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import AccuracyHistoryChart from './AccuracyHistoryChart';
 import Typography from './Typography';
 
@@ -330,8 +332,14 @@ const DevOverlay: React.FC = () => {
   // 継続測位（watch/background両経路）はhandleTrackingLocation経由でフィルタ前に
   // rawLocationAtomへ生の値を記録するため、棄却・補正された値もここから観測できる。
   const rawLocation = useAtomValue(rawLocationAtom);
-  const speed = rawLocation?.coords?.speed;
-  const accuracy = rawLocation?.coords?.accuracy;
+  const simulatedLocation = useAtomValue(locationAtom);
+  const autoModeEnabled = useAtomValue(autoModeEnabledAtom);
+  // オートモード中はGPSの継続測位を停止し、useSimulationModeが速度プロファイル由来の
+  // 位置・速度をlocationAtomへ直接書き込むため、rawLocationAtomは更新されない。
+  // 速度・精度が0や古い値で凍結しないよう、参照元をlocationAtomへ切り替える。
+  const location = autoModeEnabled ? simulatedLocation : rawLocation;
+  const speed = location?.coords?.speed;
+  const accuracy = location?.coords?.accuracy;
   const distanceToNextStation = useDistanceToNextStation();
   const nextStation = useNextStation(false);
   const isTelemetryEnabled = useTelemetryEnabled();


### PR DESCRIPTION
## 概要

オートモード有効時にDevOverlayのCURRENT SPEEDが0km/hに張り付く問題を修正しました。オートモード中は`useSimulationMode`がGPSの継続測位を停止し、速度プロファイル由来のシミュレーション位置・速度を`locationAtom`にのみ書き込むため、DevOverlayが参照する`rawLocationAtom`が更新されず速度・精度表示が凍結していました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/DevOverlay.tsx`: `autoModeEnabledAtom`を購読し、オートモード中は速度・精度の参照元を`rawLocationAtom`（生のGPS値）から`locationAtom`（シミュレーション値）へ切り替え。通常モードは従来どおり生の測位値を表示
- `src/components/DevOverlay.test.tsx`: テストセットアップに`autoModeEnabled`パラメータを追加し、オートモードON時にシミュレーション由来の速度・精度を表示すること・OFF時は生のGPS値のままであることを検証する3ケースを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_0165u3Sgs1x3HHSxkvqCKj9F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 開発者向けオーバーレイの位置情報精度および速度表示が、自動モードの有無に応じて適切なデータ源を切り替え、オートモード中でも正常に更新・反映されるよう改善しました。
* **Tests**
  * 自動モード時／非自動時の速度・精度表示と履歴サンプリング挙動を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->