### PR TITLE
TTS文言を各テーマの公式車内放送の言い回しに刷新し、他社線直通境界駅の御礼・直通先案内放送を追加

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -3,6 +3,7 @@ import { TtsAlphabet } from '~/@types/graphql';
 import {
   dedupeLinesByTtsName,
   formatFirstConnectedLineEnPhrase,
+  formatJrWestStopsListEn,
   replaceJapaneseText,
   stripParensForTTS,
   stripStationParensForTTS,
@@ -182,6 +183,61 @@ describe('formatFirstConnectedLineEnPhrase', () => {
       nameRoman: null,
     });
     expect(formatFirstConnectedLineEnPhrase([line])).toBe('');
+  });
+});
+
+describe('formatJrWestStopsListEn', () => {
+  const makeStop = (id: number, nameRoman: string): Station =>
+    ({
+      __typename: 'Station',
+      id,
+      groupId: id,
+      nameTtsSegments: null,
+      nameRoman,
+    }) as Station;
+
+  it('joins stops with an Oxford comma style "and" (official JR-West wording)', () => {
+    const stops = [
+      makeStop(1, 'Tofukuji'),
+      makeStop(2, 'Rokujizo'),
+      makeStop(3, 'Uji'),
+    ];
+    expect(formatJrWestStopsListEn(stops, () => false)).toBe(
+      'Tofukuji, Rokujizo, and Uji'
+    );
+  });
+
+  it('moves the bound stop to a "before arriving at" clause', () => {
+    const stops = [
+      makeStop(1, 'Joyo'),
+      makeStop(2, 'Tamamizu'),
+      makeStop(3, 'Kizu'),
+      makeStop(4, 'Nara'),
+    ];
+    expect(formatJrWestStopsListEn(stops, (s) => s.id === 4)).toBe(
+      'Joyo, Tamamizu, and Kizu before arriving at Nara'
+    );
+  });
+
+  it('handles a two-stop batch ending at the bound stop', () => {
+    const stops = [makeStop(1, 'Kizu'), makeStop(2, 'Nara')];
+    expect(formatJrWestStopsListEn(stops, (s) => s.id === 2)).toBe(
+      'Kizu before arriving at Nara'
+    );
+  });
+
+  it('slices the batch to the first five stops', () => {
+    const stops = [
+      makeStop(1, 'A'),
+      makeStop(2, 'B'),
+      makeStop(3, 'C'),
+      makeStop(4, 'D'),
+      makeStop(5, 'E'),
+      makeStop(6, 'F'),
+    ];
+    expect(formatJrWestStopsListEn(stops, () => false)).toBe(
+      'A, B, C, D, and E'
+    );
   });
 });
 

