### PR TITLE
PR #6176で起動クラッシュの真因が修正されたためFooterTabBarの不要になったscheduleOnUIワークアラウンドを削除

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -43,10 +43,6 @@ jest.mock("react-native-reanimated", () => {
   };
 });
 
-jest.mock("react-native-worklets", () => ({
-  scheduleOnUI: jest.fn((worklet) => worklet()),
-}));
-
 jest.mock("~/utils/isTablet", () => ({
   __esModule: true,
   default: false,

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -16,7 +16,6 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { scheduleOnUI } from 'react-native-worklets';
 import { LED_THEME_BG_COLOR } from '~/constants';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { LIQUID_GLASS_AVAILABLE } from '~/utils/liquidGlass';
@@ -142,10 +141,7 @@ const TabButton: React.FC<TabButtonProps> = ({
   const pillProgress = useSharedValue(0);
 
   useEffect(() => {
-    scheduleOnUI(() => {
-      'worklet';
-      pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
-    });
+    pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
   }, [active, pillProgress]);
 
   const handlePressIn = useCallback(() => {


### PR DESCRIPTION
## 概要

PR #6173 で導入した `scheduleOnUI` ワークアラウンドを削除する。

`scheduleOnUI` は起動時クラッシュ（`Object is not a function` / UI スレッドでの `addListener` エラー）への対症療法だったが、PR #6176 で真因（react-native-dotenv が node_modules 内の `process.env` 参照をインライン化し、reanimated の `IS_JEST` に `true` が焼き込まれて shared value のシリアライズが壊れる）が修正されたため不要になった。`useEffect` から shared value へ直接書き込むのは Reanimated の標準パターンであり、UI スレッドへの明示的なスケジューリングは必要ない。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/FooterTabBar.tsx`: ピルアニメーション更新の `scheduleOnUI` ラッパーと `react-native-worklets` の import を削除し、PR #6173 以前の直接書き込み（`pillProgress.value = withSpring(...)`）に戻した
- `jest.setup.js`: `scheduleOnUI` のためだけに存在していた `react-native-worklets` のモックを削除（`src/` 内に他の利用箇所がないことを確認済み）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_01PzxwuNzjCirmunFhbT7iAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzxwuNzjCirmunFhbT7iAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * タブバーのピルアニメーション処理の実装を最適化しました

* **テスト**
  * Jest セットアップから不要なモック設定を削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->