### PR TITLE
フッターのアクティブピルがApple Music風に軽くバウンスしながらスライドするよう調整

### DIFF
--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -66,12 +66,11 @@ const PRESS_OUT_SPRING = { damping: 13, stiffness: 320 } as const;
 // アプリ初回マウント時のみ使うピルのスケールイン出現スプリング
 const ACTIVE_PILL_SPRING = { damping: 15, stiffness: 280 } as const;
 // タブ切り替え時にピルが前のタブ位置からスライドするスプリング。
-// 目標位置を通り過ぎて戻る動きが出ないよう臨界減衰以上 + overshootClamping で
-// バウンスせずに減速して止める
+// Apple Music の選択ハイライトのように、目標位置をわずかに通り過ぎて戻る
+// 控えめな弾力を持たせる(減衰比 ≈ 0.7。臨界減衰は 2√stiffness ≈ 37)
 const PILL_SLIDE_SPRING = {
-  damping: 38,
+  damping: 26,
   stiffness: 350,
-  overshootClamping: true,
 } as const;
 
 // 直前の画面でアクティブだったタブ。タブバーは画面ごとに再マウントされるため、


### PR DESCRIPTION
## 概要

フッタータブバーのアクティブピル（選択ハイライト）のスライドアニメーションを調整し、Apple Music の選択ハイライトのように目標位置をわずかに通り過ぎて戻る控えめな弾力を持たせた。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `PILL_SLIDE_SPRING` から `overshootClamping: true` を削除し、`damping` を 38 → 26 に変更（`stiffness: 350` に対する臨界減衰 ≈ 37 なので減衰比 ≈ 0.7）
- これまでは臨界減衰以上 + overshootClamping で完全にバウンスを抑えていたが、タブ切り替え時にピルが一回だけ軽くオーバーシュートして戻る質感になる

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は変更対象の `FooterTabBar.test.tsx`（8 件）を実行して全件パスを確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善事項

* **ユーザーインターフェース**
  * タブ選択時のハイライト移動アニメーションが更新されました。目標位置を少し通り過ぎて戻る自然な挙動へ調整し、より流動的な視覚体験を実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->