### PR TITLE
cross-fetchに__esModuleマーカーを付与して起動時のinteropクラッシュを修正

### DIFF
--- a/patches/cross-fetch+3.2.0.patch
+++ b/patches/cross-fetch+3.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/cross-fetch/dist/react-native-ponyfill.js b/node_modules/cross-fetch/dist/react-native-ponyfill.js
+index 8e5baff..969b550 100644
+--- a/node_modules/cross-fetch/dist/react-native-ponyfill.js
++++ b/node_modules/cross-fetch/dist/react-native-ponyfill.js
+@@ -4,3 +4,8 @@ module.exports.fetch = global.fetch // To enable: import {fetch} from 'cross-fet
+ module.exports.Headers = global.Headers
+ module.exports.Request = global.Request
+ module.exports.Response = global.Response
++// __esModule マーカーがないと、Expo SDK 55 (live bindings) の _interopNamespace が
++// default をゲッターのみのプロパティとして複製した後 n.default = e で代入しようとして
++// 起動時に TypeError (Cannot assign to property 'default' which has only a getter) になる。
++// マーカーを立てて interop をそのまま素通りさせる。
++module.exports.__esModule = true


### PR DESCRIPTION
## 概要

起動直後に `[runtime not ready]: TypeError: Cannot assign to property 'default' which has only a getter, stack: _interopNamespace@...` でクラッシュする問題を修正する。

真因は cross-fetch（graphql-request@6 の依存。#6210 で流入）の React Native 向けエントリ `dist/react-native-ponyfill.js` が `module.exports.default = global.fetch` を設定する一方で `__esModule` マーカーを持たないこと。Expo SDK 55 の live bindings 変換（`@expo/metro-config` の `namespaceWrapHelper`）が生成する `_interopNamespace` ヘルパーは、`__esModule` なしの CJS モジュールの全プロパティを getter-only のアクセサとして新しい namespace オブジェクトへ複製した後に `n.default = e` を実行するため、`default` を持つ CJS を namespace import すると strict mode の TypeError で必ず落ちる。

graphql-request の ESM ビルドは `import crossFetch, * as CrossFetch from 'cross-fetch'` を行っており、`src/index.tsx` → `src/lib/gql.ts` → graphql-request の順でアプリ起動時（バンドル評価中）に必ず評価されるため、起動不能になっていた。バンドル全体を走査した結果、この致命的な形（`exports.default` あり・`__esModule` なし）を持つモジュールは cross-fetch のみ。なお jest は Babel 経由で Metro の live bindings 変換を通らないため、テストでは検出できない。

参照: 同型の先例パッチ #6176（react-native-dotenv）

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/cross-fetch+3.2.0.patch` を追加（postinstall の patch-package で適用）
- `dist/react-native-ponyfill.js` の末尾に `module.exports.__esModule = true` を 1 行追加し、`_interopNamespace` / `_interopDefault` が exports をそのまま素通りさせるようにする
- default import（`crossFetch` → `global.fetch`）と namespace import（`CrossFetch.Headers` 等）の両方が引き続き正しく解決されることを interop ヘルパーの単体シミュレーションで確認

検証内容:

- `@expo/metro-config` の `namespaceWrapHelper` を逐語コピーし、パッチ前の cross-fetch の exports 形状を通すと同一の TypeError が再現することを確認
- `npx expo export:embed` でバンドルを再生成し、「`exports.default` あり・`__esModule` なし」のモジュールが 0 件になったことを確認
- graphql-request を使用する `useGraphQLQuery` / `useLazyGraphQLQuery` / `useFetchNearbyStation` のテスト 16 件がパスすることを確認

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Expo SDK 55との互換性に関する起動時エラーを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->