--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -9,6 +9,10 @@ import {
   stripStationParensForTTS,
 } from './formatters';
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('replaceJapaneseText', () => {
   it('returns empty string when both name and nameKatakana are nullish', () => {
     expect(replaceJapaneseText(null, null)).toBe('');
@@ -216,6 +220,13 @@ describe('formatJrWestStopsListEn', () => {
     ];
     expect(formatJrWestStopsListEn(stops, (s) => s.id === 4)).toBe(
       'Joyo, Tamamizu, and Kizu before arriving at Nara'
+    );
+  });
+
+  it('joins two stops with a plain "and" (no serial comma)', () => {
+    const stops = [makeStop(1, 'Tofukuji'), makeStop(2, 'Rokujizo')];
+    expect(formatJrWestStopsListEn(stops, () => false)).toBe(
+      'Tofukuji and Rokujizo'
     );
   });
 

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -149,20 +149,26 @@ export const formatJrWestStopsListJa = (
     .join('、');
 
 /**
- * JR_WEST 用 (英語): `X, Y terminal, Z` 形式で先頭5駅を `, ` 連結する。
- * 終着駅には末尾に ` terminal` を付与する。
+ * JR_WEST 用 (英語): 先頭5駅を `A, B, and C` 形式で連結する。
+ * バッチ末尾が終着駅 (= selectedBound) の場合は終着駅を列挙から外し、
+ * 公式放送 (みやこ路快速) と同じ `A, B, and C before arriving at X` 形式にする。
  */
 export const formatJrWestStopsListEn = (
   stops: Station[],
   isBoundStop: (s: Station) => boolean
-): string =>
-  stops
-    .slice(0, 5)
-    .map((s) => {
-      const name = wrapPhoneme(s.nameTtsSegments, s.nameRoman);
-      return isBoundStop(s) ? `${name} terminal` : name;
-    })
-    .join(', ');
+): string => {
+  const joinWithAnd = (names: string[]): string => {
+    if (names.length <= 1) return names[0] ?? '';
+    return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+  };
+  const batch = stops.slice(0, 5);
+  const names = batch.map((s) => wrapPhoneme(s.nameTtsSegments, s.nameRoman));
+  const last = batch[batch.length - 1];
+  if (last && isBoundStop(last) && names.length > 1) {
+    return `${joinWithAnd(names.slice(0, -1))} before arriving at ${names[names.length - 1]}`;
+  }
+  return joinWithAnd(names);
+};
 
 /**
  * TY 用: 直通先1路線目のみを `on the X` 形式に整形する。該当がなければ空文字。

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -159,6 +159,8 @@ export const formatJrWestStopsListEn = (
 ): string => {
   const joinWithAnd = (names: string[]): string => {
     if (names.length <= 1) return names[0] ?? '';
+    // 2件のときにシリアルカンマを入れると `A, and B` と不自然になるため分岐する
+    if (names.length === 2) return `${names[0]} and ${names[1]}`;
     return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
   };
   const batch = stops.slice(0, 5);

--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -6,92 +6,103 @@ const t = (...parts: string[]): TemplateRenderer => compile(parts.join(''));
 
 type ThemeTemplate = { NEXT: TemplateRenderer; ARRIVING: TemplateRenderer };
 
+// 文言の出典: 東京メトロ銀座線 車内自動放送 (現行)。
+// - 始発挨拶は会社名 (「東京メトロをご利用くださいまして」) で行うのが公式。
+// - 到着前放送は乗換案内を含まない (乗換案内は発車後放送のみ)。
+// - 終点到着前は忘れ物注意と御礼が入る。
+// - 他社線直通の境界駅では直通先の列車案内と御礼を放送する。
 const TOKYO_METRO: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}',
-    '{currentLineJa}をご利用くださいまして、ありがとうございます。',
-    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
-    '{vehicleJa}は、',
-    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
+    '{currentLineCompanyJa}をご利用くださいまして、ありがとうございます。',
+    '{vehicleJa}は{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
     '{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}ゆきです。',
-    '{#if shouldAnnounceAfterNextStop}',
-    '{nextStationJa}の次は、',
-    '{#if isAfterNextStopTerminus}終点、{/if}',
-    '{afterNextStationJa}に停まります。',
     '{/if}',
-    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様はお乗り換えです。{/if}',
-    '{:else}',
-    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '次は{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
     '{#if shouldAnnounceAfterNextStop}',
-    '{nextStationJa}の次は、',
-    '{#if isAfterNextStopTerminus}終点、{/if}',
-    '{afterNextStationJa}に停まります。',
+    '{nextStationJa}の次は{#if isAfterNextStopTerminus}、終点{/if}、{afterNextStationJa}に停まります。',
     '{/if}',
     '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様はお乗り換えです。{/if}',
+    '{#if isNextStopThroughBoundary}',
+    '{vehicleJa}は、{nextLineJa}直通、{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}ゆきです。',
     '{/if}'
   ),
   ARRIVING: t(
-    'まもなく、{nextStationJa}{#if isNextStopTerminus}終点{/if}です。',
-    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '{#if isNextStopTerminus}{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}'
+    'まもなく{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '{#if isNextStopTerminus}お忘れ物なさいませんよう、ご注意ください。{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{#if isNextStopThroughBoundary}{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}'
   ),
 };
 
+// 文言の出典: 東急東横線 (w0s.jp 東急電車資料室)・東急多摩川線 (現行) 車内自動放送。
+// - 駅名は「次は◯◯、◯◯です」と2回読みが公式 (終点時は「次は◯◯、終点です」)。
+// - 乗換案内は「◯◯線ご利用のお客様はお乗り換えです」(「を」は入らない)。
+// - 他社線直通の境界駅では「この電車は◯◯線直通、…ゆきです。」+ 自社線への御礼を放送する。
 const TY: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}',
-    '{currentLineJa}をご利用くださいまして、ありがとうございます。',
-    '{vehicleJa}は',
-    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
-    '{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}ゆきです。',
+    '本日も{currentLineJa}をご利用くださいまして、ありがとうございます。',
+    '{vehicleJa}は{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
+    '{#if hasTrainType}{trainTypeJa}{/if}{boundForJa}ゆきです。',
     '{/if}',
-    '次は、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
-    '{#if hasTransferLines}{transferLinesListJa}をご利用のお客様はお乗り換えです。{/if}'
+    '次は{nextStationJa}、{#if isNextStopTerminus}終点{:else}{nextStationJa}{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}ご利用のお客様はお乗り換えです。{/if}',
+    '{#if isNextStopThroughBoundary}',
+    '{vehicleJa}は{nextLineJa}直通、{#if hasTrainType}{trainTypeJa}{/if}{boundForJa}ゆきです。',
+    '{currentLineJa}をご利用くださいまして、ありがとうございました。',
+    '{/if}'
   ),
   ARRIVING: t(
-    'まもなく、{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
-    '{#if hasTransferLines}{transferLinesListJa}をご利用のお客様はお乗り換えです。{/if}',
-    '{#if hasAfterNextStation}',
-    '{nextStationJa}を出ますと、',
-    '{#if isAfterNextStopTerminus}終点、{/if}',
-    '{afterNextStationJa}に停まります。',
-    '{/if}',
-    '{#if isNextStopTerminus} {currentLineJa}をご利用くださいまして、ありがとうございました。{/if}'
+    'まもなく{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
+    '{#if hasTransferLines}{transferLinesListJa}ご利用のお客様はお乗り換えです。{/if}',
+    '{#if isNextStopTerminus}本日も{currentLineJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{#if isNextStopThroughBoundary}',
+    '{vehicleJa}は{nextLineJa}直通、{#if hasTrainType}{trainTypeJa}{/if}{boundForJa}ゆきです。',
+    '{currentLineJa}をご利用くださいまして、ありがとうございました。',
+    '{/if}'
   ),
 };
 
-const YAMANOTE: ThemeTemplate = {
+// 文言の出典: JR東日本 通勤型車両 (E233系/E235系) 自動放送 (ydn.jp・山手線書き起こし)。
+// - 始発時は挨拶なしで列車案内のみ (「この電車は、◯◯線、◯◯ゆきです。」) が公式。
+//   御礼は終点到着前のみ (「今日も、JR東日本をご利用くださいまして、ありがとうございました。」)。
+// - 通過駅がある場合は「◯◯へおいでのお客様と、◯◯線は、お乗り換えです。」と
+//   「◯◯の次は、◯◯に止まります。」(到着前) が入る。
+// - YAMANOTE / SAIKYO 共通形。JO / JL / E231 テーマもこのテンプレートを流用する。
+const JR_EAST: ThemeTemplate = {
   NEXT: t(
-    '{#if firstSpeech}今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。{vehicleJa}は、{boundForJa}ゆきです。{/if}',
-    '次は、{nextStationJa}、{nextStationJa}{#if isNextStopTerminus}、終点です{/if}。',
-    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}'
-  ),
-  ARRIVING: t(
-    'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}',
-    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}'
-  ),
-};
-
-const SAIKYO: ThemeTemplate = {
-  NEXT: t(
-    '{#if firstSpeech}今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。{vehicleJa}は、{boundForJa}ゆきです。{/if}',
+    '{#if firstSpeech}{vehicleJa}は、{jrEastTrainDescJa}、{boundForJa}ゆきです。{/if}',
     '次は、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}'
+    '{#if hasTransferLines}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様と、{/if}',
+    '{transferLinesListJa}は、お乗り換えです。',
+    '{:else}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様は、お乗り換えです。{/if}',
+    '{/if}'
   ),
   ARRIVING: t(
     'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}',
-    '{#if isNextStopTerminus}{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。{/if}'
+    '{#if hasTransferLines}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様と、{/if}',
+    '{transferLinesListJa}は、お乗り換えです。',
+    '{:else}',
+    '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様は、お乗り換えです。{/if}',
+    '{/if}',
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}の次は、{#if isAfterNextStopTerminus}終点、{/if}{afterNextStationJa}に止まります。{/if}',
+    '{#if isNextStopTerminus}今日も、{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}'
   ),
 };
 
+// 文言の出典: JR西日本 近郊型車両 (223系/225系) 自動放送 (みやこ路快速書き起こし)。
+// - 乗換案内は到着前放送のみ (発車後の次駅案内には含まれない)。
+// - 終点到着前は「ご乗車ありがとうございました。まもなく終点・◯◯、◯◯です。…
+//   今日もJR西日本をご利用くださいまして、ありがとうございました。◯◯、◯◯です。」の構成。
 const JR_WEST: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}',
-    '今日も、{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございます。',
-    '{vehicleJa}は、{#if hasTrainType}{trainTypeJaPlain}、{/if}',
+    '今日も{currentLineCompanyJa}をご利用くださいまして、ありがとうございます。',
+    '{vehicleJa}は{#if hasTrainType}{trainTypeJaPlain}、{/if}',
     '{#if hasViaStation}{viaStationJa}方面、{/if}',
     '{boundForJa}ゆきです。',
     '{/if}',
@@ -99,52 +110,51 @@ const JR_WEST: ThemeTemplate = {
     '{jrWestStopsListJa}の順に停まります。',
     '{#if lastAnnouncedStopIsBound}{:else}{lastAnnouncedStopJa}から先は、後ほどご案内いたします。{/if}',
     '{/if}',
-    '次は、{#if nextStationIsBound}終点、{/if}{nextStationJa}、{nextStationJa}です。',
-    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}'
+    '次は{#if nextStationIsBound}終点・{/if}{nextStationJa}、{nextStationJa}です。',
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}に停まります。{/if}'
   ),
   ARRIVING: t(
     '{#if nextStationIsBound}',
-    '終点、{nextStationJa}です。',
-    'ご乗車ありがとうございました。',
-    'まもなく{nextStationJa}、{nextStationJa}です。',
+    'ご乗車ありがとうございました。まもなく終点・{nextStationJa}、{nextStationJa}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '今日も{currentLineCompanyShortJa}をご利用くださいまして、ありがとうございました。',
+    '今日も{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。',
     '{nextStationJa}、{nextStationJa}です。',
     '{:else}',
-    'まもなく、{nextStationJa}、{nextStationJa}です。',
+    'まもなく{nextStationJa}、{nextStationJa}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '{#if hasAfterNextStation}{nextStationJa}を出ますと、次は、{afterNextStationJa}に停まります。{/if}',
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}に停まります。{/if}',
     '{/if}'
   ),
 };
 
+// 文言の出典: 東京都交通局「新宿線10-300形車両 自動放送内容リスト」(公式PDF)。
+// - 駅名は「次は、◯◯、◯◯です」と2回読み。乗換案内は「◯◯は、お乗り換えです。」。
+// - 列車案内 (「この電車は、各駅停車、◯◯行きです。」) は始発時のみ。
+// - 終点の一駅手前では「(会社名)をご利用くださいまして、ありがとうございました。…
+//   この電車は、◯◯止まりです。お忘れ物のないよう、ご注意ください。」。
+// - 他社線直通の境界駅では御礼の後に「この電車は、◯◯線直通、…行きです。」を放送する。
+// - 通過駅の案内は「◯◯の次は、◯◯にとまります。」「通過する、◯◯においでの方は、
+//   お乗り換えです。」(到着前放送のみ)。
 const TOEI: ThemeTemplate = {
   NEXT: t(
-    '{#if firstSpeech}{currentLineJa}をご利用くださいまして、ありがとうございます。{/if}',
-    '次は、{nextStationJa}、{nextStationJa}{#if isNextStopTerminus}、終点です{/if}。 ',
-    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '{#if announceVehicleSummary}',
-    '{vehicleJa}は、',
-    '{#if hasConnectedLines}{connectedLinesListJa}直通、{/if}',
-    '{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}ゆきです。',
+    '{#if isNextStopTerminus}{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{#if isNextStopThroughBoundary}{currentLineCompanyJa}をご利用くださいまして、ありがとうございました。{/if}',
+    '{#if firstSpeech}',
+    '{currentLineJa}をご利用くださいまして、ありがとうございます。',
+    '{vehicleJa}は、{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}行きです。',
     '{/if}',
-    '{#if shouldAnnounceAfterNextStop}',
-    '{nextStationJa}の次は、',
-    '{#if isAfterNextStopTerminus}終点、{/if}',
-    '{afterNextStationJa}に停まります。',
-    '{/if}',
-    '{#if hasBetweenStations}通過する、{betweenStationsListJa}へおいでの方はお乗り換えです。{/if}'
+    '次は、{nextStationJa}、{nextStationJa}です。',
+    '{#if hasTransferLines}{transferLinesListJa}は、お乗り換えです。{/if}',
+    '{#if isNextStopTerminus}{vehicleJa}は、{nextStationJa}止まりです。お忘れ物のないよう、ご注意ください。{/if}',
+    '{#if isNextStopThroughBoundary}',
+    '{vehicleJa}は、{nextLineJa}直通、{#if hasTrainType}{trainTypeJa}、{/if}{boundForJa}行きです。',
+    '{/if}'
   ),
   ARRIVING: t(
-    'まもなく、{#if isNextStopTerminus}終点、{/if}{nextStationJa}、{nextStationJa}。',
-    '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '{#if shouldAnnounceAfterNextStop}',
-    '{nextStationJa}の次は、',
-    '{#if isAfterNextStopTerminus}終点、{/if}',
-    '{afterNextStationJa}に停まります。',
-    '{/if}',
-    '{#if hasBetweenStations}通過する、{betweenStationsListJa}へおいでの方はお乗り換えです。{/if}',
-    '{#if isNextStopTerminus} {currentLineJa}をご利用くださいまして、ありがとうございました。{/if}'
+    'まもなく、{nextStationJa}、{nextStationJa}です。',
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}の次は、{#if isAfterNextStopTerminus}終点、{/if}{afterNextStationJa}にとまります。{/if}',
+    '{#if hasBetweenStations}通過する、{betweenStationsListJa}においでの方は、お乗り換えです。{/if}',
+    '{#if isNextStopTerminus}{vehicleJa}は、{nextStationJa}止まりです。お忘れ物のないよう、ご注意ください。{/if}'
   ),
 };
 
@@ -163,27 +173,15 @@ const JR_KYUSHU: ThemeTemplate = {
 
 const TOKYO_METRO_EN: ThemeTemplate = {
   NEXT: t(
-    'The next stop is {nextStationEn}',
-    '{#if hasNextStationNumberText} {nextStationNumberText}{:else}.{/if}',
-    '{#if isNextStopTerminus} The last stop.{/if}',
-    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}',
     '{#if firstSpeech}',
-    ' This {vehicleEn} is',
-    '{#if yamanoteTrainTypeEn} the {yamanoteTrainTypeEn} {vehicleEn}',
-    '{:else}{#if hasTrainType} the {currentTrainTypeOrLocalEn} Service{/if} on the {currentLineEn}{/if}',
-    ' bound for {boundForEn}. ',
-    '{#if shouldAnnounceAfterNextStop}',
-    'The next stop after {nextStationEn}, is {afterNextStationEn}',
-    '{#if isAfterNextStopTerminus} terminal{/if}.',
+    'Thank you for using the {currentLineCompanyEn}. ',
+    'This {vehicleEn} is bound for {boundForEn}. ',
     '{/if}',
-    '{#if hasBetweenStations} For stations in between, Please change {vehicleEnPlural} at the next stop.{/if}',
-    '{/if}'
+    'The next stop is {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus}, the last stop{/if}.',
+    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
-    'Arriving at {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, the last stop.{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}{/if}. ',
-    '{#if isNextStopTerminus}Thank you for using the {currentLineThanksEn}.{/if}'
+    'Arriving at {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus}, the last stop{/if}.'
   ),
 };
 
@@ -191,49 +189,37 @@ const TY_EN: ThemeTemplate = {
   NEXT: t(
     '{#if firstSpeech}',
     'Thank you for using the {currentLineThanksEn}. ',
-    '{#if hasTrainType}This is the {trainTypeEn} {vehicleEn} {connectedLineEnPhrase} to {boundForEn}. ',
+    '{#if hasConnectedLines}This {vehicleEn} will merge and continue traveling {connectedLineEnPhrase} to {boundForEn}. ',
     '{:else}This {vehicleEn} is bound for {boundForEn}. {/if}',
     '{/if}',
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, the last stop{/if} ',
-    '{#if hasTransferLines}Passengers changing to {transferLinesEnList}, Please transfer at this station.{/if}'
+    'The next {placeEn} is {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus}, this is the last stop of this line{/if}.',
+    '{#if hasTransferLines} Passengers changing to {transferLinesEnList}, please transfer at this station.{/if}',
+    '{#if isNextStopThroughBoundary} This {vehicleEn} will merge and continue traveling on the {nextLineEn} to {boundForEn}. Thank you for using the {currentLineThanksEn}.{/if}'
   ),
   ARRIVING: t(
-    'We will soon make a brief stop at {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, the last stop{/if}',
-    '{#if hasTransferLines} Passengers changing to {transferLinesEnList}, Please transfer at this station.{/if}',
-    '{#if shouldAnnounceAfterNextStop} The stop after {nextStationEn}, will be {afterNextStationEn}{#if isAfterNextStopTerminus} the last stop{/if}.{/if}',
-    '{#if isNextStopTerminus} Thank you for using the {currentLineThanksEn}.{/if}'
+    '{#if isNextStopTerminus}',
+    'We will soon be arriving at {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}.',
+    '{#if hasTransferLines} Passengers changing to {transferLinesEnList}, please transfer at this station.{/if}',
+    ' Thank you for using the {currentLineThanksEn}.',
+    '{:else}',
+    'We will soon make a brief stop at {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}.',
+    '{#if hasTransferLines} Passengers changing to {transferLinesEnList}, please transfer at this station.{/if}',
+    '{#if isNextStopThroughBoundary} This {vehicleEn} will merge and continue traveling on the {nextLineEn} to {boundForEn}. Thank you for using the {currentLineThanksEn}.{/if}',
+    '{/if}'
   ),
 };
 
-const YAMANOTE_EN: ThemeTemplate = {
+const JR_EAST_EN: ThemeTemplate = {
   NEXT: t(
-    '{#if firstSpeech}This is the {currentLineEn} {vehicleEn} bound for {boundForEn}. {/if}',
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, terminal.{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
+    '{#if firstSpeech}This is the {jrEastTrainDescEn} {vehicleEn} bound for {boundForEn}. {/if}',
+    'The next {placeEn} is {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus} terminal{/if}.',
+    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}'
   ),
   ARRIVING: t(
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, terminal.{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}{/if}. ',
-    '{#if isNextStopTerminus}Thank you for traveling with us, and look forward to serving you again.{/if}'
-  ),
-};
-
-const SAIKYO_EN: ThemeTemplate = {
-  NEXT: t(
-    '{#if firstSpeech}This is the {currentLineEn} {vehicleEn} bound for {boundForEn}. {/if}',
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, terminal{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
-  ),
-  ARRIVING: t(
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, terminal.{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if} ',
-    '{#if isNextStopTerminus}Thank you for traveling with us, and look forward to serving you again.{/if}'
+    'The next {placeEn} is {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus} terminal{/if}.',
+    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}',
+    '{#if shouldAnnounceAfterNextStop} The stop after {nextStationEn} will be {afterNextStationEn}.{/if}',
+    '{#if isNextStopTerminus} Thank you for traveling with us. And we look forward to serving you again.{/if}'
   ),
 };
 
@@ -248,32 +234,37 @@ const JR_WEST_EN: ThemeTemplate = {
     'We will be stopping at {jrWestStopsListEn}. ',
     '{#if lastAnnouncedStopIsBound}{:else}Stops after {lastAnnouncedStopEn} will be announced later. {/if}',
     '{/if}',
-    'The next stop is {nextStationEn}{#if nextStationIsBound} terminal{/if}',
-    '{#if hasNextStationNumberLineSymbol} station number {nextStationNumberTextNoPeriod}.{:else}.{/if} ',
-    '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if}'
+    'The next stop is {nextStationEn}{#if hasNextStationNumberLineSymbol}, station number {nextStationNumberTextNoPeriod}{/if}{#if nextStationIsBound}, the final stop{/if}.',
+    '{#if shouldAnnounceAfterNextStop} After leaving {nextStationEn}, we will be stopping at {afterNextStationEn}.{/if}'
   ),
   ARRIVING: t(
-    'We will soon be making a brief stop at {nextStationEn}{#if nextStationIsBound} terminal{/if}',
-    '{#if hasNextStationNumberLineSymbol} station number {nextStationNumberTextNoPeriod}.{:else}.{/if} ',
-    '{#if hasTransferLines}Transfer here for {transferLinesEnList}.{/if} ',
-    '{#if hasAfterNextStation}After leaving {nextStationEn}, We will be stopping at {afterNextStationEn}.{/if}'
+    '{#if nextStationIsBound}',
+    'Thank you for riding with us. We will soon be arriving at {nextStationEn}{#if hasNextStationNumberLineSymbol}, station number {nextStationNumberTextNoPeriod}{/if}.',
+    '{#if hasTransferLines} Transfer here for {transferLinesEnList}.{/if}',
+    ' Thank you for using {currentLineCompanyEn}. {nextStationEn}, {nextStationEn}. This is the final stop.',
+    '{:else}',
+    'We will soon be making a brief stop at {nextStationEn}{#if hasNextStationNumberLineSymbol}, station number {nextStationNumberTextNoPeriod}{/if}.',
+    '{#if hasTransferLines} Transfer here for {transferLinesEnList}.{/if}',
+    '{#if shouldAnnounceAfterNextStop} After leaving {nextStationEn}, we will be stopping at {afterNextStationEn}.{/if}',
+    '{/if}'
   ),
 };
 
 const TOEI_EN: ThemeTemplate = {
   NEXT: t(
-    '{#if firstSpeech}Thank you for using the {currentLineThanksEn}. {/if}',
-    '{#if announceVehicleSummary}{#if hasTrainType}This is the {trainTypeEn} {vehicleEn}{:else}This {vehicleEn} is{/if} bound for {boundForEn}. {/if}',
-    'The next {placeEn} is {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, the last stop{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}'
+    '{#if isNextStopTerminus}Thank you for using the {currentLineThanksEn}. {/if}',
+    '{#if isNextStopThroughBoundary}Thank you for using the {currentLineThanksEn}. {/if}',
+    '{#if firstSpeech}',
+    'Thank you for using the {currentLineThanksEn}. ',
+    '{#if hasTrainType}This is the {trainTypeEn} {vehicleEn} bound for {boundForEn}. {:else}This {vehicleEn} is bound for {boundForEn}. {/if}',
+    '{/if}',
+    'The next {placeEn} is {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus}, the final stop on this line{/if}.',
+    '{#if hasTransferLines} Please change here for {transferLinesEnList}.{/if}',
+    '{#if isNextStopThroughBoundary} This is the {trainTypeEn} {vehicleEn} bound for {boundForEn}.{/if}'
   ),
   ARRIVING: t(
-    'We will soon be arriving at {nextStationEn} {nextStationNumberText}',
-    '{#if isNextStopTerminus}, the last stop{/if} ',
-    '{#if hasTransferLines}Please change here for {transferLinesEnList}.{/if}',
-    '{#if shouldAnnounceAfterNextStop} The stop after {nextStationEn}, will be {afterNextStationEn}{#if isAfterNextStopTerminus} the last stop{/if}.{/if}',
-    '{#if isNextStopTerminus} Thank you for using the {currentLineThanksEn}.{/if}'
+    'We will soon be arriving at {nextStationEn}{#if hasNextStationNumberText} {nextStationNumberTextNoPeriod}{/if}{#if isNextStopTerminus}, the final stop on this line{/if}.',
+    '{#if shouldAnnounceAfterNextStop} The stop after {nextStationEn} will be {afterNextStationEn}.{/if}'
   ),
 };
 
@@ -303,9 +294,9 @@ const EMPTY_THEME: ThemeTemplate = {
 export const JA_TEMPLATES: Record<AppTheme, ThemeTemplate> = {
   [APP_THEME.TOKYO_METRO]: TOKYO_METRO,
   [APP_THEME.TY]: TY,
-  [APP_THEME.YAMANOTE]: YAMANOTE,
+  [APP_THEME.YAMANOTE]: JR_EAST,
   [APP_THEME.JR_WEST]: JR_WEST,
-  [APP_THEME.SAIKYO]: SAIKYO,
+  [APP_THEME.SAIKYO]: JR_EAST,
   [APP_THEME.TOEI]: TOEI,
   [APP_THEME.JR_KYUSHU]: JR_KYUSHU,
   [APP_THEME.LED]: EMPTY_THEME,
@@ -318,9 +309,9 @@ export const JA_TEMPLATES: Record<AppTheme, ThemeTemplate> = {
 export const EN_TEMPLATES: Record<AppTheme, ThemeTemplate> = {
   [APP_THEME.TOKYO_METRO]: TOKYO_METRO_EN,
   [APP_THEME.TY]: TY_EN,
-  [APP_THEME.YAMANOTE]: YAMANOTE_EN,
+  [APP_THEME.YAMANOTE]: JR_EAST_EN,
   [APP_THEME.JR_WEST]: JR_WEST_EN,
-  [APP_THEME.SAIKYO]: SAIKYO_EN,
+  [APP_THEME.SAIKYO]: JR_EAST_EN,
   [APP_THEME.TOEI]: TOEI_EN,
   [APP_THEME.JR_KYUSHU]: JR_KYUSHU_EN,
   [APP_THEME.LED]: EMPTY_THEME,

--- a/src/hooks/useTTSText.bus.test.tsx
+++ b/src/hooks/useTTSText.bus.test.tsx
@@ -170,8 +170,7 @@ describe('useTTSText (bus mode)', () => {
       expect(jaText).toContain('このバスは');
       expect(jaText).toContain('ゆきです');
       expect(enText).toContain('The next stop is');
-      expect(enText).toContain('This bus is on the');
-      expect(enText).toContain('bound for');
+      expect(enText).toContain('This bus is bound for');
     });
 
     test('should generate NEXT text with firstSpeech=false', () => {
@@ -185,7 +184,7 @@ describe('useTTSText (bus mode)', () => {
       expect(jaText).toContain('次は');
       expect(jaText).not.toContain('ご利用くださいまして');
       expect(enText).toContain('The next stop is');
-      expect(enText).not.toContain('This bus is on the');
+      expect(enText).not.toContain('This bus is bound for');
     });
 
     test('should generate ARRIVING text', () => {
@@ -239,8 +238,9 @@ describe('useTTSText (bus mode)', () => {
         }
       );
       const [jaText, enText] = result.current.text;
-      expect(jaText).toContain('今日も');
+      // 公式のJR東日本 通勤型放送は始発挨拶なしで列車案内のみ
       expect(jaText).toContain('このバスは');
+      expect(jaText).toContain('ゆきです');
       expect(jaText).toContain('次は');
       expect(enText).toContain('This is the');
       expect(enText).toContain('bus bound for');
@@ -298,8 +298,9 @@ describe('useTTSText (bus mode)', () => {
         }
       );
       const [jaText, enText] = result.current.text;
-      expect(jaText).toContain('今日も');
+      // 公式のJR東日本 通勤型放送は始発挨拶なしで列車案内のみ
       expect(jaText).toContain('このバスは');
+      expect(jaText).toContain('ゆきです');
       expect(jaText).toContain('次は');
       expect(enText).toContain('This is the');
       expect(enText).toContain('bus bound for');
@@ -401,7 +402,7 @@ describe('useTTSText (bus mode)', () => {
         }
       );
       const [jaText, enText] = result.current.text;
-      expect(jaText).toContain('今日も');
+      expect(jaText).toContain('このバスは');
       expect(jaText).toContain('次は');
       expect(enText).toContain('This is the');
     });
@@ -428,7 +429,7 @@ describe('useTTSText (bus mode)', () => {
         }
       );
       const [jaText, enText] = result.current.text;
-      expect(jaText).toContain('今日も');
+      expect(jaText).toContain('このバスは');
       expect(jaText).toContain('次は');
       expect(enText).toContain('This is the');
     });

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -128,7 +128,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
         'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -139,9 +139,10 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // 公式の東京メトロ到着前放送は乗換案内を含まない
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
+        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
   });
@@ -154,9 +155,10 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // 公式の東急放送は駅名2回読み、「◯◯線ご利用のお客様はお乗り換えです」(「を」なし)
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。',
-        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, please transfer at this station.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -167,8 +169,8 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>をご利用のお客様はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, Please transfer at this station.',
+        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
+        'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, please transfer at this station.',
       ]);
     });
   });
@@ -182,7 +184,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -208,9 +210,10 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // 公式のJR西日本発車後放送は乗換案内を含まない (乗換案内は到着前のみ)
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
+        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        'The next stop is Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -221,8 +224,8 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>を出ますと、次は、<sub alias="あけぼのばし">曙橋</sub>に停まります。',
-        'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.',
+        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        'We will soon be making a brief stop at Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
   });
@@ -235,6 +238,7 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // SAIKYO は YAMANOTE と同じJR東日本 通勤型共通テンプレートを使う
       expect(result.current.text).toEqual([
         '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
@@ -262,9 +266,10 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // 公式の都営放送では列車案内は始発時のみ。乗換案内は「◯◯は、お乗り換えです。」
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。 <sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。この電車は、各駅停車、<sub alias="もとやわた">本八幡</sub>ゆきです。',
-        'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
+        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
     test('should be ARRIVING', () => {
@@ -274,9 +279,10 @@ describe('Without trainType & With numbering', () => {
           wrapper: wrapper,
         }
       );
+      // 公式の都営到着前放送は乗換案内を含まない (通過駅がある場合のみ案内)
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
-        'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
+        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
   });
@@ -290,7 +296,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
         'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -305,13 +311,13 @@ describe('Without trainType & With numbering', () => {
       // 英語SSMLがundefinedの場合は空文字列にする
       const en = typeof enSSML === 'string' ? enSSML : '';
 
-      // 日本語: 期待される日本語SSML出力を検証
+      // 日本語: 期待される日本語SSML出力を検証 (公式のメトロ到着前放送は乗換案内なし)
       expect(jaSSML).toBe(
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。'
+        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。'
       );
       // 日本語: 期待される英語SSML出力を検証
       expect(en).toBe(
-        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.'
+        'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.'
       );
 
       // 日本語: 英語SSMLに日本語文字（ひらがな・カタカナ・漢字）が含まれていないことを厳密に検証
@@ -483,21 +489,21 @@ describe('single transferLine period consistency (#5914)', () => {
     );
   });
 
-  test('TOKYO_METRO ARRIVING keeps the trailing period for length=1', () => {
+  test('TOKYO_METRO ARRIVING does not announce transfers (official wording)', () => {
     expect(renderEn('TOKYO_METRO', 'ARRIVING')).toBe(
-      'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+      'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.'
     );
   });
 
   test('TY NEXT renders list inline for length=1', () => {
     expect(renderEn('TY', 'NEXT')).toBe(
-      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, Please transfer at this station.'
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, please transfer at this station.'
     );
   });
 
   test('TY ARRIVING renders list inline for length=1', () => {
     expect(renderEn('TY', 'ARRIVING')).toBe(
-      'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, Please transfer at this station.'
+      'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line, please transfer at this station.'
     );
   });
 
@@ -525,27 +531,27 @@ describe('single transferLine period consistency (#5914)', () => {
     );
   });
 
-  test('JR_WEST NEXT keeps trailing period for length=1', () => {
+  test('JR_WEST NEXT does not announce transfers (official wording)', () => {
     expect(renderEn('JR_WEST', 'NEXT')).toBe(
-      'The next stop is Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line.'
+      'The next stop is Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>.'
     );
   });
 
   test('JR_WEST ARRIVING keeps trailing period for length=1', () => {
     expect(renderEn('JR_WEST', 'ARRIVING')).toBe(
-      'We will soon be making a brief stop at Shinjuku-sanchome station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line. After leaving Shinjuku-sanchome, We will be stopping at Akebonobashi.'
+      'We will soon be making a brief stop at Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line.'
     );
   });
 
   test('TOEI NEXT keeps trailing period for length=1', () => {
     expect(renderEn('TOEI', 'NEXT')).toBe(
-      'This is the Local train bound for Motoyawata. The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+      'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
     );
   });
 
-  test('TOEI ARRIVING keeps trailing period for length=1', () => {
+  test('TOEI ARRIVING does not announce transfers (official wording)', () => {
     expect(renderEn('TOEI', 'ARRIVING')).toBe(
-      'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line.'
+      'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.'
     );
   });
 
@@ -669,17 +675,20 @@ describe('terminus announcement (#5915)', () => {
     { theme: 'TOKYO_METRO', state: 'NEXT', ja: '終点', en: ['last stop'] },
     { theme: 'TOKYO_METRO', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
     { theme: 'TY', state: 'NEXT', ja: '終点', en: ['last stop'] },
-    { theme: 'TY', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
+    // 公式の東急終点到着前放送の英語は "We will soon be arriving at ◯◯.
+    // Thank you for using the ◯◯ Line." で last stop 相当の語を含まない。
+    { theme: 'TY', state: 'ARRIVING', ja: '終点', en: ['Thank you for using'] },
     { theme: 'YAMANOTE', state: 'NEXT', ja: '終点', en: ['terminal'] },
     { theme: 'YAMANOTE', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
     { theme: 'SAIKYO', state: 'NEXT', ja: '終点', en: ['terminal'] },
     { theme: 'SAIKYO', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
-    { theme: 'TOEI', state: 'NEXT', ja: '終点', en: ['last stop'] },
-    { theme: 'TOEI', state: 'ARRIVING', ja: '終点', en: ['last stop'] },
+    // 公式の都営放送は「終点」ではなく「この電車は、◯◯止まりです。」と案内する。
+    { theme: 'TOEI', state: 'NEXT', ja: '止まり', en: ['final stop'] },
+    { theme: 'TOEI', state: 'ARRIVING', ja: '止まり', en: ['final stop'] },
     // JR_WEST / JR_KYUSHU は nextStationIsBound 判定だが、selectedBound が
     // 物理的な終点と一致するこのケースでは isNextStopTerminus も true になる。
-    { theme: 'JR_WEST', state: 'NEXT', ja: '終点', en: ['terminal'] },
-    { theme: 'JR_WEST', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
+    { theme: 'JR_WEST', state: 'NEXT', ja: '終点', en: ['final stop'] },
+    { theme: 'JR_WEST', state: 'ARRIVING', ja: '終点', en: ['final stop'] },
     { theme: 'JR_KYUSHU', state: 'NEXT', ja: '終点', en: ['terminal'] },
     { theme: 'JR_KYUSHU', state: 'ARRIVING', ja: '終点', en: ['terminal'] },
   ];
@@ -699,11 +708,15 @@ describe('terminus announcement (#5915)', () => {
   // 採っているテーマ (JR_WEST / JR_KYUSHU) では引き続き 終点 / terminal を発話する。
   const MID_BOUND_INDEX = 5; // 神保町
   const MID_BOUND_CASES = [
-    { theme: 'JR_WEST', state: 'NEXT' as HeaderStoppingState, en: 'terminal' },
+    {
+      theme: 'JR_WEST',
+      state: 'NEXT' as HeaderStoppingState,
+      en: 'final stop',
+    },
     {
       theme: 'JR_WEST',
       state: 'ARRIVING' as HeaderStoppingState,
-      en: 'terminal',
+      en: 'final stop',
     },
     {
       theme: 'JR_KYUSHU',
@@ -729,11 +742,15 @@ describe('terminus announcement (#5915)', () => {
     }
   );
 
-  // 念のため、selectedBound = TERMINUS の通常ケースで JR_WEST ARRIVING JA に
-  // 追加された「終点、X です。」が含まれることを検証する。
-  test('JR_WEST ARRIVING JA prepends 終点 before thanks', () => {
+  // 念のため、selectedBound = TERMINUS の通常ケースで JR_WEST ARRIVING JA が
+  // 公式の終点到着前構成 (「ご乗車ありがとうございました。まもなく終点・◯◯、◯◯です。」)
+  // で始まることを検証する。
+  test('JR_WEST ARRIVING JA opens with thanks and 終点', () => {
     const [jaText] = renderTexts('JR_WEST', 'ARRIVING');
-    expect(jaText).toMatch(/終点、.+です。ご乗車ありがとうございました。/);
+    expect(jaText).toMatch(
+      /^ご乗車ありがとうございました。まもなく終点・.+です。/
+    );
+    expect(jaText).toMatch(/ご利用くださいまして、ありがとうございました。/);
   });
 
   // YAMANOTE / SAIKYO / JR_KYUSHU ARRIVING の thanks が hasTransferLines に
@@ -764,6 +781,142 @@ describe('terminus announcement (#5915)', () => {
       expect(jaText ?? '').toContain(thanksPhrase);
     }
   );
+});
+
+describe('through service boundary announcement', () => {
+  // 次駅が現在路線の最終駅で、その先が他社線へ直通する場合、公式放送に倣って
+  // 自社線利用への御礼と直通先の列車案内を放送する
+  // (都営: 公式放送内容リスト、東急: 実車放送書き起こしで確認した文言)。
+  const LAST_INDEX = TOEI_SHINJUKU_LINE_STATIONS.length - 1;
+
+  const buildKeioLine = () => {
+    const baseLine = TOEI_SHINJUKU_LINE_STATIONS[0].line;
+    return {
+      ...baseLine,
+      id: 99999,
+      nameShort: '京王線',
+      nameKatakana: 'ケイオウセン',
+      nameFull: '京王線',
+      nameRoman: 'Keio Line',
+      nameTtsSegments: [
+        {
+          __typename: 'TtsSegment' as const,
+          alphabet: 'PLAIN',
+          fallbackText: null,
+          lang: null,
+          pronunciation: null,
+          separator: null,
+          surface: 'Keio Line',
+        },
+      ],
+    };
+  };
+
+  // 終端の1駅だけを京王線所属に差し替え、その手前の駅を直通境界駅にする。
+  const buildThroughStations = (): Station[] =>
+    TOEI_SHINJUKU_LINE_STATIONS.map((s, i) =>
+      i === LAST_INDEX ? ({ ...s, line: buildKeioLine() } as Station) : s
+    );
+
+  const useThroughBoundaryHelper = ({
+    theme,
+    headerState,
+    stations,
+  }: {
+    theme: AppTheme;
+    headerState: HeaderStoppingState;
+    stations: Station[];
+  }) => {
+    const setLineState = useSetAtom(lineState);
+    const setStationState = useSetAtom(stationState);
+
+    useEffect(() => {
+      const station = stations[LAST_INDEX - 2];
+      const selectedDirection = 'INBOUND' as LineDirection;
+      const selectedLine = TOEI_SHINJUKU_LINE_LOCAL;
+      const selectedBound = stations[LAST_INDEX];
+
+      const arrived = headerState === 'CURRENT';
+      const approaching = headerState === 'ARRIVING';
+
+      store.set(themePreferenceAtom, theme);
+      setStationState((prev) => ({
+        ...prev,
+        station,
+        stations,
+        selectedDirection,
+        arrived,
+        selectedBound,
+        approaching,
+      }));
+      setLineState((prev) => ({ ...prev, selectedLine }));
+    }, [headerState, setLineState, setStationState, stations, theme]);
+
+    return useTTSText(false, true);
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    require('~/hooks/useNumbering').useNumbering.mockReturnValue([null, '']);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const renderTexts = (
+    theme: AppTheme,
+    headerState: HeaderStoppingState,
+    stations: Station[]
+  ): [string, string] => {
+    setupMockUseNextStation(stations[LAST_INDEX - 1]);
+    const { result } = renderHook(
+      () => useThroughBoundaryHelper({ theme, headerState, stations }),
+      { wrapper }
+    );
+    const [ja, en] = result.current.text;
+    return [ja ?? '', en ?? ''];
+  };
+
+  test('TOEI NEXT announces thanks and through service at the boundary stop', () => {
+    const [jaText, enText] = renderTexts(
+      'TOEI',
+      'NEXT',
+      buildThroughStations()
+    );
+    expect(jaText).toContain('をご利用くださいまして、ありがとうございました');
+    expect(jaText).toContain('京王線</sub>直通');
+    expect(jaText).toContain('行きです');
+    expect(enText).toContain('Thank you for using the');
+    expect(enText).toContain('bound for');
+  });
+
+  test('TY NEXT announces through service and thanks at the boundary stop', () => {
+    const [jaText, enText] = renderTexts('TY', 'NEXT', buildThroughStations());
+    expect(jaText).toContain('京王線</sub>直通');
+    expect(jaText).toContain('をご利用くださいまして、ありがとうございました');
+    expect(enText).toContain(
+      'will merge and continue traveling on the Keio Line'
+    );
+    expect(enText).toContain('Thank you for using the');
+  });
+
+  test('TOKYO_METRO announces through service on NEXT and thanks on ARRIVING', () => {
+    const stations = buildThroughStations();
+    const [nextJa] = renderTexts('TOKYO_METRO', 'NEXT', stations);
+    expect(nextJa).toContain('京王線</sub>直通');
+    const [arrivingJa] = renderTexts('TOKYO_METRO', 'ARRIVING', stations);
+    expect(arrivingJa).toContain(
+      'をご利用くださいまして、ありがとうございました'
+    );
+  });
+
+  test('does not announce through service when the line does not change', () => {
+    const [jaText] = renderTexts('TOEI', 'NEXT', TOEI_SHINJUKU_LINE_STATIONS);
+    expect(jaText).not.toContain('直通');
+    expect(jaText).not.toContain('ありがとうございました');
+  });
 });
 
 describe('station name parens are not read aloud (issue #1175)', () => {

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -268,6 +268,13 @@ export const useTTSText = (
 
   const isAfterNextStopTerminus = useIsTerminus(afterNextStation);
 
+  // 次駅のさらに先の駅。次駅が他社線直通の境界駅かどうかの判定に使う。
+  const stationAfterNextStop = useMemo(
+    () =>
+      nextStationIndex >= 0 ? slicedStations[nextStationIndex + 1] : undefined,
+    [nextStationIndex, slicedStations]
+  );
+
   const allStops = useMemo(
     () =>
       slicedStations.filter((s) => {
@@ -343,11 +350,39 @@ export const useTTSText = (
     const shouldAnnounceAfterNextStop = isBus
       ? !!afterNextStation
       : !!(currentTrainType && afterNextStation);
-    // TOEI 等で `{vehicleJa}は、…{boundForJa}ゆきです` の塊を出すかどうか。
-    // 鉄道は停車のたびに繰り返し読み上げる (常に true)。
-    // バスは初回放送のみ (実機の都営バスがそういう挙動なので、PR #5990 で
-    // バス版だけ明示的に firstSpeech ゲートを入れていた)。
-    const announceVehicleSummary = !isBus || firstSpeech;
+
+    const nextStationIsBound =
+      nextStation?.groupId === selectedBound?.groupId && !isLoopLine;
+
+    // 次駅が現在路線の最終駅で、その先が他路線へ直通する境界駅かどうか。
+    // 公式放送では境界駅の手前で自社線利用への御礼と直通先の列車案内を行う
+    // (東急・都営は実車放送、東京メトロは終点形と同一の御礼文言で確認)。
+    const throughLine = stationAfterNextStop?.line;
+    const isNextStopThroughBoundary =
+      !isBus &&
+      !isLoopLine &&
+      !isNextStopTerminus &&
+      !nextStationIsBound &&
+      !!throughLine?.id &&
+      throughLine.id !== currentLine.id;
+
+    const currentLineJa = replaceJapaneseText(
+      currentLine.nameShort,
+      currentLine.nameKatakana
+    );
+    const currentLineEn = ph(
+      currentLine.nameTtsSegments,
+      currentLine.nameRoman
+    );
+    const currentTrainTypeJa = currentTrainType
+      ? replaceJapaneseText(
+          currentTrainType.name,
+          currentTrainType.nameKatakana
+        )
+      : '';
+    const currentTrainTypeEn = currentTrainType
+      ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman)
+      : '';
 
     return {
       // フラグ
@@ -360,16 +395,14 @@ export const useTTSText = (
       hasAfterNextStation: !!afterNextStation,
       hasTrainType,
       shouldAnnounceAfterNextStop,
-      announceVehicleSummary,
       hasViaStation: !!viaStation,
-      nextStationIsBound:
-        nextStation?.groupId === selectedBound?.groupId && !isLoopLine,
+      nextStationIsBound,
+      isNextStopThroughBoundary,
       lastAnnouncedStopIsBound:
         lastAnnouncedStop?.groupId === selectedBound?.groupId,
       shouldAnnounceJrWestStopList,
       hasNextStationNumberLineSymbol: !!nextStationNumber?.lineSymbol?.length,
       hasNextStationNumberText: nextStationNumberText.length > 0,
-      yamanoteTrainTypeEn: yamanoteTrainTypeEn ?? '',
 
       // 乗り物名 (アナウンスで `この電車` / `この列車` / `このバス` をテーマと
       // モードで切り替える)。JR_KYUSHU の鉄道のみ歴史的に `この列車` を使うため
@@ -380,7 +413,6 @@ export const useTTSText = (
           ? 'この列車'
           : 'この電車',
       vehicleEn: isBus ? 'bus' : 'train',
-      vehicleEnPlural: isBus ? 'buses' : 'trains',
       // 「次の停車場」を表す語。バスアナウンスは慣習的に "stop" を用いる。
       // 鉄道は既存表記 "station" を維持。
       placeEn: isBus ? 'stop' : 'station',
@@ -390,10 +422,7 @@ export const useTTSText = (
         nextStation?.name,
         nextStation?.nameKatakana
       ),
-      currentLineJa: replaceJapaneseText(
-        currentLine.nameShort,
-        currentLine.nameKatakana
-      ),
+      currentLineJa,
       currentLineShortJa: currentLine.nameShort ?? '',
       currentLineCompanyJa: replaceJapaneseText(
         currentLine.company?.nameShort,
@@ -402,34 +431,21 @@ export const useTTSText = (
       currentLineCompanyShortJa: currentLine.company?.nameShort ?? '',
       boundForJa: boundForJa ?? '',
       // TOKYO_METRO/TY/TOEI 用 (各駅停車 デフォルト)
-      trainTypeJa:
-        yamanoteTrainTypeJa ??
-        (currentTrainType
-          ? replaceJapaneseText(
-              currentTrainType.name,
-              currentTrainType.nameKatakana
-            )
-          : '各駅停車'),
+      trainTypeJa: yamanoteTrainTypeJa ?? (currentTrainTypeJa || '各駅停車'),
       // JR_WEST 用 (各駅停車 デフォルト)。
       // 以前は replaceJapaneseText の暗黙フォールバックに依存していたが、
       // ヘルパは値欠落時に空文字を返すよう変更されたため、ここで明示する (#5917)。
       trainTypeJaPlain:
-        yamanoteTrainTypeJa ??
-        (currentTrainType
-          ? replaceJapaneseText(
-              currentTrainType.name,
-              currentTrainType.nameKatakana
-            )
-          : '各駅停車'),
+        yamanoteTrainTypeJa ?? (currentTrainTypeJa || '各駅停車'),
       // JR_KYUSHU 用 (普通 デフォルト)
-      trainTypeJaKyushu:
+      trainTypeJaKyushu: yamanoteTrainTypeJa ?? (currentTrainTypeJa || '普通'),
+      // JR東日本 (YAMANOTE/SAIKYO) の列車案内
+      // 「この電車は、◯◯線、(種別、)◯◯ゆきです。」に入る路線+種別の塊。
+      // 山手線は公式が「山手線内回り/外回り」と読むため専用文言で置き換える。
+      // 種別が無い普通列車は公式同様に路線名のみ (各駅停車とは読まない)。
+      jrEastTrainDescJa:
         yamanoteTrainTypeJa ??
-        (currentTrainType
-          ? replaceJapaneseText(
-              currentTrainType.name,
-              currentTrainType.nameKatakana
-            )
-          : '普通'),
+        [currentLineJa, currentTrainTypeJa].filter(Boolean).join('、'),
       transferLinesListJa: formatLinesListJa(ttsTransferLines),
       connectedLinesListJa: formatLinesListJa(connectedLines),
       betweenStationsListJa: formatStationsListJa(betweenNextStation),
@@ -449,10 +465,14 @@ export const useTTSText = (
             lastAnnouncedStop.nameKatakana
           )
         : '',
+      // 直通境界駅で案内する直通先路線
+      nextLineJa: isNextStopThroughBoundary
+        ? replaceJapaneseText(throughLine?.nameShort, throughLine?.nameKatakana)
+        : '',
 
       // 英語
       nextStationEn: ph(nextStation?.nameTtsSegments, nextStation?.nameRoman),
-      currentLineEn: ph(currentLine.nameTtsSegments, currentLine.nameRoman),
+      currentLineEn,
       currentLineCompanyEn: currentLine.company?.nameEnglishShort ?? '',
       // "Thank you for using the X" に差し込む語。鉄道は路線名 (e.g. "Tokyo Metro Tozai Line")、
       // バスは路線レコードに英語名が無いケースが多いので会社名 (e.g. "Toei Bus") を使う。
@@ -462,14 +482,13 @@ export const useTTSText = (
         : ph(currentLine.nameTtsSegments, currentLine.nameRoman),
       boundForEn,
       // 多くのテーマで使う共通形 (yamanote ?? phoneme || 'Local')
-      trainTypeEn:
+      trainTypeEn: yamanoteTrainTypeEn ?? (currentTrainTypeEn || 'Local'),
+      // JR東日本 (YAMANOTE/SAIKYO) の列車案内 (路線名 + 種別)。
+      // 公式: "This is the Yamanote Line train bound for ..." /
+      // "This is a Chuo Line rapid service train for ..." 形。
+      jrEastTrainDescEn:
         yamanoteTrainTypeEn ??
-        (ph(currentTrainType?.nameTtsSegments, currentTrainType?.nameRoman) ||
-          'Local'),
-      // TOKYO_METRO 用 (currentTrainType の真偽で 'Local' フォールバック)
-      currentTrainTypeOrLocalEn: currentTrainType
-        ? ph(currentTrainType.nameTtsSegments, currentTrainType.nameRoman)
-        : 'Local',
+        `${currentLineEn}${currentTrainTypeEn ? ` ${currentTrainTypeEn} service` : ''}`,
       transferLinesEnList: formatLinesListEn(ttsTransferLines),
       connectedLineEnPhrase: formatFirstConnectedLineEnPhrase(connectedLines),
       afterNextStationEn: afterNextStation
@@ -481,6 +500,10 @@ export const useTTSText = (
       jrWestStopsListEn: formatJrWestStopsListEn(allStops, isBoundStop),
       lastAnnouncedStopEn: lastAnnouncedStop
         ? ph(lastAnnouncedStop.nameTtsSegments, lastAnnouncedStop.nameRoman)
+        : '',
+      // 直通境界駅で案内する直通先路線
+      nextLineEn: isNextStopThroughBoundary
+        ? ph(throughLine?.nameTtsSegments, throughLine?.nameRoman)
         : '',
       nextStationNumberText,
       nextStationNumberTextNoPeriod: nextStationNumberText.replace(/\.$/, ''),
@@ -505,6 +528,7 @@ export const useTTSText = (
     nextStationNumberText,
     selectedBound,
     shouldAnnounceJrWestStopList,
+    stationAfterNextStop,
     theme,
     ttsTransferLines,
     viaStation,


### PR DESCRIPTION
## 概要

TTSの読み上げ文言を、各テーマが模している鉄道事業者の実車自動放送の公式文言に合わせて書き換えました。文言は以下の一次資料・実車放送書き起こしで一字一句確認したものをベースにしています(会社名・路線名・駅番号はすべて既存の動的変数のままで、定型句のみ公式の言い回しに変更)。

- TOEI: 東京都交通局 公式PDF「新宿線10-300形車両 自動放送内容リスト」
- TOKYO_METRO: 銀座線 車内自動放送(現行)書き起こし
- YAMANOTE / SAIKYO: JR東日本 通勤型(E233/E235系)自動放送の文章化資料
- JR_WEST: みやこ路快速(223系近郊型)・大阪環状線(323系)書き起こし
- TY: 東急東横線・東急多摩川線(現行)書き起こし
- JR_KYUSHU: 信頼できる文字資料が見つからなかったため現行文言を維持

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/templates.ts`: 全テーマのNEXT/ARRIVINGテンプレートを公式文言に書き換え(YAMANOTE/SAIKYOはJR東日本 通勤型共通テンプレートに統合)
- 東京メトロ: 始発挨拶を会社名ベースに変更、公式に存在しない到着前の乗換案内を削除、終点到着前に「お忘れ物なさいませんよう…」+御礼を追加
- 東急: 駅名2回読み、「◯◯線ご利用のお客様はお乗り換えです」(「を」なし)、始発挨拶に「本日も」、終点到着前の御礼を公式構成に変更
- 山手/埼京: 公式に存在しない始発挨拶「今日も〜ありがとうございます」を削除して列車案内のみに変更、通過駅の「◯◯へおいでのお客様と」連結と「◯◯の次は、◯◯に止まります。」(到着前)を追加、終点英語御礼を公式文言に修正
- JR西日本: 発車後の乗換案内を削除(公式は到着前のみ)、終点到着前を「ご乗車ありがとうございました。まもなく終点・◯◯、◯◯です。…」の公式構成に変更、英語停車駅リストを「A, B, and C before arriving at X」形式に変更(`formatJrWestStopsListEn`)
- 都営: 公式PDF準拠で駅名2回読み+「◯◯は、お乗り換えです。」、列車案内を始発時のみに変更、終点手前の「この電車は、◯◯止まりです。お忘れ物のないよう、ご注意ください。」、通過案内を「においでの方」「にとまります」に修正
- 新機能: 他社線直通の境界駅で自社線利用への御礼+直通先の列車案内(「この電車は、◯◯線直通、…行きです。」)を放送する `isNextStopThroughBoundary` / `nextLineJa` / `nextLineEn` を `useTTSText.ts` に追加(東京メトロ・東急・都営テーマで使用。JR系は出典未確認のため対象外)
- テスト: 全テーマの期待値を新文言に更新し、直通境界放送と `formatJrWestStopsListEn` のテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01VjybTsxBDbdYoYsXQPa39B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 直通境界駅の案内で直通先路線名を読み上げするようになりました（より正確な案内）
  * JR西日本向けの駅名列挙が「A, B, and C」形式に改善され、終着駅の表現がより自然になりました

* **Bug Fixes**
  * 各テーマ（JR東日本・東京メトロ等）の放送文言を見直し、終点前後や通過境界での表現を統一しました

* **Tests**
  * 多数の期待値テストを追加・更新し、放送文言の回帰検証を強化しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->