### PR TITLE
試験的機能としてポートレートモードを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -310,5 +310,10 @@
   "androidSettings": "For Android",
   "pictureInPictureTitle": "Picture in Picture",
   "pictureInPictureDescription": "Show a compact floating window with the next station when you leave the app while riding.",
-  "passingStation": "Passing %{stationName}"
+  "passingStation": "Passing %{stationName}",
+  "experimentalSettings": "Experimental Features",
+  "experimentalSettingsNotice": "Experimental features are under development and may change or be removed without notice.",
+  "portraitModeTitle": "Portrait Mode",
+  "portraitModeDescription": "When enabled, the running screen switches to a layout optimized for portrait orientation while you hold your device upright.",
+  "passStationLabel": "Pass"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -311,5 +311,10 @@
   "androidSettings": "Android向け",
   "pictureInPictureTitle": "Picture in Picture",
   "pictureInPictureDescription": "走行中にホーム画面や他のアプリへ移動したとき、次駅などを小窓で表示します。",
-  "passingStation": "%{stationName}を通過中"
+  "passingStation": "%{stationName}を通過中",
+  "experimentalSettings": "試験的機能",
+  "experimentalSettingsNotice": "試験的機能は開発中のため、予告なく変更または削除されることがあります。",
+  "portraitModeTitle": "ポートレートモード",
+  "portraitModeDescription": "有効にすると、走行画面で端末を縦向きにした際に、縦画面に最適化されたデザインで表示します。",
+  "passStationLabel": "通過"
 }

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -42,6 +42,7 @@ import {
 } from '../hooks';
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
+import { portraitModeEnabledAtom } from '../store/atoms/experimental';
 import navigationState, {
   autoModeEnabledAtom,
   isAppLatestAtom,
@@ -72,6 +73,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setSpeech = useSetAtom(speechState);
   const setNotify = useSetAtom(notifyState);
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
+  const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
   const { active: pictureInPictureActive } = useAtomValue(pictureInPictureAtom);
   const setTuning = useSetAtom(tuningState);
   const [themePreference, setThemePreference] = useAtom(themePreferenceAtom);
@@ -413,6 +415,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         untouchableModeEnabledStr,
         wrongDirectionNotifyEnabledStr,
         pictureInPictureEnabledStr,
+        portraitModeEnabledStr,
       ] = await Promise.all([
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.THEME_PREFERENCE),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PREVIOUS_THEME),
@@ -428,6 +431,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.UNTOUCHABLE_MODE_ENABLED),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.WRONG_DIRECTION_NOTIFY_ENABLED),
         AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PICTURE_IN_PICTURE_ENABLED),
+        AsyncStorage.getItem(ASYNC_STORAGE_KEYS.PORTRAIT_MODE_ENABLED),
       ]);
 
       if (themePreferenceKey) {
@@ -538,6 +542,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
           enabled: pictureInPictureEnabledStr === 'true',
         }));
       }
+      if (portraitModeEnabledStr) {
+        setPortraitModeEnabled(portraitModeEnabledStr === 'true');
+      }
     };
 
     loadSettings();
@@ -548,6 +555,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     setThemePreference,
     setNotify,
     setPictureInPicture,
