### PR TITLE
フッタータブバーの画面遷移をnavigateからreplaceに変更して履歴の積み上がりを防止

### DIFF
--- a/src/components/FooterTabBar.test.tsx
+++ b/src/components/FooterTabBar.test.tsx
@@ -1,10 +1,15 @@
 import { fireEvent, render } from '@testing-library/react-native';
 import FooterTabBar, { resetLastActiveTabForTesting } from './FooterTabBar';
 
-const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
+let mockRouteName = 'SelectLine';
 
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({ dispatch: mockDispatch }),
+  useRoute: () => ({ name: mockRouteName }),
+  StackActions: {
+    replace: (name: string) => ({ type: 'REPLACE', payload: { name } }),
+  },
 }));
 
 jest.mock('jotai', () => ({
@@ -36,6 +41,7 @@ jest.mock('~/utils/liquidGlass', () => ({
 describe('FooterTabBar', () => {
   beforeEach(() => {
     mockLiquidGlassAvailable = false;
+    mockRouteName = 'SelectLine';
     // モジュールスコープの lastActiveTab がテスト間でリークして
     // 実行順序依存にならないよう毎回リセットする
     resetLastActiveTabForTesting();
@@ -63,18 +69,37 @@ describe('FooterTabBar', () => {
     expect(settings.props.accessibilityState.selected).toBe(true);
   });
 
-  it('各タブを押すと対応する画面へ遷移する', () => {
+  it('各タブを押すと対応する画面へ replace で遷移する', () => {
+    mockRouteName = 'Main';
     const { getAllByRole } = render(<FooterTabBar active="home" />);
     const [search, home, settings] = getAllByRole('button');
 
     fireEvent.press(search);
-    expect(mockNavigate).toHaveBeenLastCalledWith('RouteSearch');
+    expect(mockDispatch).toHaveBeenLastCalledWith({
+      type: 'REPLACE',
+      payload: { name: 'RouteSearch' },
+    });
 
     fireEvent.press(home);
-    expect(mockNavigate).toHaveBeenLastCalledWith('SelectLine');
+    expect(mockDispatch).toHaveBeenLastCalledWith({
+      type: 'REPLACE',
+      payload: { name: 'SelectLine' },
+    });
 
     fireEvent.press(settings);
-    expect(mockNavigate).toHaveBeenLastCalledWith('AppSettings');
+    expect(mockDispatch).toHaveBeenLastCalledWith({
+      type: 'REPLACE',
+      payload: { name: 'AppSettings' },
+    });
+  });
+
+  it('現在の画面と同じタブを押しても replace を発行しない', () => {
+    mockRouteName = 'SelectLine';
+    const { getAllByRole } = render(<FooterTabBar active="home" />);
+    const [, home] = getAllByRole('button');
+
+    fireEvent.press(home);
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   describe('Liquid Glass モード', () => {

--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -1,5 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
+import {
+  StackActions,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import { GlassView } from 'expo-glass-effect';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useRef } from 'react';
@@ -202,7 +206,18 @@ const FooterTabBar: React.FC<Props> = ({
 }) => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const route = useRoute();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  // タブ間の移動で履歴を積まないよう navigate ではなく replace で遷移する。
+  // 同一画面への replace は画面の再マウントになるだけなので無視する
+  const replaceTo = useCallback(
+    (screen: string) => {
+      if (route.name === screen) return;
+      navigation.dispatch(StackActions.replace(screen));
+    },
+    [navigation, route.name]
+  );
   const searchButtonRef = useRef<View>(null);
   const settingsButtonRef = useRef<View>(null);
 
@@ -317,7 +332,7 @@ const FooterTabBar: React.FC<Props> = ({
         buttonRef={searchButtonRef}
         active={active === 'search'}
         onPress={() => {
-          navigation.navigate('RouteSearch' as never);
+          replaceTo('RouteSearch');
         }}
         onLayout={handleSearchButtonLayout}
       >
@@ -331,7 +346,7 @@ const FooterTabBar: React.FC<Props> = ({
       <TabButton
         active={active === 'home'}
         onPress={() => {
-          navigation.navigate('SelectLine' as never);
+          replaceTo('SelectLine');
         }}
         onLayout={handleHomeButtonLayout}
       >
@@ -346,7 +361,7 @@ const FooterTabBar: React.FC<Props> = ({
         buttonRef={settingsButtonRef}
         active={active === 'settings'}
         onPress={() => {
-          navigation.navigate('AppSettings' as never);
+          replaceTo('AppSettings');
         }}
         onLayout={handleSettingsButtonLayout}
       >


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- フッタータブバー（`src/components/FooterTabBar.tsx`）の3タブ（検索・ホーム・設定）の画面遷移を、OS に関わらず `navigation.navigate` から `StackActions.replace` のディスパッチに変更し、タブ間移動でスタック履歴が積み上がらないようにした
- 現在のルート名と遷移先が同じ場合は replace を発行しないガードを追加（同一画面の無駄な再マウントを防止。navigate の重複抑止と同等の挙動）
- `FooterTabBar.test.tsx` のモックを `dispatch` ベースに更新し、replace アクション発行と同一画面スキップのテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_01HPePacCm3XJUAjUkYUGwi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPePacCm3XJUAjUkYUGwi8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * フッターのタブ切り替え時の画面遷移動作を改善しました。同じタブを複数回タップした場合の挙動が改善されます。

* **Tests**
  * タブナビゲーションのテストをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->