### PR TITLE
フッターのアクティブピルのスライドオーバーシュートを減衰比0.8に抑えて控えめなはみ出しに調整

### DIFF
--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -71,9 +71,11 @@ const PRESS_OUT_SPRING = { damping: 13, stiffness: 320 } as const;
 const ACTIVE_PILL_SPRING = { damping: 15, stiffness: 280 } as const;
 // タブ切り替え時にピルが前のタブ位置からスライドするスプリング。
 // Apple Music の選択ハイライトのように、目標位置をわずかに通り過ぎて戻る
-// 控えめな弾力を持たせる(減衰比 ≈ 0.7。臨界減衰は 2√stiffness ≈ 37)
+// 控えめな弾力を持たせる(減衰比 ≈ 0.8。臨界減衰は 2√stiffness ≈ 37)。
+// 減衰比 0.7 ではオーバーシュートが移動距離の約 5% となり離れたタブ間で
+// はみ出しが過剰だったため、約 1.5% に抑えている
 const PILL_SLIDE_SPRING = {
-  damping: 26,
+  damping: 30,
   stiffness: 350,
 } as const;
 


### PR DESCRIPTION
## 概要

#6194 でフッタータブバーのアクティブピルにスライド時のオーバーシュート（弾力）を導入したが、減衰比 ≈ 0.7 ではオーバーシュート量が移動距離の約 5% となり、離れたタブ間の移動でピルが過剰にはみ出していた。減衰比を ≈ 0.8 に上げ、わずかにはみ出る程度のバランスに調整した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `PILL_SLIDE_SPRING` の `damping` を 26 → 30 に変更（`stiffness: 350` に対する減衰比 ≈ 0.7 → ≈ 0.8、オーバーシュートは移動距離の約 5% → 約 1.5%）
- 減衰比を上げた根拠をコメントに追記

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は変更対象の `FooterTabBar.test.tsx`（9 件）を実行して全件パスを確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_019e7yy88Q9T9GT5MxRVhQuj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * タブバーのピル移動アニメーションをより滑らかで自然な動きに調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->