### PR TITLE
react-native-dotenvがnode_modules内のprocess.env参照をインライン化しないようパッチ

### DIFF
--- a/patches/react-native-dotenv+3.4.11.patch
+++ b/patches/react-native-dotenv+3.4.11.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/react-native-dotenv/index.js b/node_modules/react-native-dotenv/index.js
+index e2a360d..230ca44 100644
+--- a/node_modules/react-native-dotenv/index.js
++++ b/node_modules/react-native-dotenv/index.js
+@@ -147,7 +147,17 @@ module.exports = (api, options) => {
+           path.remove()
+         }
+       },
+-      MemberExpression(path) {
++      MemberExpression(path, state) {
++        // PATCH(TrainLCD): node_modules 内のコードには process.env インライン化を
++        // 適用しない。Metro の変換ワーカーは jest-worker 製で JEST_WORKER_ID が
++        // 設定されており、react-native-reanimated の
++        // `IS_JEST = !!process.env.JEST_WORKER_ID` に true が焼き込まれて
++        // 実機で Jest/Web 用実装が選ばれ、shared value のシリアライズが壊れて
++        // 起動時クラッシュ(Object is not a function / addListener)になるため。
++        // 参照: https://github.com/software-mansion/react-native-reanimated/discussions/9023
++        if (state.filename && /[\\/]node_modules[\\/]/.test(state.filename)) {
++          return
++        }
+         if (path.get('object').matchesPattern('process.env')) {
+           const key = path.toComputedKey()
+           if (t.isStringLiteral(key)) {


### PR DESCRIPTION
## 概要

起動時に `TypeError: Object is not a function`（dev ビルドでは `[Worklets] Tried to synchronously call a non-worklet function addListener on the UI thread`）でクラッシュする問題を修正する。

真因は react-native-dotenv の babel プラグインが、node_modules 内を含む全ファイルの `process.env.X` 参照を babel ワーカープロセスの環境変数でインライン化してしまうこと。Metro の変換ワーカーは jest-worker 製で `JEST_WORKER_ID` が設定されているため、react-native-reanimated の `IS_JEST = !!process.env.JEST_WORKER_ID` に `true` が焼き込まれ、実機でも Jest/Web 用の `makeMutableWeb`（shared value を serializableMappingCache に登録しない実装）が選ばれていた。その結果 shared value が worklet へフィールド単位でコピーされ、UI スレッド上で `addListener` が関数ではなくなりクラッシュしていた。

Metro がワーカーを使うフルビルド（CI/EAS、ローカルでは `--clear` 後）だけが汚染され、インクリメンタル変換はメインプロセス（`JEST_WORKER_ID` なし）で走るため、症状が非決定的に見えるのが特徴。

参照: https://github.com/software-mansion/react-native-reanimated/discussions/9023

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/react-native-dotenv+3.4.11.patch` を追加（postinstall の patch-package で適用）
- react-native-dotenv の `MemberExpression` visitor が node_modules 内のファイルに対しては `process.env.X` のインライン化を行わないようにする
- アプリコード（`src/` など）での `react-native-dotenv` import のインライン化と `process.env.X` 置換は従来どおり動作する

検証内容:

- Android 実機（devDebug）でクラッシュを再現し、reanimated 側のプローブで実機なのに `IS_JEST = true` / `SHOULD_BE_USE_WEB = true` になっていることを確認
- パッチ適用後、同実機で Worklets エラーが消えアプリが正常に起動・描画されることを確認
- `JEST_WORKER_ID=1` を設定した babel 単体実行で、パッチ前は `IS_JEST = !!"1"` が焼き込まれ、パッチ後は `!!process.env.JEST_WORKER_ID` のまま保持されることを確認

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存ライブラリのパッチを適用し、ビルドプロセスの最適化とアプリケーション実行時の安定性向上を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->