### PR TITLE
フッターのアクティブピルのスライドをオーバーシュートしない元の挙動に戻す

### DIFF
--- a/src/components/FooterTabBar.tsx
+++ b/src/components/FooterTabBar.tsx
@@ -70,13 +70,12 @@ const PRESS_OUT_SPRING = { damping: 13, stiffness: 320 } as const;
 // アプリ初回マウント時のみ使うピルのスケールイン出現スプリング
 const ACTIVE_PILL_SPRING = { damping: 15, stiffness: 280 } as const;
 // タブ切り替え時にピルが前のタブ位置からスライドするスプリング。
-// Apple Music の選択ハイライトのように、目標位置をわずかに通り過ぎて戻る
-// 控えめな弾力を持たせる(減衰比 ≈ 0.8。臨界減衰は 2√stiffness ≈ 37)。
-// 減衰比 0.7 ではオーバーシュートが移動距離の約 5% となり離れたタブ間で
-// はみ出しが過剰だったため、約 1.5% に抑えている
+// 目標位置を通り過ぎて戻る動きが出ないよう臨界減衰以上 + overshootClamping で
+// バウンスせずに減速して止める
 const PILL_SLIDE_SPRING = {
-  damping: 30,
+  damping: 38,
   stiffness: 350,
+  overshootClamping: true,
 } as const;
 
 // 直前の画面でアクティブだったタブ。タブバーは画面ごとに再マウントされるため、


### PR DESCRIPTION
## 概要

#6197 で減衰比 ≈ 0.8 に抑えたフッタータブバーのアクティブピルのスライドだが、わずかでもはみ出さないほうが好ましいため、#6194 以前の元の挙動（臨界減衰以上 + `overshootClamping` でオーバーシュートなし）に戻した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `PILL_SLIDE_SPRING` を #6194 以前の `{ damping: 38, stiffness: 350, overshootClamping: true }` に復元し、ピルが目標位置を通り過ぎずに減速して止まるようにした
- スプリング定数のコメントも元の説明に戻した

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は変更対象の `FooterTabBar.test.tsx`（9 件）を実行して全件パスを確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_019e7yy88Q9T9GT5MxRVhQuj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * タブ切り替え時のピルスライドアニメーションの動きを調整し、より自然なモーションを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->