### PR TITLE
iOS 26のLiquid Glassタブバーに押下バウンスアニメーションとアクティブタブ背面のピルを追加

### DIFF
--- a/src/components/FooterTabBar.test.tsx
+++ b/src/components/FooterTabBar.test.tsx
@@ -35,8 +35,11 @@ jest.mock('~/utils/liquidGlass', () => ({
 
 describe('FooterTabBar', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
     mockLiquidGlassAvailable = false;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('visible=false の場合は何もレンダリングしない', () => {

--- a/src/components/FooterTabBar.test.tsx
+++ b/src/components/FooterTabBar.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import FooterTabBar from './FooterTabBar';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 34, left: 0 }),
+}));
+
+jest.mock('expo-glass-effect', () => {
+  const { View } = require('react-native');
+  return {
+    GlassView: View,
+    isLiquidGlassAvailable: jest.fn(() => false),
+  };
+});
+
+// LIQUID_GLASS_AVAILABLE はモジュール読み込み時に確定するため、
+// getter 経由でテストごとに切り替えられるようにする
+let mockLiquidGlassAvailable = false;
+jest.mock('~/utils/liquidGlass', () => ({
+  get LIQUID_GLASS_AVAILABLE() {
+    return mockLiquidGlassAvailable;
+  },
+}));
+
+describe('FooterTabBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLiquidGlassAvailable = false;
+  });
+
+  it('visible=false の場合は何もレンダリングしない', () => {
+    const { toJSON } = render(<FooterTabBar visible={false} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('検索・ホーム・設定の3つのタブボタンをレンダリングする', () => {
+    const { getAllByRole } = render(<FooterTabBar active="home" />);
+    expect(getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('アクティブなタブに selected 状態が付与される', () => {
+    const { getAllByRole } = render(<FooterTabBar active="settings" />);
+    const [search, home, settings] = getAllByRole('button');
+    expect(search.props.accessibilityState.selected).toBe(false);
+    expect(home.props.accessibilityState.selected).toBe(false);
+    expect(settings.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('各タブを押すと対応する画面へ遷移する', () => {
+    const { getAllByRole } = render(<FooterTabBar active="home" />);
+    const [search, home, settings] = getAllByRole('button');
+
+    fireEvent.press(search);
+    expect(mockNavigate).toHaveBeenLastCalledWith('RouteSearch');
+
+    fireEvent.press(home);
+    expect(mockNavigate).toHaveBeenLastCalledWith('SelectLine');
+
+    fireEvent.press(settings);
+    expect(mockNavigate).toHaveBeenLastCalledWith('AppSettings');
+  });
+
+  describe('Liquid Glass モード', () => {
+    beforeEach(() => {
+      mockLiquidGlassAvailable = true;
+    });
+
+    it('アクティブタブの裏にピルが表示される', () => {
+      const { getByTestId } = render(<FooterTabBar active="home" />);
+      expect(getByTestId('footer-active-pill')).toBeTruthy();
+    });
+
+    it('ピルはアクティブタブにのみ表示される', () => {
+      const { getAllByTestId } = render(<FooterTabBar active="search" />);
+      expect(getAllByTestId('footer-active-pill')).toHaveLength(1);
+    });
+  });
+
+  describe('従来バー（Liquid Glass 非対応）', () => {
+    it('アクティブピルを表示しない', () => {
+      const { queryByTestId } = render(<FooterTabBar active="home" />);
+      expect(queryByTestId('footer-active-pill')).toBeNull();
+    });
+  });
+});

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { GlassView } from 'expo-glass-effect';
 import { useAtomValue } from 'jotai';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import {
   type LayoutChangeEvent,
   Platform,
@@ -10,6 +10,11 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
@@ -45,6 +50,21 @@ const ICON_COLOR = {
   active: '#0A84FF',
   inactive: '#6B7280', // gray-500 相当
 } as const;
+
+// アクティブタブのアイコン裏に敷くピル。iOS 26 純正タブバーの選択ハイライトを模した
+// アクセントカラーの半透明ティント
+const ACTIVE_PILL_COLOR = 'rgba(10, 132, 255, 0.16)';
+
+// 押下中に沈み込むスケール値
+const PRESSED_SCALE = 0.85;
+
+// 押下時は素早く沈み、離した時はバウンドしながら戻す
+const PRESS_IN_SPRING = { damping: 24, stiffness: 420 } as const;
+const PRESS_OUT_SPRING = { damping: 13, stiffness: 320 } as const;
+// アクティブピルの出現スプリング。画面遷移直後に弾みながら現れる
+const ACTIVE_PILL_SPRING = { damping: 15, stiffness: 280 } as const;
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const styles = StyleSheet.create({
   container: {
@@ -90,7 +110,79 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  activePill: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 24, // button(48px) の半分で正円にする
+    backgroundColor: ACTIVE_PILL_COLOR,
+  },
 });
+
+type TabButtonProps = {
+  active: boolean;
+  /** アクティブタブの背面ピルを表示するか（Liquid Glass バーのみ true） */
+  showActivePill: boolean;
+  onPress: () => void;
+  onLayout?: (event: LayoutChangeEvent) => void;
+  buttonRef?: React.Ref<View>;
+  children: React.ReactNode;
+};
+
+const TabButton: React.FC<TabButtonProps> = ({
+  active,
+  showActivePill,
+  onPress,
+  onLayout,
+  buttonRef,
+  children,
+}) => {
+  const pressScale = useSharedValue(1);
+  // 0 → 1 でピルがスプリング出現する。タブバーは画面ごとにマウントされるため、
+  // 遷移直後のマウント時アニメーションが実質的な「選択が移った」表現になる
+  const pillProgress = useSharedValue(0);
+
+  useEffect(() => {
+    pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
+  }, [active, pillProgress]);
+
+  const handlePressIn = useCallback(() => {
+    pressScale.value = withSpring(PRESSED_SCALE, PRESS_IN_SPRING);
+  }, [pressScale]);
+
+  const handlePressOut = useCallback(() => {
+    pressScale.value = withSpring(1, PRESS_OUT_SPRING);
+  }, [pressScale]);
+
+  const pressAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pressScale.value }],
+  }));
+
+  const pillAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: pillProgress.value,
+    transform: [{ scale: 0.5 + pillProgress.value * 0.5 }],
+  }));
+
+  return (
+    <AnimatedPressable
+      ref={buttonRef}
+      style={[styles.button, pressAnimatedStyle]}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      onLayout={onLayout}
+    >
+      {showActivePill && active ? (
+        <Animated.View
+          testID="footer-active-pill"
+          pointerEvents="none"
+          style={[styles.activePill, pillAnimatedStyle]}
+        />
+      ) : null}
+      {children}
+    </AnimatedPressable>
+  );
+};
 
 type Props = {
   active?: FooterTab;
@@ -137,12 +229,15 @@ const FooterTabBar: React.FC<Props> = ({
 
   const safePad = Math.max(insets.bottom, Platform.OS === 'android' ? 8 : 0);
 
+  // LED テーマは独自の質感を持つためガラス化せず従来のソリッドなバーを維持する
+  const isGlassBar = LIQUID_GLASS_AVAILABLE && !isLEDTheme;
+
   const tabButtons = (
     <>
-      <Pressable
-        ref={searchButtonRef}
-        style={styles.button}
-        accessibilityRole="button"
+      <TabButton
+        buttonRef={searchButtonRef}
+        active={active === 'search'}
+        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('RouteSearch' as never);
         }}
@@ -153,11 +248,11 @@ const FooterTabBar: React.FC<Props> = ({
           size={26}
           color={active === 'search' ? ICON_COLOR.active : ICON_COLOR.inactive}
         />
-      </Pressable>
+      </TabButton>
 
-      <Pressable
-        style={styles.button}
-        accessibilityRole="button"
+      <TabButton
+        active={active === 'home'}
+        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('SelectLine' as never);
         }}
@@ -167,12 +262,12 @@ const FooterTabBar: React.FC<Props> = ({
           size={28}
           color={active === 'home' ? ICON_COLOR.active : ICON_COLOR.inactive}
         />
-      </Pressable>
+      </TabButton>
 
-      <Pressable
-        ref={settingsButtonRef}
-        style={styles.button}
-        accessibilityRole="button"
+      <TabButton
+        buttonRef={settingsButtonRef}
+        active={active === 'settings'}
+        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('AppSettings' as never);
         }}
@@ -185,16 +280,17 @@ const FooterTabBar: React.FC<Props> = ({
             active === 'settings' ? ICON_COLOR.active : ICON_COLOR.inactive
           }
         />
-      </Pressable>
+      </TabButton>
     </>
   );
 
-  // LED テーマは独自の質感を持つためガラス化せず従来のソリッドなバーを維持する
-  if (LIQUID_GLASS_AVAILABLE && !isLEDTheme) {
+  if (isGlassBar) {
     return (
       <View pointerEvents="box-none" style={styles.container}>
         <GlassView
           glassEffectStyle="regular"
+          // タッチに反応してガラスが揺らぐ iOS 26 ネイティブのインタラクションを有効化
+          isInteractive
           style={[
             styles.glassBar,
             {


### PR DESCRIPTION
## 概要

iOS 26 の Liquid Glass 対応フッタータブバーに、操作時のアニメーションと iOS 26 純正タブバー風のアクティブタブ背面ピルを追加しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `FooterTabBar` の各タブを `TabButton` サブコンポーネントに切り出し、Reanimated のスプリングで押下中はアイコンが 0.85 倍に沈み込み、離すとバウンドしながら戻るアニメーションを追加（Liquid Glass バー・従来バー共通）
- Liquid Glass バーの `GlassView` に `isInteractive` を付与し、タッチに反応する iOS 26 ネイティブのガラスインタラクションを有効化
- アクティブタブのアイコン裏に、純正タブバーの選択ハイライトを模したアクセントカラー半透明ピル（`rgba(10, 132, 255, 0.16)` の正円）を追加。タブバーは画面ごとにマウントされるため、画面遷移直後にスプリングで出現し「選択が移った」表現になる
- ピルは Liquid Glass バーのみに表示し、LED テーマ・従来バーの見た目は不変。あわせて各タブに `accessibilityState={{ selected }}` を付与
- `FooterTabBar.test.tsx` を新規追加（タブ遷移・selected 状態・Glass モードでのピル表示有無の 7 ケース）

### 回帰リスクと対策

- タブバーは全画面共通のため、押下アニメーション起因のタップ取りこぼしが主なリスク。`Pressable` の構造とレイアウト計測（ウォークスルー用の `measureInWindow`）は変えておらず、新規テストでタブ遷移とアクセシビリティ状態を担保
- Liquid Glass 非対応環境（Android・旧 iOS・LED テーマ）はピル非表示の従来描画にフォールバックすることをテストで確認

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行コマンド: `npm run lint && npm test && npm run typecheck`（172 suites / 1849 tests パス）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_016yuNrnJXoAwLNLd3aoUgHF

---
_Generated by [Claude Code](https://claude.ai/code/session_016yuNrnJXoAwLNLd3aoUgHF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * フッターのタブにアニメーション効果（背面ピル表示と押下時のスケール沈み込み）を導入しました
  * Liquid Glass モード時のみアクティブタブの背後に視覚的なピルを表示する挙動を追加しました
  * ガラス表示時のインタラクション挙動を改善しました

* **Tests**
  * フッターバーの表示、タブ遷移、アクティブ状態、Liquid Glass 動作を検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->