### PR TITLE
次々駅の算出を案内中の次駅基準に変更し到着判定取りこぼし時に「大門の次は大門」と誤案内される問題を修正

### DIFF
--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -22,8 +22,8 @@ jest.mock('~/hooks/useAfterNextStation', () => ({
   useAfterNextStation: jest.fn(() => undefined),
 }));
 
-jest.mock('~/hooks/useNextStation', () => ({
-  useNextStation: jest.fn(() => undefined),
+jest.mock('~/hooks/useDisplayNextStation', () => ({
+  useDisplayNextStation: jest.fn(() => undefined),
 }));
 
 jest.mock('~/hooks/useScale', () => ({

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -10,7 +10,7 @@ import {
   useTransferLinesFromStation,
 } from '~/hooks';
 import { useAfterNextStation } from '~/hooks/useAfterNextStation';
-import { useNextStation } from '~/hooks/useNextStation';
+import { useDisplayNextStation } from '~/hooks/useDisplayNextStation';
 import { useScale } from '~/hooks/useScale';
 import { arrivedAtom } from '~/store/atoms/station';
 import { isEnAtom } from '~/store/selectors/isEn';
@@ -480,7 +480,9 @@ const LineBoardEast: React.FC<Props> = ({
 }: Props) => {
   const selectedLine = useAtomValue(selectedLineAtom);
   const currentLine = useCurrentLine();
-  const nextStation = useNextStation();
+  // useAfterNextStation が案内面共通の次駅 (useDisplayNextStation) 起点に
+  // なったため、バナーの「◯◯のつぎは」側も同じ次駅を参照して整合を保つ
+  const nextStation = useDisplayNextStation();
   const afterNextStation = useAfterNextStation();
 
   const dim = useLandscapeWindowDimensions();

--- a/src/hooks/useAfterNextStation.test.tsx
+++ b/src/hooks/useAfterNextStation.test.tsx
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react-native';
+import { type Station, StopCondition } from '~/@types/graphql';
+import { useAfterNextStation } from './useAfterNextStation';
+
+jest.mock('./useDisplayNextStation', () => ({
+  useDisplayNextStation: jest.fn(),
+}));
+
+jest.mock('./useSlicedStations', () => ({
+  useSlicedStations: jest.fn(),
+}));
+
+const { useDisplayNextStation } = require('./useDisplayNextStation');
+const { useSlicedStations } = require('./useSlicedStations');
+
+const makeStation = (
+  id: number,
+  groupId: number,
+  name: string,
+  stopCondition: StopCondition = StopCondition.All
+): Station =>
+  ({
+    id,
+    groupId,
+    name,
+    stopCondition,
+  }) as unknown as Station;
+
+describe('useAfterNextStation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('案内中の次駅の直後の停車駅を返す', () => {
+    const stations = [
+      makeStation(1, 1, '築地市場'),
+      makeStation(2, 2, '汐留'),
+      makeStation(3, 3, '大門'),
+      makeStation(4, 4, '赤羽橋'),
+    ];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(stations[1]);
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current?.name).toBe('大門');
+  });
+
+  it('次駅の直後が通過駅の場合はスキップして次の停車駅を返す', () => {
+    const stations = [
+      makeStation(1, 1, 'A'),
+      makeStation(2, 2, 'B'),
+      makeStation(3, 3, 'C', StopCondition.Not),
+      makeStation(4, 4, 'D'),
+    ];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(stations[1]);
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current?.name).toBe('D');
+  });
+
+  it('到着判定の取りこぼしで状態が古くても案内中の次駅自身を次々駅にしない', () => {
+    // 汐留到着の取りこぼしで stationState が築地市場のまま大門へ接近したケース。
+    // useDisplayNextStation はGPS基準で大門へ自己修復されるため、
+    // 次々駅は大門ではなく赤羽橋でなければならない (「大門の次は大門」回帰防止)。
+    const stations = [
+      makeStation(1, 1, '築地市場'),
+      makeStation(2, 2, '汐留'),
+      makeStation(3, 3, '大門'),
+      makeStation(4, 4, '赤羽橋'),
+    ];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(stations[2]);
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current?.name).toBe('赤羽橋');
+  });
+
+  it('直通時に同じGroupIDの駅を別駅として扱わない', () => {
+    // 直通境界駅 (同一 groupId の別レコード) が続く場合、
+    // 「渋谷の次は渋谷」とならないよう重複を除外する
+    const stations = [
+      makeStation(1, 1, '中目黒'),
+      makeStation(2, 2, '渋谷'),
+      makeStation(3, 2, '渋谷'),
+      makeStation(4, 4, '明治神宮前'),
+    ];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(stations[1]);
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current?.name).toBe('明治神宮前');
+  });
+
+  it('次駅が駅リストに見つからない場合は undefined を返す', () => {
+    const stations = [makeStation(1, 1, 'A'), makeStation(2, 2, 'B')];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(makeStation(99, 99, 'X'));
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('次駅が終点 (リスト末尾) の場合は undefined を返す', () => {
+    const stations = [makeStation(1, 1, 'A'), makeStation(2, 2, 'B')];
+    useSlicedStations.mockReturnValue(stations);
+    useDisplayNextStation.mockReturnValue(stations[1]);
+
+    const { result } = renderHook(() => useAfterNextStation());
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/src/hooks/useAfterNextStation.ts
+++ b/src/hooks/useAfterNextStation.ts
@@ -1,13 +1,16 @@
 import { useMemo } from 'react';
 import type { Station } from '~/@types/graphql';
 import getIsPass from '../utils/isPass';
-import { useCurrentStation } from './useCurrentStation';
-import { useNextStation } from './useNextStation';
+import { useDisplayNextStation } from './useDisplayNextStation';
 import { useSlicedStations } from './useSlicedStations';
 
 export const useAfterNextStation = () => {
-  const currentStation = useCurrentStation();
-  const nextStation = useNextStation();
+  // 案内面 (ヘッダー・TTS・LED) が「次の駅」として見せる駅を起点にする。
+  // 到着判定の取りこぼしで stationState が古いまま接近放送に入ると、
+  // useNextStation 起点では案内中の次駅自身が次々駅として選ばれてしまい
+  // 「大門の次は、大門にとまります」のような誤案内になる (useDisplayNextStation は
+  // 接近中はGPS基準で自己修復されるため、案内中の次駅と必ず一致する)。
+  const nextStation = useDisplayNextStation();
   const slicedStationsOrigin = useSlicedStations();
 
   // 直通時、同じGroupIDの駅が違う駅として扱われるのを防ぐ(ex. 渋谷の次は、渋谷に止まります)
@@ -25,19 +28,18 @@ export const useAfterNextStation = () => {
     return result;
   }, [slicedStationsOrigin]);
 
-  const afterNextStation = useMemo(
-    () =>
-      slicedStations.find((s) => {
-        if (s.groupId === currentStation?.groupId) {
-          return false;
-        }
-        if (s.groupId === nextStation?.groupId) {
-          return false;
-        }
-        return !getIsPass(s);
-      }),
-    [currentStation?.groupId, nextStation?.groupId, slicedStations]
-  );
+  const afterNextStation = useMemo(() => {
+    const nextStationIndex = slicedStations.findIndex(
+      (s) => s.groupId === nextStation?.groupId
+    );
+    // 次駅が進行方向の駅リストに見つからない場合は、誤った駅を案内するより
+    // 次々駅の案内自体を省略する方が安全なので undefined を返す。
+    if (nextStationIndex === -1) {
+      return undefined;
+    }
+    // 次駅より進行方向側で最初に停車する駅が「次々駅」
+    return slicedStations.find((s, i) => i > nextStationIndex && !getIsPass(s));
+  }, [nextStation?.groupId, slicedStations]);
 
   return afterNextStation;
 };


### PR DESCRIPTION
## 概要

都営テーマのTTSで「大門の次は、大門にとまります」と案内中の次駅自身が次々駅として読み上げられる不具合を修正しました。

接近放送（まもなく〜）の次駅名はGPS基準で自己修復される `useDisplayNextStation`（実際に接近中の駅）を使う一方、次々駅を返す `useAfterNextStation` は到着判定ベースの `useNextStation` を起点にしていたため、汐留→大門のような短い駅間で到着判定を取りこぼすと両者がズレ、次駅と同じ駅が次々駅として案内されていました。都営テーマ固有ではなく、次々駅を案内する全テーマとLED表示・小田急バナーにも同じ不整合がありました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useAfterNextStation.ts`: 次々駅の起点を案内面共通の `useDisplayNextStation` に変更し、「進行方向の駅リスト上で次駅より後ろにある最初の停車駅」を位置ベースで返すように修正。次駅がリストに見つからない場合は誤案内を避けて `undefined`（案内省略）を返す。直通時の同一GroupID重複除外は従来どおり維持。
- `src/components/LineBoardEast.tsx`: 小田急テーマの「◯◯のつぎは◯◯にとまります」バナーも同じ次駅（`useDisplayNextStation`）を参照するよう揃え、次駅と次々駅のペア不整合を防止。
- `src/hooks/useAfterNextStation.test.tsx`(新規): 到着判定取りこぼし時に案内中の次駅自身を次々駅にしない回帰テスト（築地市場/汐留/大門/赤羽橋）を含む6ケースを追加。
- `src/components/LineBoardEast.test.tsx`: モック対象を `useNextStation` から `useDisplayNextStation` に更新。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

全テストスイート通過を確認済み（173 suites / 1856 tests）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_01JPJk4ZNFQKxXeD8FmCodQs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPJk4ZNFQKxXeD8FmCodQs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 次駅情報の表示精度を改善しました。次駅バナーに表示される駅が案内画面全体で一貫するよう調整されました。

* **テスト**
  * 次々駅取得ロジックの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->