### PR TITLE
Liquid Glassタブバーのアクティブピルを前のタブ位置からスライドさせるApple Music風アニメーションに変更

### DIFF
--- a/src/components/FooterTabBar.test.tsx
+++ b/src/components/FooterTabBar.test.tsx
@@ -79,14 +79,42 @@ describe('FooterTabBar', () => {
       mockLiquidGlassAvailable = true;
     });
 
-    it('アクティブタブの裏にピルが表示される', () => {
-      const { getByTestId } = render(<FooterTabBar active="home" />);
-      expect(getByTestId('footer-active-pill')).toBeTruthy();
+    const layoutEvent = (x: number) => ({
+      nativeEvent: { layout: { x, y: 8, width: 48, height: 48 } },
     });
 
-    it('ピルはアクティブタブにのみ表示される', () => {
-      const { getAllByTestId } = render(<FooterTabBar active="search" />);
+    // ピルとタブボタンの onLayout を発火させ、ピル配置ロジックを通す
+    const fireBarLayouts = (api: ReturnType<typeof render>) => {
+      fireEvent(api.getByTestId('footer-active-pill'), 'layout', {
+        nativeEvent: { layout: { x: 0, y: 8, width: 48, height: 48 } },
+      });
+      const [search, home, settings] = api.getAllByRole('button');
+      fireEvent(search, 'layout', layoutEvent(20));
+      fireEvent(home, 'layout', layoutEvent(84));
+      fireEvent(settings, 'layout', layoutEvent(148));
+    };
+
+    it('タブバー全体で共有ピルが1つだけ表示される', () => {
+      const { getAllByTestId } = render(<FooterTabBar active="home" />);
       expect(getAllByTestId('footer-active-pill')).toHaveLength(1);
+    });
+
+    it('レイアウト確定後もピルは1つのまま維持される', () => {
+      const api = render(<FooterTabBar active="home" />);
+      fireBarLayouts(api);
+      expect(api.getAllByTestId('footer-active-pill')).toHaveLength(1);
+    });
+
+    it('別タブがアクティブなバーを再マウントしてもクラッシュしない（スライド経路）', () => {
+      // 画面遷移によるタブバーの再マウントを模す。1 回目で lastActiveTab が
+      // 記録され、2 回目のマウントでスライド配置の分岐を通る
+      const first = render(<FooterTabBar active="home" />);
+      fireBarLayouts(first);
+      first.unmount();
+
+      const second = render(<FooterTabBar active="search" />);
+      fireBarLayouts(second);
+      expect(second.getAllByTestId('footer-active-pill')).toHaveLength(1);
     });
   });
 

--- a/src/components/FooterTabBar.test.tsx
+++ b/src/components/FooterTabBar.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native';
-import FooterTabBar from './FooterTabBar';
+import FooterTabBar, { resetLastActiveTabForTesting } from './FooterTabBar';
 
 const mockNavigate = jest.fn();
 
@@ -36,6 +36,9 @@ jest.mock('~/utils/liquidGlass', () => ({
 describe('FooterTabBar', () => {
   beforeEach(() => {
     mockLiquidGlassAvailable = false;
+    // モジュールスコープの lastActiveTab がテスト間でリークして
+    // 実行順序依存にならないよう毎回リセットする
+    resetLastActiveTabForTesting();
   });
 
   afterEach(() => {

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -73,6 +73,12 @@ const PILL_SLIDE_SPRING = { damping: 24, stiffness: 350 } as const;
 // マウントをまたいだピルのスライド元をモジュールスコープで保持する
 let lastActiveTab: FooterTab | null = null;
 
+// テスト専用。モジュールスコープの lastActiveTab がテスト間でリークして
+// 順序依存にならないよう、beforeEach でリセットするためのヘルパー
+export const resetLastActiveTabForTesting = (): void => {
+  lastActiveTab = null;
+};
+
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const styles = StyleSheet.create({

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { GlassView } from 'expo-glass-effect';
 import { useAtomValue } from 'jotai';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   type LayoutChangeEvent,
   Platform,
@@ -55,14 +55,23 @@ const ICON_COLOR = {
 // アクセントカラーの半透明ティント
 const ACTIVE_PILL_COLOR = 'rgba(10, 132, 255, 0.16)';
 
+const TAB_BUTTON_SIZE = 48;
+
 // 押下中に沈み込むスケール値
 const PRESSED_SCALE = 0.85;
 
 // 押下時は素早く沈み、離した時はバウンドしながら戻す
 const PRESS_IN_SPRING = { damping: 24, stiffness: 420 } as const;
 const PRESS_OUT_SPRING = { damping: 13, stiffness: 320 } as const;
-// アクティブピルの出現スプリング。画面遷移直後に弾みながら現れる
+// アプリ初回マウント時のみ使うピルのスケールイン出現スプリング
 const ACTIVE_PILL_SPRING = { damping: 15, stiffness: 280 } as const;
+// タブ切り替え時にピルが前のタブ位置からスライドするスプリング。
+// 進行方向へわずかにオーバーシュートさせ、Apple Music の選択ハイライトの動きに寄せる
+const PILL_SLIDE_SPRING = { damping: 24, stiffness: 350 } as const;
+
+// 直前の画面でアクティブだったタブ。タブバーは画面ごとに再マウントされるため、
+// マウントをまたいだピルのスライド元をモジュールスコープで保持する
+let lastActiveTab: FooterTab | null = null;
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -105,22 +114,25 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
   button: {
-    width: 48,
-    height: 48,
+    width: TAB_BUTTON_SIZE,
+    height: TAB_BUTTON_SIZE,
     justifyContent: 'center',
     alignItems: 'center',
   },
+  // タブバー全体で 1 つだけ描画する共有ピル。translateX でアクティブタブ間をスライドする
   activePill: {
-    ...StyleSheet.absoluteFillObject,
-    borderRadius: 24, // button(48px) の半分で正円にする
+    position: 'absolute',
+    top: (GLASS_BAR_HEIGHT - TAB_BUTTON_SIZE) / 2,
+    left: 0,
+    width: TAB_BUTTON_SIZE,
+    height: TAB_BUTTON_SIZE,
+    borderRadius: TAB_BUTTON_SIZE / 2,
     backgroundColor: ACTIVE_PILL_COLOR,
   },
 });
 
 type TabButtonProps = {
   active: boolean;
-  /** アクティブタブの背面ピルを表示するか（Liquid Glass バーのみ true） */
-  showActivePill: boolean;
   onPress: () => void;
   onLayout?: (event: LayoutChangeEvent) => void;
   buttonRef?: React.Ref<View>;
@@ -129,20 +141,12 @@ type TabButtonProps = {
 
 const TabButton: React.FC<TabButtonProps> = ({
   active,
-  showActivePill,
   onPress,
   onLayout,
   buttonRef,
   children,
 }) => {
   const pressScale = useSharedValue(1);
-  // 0 → 1 でピルがスプリング出現する。タブバーは画面ごとにマウントされるため、
-  // 遷移直後のマウント時アニメーションが実質的な「選択が移った」表現になる
-  const pillProgress = useSharedValue(0);
-
-  useEffect(() => {
-    pillProgress.value = withSpring(active ? 1 : 0, ACTIVE_PILL_SPRING);
-  }, [active, pillProgress]);
 
   const handlePressIn = useCallback(() => {
     pressScale.value = withSpring(PRESSED_SCALE, PRESS_IN_SPRING);
@@ -156,11 +160,6 @@ const TabButton: React.FC<TabButtonProps> = ({
     transform: [{ scale: pressScale.value }],
   }));
 
-  const pillAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: pillProgress.value,
-    transform: [{ scale: 0.5 + pillProgress.value * 0.5 }],
-  }));
-
   return (
     <AnimatedPressable
       ref={buttonRef}
@@ -172,13 +171,6 @@ const TabButton: React.FC<TabButtonProps> = ({
       onPressOut={handlePressOut}
       onLayout={onLayout}
     >
-      {showActivePill && active ? (
-        <Animated.View
-          testID="footer-active-pill"
-          pointerEvents="none"
-          style={[styles.activePill, pillAnimatedStyle]}
-        />
-      ) : null}
       {children}
     </AnimatedPressable>
   );
@@ -203,27 +195,103 @@ const FooterTabBar: React.FC<Props> = ({
   const searchButtonRef = useRef<View>(null);
   const settingsButtonRef = useRef<View>(null);
 
+  const pillTranslateX = useSharedValue(0);
+  // 0 → 1 でピルがスケールインする。初回マウント時の出現にのみ使い、
+  // タブ切り替え時は 1 のままスライドだけを行う
+  const pillProgress = useSharedValue(0);
+  const pillBaseXRef = useRef<number | null>(null);
+  const slotXsRef = useRef<Partial<Record<FooterTab, number>>>({});
+  const pillPlacedRef = useRef(false);
+
+  // ピル自身と各タブの onLayout が揃った時点で一度だけ配置を確定する。
+  // 直前の画面でアクティブだったタブが異なる場合は、その位置からスライドさせて
+  // Apple Music のように選択ハイライトが移動して見えるようにする
+  const placePillIfReady = useCallback(() => {
+    if (pillPlacedRef.current) return;
+    const baseX = pillBaseXRef.current;
+    const activeX = slotXsRef.current[active];
+    if (baseX == null || activeX == null) return;
+    const fromTab = lastActiveTab;
+    const fromX = fromTab == null ? null : slotXsRef.current[fromTab];
+    // スライド元スロットの位置が未測定なら、その onLayout を待つ
+    if (fromTab != null && fromTab !== active && fromX == null) return;
+    pillPlacedRef.current = true;
+    lastActiveTab = active;
+    if (fromTab != null && fromTab !== active && fromX != null) {
+      pillProgress.value = 1;
+      pillTranslateX.value = fromX - baseX;
+      pillTranslateX.value = withSpring(activeX - baseX, PILL_SLIDE_SPRING);
+      return;
+    }
+    pillTranslateX.value = activeX - baseX;
+    // 同一タブ内の画面遷移（設定サブ画面間など）ではアニメーションを再生しない
+    pillProgress.value =
+      fromTab === active ? 1 : withSpring(1, ACTIVE_PILL_SPRING);
+  }, [active, pillProgress, pillTranslateX]);
+
+  const handlePillLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      pillBaseXRef.current = event.nativeEvent.layout.x;
+      placePillIfReady();
+    },
+    [placePillIfReady]
+  );
+
+  const registerSlotLayout = useCallback(
+    (tab: FooterTab, event: LayoutChangeEvent) => {
+      const x = event.nativeEvent.layout.x;
+      const prevX = slotXsRef.current[tab];
+      slotXsRef.current[tab] = x;
+      if (pillPlacedRef.current) {
+        // 配置確定後のレイアウト変化（回転など）にはアニメーションなしで追従する
+        if (tab === active && prevX !== x && pillBaseXRef.current != null) {
+          pillTranslateX.value = x - pillBaseXRef.current;
+        }
+        return;
+      }
+      placePillIfReady();
+    },
+    [active, pillTranslateX, placePillIfReady]
+  );
+
   const handleSearchButtonLayout = useCallback(
-    (_event: LayoutChangeEvent) => {
+    (event: LayoutChangeEvent) => {
+      registerSlotLayout('search', event);
       if (onSearchButtonLayout && searchButtonRef.current) {
         searchButtonRef.current.measureInWindow((x, y, width, height) => {
           onSearchButtonLayout({ x, y, width, height });
         });
       }
     },
-    [onSearchButtonLayout]
+    [onSearchButtonLayout, registerSlotLayout]
+  );
+
+  const handleHomeButtonLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      registerSlotLayout('home', event);
+    },
+    [registerSlotLayout]
   );
 
   const handleSettingsButtonLayout = useCallback(
-    (_event: LayoutChangeEvent) => {
+    (event: LayoutChangeEvent) => {
+      registerSlotLayout('settings', event);
       if (onSettingsButtonLayout && settingsButtonRef.current) {
         settingsButtonRef.current.measureInWindow((x, y, width, height) => {
           onSettingsButtonLayout({ x, y, width, height });
         });
       }
     },
-    [onSettingsButtonLayout]
+    [onSettingsButtonLayout, registerSlotLayout]
   );
+
+  const pillAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: pillProgress.value,
+    transform: [
+      { translateX: pillTranslateX.value },
+      { scale: 0.5 + pillProgress.value * 0.5 },
+    ],
+  }));
 
   if (!visible) return null;
 
@@ -237,7 +305,6 @@ const FooterTabBar: React.FC<Props> = ({
       <TabButton
         buttonRef={searchButtonRef}
         active={active === 'search'}
-        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('RouteSearch' as never);
         }}
@@ -252,10 +319,10 @@ const FooterTabBar: React.FC<Props> = ({
 
       <TabButton
         active={active === 'home'}
-        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('SelectLine' as never);
         }}
+        onLayout={handleHomeButtonLayout}
       >
         <Ionicons
           name={active === 'home' ? 'navigate' : 'navigate-outline'}
@@ -267,7 +334,6 @@ const FooterTabBar: React.FC<Props> = ({
       <TabButton
         buttonRef={settingsButtonRef}
         active={active === 'settings'}
-        showActivePill={isGlassBar}
         onPress={() => {
           navigation.navigate('AppSettings' as never);
         }}
@@ -298,6 +364,12 @@ const FooterTabBar: React.FC<Props> = ({
             },
           ]}
         >
+          <Animated.View
+            testID="footer-active-pill"
+            pointerEvents="none"
+            onLayout={handlePillLayout}
+            style={[styles.activePill, pillAnimatedStyle]}
+          />
           {tabButtons}
         </GlassView>
       </View>


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Liquid Glass タブバーのアクティブピル（選択ハイライト）のアニメーションを、Apple Music のようにアクティブになった項目の方向へスライドする動きに変更する。従来はアクティブタブ上でスケールイン（バウンス）するのみで、選択がどこから移ったのかが表現できていなかった。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 各タブボタン内に個別に描画していたピルを、ガラスバー直下の単一の共有ピル（絶対配置）に統合し、`translateX` のスプリングでタブ間をスライドさせるよう変更
- タブバーは画面ごとに再マウントされるため、直前のアクティブタブをモジュールスコープの `lastActiveTab` で保持し、マウント時に前のタブ位置から新しいアクティブタブへスライドさせる
- ピルのスロット位置はピル自身と各タブボタンの `onLayout` 実測値から算出し、パディング・ギャップ変更や回転後のレイアウト変化にも追従
- 同一タブ内の画面遷移（設定サブ画面間など）ではアニメーションを再生せず、アプリ初回マウント時のみ従来のスケールイン出現を維持
- テストを共有ピル仕様に合わせて更新し、レイアウト確定フローと再マウント時のスライド経路のテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint && npm test && npm run typecheck` をローカルで実行し、172 スイート / 1850 件すべてパスを確認。なお Reanimated は Jest で完全モックされているため、スライドの動き自体は iOS 26 実機での目視確認を推奨。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_014km2dew3Ex1PsVXccMchCG

---
_Generated by [Claude Code](https://claude.ai/code/session_014km2dew3Ex1PsVXccMchCG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * タブバーのアクティブ表示（ピル）挙動を改善。常に1つだけ表示され、レイアウト確定後も維持され、タブ切替や再マウント時に滑らかにスライドしてクラッシュしないようになりました。

* **Tests**
  * Liquid Glass モードのテストを更新し、共有ピルが1つだけ表示されることやレイアウト後の安定性を検証するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->