### PR TITLE
iOS版のタブバーとヘッダーをLiquid Glass対応に置換

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "expo-device": "~55.0.15",
         "expo-file-system": "~55.0.10",
         "expo-font": "~55.0.4",
+        "expo-glass-effect": "~55.0.11",
         "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.8",
         "expo-insights": "~55.0.16",
@@ -9940,6 +9941,17 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-glass-effect": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-55.0.11.tgz",
+      "integrity": "sha512-wqq7GUOqSkfoFJzreZvBG0jzjsq5c582m3glhWSjcmIuByxXXWp6j6GY6hyFuYKzpOXhbuvusVxGCQi0yWnp3g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "expo-device": "~55.0.15",
     "expo-file-system": "~55.0.10",
     "expo-font": "~55.0.4",
+    "expo-glass-effect": "~55.0.11",
     "expo-haptics": "~55.0.14",
     "expo-image": "~55.0.8",
     "expo-insights": "~55.0.16",

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
-import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
+import { GlassView } from 'expo-glass-effect';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useRef } from 'react';
 import {
@@ -13,14 +13,26 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { LIQUID_GLASS_AVAILABLE } from '~/utils/liquidGlass';
 
 type FooterTab = 'home' | 'search' | 'settings';
 
 export const FOOTER_BASE_HEIGHT = 72; // Figma: h=72px
 
-// iOS 26+ かつ Xcode 26 ビルドでのみ true。Android や旧 iOS では従来バーへフォールバックする
-const LIQUID_GLASS_AVAILABLE =
-  Platform.OS === 'ios' && isLiquidGlassAvailable();
+const GLASS_BAR_HEIGHT = 64;
+const GLASS_BAR_MIN_BOTTOM_MARGIN = 12;
+
+// タブバーが画面下部で占有する実高さ。描画モード（Liquid Glass / 従来バー）で
+// 高さが異なるため、各画面の bottom padding 計算は必ずこのフックを使うこと
+export const useFooterHeight = (): number => {
+  const insets = useSafeAreaInsets();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const safePad = Math.max(insets.bottom, Platform.OS === 'android' ? 8 : 0);
+  if (LIQUID_GLASS_AVAILABLE && !isLEDTheme) {
+    return GLASS_BAR_HEIGHT + Math.max(safePad, GLASS_BAR_MIN_BOTTOM_MARGIN);
+  }
+  return FOOTER_BASE_HEIGHT + safePad;
+};
 
 export type ButtonLayout = {
   x: number;
@@ -64,8 +76,8 @@ const styles = StyleSheet.create({
   // iOS 26 のフローティングタブバーを模したカプセル形状。
   // 占有高さが FOOTER_BASE_HEIGHT + insets.bottom に収まるよう高さを抑えている
   glassBar: {
-    height: 64,
-    borderRadius: 32,
+    height: GLASS_BAR_HEIGHT,
+    borderRadius: GLASS_BAR_HEIGHT / 2,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
@@ -183,7 +195,12 @@ const FooterTabBar: React.FC<Props> = ({
       <View pointerEvents="box-none" style={styles.container}>
         <GlassView
           glassEffectStyle="regular"
-          style={[styles.glassBar, { marginBottom: Math.max(safePad, 12) }]}
+          style={[
+            styles.glassBar,
+            {
+              marginBottom: Math.max(safePad, GLASS_BAR_MIN_BOTTOM_MARGIN),
+            },
+          ]}
         >
           {tabButtons}
         </GlassView>

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useRef } from 'react';
 import {
@@ -16,6 +17,10 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 type FooterTab = 'home' | 'search' | 'settings';
 
 export const FOOTER_BASE_HEIGHT = 72; // Figma: h=72px
+
+// iOS 26+ かつ Xcode 26 ビルドでのみ true。Android や旧 iOS では従来バーへフォールバックする
+const LIQUID_GLASS_AVAILABLE =
+  Platform.OS === 'ios' && isLiquidGlassAvailable();
 
 export type ButtonLayout = {
   x: number;
@@ -55,6 +60,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-evenly',
     paddingHorizontal: 24,
+  },
+  // iOS 26 のフローティングタブバーを模したカプセル形状。
+  // 占有高さが FOOTER_BASE_HEIGHT + insets.bottom に収まるよう高さを抑えている
+  glassBar: {
+    height: 64,
+    borderRadius: 32,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    paddingHorizontal: 20,
   },
   button: {
     width: 48,
@@ -109,6 +125,72 @@ const FooterTabBar: React.FC<Props> = ({
 
   const safePad = Math.max(insets.bottom, Platform.OS === 'android' ? 8 : 0);
 
+  const tabButtons = (
+    <>
+      <Pressable
+        ref={searchButtonRef}
+        style={styles.button}
+        accessibilityRole="button"
+        onPress={() => {
+          navigation.navigate('RouteSearch' as never);
+        }}
+        onLayout={handleSearchButtonLayout}
+      >
+        <Ionicons
+          name={active === 'search' ? 'git-commit' : 'git-commit-outline'}
+          size={26}
+          color={active === 'search' ? ICON_COLOR.active : ICON_COLOR.inactive}
+        />
+      </Pressable>
+
+      <Pressable
+        style={styles.button}
+        accessibilityRole="button"
+        onPress={() => {
+          navigation.navigate('SelectLine' as never);
+        }}
+      >
+        <Ionicons
+          name={active === 'home' ? 'navigate' : 'navigate-outline'}
+          size={28}
+          color={active === 'home' ? ICON_COLOR.active : ICON_COLOR.inactive}
+        />
+      </Pressable>
+
+      <Pressable
+        ref={settingsButtonRef}
+        style={styles.button}
+        accessibilityRole="button"
+        onPress={() => {
+          navigation.navigate('AppSettings' as never);
+        }}
+        onLayout={handleSettingsButtonLayout}
+      >
+        <Ionicons
+          name={active === 'settings' ? 'settings' : 'settings-outline'}
+          size={26}
+          color={
+            active === 'settings' ? ICON_COLOR.active : ICON_COLOR.inactive
+          }
+        />
+      </Pressable>
+    </>
+  );
+
+  // LED テーマは独自の質感を持つためガラス化せず従来のソリッドなバーを維持する
+  if (LIQUID_GLASS_AVAILABLE && !isLEDTheme) {
+    return (
+      <View pointerEvents="box-none" style={styles.container}>
+        <GlassView
+          glassEffectStyle="regular"
+          style={[styles.glassBar, { marginBottom: Math.max(safePad, 12) }]}
+        >
+          {tabButtons}
+        </GlassView>
+      </View>
+    );
+  }
+
   return (
     <View pointerEvents="box-none" style={styles.container}>
       <View
@@ -120,59 +202,7 @@ const FooterTabBar: React.FC<Props> = ({
           },
         ]}
       >
-        <View style={styles.content}>
-          <Pressable
-            ref={searchButtonRef}
-            style={styles.button}
-            accessibilityRole="button"
-            onPress={() => {
-              navigation.navigate('RouteSearch' as never);
-            }}
-            onLayout={handleSearchButtonLayout}
-          >
-            <Ionicons
-              name={active === 'search' ? 'git-commit' : 'git-commit-outline'}
-              size={26}
-              color={
-                active === 'search' ? ICON_COLOR.active : ICON_COLOR.inactive
-              }
-            />
-          </Pressable>
-
-          <Pressable
-            style={styles.button}
-            accessibilityRole="button"
-            onPress={() => {
-              navigation.navigate('SelectLine' as never);
-            }}
-          >
-            <Ionicons
-              name={active === 'home' ? 'navigate' : 'navigate-outline'}
-              size={28}
-              color={
-                active === 'home' ? ICON_COLOR.active : ICON_COLOR.inactive
-              }
-            />
-          </Pressable>
-
-          <Pressable
-            ref={settingsButtonRef}
-            style={styles.button}
-            accessibilityRole="button"
-            onPress={() => {
-              navigation.navigate('AppSettings' as never);
-            }}
-            onLayout={handleSettingsButtonLayout}
-          >
-            <Ionicons
-              name={active === 'settings' ? 'settings' : 'settings-outline'}
-              size={26}
-              color={
-                active === 'settings' ? ICON_COLOR.active : ICON_COLOR.inactive
-              }
-            />
-          </Pressable>
-        </View>
+        <View style={styles.content}>{tabButtons}</View>
       </View>
     </View>
   );

--- a/src/components/GlassHeaderBackground.tsx
+++ b/src/components/GlassHeaderBackground.tsx
@@ -1,0 +1,32 @@
+import { BlurView } from 'expo-blur';
+import { GlassView } from 'expo-glass-effect';
+import React from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import { LIQUID_GLASS_AVAILABLE } from '~/utils/liquidGlass';
+
+type Props = {
+  isLEDTheme: boolean;
+};
+
+// ヘッダーカードの背面に敷くガラス面。iOS 26+ では Liquid Glass、旧 iOS では従来の BlurView を使う。
+// LED テーマは独自の質感を保つため Liquid Glass 化せずダークブラーを維持する。
+// Android は呼び出し側が背景色で表現するため何も描画しない
+const GlassHeaderBackground: React.FC<Props> = ({ isLEDTheme }) => {
+  if (Platform.OS !== 'ios') return null;
+
+  if (LIQUID_GLASS_AVAILABLE && !isLEDTheme) {
+    return (
+      <GlassView glassEffectStyle="regular" style={StyleSheet.absoluteFill} />
+    );
+  }
+
+  return (
+    <BlurView
+      intensity={40}
+      tint={isLEDTheme ? 'dark' : 'light'}
+      style={StyleSheet.absoluteFill}
+    />
+  );
+};
+
+export default React.memo(GlassHeaderBackground);

--- a/src/components/NowHeader.tsx
+++ b/src/components/NowHeader.tsx
@@ -1,4 +1,3 @@
-import { BlurView } from 'expo-blur';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
@@ -22,6 +21,7 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
+import GlassHeaderBackground from './GlassHeaderBackground';
 import { StationSearchModal } from './StationSearchModal';
 import Typography from './Typography';
 
@@ -238,13 +238,7 @@ export const NowHeader = ({
           ]}
           onLayout={handleHeaderLayout}
         >
-          {Platform.OS === 'ios' ? (
-            <BlurView
-              intensity={40}
-              tint={isLEDTheme ? 'dark' : 'light'}
-              style={StyleSheet.absoluteFill}
-            />
-          ) : null}
+          <GlassHeaderBackground isLEDTheme={isLEDTheme} />
           <View style={[styles.nowHeaderContent, nowHeaderAdditionalStyle]}>
             {/* Stacked layout (fades out) */}
             <RNAnimated.View style={{ opacity: stackedOpacity }}>

--- a/src/components/SettingsHeader.tsx
+++ b/src/components/SettingsHeader.tsx
@@ -1,4 +1,3 @@
-import { BlurView } from 'expo-blur';
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import {
@@ -12,6 +11,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import GlassHeaderBackground from './GlassHeaderBackground';
 import Typography from './Typography';
 
 const styles = StyleSheet.create({
@@ -114,13 +114,7 @@ export const SettingsHeader = ({ title, onLayout, scrollY }: Props) => {
         ]}
         onLayout={onLayout}
       >
-        {Platform.OS === 'ios' ? (
-          <BlurView
-            intensity={40}
-            tint={isLEDTheme ? 'dark' : 'light'}
-            style={StyleSheet.absoluteFill}
-          />
-        ) : null}
+        <GlassHeaderBackground isLEDTheme={isLEDTheme} />
         <View style={[styles.nowHeaderContent, nowHeaderAdditionalStyle]}>
           {/* Stacked layout (fades out) */}
           <RNAnimated.View style={{ opacity: stackedOpacity }}>

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -21,10 +21,7 @@ import {
 } from 'react-native';
 import { isClip } from 'react-native-app-clip';
 import Animated from 'react-native-reanimated';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { CardChevron } from '~/components/CardChevron';
 import { Heading } from '~/components/Heading';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -33,7 +30,7 @@ import WalkthroughOverlay from '~/components/WalkthroughOverlay';
 import { useSettingsWalkthrough } from '~/hooks/useSettingsWalkthrough';
 import { isBetaBuild } from '~/utils/isBetaBuild';
 import { isDevApp } from '~/utils/isDevApp';
-import FooterTabBar, { FOOTER_BASE_HEIGHT } from '../components/FooterTabBar';
+import FooterTabBar, { useFooterHeight } from '../components/FooterTabBar';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import { translate } from '../translation';
 import { RFValue } from '../utils/rfValue';
@@ -185,7 +182,7 @@ const AppSettingsScreen: React.FC = () => {
     useState<ItemLayout | null>(null);
 
   const scrollY = useRef(new RNAnimated.Value(0)).current;
-  const { bottom: safeAreaBottom } = useSafeAreaInsets();
+  const footerHeight = useFooterHeight();
 
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const navigation = useNavigation();
@@ -374,7 +371,7 @@ const AppSettingsScreen: React.FC = () => {
           contentContainerStyle={[
             styles.listContainerStyle,
             headerHeight ? { paddingTop: headerHeight } : null,
-            { paddingBottom: FOOTER_BASE_HEIGHT + safeAreaBottom },
+            { paddingBottom: footerHeight },
           ]}
         >
           {/* パーソナライズセクション */}

--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -147,6 +147,7 @@ jest.mock('../components/FooterTabBar', () => {
     __esModule: true,
     default: FooterTabBar,
     FOOTER_BASE_HEIGHT: 72,
+    useFooterHeight: () => 80,
   };
 });
 

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -16,10 +16,7 @@ import {
   View,
 } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Line, LineNested } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
@@ -35,7 +32,7 @@ import { useSelectLineWalkthrough } from '~/hooks/useSelectLineWalkthrough';
 import { useStationsCache } from '~/hooks/useStationsCache';
 import isTablet from '~/utils/isTablet';
 import { isBusLine } from '~/utils/line';
-import FooterTabBar, { FOOTER_BASE_HEIGHT } from '../components/FooterTabBar';
+import FooterTabBar, { useFooterHeight } from '../components/FooterTabBar';
 import { Heading } from '../components/Heading';
 import navigationState, {
   pendingQuickActionRouteIdAtom,
@@ -122,7 +119,6 @@ const SelectLineScreen = () => {
   const pendingQuickActionRouteId = useAtomValue(pendingQuickActionRouteIdAtom);
   const setNavigationState = useSetAtom(navigationState);
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
-  const insets = useSafeAreaInsets();
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
   // --- クイックアクションからのプリセット選択 ---
@@ -155,7 +151,7 @@ const SelectLineScreen = () => {
   }, [isLEDTheme]);
 
   // --- 派生値 ---
-  const footerHeight = FOOTER_BASE_HEIGHT + Math.max(insets.bottom, 8);
+  const footerHeight = useFooterHeight();
   const listPaddingBottom = useMemo(() => {
     const flattened = StyleSheet.flatten(styles.listContainerStyle) as {
       paddingBottom?: number;

--- a/src/utils/liquidGlass.ts
+++ b/src/utils/liquidGlass.ts
@@ -1,0 +1,6 @@
+import { isLiquidGlassAvailable } from 'expo-glass-effect';
+import { Platform } from 'react-native';
+
+// iOS 26+ かつ Xcode 26 ビルドでのみ true。Android や旧 iOS では各コンポーネントが従来表現へフォールバックする
+export const LIQUID_GLASS_AVAILABLE =
+  Platform.OS === 'ios' && isLiquidGlassAvailable();


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `expo-glass-effect ~55.0.11` を追加（`npx expo install expo-glass-effect` で SDK 55 互換バージョンを導入）
- `FooterTabBar` を Liquid Glass 対応に置換し、iOS 26+（`isLiquidGlassAvailable()` が true のビルド）では `GlassView` によるフローティングカプセル型タブバーで描画
- ヘッダー（`SettingsHeader` / `NowHeader`）の背景も Liquid Glass に統一。共通コンポーネント `GlassHeaderBackground` を新設し、iOS 26+ では `GlassView`、旧 iOS では従来の `BlurView` を使用
- Liquid Glass 可否判定を `src/utils/liquidGlass.ts` の `LIQUID_GLASS_AVAILABLE` に共通化
- タブバーの実高さ計算を `useFooterHeight` フックに共通化し、ガラスモード時の各画面（`SelectLineScreen` / `AppSettings`）の bottom padding 不整合を解消（CodeRabbit 指摘対応）
- Android・旧 iOS・LED テーマは従来表現へフォールバック（LED テーマは独自の質感維持のため意図的に非ガラス）
- 注意: 作業環境が Linux のため `ios/Podfile.lock` は未更新（EAS/CI ビルドで解決される想定。ローカル macOS ビルド時は `npx pod-install` が必要）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS 26以上でガラス調フローティングタブバーを表示可能に。タブの表示ロジックを統一し、ガラス表示時と通常表示時で同一のボタン構成に整理しました。
  * ヘッダー背景はガラス表示を優先し、非対応時はブラーでフォールバックする描画に変更。フッター高さの算出を共通化して画面下部余白が正しく反映されます。

* **Chores**
  * ガラス調エフェクト表示用ライブラリを依存関係に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->