+    setPortraitModeEnabled,
   ]);
 
   useEffect(() => {

--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -1,0 +1,140 @@
+import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import { type Station, StopCondition } from '~/@types/graphql';
+import {
+  useCurrentLine,
+  useCurrentTrainType,
+  useHeaderCommonData,
+  useTransferLinesFromStation,
+} from '~/hooks';
+import { leftStationsAtom } from '~/store/atoms/navigation';
+import PortraitMain from './PortraitMain';
+
+jest.mock('~/translation', () => ({
+  isJapanese: true,
+  translate: (key: string) => key,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('./NumberingIcon', () => () => null);
+
+jest.mock('~/hooks', () => ({
+  useCurrentLine: jest.fn(),
+  useCurrentTrainType: jest.fn(),
+  useHeaderCommonData: jest.fn(),
+  useStationNumberIndexFunc: jest.fn(() => () => 0),
+  useTransferLinesFromStation: jest.fn(() => []),
+}));
+
+const mockedUseHeaderCommonData = useHeaderCommonData as jest.Mock;
+const mockedUseCurrentLine = useCurrentLine as jest.Mock;
+const mockedUseCurrentTrainType = useCurrentTrainType as jest.Mock;
+const mockedUseTransferLinesFromStation =
+  useTransferLinesFromStation as jest.Mock;
+
+const yamanoteLine = {
+  id: 11302,
+  color: '#80C241',
+  nameShort: '山手線',
+  nameRoman: 'Yamanote Line',
+};
+
+const commonData = {
+  stateText: 'nextKana',
+  stationText: '高輪ゲートウェイ',
+  boundText: '品川・大崎方面',
+  currentStationNumber: {
+    lineSymbol: 'JY',
+    lineSymbolColor: '#80C241',
+    lineSymbolShape: 'ROUND',
+    stationNumber: 'JY-26',
+  },
+  threeLetterCode: undefined,
+  numberingColor: '#80C241',
+};
+
+const buildStation = (
+  id: number,
+  name: string,
+  stopCondition: StopCondition,
+  stationNumber?: string
+): Station =>
+  ({
+    id,
+    name,
+    nameRoman: `${name}-roman`,
+    stopCondition,
+    stationNumbers: stationNumber ? [{ stationNumber }] : [],
+    line: yamanoteLine,
+    lines: [],
+  }) as unknown as Station;
+
+const renderWithStations = (stations: Station[]) => {
+  const store = createStore();
+  store.set(leftStationsAtom, stations);
+
+  return render(
+    <Provider store={store}>
+      <PortraitMain />
+    </Provider>
+  );
+};
+
+describe('PortraitMain', () => {
+  beforeEach(() => {
+    mockedUseHeaderCommonData.mockReturnValue(commonData);
+    mockedUseCurrentLine.mockReturnValue(yamanoteLine);
+    mockedUseCurrentTrainType.mockReturnValue({
+      name: '各駅停車',
+      nameRoman: 'Local',
+      color: '#123456',
+    });
+    mockedUseTransferLinesFromStation.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('路線名・種別・行き先・状態テキスト・駅名を表示する', () => {
+    const { getByText } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    expect(getByText('山手線')).toBeTruthy();
+    expect(getByText('各駅停車')).toBeTruthy();
+    expect(getByText('品川・大崎方面')).toBeTruthy();
+    expect(getByText('nextKana')).toBeTruthy();
+    expect(getByText('高輪ゲートウェイ')).toBeTruthy();
+  });
+
+  it('停車駅リストに駅名とナンバリングを表示し通過駅には通過ラベルを付ける', () => {
+    const { getByText, getAllByText } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+      buildStation(2, '高輪ゲートウェイ', StopCondition.Not, 'JY-26'),
+      buildStation(3, '田町', StopCondition.All, 'JY-27'),
+    ]);
+
+    expect(getByText('品川')).toBeTruthy();
+    expect(getByText('田町')).toBeTruthy();
+    expect(getByText('JY-25')).toBeTruthy();
+    expect(getByText('JY-27')).toBeTruthy();
+    // 通過駅は1駅だけなので通過ラベルも1つ
+    expect(getAllByText('passStationLabel')).toHaveLength(1);
+  });
+
+  it('ヘッダーデータが揃っていない間は何も表示しない', () => {
+    mockedUseHeaderCommonData.mockReturnValue(null);
+
+    const { queryByText } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    expect(queryByText('山手線')).toBeNull();
+    expect(queryByText('品川')).toBeNull();
+  });
+});

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1,0 +1,392 @@
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import { memo, useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { Station } from '~/@types/graphql';
+import { parenthesisRegexp } from '~/constants';
+import {
+  useCurrentLine,
+  useCurrentTrainType,
+  useHeaderCommonData,
+  useStationNumberIndexFunc,
+  useTransferLinesFromStation,
+} from '~/hooks';
+import { leftStationsAtom } from '~/store/atoms/navigation';
+import { isJapanese, translate } from '~/translation';
+import getIsPass from '~/utils/isPass';
+import { RFValue } from '~/utils/rfValue';
+import NumberingIcon from './NumberingIcon';
+import Typography from './Typography';
+
+// テーマ非依存の独自カラーパレット。選択中のテーマに関わらず同じ見た目にする。
+const COLORS = {
+  background: '#13131A',
+  card: '#1E1E28',
+  textPrimary: '#FFFFFF',
+  textSecondary: '#A0A0B0',
+  divider: '#2C2C38',
+  fallbackAccent: '#888888',
+} as const;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+  },
+  lineCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginTop: 8,
+    backgroundColor: COLORS.card,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  lineColorBar: {
+    width: 8,
+    alignSelf: 'stretch',
+  },
+  lineCardBody: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  lineNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  lineName: {
+    flex: 1,
+    color: COLORS.textPrimary,
+    fontSize: RFValue(16),
+    fontWeight: 'bold',
+  },
+  trainTypeBadge: {
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginLeft: 8,
+  },
+  trainTypeText: {
+    fontSize: RFValue(12),
+    fontWeight: 'bold',
+  },
+  boundText: {
+    marginTop: 4,
+    color: COLORS.textSecondary,
+    fontSize: RFValue(13),
+    fontWeight: 'bold',
+  },
+  stationSection: {
+    alignItems: 'center',
+    paddingVertical: 24,
+    paddingHorizontal: 24,
+  },
+  stateText: {
+    color: COLORS.textSecondary,
+    fontSize: RFValue(18),
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  stationNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  numberingContainer: {
+    marginRight: 16,
+  },
+  stationName: {
+    flexShrink: 1,
+    color: COLORS.textPrimary,
+    fontSize: RFValue(32),
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  stopListContainer: {
+    flex: 1,
+    marginHorizontal: 16,
+    marginBottom: 8,
+    backgroundColor: COLORS.card,
+    borderRadius: 12,
+  },
+  stopListContent: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  stopRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    minHeight: 56,
+  },
+  trackColumn: {
+    width: 24,
+    alignItems: 'center',
+  },
+  trackLine: {
+    flex: 1,
+    width: 6,
+  },
+  stopDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 3,
+    backgroundColor: COLORS.card,
+    marginVertical: -2,
+    zIndex: 1,
+  },
+  passDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    borderWidth: 2,
+    marginHorizontal: 3,
+  },
+  stopBody: {
+    flex: 1,
+    marginLeft: 16,
+    justifyContent: 'center',
+    paddingVertical: 8,
+  },
+  stopName: {
+    color: COLORS.textPrimary,
+    fontSize: RFValue(16),
+    fontWeight: 'bold',
+  },
+  stopNameCurrent: {
+    fontSize: RFValue(18),
+  },
+  stopNamePass: {
+    color: COLORS.textSecondary,
+    fontWeight: 'normal',
+  },
+  stopNumbering: {
+    marginTop: 2,
+    color: COLORS.textSecondary,
+    fontSize: RFValue(11),
+  },
+  transferDotsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 6,
+  },
+  transferDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginRight: 6,
+  },
+  passLabel: {
+    alignSelf: 'center',
+    color: COLORS.textSecondary,
+    fontSize: RFValue(12),
+  },
+});
+
+const StopRow = ({
+  station,
+  isFirst,
+  isLast,
+  lineColor,
+}: {
+  station: Station;
+  isFirst: boolean;
+  isLast: boolean;
+  lineColor: string;
+}) => {
+  const isPass = getIsPass(station);
+  const getStationNumberIndex = useStationNumberIndexFunc();
+  const transferLines = useTransferLinesFromStation(station, {
+    omitRepeatingLine: true,
+  });
+
+  const numberingIndex = getStationNumberIndex(station);
+  const stationNumber =
+    station.stationNumbers?.[numberingIndex]?.stationNumber ?? null;
+
+  const stationName = isJapanese
+    ? (station.name ?? '')
+    : (station.nameRoman ?? station.name ?? '');
+
+  return (
+    <View style={styles.stopRow}>
+      <View style={styles.trackColumn}>
+        <View
+          style={[
+            styles.trackLine,
+            { backgroundColor: lineColor, opacity: isFirst ? 0 : 1 },
+          ]}
+        />
+        {isPass ? (
+          <View style={[styles.passDot, { borderColor: lineColor }]} />
+        ) : (
+          <View style={[styles.stopDot, { borderColor: lineColor }]} />
+        )}
+        <View
+          style={[
+            styles.trackLine,
+            { backgroundColor: lineColor, opacity: isLast ? 0 : 1 },
+          ]}
+        />
+      </View>
+      <View style={styles.stopBody}>
+        <Typography
+          numberOfLines={1}
+          style={[
+            styles.stopName,
+            isFirst && styles.stopNameCurrent,
+            isPass && styles.stopNamePass,
+          ]}
+        >
+          {stationName}
+        </Typography>
+        {stationNumber ? (
+          <Typography style={styles.stopNumbering}>{stationNumber}</Typography>
+        ) : null}
+        {!isPass && transferLines.length > 0 ? (
+          <View style={styles.transferDotsRow}>
+            {transferLines.slice(0, 8).map((line) => (
+              <View
+                key={line.id}
+                style={[
+                  styles.transferDot,
+                  { backgroundColor: line.color ?? COLORS.fallbackAccent },
+                ]}
+              />
+            ))}
+          </View>
+        ) : null}
+      </View>
+      {isPass ? (
+        <Typography style={styles.passLabel}>
+          {translate('passStationLabel')}
+        </Typography>
+      ) : null}
+    </View>
+  );
+};
+
+const PortraitMain: React.FC = () => {
+  const commonData = useHeaderCommonData();
+  const leftStations = useAtomValue(leftStationsAtom);
+  const currentLine = useCurrentLine();
+  const trainType = useCurrentTrainType();
+
+  const lineColor = currentLine?.color ?? COLORS.fallbackAccent;
+
+  const lineName = useMemo(
+    () =>
+      (isJapanese ? currentLine?.nameShort : currentLine?.nameRoman)?.replace(
+        parenthesisRegexp,
+        ''
+      ) ?? '',
+    [currentLine?.nameShort, currentLine?.nameRoman]
+  );
+
+  const trainTypeName = useMemo(
+    () =>
+      (isJapanese ? trainType?.name : trainType?.nameRoman)?.replace(
+        parenthesisRegexp,
+        ''
+      ) ?? '',
+    [trainType?.name, trainType?.nameRoman]
+  );
+
+  const stops = useMemo(
+    () => leftStations.filter((s): s is Station => !!s),
+    [leftStations]
+  );
+
+  if (!commonData) {
+    return <View style={styles.root} />;
+  }
+
+  const {
+    stateText,
+    stationText,
+    boundText,
+    currentStationNumber,
+    numberingColor,
+  } = commonData;
+
+  return (
+    <SafeAreaView style={styles.root}>
+      {/* 路線・行き先情報 */}
+      <View style={styles.lineCard}>
+        <View style={[styles.lineColorBar, { backgroundColor: lineColor }]} />
+        <View style={styles.lineCardBody}>
+          <View style={styles.lineNameRow}>
+            <Typography numberOfLines={1} style={styles.lineName}>
+              {lineName}
+            </Typography>
+            {trainTypeName ? (
+              <View
+                style={[
+                  styles.trainTypeBadge,
+                  { borderColor: trainType?.color ?? COLORS.textSecondary },
+                ]}
+              >
+                <Typography
+                  style={[
+                    styles.trainTypeText,
+                    { color: trainType?.color ?? COLORS.textSecondary },
+                  ]}
+                >
+                  {trainTypeName}
+                </Typography>
+              </View>
+            ) : null}
+          </View>
+          <Typography numberOfLines={1} style={styles.boundText}>
+            {boundText}
+          </Typography>
+        </View>
+      </View>
+
+      {/* 駅名表示 */}
+      <View style={styles.stationSection}>
+        <Typography style={styles.stateText}>{stateText}</Typography>
+        <View style={styles.stationNameRow}>
+          {currentStationNumber ? (
+            <View style={styles.numberingContainer}>
+              <NumberingIcon
+                shape={currentStationNumber.lineSymbolShape || ''}
+                lineColor={numberingColor}
+                stationNumber={currentStationNumber.stationNumber || ''}
+                threeLetterCode={commonData.threeLetterCode}
+                withDarkTheme
+              />
+            </View>
+          ) : null}
+          <Typography
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            style={styles.stationName}
+          >
+            {stationText}
+          </Typography>
+        </View>
+      </View>
+
+      {/* 停車駅リスト */}
+      <View style={styles.stopListContainer}>
+        <ScrollView contentContainerStyle={styles.stopListContent}>
+          {stops.map((station, index) => (
+            <StopRow
+              key={station.id}
+              station={station}
+              isFirst={index === 0}
+              isLast={index === stops.length - 1}
+              lineColor={lineColor}
+            />
+          ))}
+        </ScrollView>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default memo(PortraitMain);

--- a/src/constants/asyncStorage.ts
+++ b/src/constants/asyncStorage.ts
@@ -31,6 +31,7 @@ export const ASYNC_STORAGE_KEYS = {
   SETTINGS_WALKTHROUGH_COMPLETED: '@TrainLCD:settingsWalkthroughCompleted',
   WRONG_DIRECTION_NOTIFY_ENABLED: '@TrainLCD:wrongDirectionNotifyEnabled',
   PICTURE_IN_PICTURE_ENABLED: '@TrainLCD:pictureInPictureEnabled',
+  PORTRAIT_MODE_ENABLED: '@TrainLCD:portraitModeEnabled',
 } as const;
 
 export type AsyncStorageKeys =

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -40,6 +40,7 @@ const SETTING_ITEM_ID_MAP = {
   personalize_tts: 'personalize_tts',
   personalize_languages: 'personalize_languages',
   personalize_notifications: 'personalize_notifications',
+  personalize_experimental: 'personalize_experimental',
   personalize_android: 'personalize_android',
   about_app_licenses: 'about_app_licenses',
   developer_tuning: 'developer_tuning',
@@ -109,6 +110,8 @@ const SettingsItem = ({
         return 'globe';
       case 'personalize_notifications':
         return 'notifications';
+      case 'personalize_experimental':
+        return 'flask';
       case 'personalize_android':
         return 'phone-portrait';
       case 'about_app_licenses':
@@ -309,6 +312,12 @@ const AppSettingsScreen: React.FC = () => {
           color: '#FF3B30',
           onPress: () => navigation.navigate('NotificationSettings' as never),
         },
+        {
+          id: SETTING_ITEM_ID_MAP.personalize_experimental,
+          title: translate('experimentalSettings'),
+          color: '#AF52DE',
+          onPress: () => navigation.navigate('ExperimentalSettings' as never),
+        },
         ...(Platform.OS === 'android'
           ? [
               {
@@ -359,8 +368,6 @@ const AppSettingsScreen: React.FC = () => {
     [scrollY]
   );
 
-  const showTtsItem = !isClip();
-
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
@@ -379,46 +386,48 @@ const AppSettingsScreen: React.FC = () => {
             <Heading style={styles.sectionHeading}>
               {translate('personalize')}
             </Heading>
-            <View ref={themeRef} onLayout={handleThemeLayout}>
-              <SettingsItem
-                item={personalizeItems[0]}
-                isFirst={true}
-                isLast={!showTtsItem && personalizeItems.length === 1}
-                onPress={personalizeItems[0].onPress}
-              />
-            </View>
-            {showTtsItem && (
-              <View ref={ttsRef} onLayout={handleTtsLayout}>
+            {personalizeItems.map((item, index) => {
+              const row = (
                 <SettingsItem
-                  item={personalizeItems[1]}
-                  isFirst={false}
-                  isLast={false}
-                  onPress={personalizeItems[1].onPress}
+                  key={item.id}
+                  item={item}
+                  isFirst={index === 0}
+                  isLast={index === personalizeItems.length - 1}
+                  onPress={item.onPress}
                 />
-              </View>
-            )}
-            <View ref={languagesRef} onLayout={handleLanguagesLayout}>
-              <SettingsItem
-                item={personalizeItems[showTtsItem ? 2 : 1]}
-                isFirst={false}
-                isLast={false}
-                onPress={personalizeItems[showTtsItem ? 2 : 1].onPress}
-              />
-            </View>
-            <SettingsItem
-              item={personalizeItems[showTtsItem ? 3 : 2]}
-              isFirst={false}
-              isLast={Platform.OS !== 'android'}
-              onPress={personalizeItems[showTtsItem ? 3 : 2].onPress}
-            />
-            {Platform.OS === 'android' && (
-              <SettingsItem
-                item={personalizeItems[showTtsItem ? 4 : 3]}
-                isFirst={false}
-                isLast={true}
-                onPress={personalizeItems[showTtsItem ? 4 : 3].onPress}
-              />
-            )}
+              );
+              // ウォークスルーのスポットライト対象はレイアウト計測用のViewで包む
+              switch (item.id) {
+                case 'personalize_theme':
+                  return (
+                    <View
+                      key={item.id}
+                      ref={themeRef}
+                      onLayout={handleThemeLayout}
+                    >
+                      {row}
+                    </View>
+                  );
+                case 'personalize_tts':
+                  return (
+                    <View key={item.id} ref={ttsRef} onLayout={handleTtsLayout}>
+                      {row}
+                    </View>
+                  );
+                case 'personalize_languages':
+                  return (
+                    <View
+                      key={item.id}
+                      ref={languagesRef}
+                      onLayout={handleLanguagesLayout}
+                    >
+                      {row}
+                    </View>
+                  );
+                default:
+                  return row;
+              }
+            })}
           </View>
 
           {/* アプリについてセクション */}

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -312,12 +312,18 @@ const AppSettingsScreen: React.FC = () => {
           color: '#FF3B30',
           onPress: () => navigation.navigate('NotificationSettings' as never),
         },
-        {
-          id: SETTING_ITEM_ID_MAP.personalize_experimental,
-          title: translate('experimentalSettings'),
-          color: '#AF52DE',
-          onPress: () => navigation.navigate('ExperimentalSettings' as never),
-        },
+        // 試験的機能はカナリアリリース(devアプリ)限定で表示する
+        ...(isDevApp
+          ? [
+              {
+                id: SETTING_ITEM_ID_MAP.personalize_experimental,
+                title: translate('experimentalSettings'),
+                color: '#AF52DE',
+                onPress: () =>
+                  navigation.navigate('ExperimentalSettings' as never),
+              },
+            ]
+          : []),
         ...(Platform.OS === 'android'
           ? [
               {

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -1,0 +1,64 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { fireEvent, render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import { ASYNC_STORAGE_KEYS } from '~/constants';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import ExperimentalSettingsScreen from './ExperimentalSettings';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    goBack: jest.fn(),
+  }),
+}));
+
+jest.mock('~/components/FooterTabBar', () => () => null);
+jest.mock('~/components/SettingsHeader', () => ({
+  SettingsHeader: () => null,
+}));
+jest.mock('~/components/Button', () => () => null);
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+const renderWithStore = (portraitModeEnabled: boolean) => {
+  const store = createStore();
+  store.set(portraitModeEnabledAtom, portraitModeEnabled);
+
+  const screen = render(
+    <Provider store={store}>
+      <ExperimentalSettingsScreen />
+    </Provider>
+  );
+
+  return { ...screen, store };
+};
+
+describe('ExperimentalSettingsScreen', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ポートレートモードをONにするとatomとAsyncStorageへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    expect(store.get(portraitModeEnabledAtom)).toBe(true);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      ASYNC_STORAGE_KEYS.PORTRAIT_MODE_ENABLED,
+      'true'
+    );
+  });
+
+  it('ポートレートモードをOFFにするとatomとAsyncStorageへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(true);
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    expect(store.get(portraitModeEnabledAtom)).toBe(false);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      ASYNC_STORAGE_KEYS.PORTRAIT_MODE_ENABLED,
+      'false'
+    );
+  });
+});

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
+import { Alert } from 'react-native';
 import { ASYNC_STORAGE_KEYS } from '~/constants';
 import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
@@ -62,13 +63,14 @@ describe('ExperimentalSettingsScreen', () => {
     );
   });
 
-  it('AsyncStorageへの保存に失敗した場合はatom状態をロールバックする', async () => {
+  it('AsyncStorageへの保存に失敗した場合はatom状態をロールバックしエラーを通知する', async () => {
     (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(
       new Error('storage failure')
     );
     const consoleErrorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
     const { getByLabelText, store } = renderWithStore(false);
 
@@ -82,6 +84,17 @@ describe('ExperimentalSettingsScreen', () => {
       expect(store.get(portraitModeEnabledAtom)).toBe(false);
     });
 
+    // エラーログとユーザーへのアラート表示を検証
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to save portrait mode setting',
+      expect.any(Error)
+    );
+    expect(alertSpy).toHaveBeenCalledWith(
+      'errorTitle',
+      'failedToSavePreference'
+    );
+
     consoleErrorSpy.mockRestore();
+    alertSpy.mockRestore();
   });
 });

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { ASYNC_STORAGE_KEYS } from '~/constants';
 import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
@@ -60,5 +60,28 @@ describe('ExperimentalSettingsScreen', () => {
       ASYNC_STORAGE_KEYS.PORTRAIT_MODE_ENABLED,
       'false'
     );
+  });
+
+  it('AsyncStorageへの保存に失敗した場合はatom状態をロールバックする', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(
+      new Error('storage failure')
+    );
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    // 楽観的更新で一度ONになる
+    expect(store.get(portraitModeEnabledAtom)).toBe(true);
+
+    // 保存失敗後にロールバックされる
+    await waitFor(() => {
+      expect(store.get(portraitModeEnabledAtom)).toBe(false);
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -1,0 +1,160 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import { useAtom, useAtomValue } from 'jotai';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  Animated as RNAnimated,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import Button from '~/components/Button';
+import FooterTabBar from '~/components/FooterTabBar';
+import { SettingsHeader } from '~/components/SettingsHeader';
+import { StatePanel } from '~/components/ToggleButton';
+import Typography from '~/components/Typography';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+import { ASYNC_STORAGE_KEYS } from '../constants';
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 24,
+    flex: 1,
+  },
+  screenBg: {
+    backgroundColor: '#FAFAFA',
+  },
+  description: {
+    marginTop: 16,
+    color: '#8B8B8B',
+    lineHeight: 21,
+  },
+  notice: {
+    marginTop: 32,
+    textAlign: 'center',
+    color: '#8B8B8B',
+  },
+  okButton: {
+    width: 128,
+    alignSelf: 'center',
+    marginTop: 32,
+  },
+});
+
+const ToggleItem = ({
+  title,
+  state,
+  onToggle,
+}: {
+  title: string;
+  state: boolean;
+  onToggle: () => void;
+}) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityLabel={title}
+      accessibilityState={{ checked: state }}
+      onPress={onToggle}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 24,
+        paddingVertical: 16,
+        backgroundColor: isLEDTheme ? '#333' : 'white',
+        borderRadius: isLEDTheme ? 0 : 12,
+      }}
+    >
+      <Typography style={{ flex: 1, fontSize: 21, fontWeight: 'bold' }}>
+        {title}
+      </Typography>
+
+      <StatePanel state={state} />
+    </Pressable>
+  );
+};
+
+const ExperimentalSettingsScreen: React.FC = () => {
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
+    portraitModeEnabledAtom
+  );
+
+  const navigation = useNavigation();
+
+  const handleTogglePortraitMode = useCallback(async () => {
+    const flag = !portraitModeEnabled;
+    setPortraitModeEnabled(flag);
+    try {
+      await AsyncStorage.setItem(
+        ASYNC_STORAGE_KEYS.PORTRAIT_MODE_ENABLED,
+        flag ? 'true' : 'false'
+      );
+    } catch (error) {
+      console.error('Failed to save portrait mode setting', error);
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [portraitModeEnabled, setPortraitModeEnabled]);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollY.setValue(e.nativeEvent.contentOffset.y);
+    },
+    [scrollY]
+  );
+
+  return (
+    <>
+      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
+        <ScrollView
+          contentContainerStyle={
+            headerHeight
+              ? { marginTop: headerHeight, paddingBottom: headerHeight }
+              : null
+          }
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+        >
+          <ToggleItem
+            title={translate('portraitModeTitle')}
+            state={portraitModeEnabled}
+            onToggle={handleTogglePortraitMode}
+          />
+          <Typography style={styles.description}>
+            {translate('portraitModeDescription')}
+          </Typography>
+          <Typography style={styles.notice}>
+            {translate('experimentalSettingsNotice')}
+          </Typography>
+          <Button
+            style={styles.okButton}
+            textStyle={{ fontWeight: 'bold' }}
+            onPress={() => navigation.goBack()}
+          >
+            OK
+          </Button>
+        </ScrollView>
+      </View>
+      <SettingsHeader
+        title={translate('experimentalSettings')}
+        onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height + 32)}
+        scrollY={scrollY}
+      />
+      <FooterTabBar active="settings" />
+    </>
+  );
+};
+
+export default React.memo(ExperimentalSettingsScreen);

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -103,6 +103,9 @@ const ExperimentalSettingsScreen: React.FC = () => {
         flag ? 'true' : 'false'
       );
     } catch (error) {
+      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
+      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
+      setPortraitModeEnabled(!flag);
       console.error('Failed to save portrait mode setting', error);
       Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -62,6 +62,7 @@ import {
   GET_STATION_TRAIN_TYPES_LIGHT,
 } from '~/lib/graphql/queries';
 import { APP_THEME } from '~/models/Theme';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import lineState from '~/store/atoms/line';
 import { isLEDThemeAtom, themeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
@@ -71,6 +72,7 @@ import { getIsHoliday } from '~/utils/isHoliday';
 import { requestIgnoreBatteryOptimizationsAndroid } from '~/utils/native/android/ignoreBatteryOptimizationsModule';
 import { getIsLocal } from '~/utils/trainTypeString';
 import LineBoard from '../components/LineBoard';
+import PortraitMain from '../components/PortraitMain';
 import Transfers from '../components/Transfers';
 import TransfersYamanote from '../components/TransfersYamanote';
 import TypeChangeNotify from '../components/TypeChangeNotify';
@@ -130,6 +132,7 @@ const MainScreen: React.FC = () => {
   const setLineState = useSetAtom(lineState);
   const { devOverlayEnabled } = useAtomValue(tuningState);
   const { untouchableModeEnabled } = useAtomValue(tuningState);
+  const portraitModeEnabled = useAtomValue(portraitModeEnabledAtom);
 
   const currentLine = useCurrentLine();
   const currentStation = useCurrentStation();
@@ -689,6 +692,17 @@ const MainScreen: React.FC = () => {
 
   if (pictureInPictureActive) {
     return <AndroidPictureInPictureView />;
+  }
+
+  // ポートレートモード有効時、端末が縦向きの間はテーマ非依存の
+  // 縦画面最適化レイアウトへ切り替える(横向きに戻すと通常表示)。
+  if (portraitModeEnabled && windowHeight > windowWidth) {
+    return (
+      <>
+        <PortraitMain />
+        {isDevApp && devOverlayEnabled && <DevOverlay />}
+      </>
+    );
   }
 
   if (isLEDTheme) {

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -5,6 +5,7 @@ import {
 import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
 import AndroidSettings from '~/screens/AndroidSettings';
+import ExperimentalSettings from '~/screens/ExperimentalSettings';
 import Licenses from '~/screens/Licenses';
 import NotificationSettings from '~/screens/NotificationSettings';
 import RouteSearchScreen from '~/screens/RouteSearchScreen';
@@ -111,6 +112,11 @@ const MainStack: React.FC = () => {
           options={optionsWithCustomStyle}
           name="AndroidSettings"
           component={AndroidSettings}
+        />
+        <Stack.Screen
+          options={optionsWithCustomStyle}
+          name="ExperimentalSettings"
+          component={ExperimentalSettings}
         />
         <Stack.Screen
           options={optionsWithCustomStyle}

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai';
+
+// 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
+// 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
+export const portraitModeEnabledAtom = atom(false);


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 設定画面の「通知」直下に「試験的機能」メニューを新設(`AppSettings.tsx`。カナリアリリース(`isDevApp`)限定で表示。項目挿入に強いよう、パーソナライズ節のレンダリングを `map` ベースに整理)
- ポートレートモードをトグルできる試験的機能設定画面 `ExperimentalSettings.tsx` を追加(`portraitModeEnabledAtom` + AsyncStorage `@TrainLCD:portraitModeEnabled` で永続化し、起動時に `Permitted.tsx` で読み込み。保存失敗時はatom状態をロールバック)
- ポートレートモード有効かつ端末が縦向きの間、Main画面をテーマ非依存の縦画面最適化レイアウト `PortraitMain.tsx` に切り替え(路線カード/状態テキスト+駅名+ナンバリング/停車駅の縦リスト。横向きに戻すと従来表示。閲覧専用の簡易表示とし、路線・種別変更の導線は対象外)
- 日英の翻訳キーと、ユニットテストを追加(`ExperimentalSettings.test.tsx`: トグル永続化・保存失敗時ロールバック、`PortraitMain.test.tsx`: 表示要素・通過駅ラベル・データ未取得時の分岐)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

https://claude.ai/code/session_01Nv3odSWJubXwE8s4jewpQw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 縦向き表示（Portrait）専用レイアウトを追加。端末が縦向きかつ有効時に専用画面で主要駅情報を表示（通過駅表示を含む）。
  * 実験設定画面を追加し、縦向きモードをトグルで有効/無効にできる。

* **多言語対応**
  * 実験設定、縦向きモードの見出し/説明、通過ラベルの日本語／英語文言を追加。

* **改善**
  * 設定画面のパーソナライズ項目表示を整理し、起動時に保存済み設定を反映。

* **テスト**
  * 縦向きモード関連の単体テストと表示テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->