### PR TITLE
StrictModeを無効化しタブバーのピルアニメーション更新をscheduleOnUIでUIスレッドに移動

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -43,6 +43,10 @@ jest.mock("react-native-reanimated", () => {
   };
 });
 
+jest.mock("react-native-worklets", () => ({
+  scheduleOnUI: jest.fn((worklet) => worklet()),
+}));
+
 jest.mock("~/utils/isTablet", () => ({
   __esModule: true,
   default: false,

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -16,6 +16,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { scheduleOnUI } from 'react-native-worklets';
 import { LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { LIQUID_GLASS_AVAILABLE } from '~/utils/liquidGlass';
@@ -141,7 +142,10 @@ const TabButton: React.FC<TabButtonProps> = ({
   const pillProgress = useSharedValue(0);
 
   useEffect(() => {
-    pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
+    scheduleOnUI(() => {
+      'worklet';
+      pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
+    });
   }, [active, pillProgress]);
 
   const handlePressIn = useCallback(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { useFonts } from 'expo-font';
 import * as Location from 'expo-location';
 import * as SplashScreen from 'expo-splash-screen';
 import { Provider } from 'jotai';
-import React, { useEffect } from 'react';
+import React, { StrictMode, useEffect } from 'react';
 import { Platform, StatusBar, Text } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -120,7 +120,9 @@ const App: React.FC = () => {
                 <DeepLinkProvider>
                   <QuickActionsProvider>
                     <PortalProvider>
-                      <AppContent />
+                      <StrictMode>
+                        <AppContent />
+                      </StrictMode>
                     </PortalProvider>
                   </QuickActionsProvider>
                   <GlobalToast />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { useFonts } from 'expo-font';
 import * as Location from 'expo-location';
 import * as SplashScreen from 'expo-splash-screen';
 import { Provider } from 'jotai';
-import React, { StrictMode, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Platform, StatusBar, Text } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -120,9 +120,7 @@ const App: React.FC = () => {
                 <DeepLinkProvider>
                   <QuickActionsProvider>
                     <PortalProvider>
-                      <StrictMode>
-                        <AppContent />
-                      </StrictMode>
+                      <AppContent />
                     </PortalProvider>
                   </QuickActionsProvider>
                   <GlobalToast />


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/components/FooterTabBar.tsx`: アクティブタブのピルアニメーション（`pillProgress`）の更新を `scheduleOnUI` の worklet 経由で UI スレッドにスケジュールするよう変更
- `src/index.tsx`: `AppContent` を包んでいた `StrictMode` ラッパーを削除（StrictMode×Reanimated 4 の既知の非互換により dev ビルドが起動不能になるため。一度レビュー指摘を受けて復元したが、dev 環境の起動不能が再現したため無効化を最終決定）
- `jest.setup.js`: jest 環境では `react-native-worklets` のネイティブ初期化ができないため、`scheduleOnUI` を即時実行のモックに置換

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
