### PR TITLE
駅検索・経路情報・種別一覧のFlatListをFlashList v2に置き換えて長いリストの描画パフォーマンスを改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.3.1",
         "@sentry/react-native": "~8.11.1",
+        "@shopify/flash-list": "2.0.2",
         "dayjs": "^1.11.19",
         "expo": "~55.0.15",
         "expo-application": "~55.0.14",
@@ -6629,6 +6630,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@shopify/flash-list": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-2.0.2.tgz",
+      "integrity": "sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@sideway/address": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.3.1",
     "@sentry/react-native": "~8.11.1",
+    "@shopify/flash-list": "2.0.2",
     "dayjs": "^1.11.19",
     "expo": "~55.0.15",
     "expo-application": "~55.0.14",

--- a/src/components/RouteInfoModal.tsx
+++ b/src/components/RouteInfoModal.tsx
@@ -1,13 +1,8 @@
+import { FlashList } from '@shopify/flash-list';
 import { BlurView } from 'expo-blur';
 import { useAtomValue } from 'jotai';
 import { useCallback, useMemo, useState } from 'react';
-import {
-  FlatList,
-  Platform,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Station, TrainType } from '~/@types/graphql';
 import { LED_THEME_BG_COLOR } from '~/constants/color';
@@ -324,7 +319,7 @@ export const RouteInfoModal = ({
         </Heading>
       </View>
 
-      <FlatList<Station>
+      <FlashList<Station>
         data={deduppedStations}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
@@ -336,7 +331,6 @@ export const RouteInfoModal = ({
           { paddingTop: headerHeight },
         ]}
         scrollIndicatorInsets={{ top: headerHeight, bottom: 72 }}
-        removeClippedSubviews={Platform.OS === 'android'}
         ListEmptyComponent={
           loading ? (
             <SkeletonPlaceholder borderRadius={4} speed={1500}>

--- a/src/components/StationSearchModal.tsx
+++ b/src/components/StationSearchModal.tsx
@@ -1,11 +1,11 @@
 import { useLazyQuery, useQuery } from '@apollo/client/react';
+import { FlashList } from '@shopify/flash-list';
 import { BlurView } from 'expo-blur';
 import { useAtomValue } from 'jotai';
 import uniqBy from 'lodash/uniqBy';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
-  FlatList,
   Platform,
   StyleSheet,
   useWindowDimensions,
@@ -320,7 +320,7 @@ export const StationSearchModal = ({ visible, onClose, onSelect }: Props) => {
         <SearchBar onSearch={handleSearchStations} nameSearch />
       </View>
 
-      <FlatList<Station>
+      <FlashList<Station>
         style={StyleSheet.absoluteFill}
         data={stations ?? []}
         renderItem={renderItem}
@@ -329,7 +329,6 @@ export const StationSearchModal = ({ visible, onClose, onSelect }: Props) => {
         scrollEventThrottle={16}
         contentContainerStyle={styles.flatListContentContainer}
         scrollIndicatorInsets={{ top: 150, bottom: 72 }}
-        removeClippedSubviews={Platform.OS === 'android'}
         ListEmptyComponent={
           <EmptyResult
             loading={fetchStationsNearbyLoading || fetchStationsByNameLoading}

--- a/src/components/TrainTypeList.tsx
+++ b/src/components/TrainTypeList.tsx
@@ -1,12 +1,7 @@
+import { FlashList } from '@shopify/flash-list';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
-import {
-  FlatList,
-  Platform,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { Line, TrainType } from '~/@types/graphql';
 import { useCurrentLine } from '~/hooks';
@@ -155,17 +150,19 @@ export const TrainTypeList = ({
   );
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
 
+  // FlashList v2のstyleは配列を受け付けないため単一オブジェクトに統合する
+  const listStyle = useMemo(
+    () => ({
+      ...styles.root,
+      borderColor: isLEDTheme ? '#fff' : '#aaa',
+      marginBottom: safeAreaBottom,
+    }),
+    [isLEDTheme, safeAreaBottom]
+  );
+
   return (
-    <FlatList
-      initialNumToRender={15}
-      removeClippedSubviews={Platform.OS === 'android'}
-      style={[
-        styles.root,
-        {
-          borderColor: isLEDTheme ? '#fff' : '#aaa',
-          marginBottom: safeAreaBottom,
-        },
-      ]}
+    <FlashList
+      style={listStyle}
       data={data}
       renderItem={renderItem}
       keyExtractor={keyExtractor}

--- a/src/components/TrainTypeListModal.tsx
+++ b/src/components/TrainTypeListModal.tsx
@@ -1,14 +1,9 @@
+import { FlashList } from '@shopify/flash-list';
 import { BlurView } from 'expo-blur';
 import { useAtomValue } from 'jotai';
 import uniqBy from 'lodash/uniqBy';
 import { useCallback, useMemo } from 'react';
-import {
-  FlatList,
-  Platform,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import { LED_THEME_BG_COLOR } from '~/constants/color';
@@ -353,7 +348,7 @@ export const TrainTypeListModal = ({
         ) : null}
       </View>
 
-      <FlatList<TrainType>
+      <FlashList<TrainType>
         style={StyleSheet.absoluteFill}
         data={trainTypes}
         renderItem={renderItem}
@@ -362,7 +357,6 @@ export const TrainTypeListModal = ({
         scrollEventThrottle={16}
         contentContainerStyle={styles.flatListContentContainer}
         scrollIndicatorInsets={{ top: 72, bottom: 72 }}
-        removeClippedSubviews={Platform.OS === 'android'}
         ListEmptyComponent={
           loading ? (
             <SkeletonPlaceholder borderRadius={4} speed={1500}>


### PR DESCRIPTION
## 概要

FlatList を使用していた長いリスト表示の4コンポーネント（駅検索・経路情報・種別一覧）を Shopify FlashList v2 に置き換え、スクロール時の描画パフォーマンスを改善しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `@shopify/flash-list` v2.0.2 を追加（Expo SDK 55 / New Architecture 前提の v2 系）
- `StationSearchModal`（駅検索結果）・`RouteInfoModal`（経路の駅一覧）・`TrainTypeListModal` / `TrainTypeList`（種別一覧）の `FlatList` を `FlashList` に置き換え
- FlashList に存在しない `initialNumToRender` と、セルリサイクル機構と重複する `removeClippedSubviews`（Android のみ有効化していたもの）を削除
- FlashList v2 の `style` prop は配列を受け付けない（`ViewStyle` 単一オブジェクトのみ）ため、`TrainTypeList` のスタイル配列を `useMemo` で単一オブジェクトに統合

回帰リスクと対策: モーダル内リストのスクロール挙動・ヘッダー/フッターのオーバーレイ表示が影響範囲。props はほぼ互換（`ItemSeparatorComponent` / `ListEmptyComponent` / `scrollIndicatorInsets` 等はそのまま）で、既存のレンダリングテストを含む全テストが通過しています。FlashList は CJS 配布のため Jest の `transformIgnorePatterns` 変更は不要でした。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint && npm test && npm run typecheck` をローカルで実行し、すべて通過（172 suites / 1850 tests）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_01LjRF696wCMik21ss9KMgAb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjRF696wCMik21ss9KMgAb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ルート情報、駅検索結果、列車種別リストなど複数のリスト表示コンポーネントの描画実装を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->