### PR TITLE
Androidでexpo-audioからエラーイベントがJSへ届かずTTS再生パイプラインが長時間ロックされる問題をストール検知ウォッチドッグで修正

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -50,11 +50,16 @@ type StatusCallback = (status: {
   error?: string;
 }) => void;
 
-const createMockPlayer = (opts?: { autoFinish?: boolean }) => {
+const createMockPlayer = (opts?: {
+  autoFinish?: boolean;
+  playing?: boolean;
+}) => {
   let playbackStatusListener: StatusCallback | null = null;
   const autoFinish = opts?.autoFinish ?? true;
 
   return {
+    playing: opts?.playing ?? false,
+    currentTime: 0,
     addListener: jest.fn((_event: string, callback: StatusCallback) => {
       playbackStatusListener = callback;
       return { remove: jest.fn() };
@@ -285,9 +290,10 @@ describe('useTTS', () => {
       ttsEnabledLanguages: ['EN'],
     });
 
-    // didJustFinish を発火しないプレイヤー
+    // didJustFinish を発火しないが再生中(playing=true)であり続けるプレイヤー
+    // （ストール検知に掛からず最終タイムアウトまで到達するケース）
     mockCreateAudioPlayer.mockImplementation(() =>
-      createMockPlayer({ autoFinish: false })
+      createMockPlayer({ autoFinish: false, playing: true })
     );
 
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -311,6 +317,46 @@ describe('useTTS', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[useTTS] Playback safety timeout reached, force resetting'
     );
+
+    warnSpy.mockRestore();
+  });
+
+  it('didJustFinishが届かず再生位置も進まない場合はストール検知で復帰する', async () => {
+    const store = createStore();
+    store.set(speechState, {
+      ...defaultSpeechState,
+      ttsEnabledLanguages: ['EN'],
+    });
+
+    // Androidでネイティブエラーや音声フォーカス喪失により
+    // イベントが一切届かなくなった状態を再現する
+    const mockPlayer = createMockPlayer({ autoFinish: false, playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mockPlayer);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    jest.advanceTimersByTime(100);
+
+    await waitFor(() => {
+      expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    // ストール検知タイムアウト（約10秒）経過で打ち切られる
+    jest.advanceTimersByTime(11_000);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ttsAudioPlayer] playback stalled, aborting:',
+      '/tmp/tts-id_en.mp3'
+    );
+    // ストールしたプレイヤーは破棄され、再生パイプラインが解放される
+    expect(mockPlayer.pause).toHaveBeenCalled();
+    expect(mockPlayer.remove).toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -24,9 +24,10 @@ import { usePrevious } from './usePrevious';
 import { useStoppingState } from './useStoppingState';
 import { useTTSText } from './useTTSText';
 
-// 再生が完了しない場合のフォールバックタイムアウト（ミリ秒）
-// 長い路線放送でも途切れないよう十分な余裕を持たせつつ、
-// didJustFinishが発火しないエッジケースでのデッドロックを防止する
+// 再生が完了しない場合の最終フォールバックタイムアウト（ミリ秒）
+// 通常のストール（Androidでのネイティブエラーや音声フォーカス喪失など）は
+// ttsAudioPlayerのストール検知ウォッチドッグが先に打ち切って復帰させるため、
+// これはウォッチドッグでも捕捉できない異常系に対する最後の砦
 const PLAYBACK_TIMEOUT_MS = 300_000;
 
 // 日本語再生完了後に英語プレイヤーを生成するまでのディレイ（ミリ秒）
@@ -219,11 +220,18 @@ export const useTTS = (): void => {
                 finishPlaying();
               };
 
-              enHandleRef.current = playAudio({
-                uri: pathEn,
-                onFinish: enCleanup,
-                onError: () => enCleanup(),
-              });
+              // setTimeoutコールバック内の例外は誰もキャッチしないため、
+              // プレイヤー生成失敗時もここで確実にfinishPlayingへ到達させる
+              try {
+                enHandleRef.current = playAudio({
+                  uri: pathEn,
+                  onFinish: enCleanup,
+                  onError: () => enCleanup(),
+                });
+              } catch (e) {
+                console.warn('[useTTS] EN playback failed to start:', e);
+                enCleanup();
+              }
             }, EN_PLAYBACK_DELAY_MS);
           } else {
             removeSoundJa();

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -195,6 +195,10 @@ describe('playAudio', () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
     expect(onFinish).not.toHaveBeenCalled();
     expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ttsAudioPlayer] playback stalled, aborting:',
+      'stalled.mp3'
+    );
 
     warnSpy.mockRestore();
   });

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -1,5 +1,7 @@
 import {
   playAudio,
+  STALL_CHECK_INTERVAL_MS,
+  STALL_TIMEOUT_MS,
   safeRemoveListener,
   safeRemovePlayer,
 } from './ttsAudioPlayer';
@@ -15,19 +17,22 @@ type StatusCallback = (status: {
   error?: string;
 }) => void;
 
-const createMockPlayer = () => {
+const createMockPlayer = (opts?: { playing?: boolean }) => {
   let statusCallback: StatusCallback | null = null;
   const listenerRemove = jest.fn();
+  const player = {
+    playing: opts?.playing ?? false,
+    currentTime: 0,
+    addListener: jest.fn((_event: string, callback: StatusCallback) => {
+      statusCallback = callback;
+      return { remove: listenerRemove };
+    }),
+    play: jest.fn(),
+    pause: jest.fn(),
+    remove: jest.fn(),
+  };
   return {
-    player: {
-      addListener: jest.fn((_event: string, callback: StatusCallback) => {
-        statusCallback = callback;
-        return { remove: listenerRemove };
-      }),
-      play: jest.fn(),
-      pause: jest.fn(),
-      remove: jest.fn(),
-    },
+    player,
     listenerRemove,
     emitStatus: (status: { didJustFinish?: boolean; error?: string }) => {
       statusCallback?.(status);
@@ -86,12 +91,15 @@ describe('safeRemovePlayer', () => {
 
 describe('playAudio', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
+
   it('再生完了時に onFinish を呼ぶ', () => {
     const mock = createMockPlayer();
     mockCreateAudioPlayer.mockReturnValue(mock.player);
@@ -168,5 +176,108 @@ describe('playAudio', () => {
     expect(mockCreateAudioPlayer).toHaveBeenCalledWith({
       uri: '/path/to/audio.mp3',
     });
+  });
+
+  it('再生位置が進まないままの場合はストールとして onError を呼ぶ', () => {
+    // Androidではネイティブエラーや音声フォーカス喪失でプレイヤーが
+    // 停止してもイベントが届かないため、ウォッチドッグで検知する
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'stalled.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS + STALL_CHECK_INTERVAL_MS);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('playing=true の間はストール扱いしない', () => {
+    const mock = createMockPlayer({ playing: true });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'long.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('currentTime が進んでいる間はストール扱いしない', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'progressing.mp3', onFinish, onError });
+
+    // ポーリングごとに再生位置を進める
+    for (let i = 0; i < (STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS) * 3; i++) {
+      mock.player.currentTime += 1;
+      jest.advanceTimersByTime(STALL_CHECK_INTERVAL_MS);
+    }
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('再生完了後はウォッチドッグが停止する', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'finished.mp3', onFinish, onError });
+
+    mock.emitStatus({ didJustFinish: true });
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('listener.remove() 後はウォッチドッグが停止する', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    const handle = playAudio({ uri: 'removed.mp3', onFinish, onError });
+
+    handle.listener.remove();
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('プレイヤーのプロパティ参照が例外を投げた場合は onError で復帰する', () => {
+    const mock = createMockPlayer();
+    Object.defineProperty(mock.player, 'playing', {
+      get: () => {
+        throw new Error('player released');
+      },
+    });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'released.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_CHECK_INTERVAL_MS);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onFinish).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -1,6 +1,14 @@
 import type { AudioPlayer } from 'expo-audio';
 import { createAudioPlayer } from 'expo-audio';
 
+// 再生位置が進まない状態がこの時間続いたらストールとみなして打ち切る
+// Android(ExoPlayer)は再生エラーや音声フォーカス喪失で停止しても
+// JSへerrorイベントもdidJustFinishも届かないため、ポーリングで検知して
+// 再生パイプラインをデッドロックから復帰させる
+export const STALL_TIMEOUT_MS = 10_000;
+// ストール監視のポーリング間隔
+export const STALL_CHECK_INTERVAL_MS = 1_000;
+
 export const safeRemoveListener = (
   listener: { remove: () => void } | null
 ): void => {
@@ -29,23 +37,63 @@ export const playAudio = (options: {
   const { uri, onFinish, onError } = options;
   const player = createAudioPlayer({ uri });
 
-  const listener = player.addListener('playbackStatusUpdate', (status) => {
-    if (status.didJustFinish) {
-      safeRemoveListener(listener);
-      onFinish();
-    } else if ('error' in status && status.error) {
-      console.warn('[ttsAudioPlayer] playback error:', status.error);
-      safeRemoveListener(listener);
-      onError(status.error);
+  let settled = false;
+  let stalledTicks = 0;
+  let lastCurrentTime = -1;
+  const maxStalledTicks = Math.ceil(STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS);
+
+  const statusListener = player.addListener(
+    'playbackStatusUpdate',
+    (status) => {
+      if (status.didJustFinish) {
+        settle(onFinish);
+      } else if ('error' in status && status.error) {
+        console.warn('[ttsAudioPlayer] playback error:', status.error);
+        settle(() => onError(status.error));
+      }
     }
-  });
+  );
+
+  const dispose = () => {
+    clearInterval(watchdog);
+    safeRemoveListener(statusListener);
+  };
+
+  const settle = (callback: () => void) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    dispose();
+    callback();
+  };
+
+  // didJustFinishが届かないままプレイヤーが停止した場合の検知
+  // （Androidのネイティブエラー・音声フォーカス喪失・バックグラウンド遷移など）
+  const watchdog = setInterval(() => {
+    try {
+      const playing = player.playing;
+      const currentTime = player.currentTime;
+      if (playing || currentTime !== lastCurrentTime) {
+        lastCurrentTime = currentTime;
+        stalledTicks = 0;
+        return;
+      }
+      stalledTicks += 1;
+      if (stalledTicks >= maxStalledTicks) {
+        console.warn('[ttsAudioPlayer] playback stalled, aborting:', uri);
+        settle(() => onError(new Error('Playback stalled')));
+      }
+    } catch (e) {
+      settle(() => onError(e));
+    }
+  }, STALL_CHECK_INTERVAL_MS);
 
   try {
     player.play();
   } catch (e) {
-    safeRemoveListener(listener);
-    onError(e);
+    settle(() => onError(e));
   }
 
-  return { player, listener };
+  return { player, listener: { remove: dispose } };
 };


### PR DESCRIPTION
## 概要

Android版でTTSがとあるタイミングで全く再生されなくなる問題の調査と修正。

expo-audio 55.0.13のAndroidネイティブ実装（`AudioPlayer.kt`）には`Player.Listener#onPlayerError`が実装されておらず、ExoPlayerが再生エラーで停止してもJSへは`error`イベントも`didJustFinish`も届かない。また音声フォーカスの恒久喪失（`AUDIOFOCUS_LOSS`）時は全プレイヤーが無通知でpauseされ自動復帰しない。この状態に陥ると`useTTS`の`playingRef`が300秒のセーフティタイムアウトまでロックされ、その間のアナウンスはすべて握り潰される（＝他アプリの音声再生・フォーカス喪失・再生エラー直後にTTSが全く再生されない症状と一致）。

`playAudio`に再生位置ポーリングによるストール検知ウォッチドッグを追加し、ネイティブからイベントが届かなくても約10秒で打ち切って次のアナウンスへ復帰できるようにした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/ttsAudioPlayer.ts`: `playAudio`に1秒間隔のストール検知ウォッチドッグを追加。`player.playing`と`player.currentTime`をポーリングし、再生位置が10秒間進まなければ`onError`で打ち切って再生パイプラインを解放する。完了・エラー・破棄時の二重発火はsettledフラグで防止し、リスナー解除と同時にウォッチドッグも確実に停止する
- `src/hooks/useTTS.ts`: 日本語再生完了後にsetTimeout内で英語プレイヤーを生成する箇所をtry/catchで保護（コールバック内の例外は誰もキャッチせず`playingRef`がロックされたままになるため）。`PLAYBACK_TIMEOUT_MS`のコメントを実態（最終フォールバック）に合わせて更新
- `src/utils/ttsAudioPlayer.test.ts` / `src/hooks/useTTS.test.ts`: ストール検知・再生進行中の誤検知防止・完了/解除後のウォッチドッグ停止・ストールからの復帰シナリオのテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJht8Dkg9WNYvjGhWj6YWi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TTS再生開始でのエラー時に確実に後片付けと終了処理が行われるようになりました。
  * 再生が進まない（ストール）状態を検知し、警告ログ出力のうえ対象プレイヤーを停止/削除して復帰を図ります。
  * 状態リスナーと監視タイマーの解除処理を一元化しました。

* **Tests**
  * ストール検知や復帰、タイマー制御、各種例外挙動を含むテストを大幅に拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->