### PR TITLE
ポートレートモードのデザインを改善し列車位置マーカーと直通ラインカラー表示を追加

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -1,6 +1,7 @@
-import { render } from '@testing-library/react-native';
+import { render, within } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
+import { StyleSheet } from 'react-native';
 import { type Station, StopCondition } from '~/@types/graphql';
 import {
   useCurrentLine,
@@ -9,6 +10,8 @@ import {
   useTransferLinesFromStation,
 } from '~/hooks';
 import { leftStationsAtom } from '~/store/atoms/navigation';
+import { arrivedAtom } from '~/store/atoms/station';
+import { RFValue } from '~/utils/rfValue';
 import PortraitMain from './PortraitMain';
 
 jest.mock('~/translation', () => ({
@@ -61,7 +64,8 @@ const buildStation = (
   id: number,
   name: string,
   stopCondition: StopCondition,
-  stationNumber?: string
+  stationNumber?: string,
+  line: typeof yamanoteLine = yamanoteLine
 ): Station =>
   ({
     id,
@@ -69,13 +73,17 @@ const buildStation = (
     nameRoman: `${name}-roman`,
     stopCondition,
     stationNumbers: stationNumber ? [{ stationNumber }] : [],
-    line: yamanoteLine,
+    line,
     lines: [],
   }) as unknown as Station;
 
-const renderWithStations = (stations: Station[]) => {
+const renderWithStations = (
+  stations: Station[],
+  { arrived = true }: { arrived?: boolean } = {}
+) => {
   const store = createStore();
   store.set(leftStationsAtom, stations);
+  store.set(arrivedAtom, arrived);
 
   return render(
     <Provider store={store}>
@@ -125,6 +133,79 @@ describe('PortraitMain', () => {
     expect(getByText('JY-27')).toBeTruthy();
     // 通過駅は1駅だけなので通過ラベルも1つ
     expect(getAllByText('passStationLabel')).toHaveLength(1);
+  });
+
+  it('発車後は先頭駅の行が半透明になり強調が次の停車駅へ移る', () => {
+    const { getByTestId, getByText } = renderWithStations(
+      [
+        buildStation(1, '品川', StopCondition.All, 'JY-25'),
+        buildStation(2, '田町', StopCondition.All, 'JY-27'),
+        buildStation(3, '浜松町', StopCondition.All, 'JY-28'),
+      ],
+      { arrived: false }
+    );
+
+    expect(
+      StyleSheet.flatten(getByTestId('stop-row-1').props.style).opacity
+    ).toBe(0.4);
+    expect(
+      StyleSheet.flatten(getByTestId('stop-row-2').props.style).opacity
+    ).toBeUndefined();
+    // 強調(フォント拡大)は発車済みの品川ではなく次の停車駅の田町に付く
+    expect(StyleSheet.flatten(getByText('田町').props.style).fontSize).toBe(
+      RFValue(18)
+    );
+    expect(StyleSheet.flatten(getByText('品川').props.style).fontSize).toBe(
+      RFValue(16)
+    );
+    // 列車位置の三角は現在駅と次駅の間(次駅行の上側セグメント)に出る
+    expect(
+      within(getByTestId('stop-row-2')).getByTestId('train-chevron')
+    ).toBeTruthy();
+    expect(
+      within(getByTestId('stop-row-1')).queryByTestId('train-chevron')
+    ).toBeNull();
+  });
+
+  it('停車中は先頭駅が強調され半透明にならない', () => {
+    const { getByTestId, getByText } = renderWithStations(
+      [
+        buildStation(1, '品川', StopCondition.All, 'JY-25'),
+        buildStation(2, '田町', StopCondition.All, 'JY-27'),
+      ],
+      { arrived: true }
+    );
+
+    expect(
+      StyleSheet.flatten(getByTestId('stop-row-1').props.style).opacity
+    ).toBeUndefined();
+    expect(StyleSheet.flatten(getByText('品川').props.style).fontSize).toBe(
+      RFValue(18)
+    );
+    // 列車位置の三角は現在駅の行に出る
+    expect(
+      within(getByTestId('stop-row-1')).getByTestId('train-chevron')
+    ).toBeTruthy();
+  });
+
+  it('直通先の駅は直通先のラインカラーで描画される', () => {
+    const keihinTohokuLine = {
+      id: 11332,
+      color: '#00B2E5',
+      nameShort: '京浜東北線',
+      nameRoman: 'Keihin-Tohoku Line',
+    };
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+      buildStation(2, '大井町', StopCondition.All, 'JK-19', keihinTohokuLine),
+    ]);
+
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-1').props.style).borderColor
+    ).toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-2').props.style).borderColor
+    ).toBe(keihinTohokuLine.color);
   });
 
   it('ヘッダーデータが揃っていない間は何も表示しない', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from 'jotai';
+import { darken, getLuminance, rgba } from 'polished';
 import type React from 'react';
 import { memo, useMemo } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
@@ -13,44 +14,73 @@ import {
   useTransferLinesFromStation,
 } from '~/hooks';
 import { leftStationsAtom } from '~/store/atoms/navigation';
+import { arrivedAtom } from '~/store/atoms/station';
 import { isJapanese, translate } from '~/translation';
 import getIsPass from '~/utils/isPass';
+import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
+import {
+  getTrainTypeTextColor,
+  normalizeTrainTypeColor,
+} from '~/utils/trainTypeTextColor';
 import NumberingIcon from './NumberingIcon';
 import Typography from './Typography';
 
 // テーマ非依存の独自カラーパレット。選択中のテーマに関わらず、設定画面などの
 // 操作系画面と印象を揃えたライト基調(白ベース)で統一する。
 const COLORS = {
-  background: '#FAFAFA',
-  card: '#FFFFFF',
+  background: '#FFFFFF',
   textPrimary: '#212121',
   textSecondary: '#8B8B8B',
-  divider: '#EEEEEE',
+  divider: '#E0E0E0',
   fallbackAccent: '#888888',
 } as const;
+
+// 白背景の上に文字色として置いても読めるよう、明るい路線色は暗めに倒す。
+const readableAccentColor = (color: string): string => {
+  try {
+    return getLuminance(color) > 0.5 ? darken(0.25, color) : color;
+  } catch {
+    return COLORS.fallbackAccent;
+  }
+};
+
+// 駅名セクションの背景に敷く路線色の淡いティント。
+const lineTintColor = (color: string): string => {
+  try {
+    return rgba(color, 0.08);
+  } catch {
+    return COLORS.background;
+  }
+};
+
+// 画面端からコンテンツまでの左右余白。区切り線は全幅のまま、
+// 路線カラーバー・駅名・停車駅リストをこの分だけ内側に寄せる。
+const CONTENT_INSET = 24;
+
+// NumberingIcon の LARGE サイズ実寸(NumberingIconRound 基準)に合わせた固定幅。
+// 駅名の長さやナンバリングの有無で記号の表示位置が動かないよう、
+// 駅名行の左端に固定幅の枠を確保する。
+const NUMBERING_COLUMN_WIDTH = isTablet ? 72 * 1.5 : 72;
 
 const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: COLORS.background,
   },
-  lineCard: {
+  lineSection: {
     flexDirection: 'row',
-    alignItems: 'center',
-    marginHorizontal: 16,
-    marginTop: 8,
-    backgroundColor: COLORS.card,
-    borderRadius: 12,
-    overflow: 'hidden',
+    alignItems: 'stretch',
+    paddingHorizontal: CONTENT_INSET,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: COLORS.divider,
   },
   lineColorBar: {
     width: 8,
-    alignSelf: 'stretch',
   },
-  lineCardBody: {
+  lineSectionBody: {
     flex: 1,
-    paddingHorizontal: 16,
+    paddingLeft: 16,
     paddingVertical: 12,
   },
   lineNameRow: {
@@ -64,87 +94,133 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   trainTypeBadge: {
-    borderWidth: 1,
-    borderRadius: 4,
     paddingHorizontal: 8,
-    paddingVertical: 2,
+    paddingVertical: 3,
     marginLeft: 8,
   },
   trainTypeText: {
     fontSize: RFValue(12),
     fontWeight: 'bold',
   },
+  // 行き先・状態テキスト・駅名はヘッダーの言語切り替えタイマーで内容が変わる。
+  // 和文と欧文でフォントメトリクスが異なり行の高さが変動するため、
+  // 高さと lineHeight を固定してセクション全体がガタつかないようにする。
   boundText: {
     marginTop: 4,
     color: COLORS.textSecondary,
     fontSize: RFValue(13),
     fontWeight: 'bold',
+    height: RFValue(20),
+    lineHeight: RFValue(20),
   },
   stationSection: {
-    alignItems: 'center',
-    paddingVertical: 24,
-    paddingHorizontal: 24,
+    alignItems: 'stretch',
+    paddingVertical: 20,
+    paddingHorizontal: CONTENT_INSET,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: COLORS.divider,
   },
   stateText: {
     color: COLORS.textSecondary,
     fontSize: RFValue(18),
     fontWeight: 'bold',
-    textAlign: 'center',
+    height: RFValue(28),
+    lineHeight: RFValue(28),
   },
   stationNameRow: {
     flexDirection: 'row',
     alignItems: 'center',
+    alignSelf: 'stretch',
     marginTop: 12,
+    minHeight: NUMBERING_COLUMN_WIDTH,
   },
-  numberingContainer: {
-    marginRight: 16,
+  numberingColumn: {
+    width: NUMBERING_COLUMN_WIDTH,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   stationName: {
-    flexShrink: 1,
+    flex: 1,
     color: COLORS.textPrimary,
     fontSize: RFValue(32),
     fontWeight: 'bold',
-    textAlign: 'center',
+    paddingLeft: 8,
   },
-  stopListContainer: {
+  stopList: {
     flex: 1,
-    marginHorizontal: 16,
-    marginBottom: 8,
-    backgroundColor: COLORS.card,
-    borderRadius: 12,
   },
   stopListContent: {
     paddingVertical: 12,
-    paddingHorizontal: 16,
+    paddingHorizontal: CONTENT_INSET,
   },
   stopRow: {
     flexDirection: 'row',
     alignItems: 'stretch',
     minHeight: 56,
   },
+  stopRowDeparted: {
+    opacity: 0.4,
+  },
   trackColumn: {
-    width: 24,
+    width: 32,
     alignItems: 'center',
   },
-  trackLine: {
+  trackSegment: {
     flex: 1,
-    width: 6,
+    alignSelf: 'stretch',
+    alignItems: 'center',
   },
+  // 発車後: 上の行(発車済み駅)との境目=透明度が切り替わる位置に寄せる
+  trackSegmentChevronTop: {
+    justifyContent: 'flex-start',
+  },
+  // 停車中: 現在駅のドットのすぐ上に寄せる。セグメント終端(中心から6px)は
+  // ドット上端(中心から11px)より円側に食い込んでいるため、その差分を逃がす
+  trackSegmentChevronBottom: {
+    justifyContent: 'flex-end',
+    paddingBottom: 5,
+  },
+  // 行高は小数を含むためセグメント境界が物理ピクセルに揃わず、丸めの
+  // 具合で白い継ぎ目が出ることがある。上下1pxずつ食み出させて隣接する
+  // セグメント同士を重ね、継ぎ目が出ないようにする。
+  trackLine: {
+    position: 'absolute',
+    top: -1,
+    bottom: -1,
+    width: 12,
+  },
+  chevronTriangle: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 11,
+    borderRightWidth: 11,
+    borderTopWidth: 13,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+  },
+  // 負マージンで上下セグメントを円の背後まで重ねる。セグメント終端は
+  // 中心から±6px: 棒の途切れ矩形の角(6,6)=8.5px も棒の先端(±6px、
+  // その高さの円の輪郭半幅は9.2px)も半径11の円に余裕を持って収まり、
+  // ピクセル丸めで白い隙間や棒のはみ出しが出ない。
   stopDot: {
-    width: 16,
-    height: 16,
-    borderRadius: 8,
-    borderWidth: 3,
-    backgroundColor: COLORS.card,
-    marginVertical: -2,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 4,
+    backgroundColor: COLORS.background,
+    marginVertical: -5,
     zIndex: 1,
   },
+  // 通過駅は縦棒より細い「抜き穴」で表現する。棒をまたぐリングだと
+  // 円からはみ出した棒の直線エッジが見えてしまうため、穴を棒の内側に収める。
+  // 高さぶんの負マージンでフロー占有を0にし、上下のセグメントを背後で連結する。
   passDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    borderWidth: 2,
-    marginHorizontal: 3,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: COLORS.background,
+    marginVertical: -4,
+    zIndex: 1,
   },
   stopBody: {
     flex: 1,
@@ -165,9 +241,10 @@ const styles = StyleSheet.create({
     fontWeight: 'normal',
   },
   stopNumbering: {
-    marginTop: 2,
+    marginTop: -2,
     color: COLORS.textSecondary,
     fontSize: RFValue(11),
+    lineHeight: RFValue(13),
   },
   transferDotsRow: {
     flexDirection: 'row',
@@ -187,18 +264,63 @@ const styles = StyleSheet.create({
   },
 });
 
+type ChevronPosition = 'above-dot' | 'segment-top' | null;
+
+const TrackSegment = ({
+  color,
+  hidden,
+  chevron = null,
+}: {
+  color: string;
+  hidden: boolean;
+  chevron?: ChevronPosition;
+}) => (
+  <View
+    style={[
+      styles.trackSegment,
+      chevron === 'segment-top' && styles.trackSegmentChevronTop,
+      chevron === 'above-dot' && styles.trackSegmentChevronBottom,
+    ]}
+  >
+    <View
+      style={[
+        styles.trackLine,
+        { backgroundColor: color, opacity: hidden ? 0 : 1 },
+      ]}
+    />
+    {chevron ? (
+      <View
+        style={[styles.chevronTriangle, { borderTopColor: color }]}
+        testID="train-chevron"
+      />
+    ) : null}
+  </View>
+);
+
 const StopRow = ({
   station,
   isFirst,
   isLast,
-  lineColor,
+  isCurrent,
+  departed,
+  chevron,
+  fallbackLineColor,
 }: {
   station: Station;
   isFirst: boolean;
   isLast: boolean;
-  lineColor: string;
+  isCurrent: boolean;
+  departed: boolean;
+  chevron: ChevronPosition;
+  fallbackLineColor: string;
 }) => {
   const isPass = getIsPass(station);
+  // 直通運転で路線が変わったら縦棒も直通先のラインカラーで塗る
+  const lineColor = station.line?.color ?? fallbackLineColor;
+  const accentColor = useMemo(
+    () => readableAccentColor(lineColor),
+    [lineColor]
+  );
   const getStationNumberIndex = useStationNumberIndexFunc();
   const transferLines = useTransferLinesFromStation(station, {
     omitRepeatingLine: true,
@@ -213,32 +335,32 @@ const StopRow = ({
     : (station.nameRoman ?? station.name ?? '');
 
   return (
-    <View style={styles.stopRow}>
+    <View
+      style={[styles.stopRow, departed && styles.stopRowDeparted]}
+      testID={`stop-row-${station.id}`}
+    >
       <View style={styles.trackColumn}>
-        <View
-          style={[
-            styles.trackLine,
-            { backgroundColor: lineColor, opacity: isFirst ? 0 : 1 },
-          ]}
-        />
+        <TrackSegment color={lineColor} hidden={isFirst} chevron={chevron} />
         {isPass ? (
           <View style={[styles.passDot, { borderColor: lineColor }]} />
         ) : (
-          <View style={[styles.stopDot, { borderColor: lineColor }]} />
+          <View
+            style={[
+              styles.stopDot,
+              { borderColor: lineColor },
+              isCurrent && { backgroundColor: lineColor },
+            ]}
+            testID={`stop-dot-${station.id}`}
+          />
         )}
-        <View
-          style={[
-            styles.trackLine,
-            { backgroundColor: lineColor, opacity: isLast ? 0 : 1 },
-          ]}
-        />
+        <TrackSegment color={lineColor} hidden={isLast} />
       </View>
       <View style={styles.stopBody}>
         <Typography
           numberOfLines={1}
           style={[
             styles.stopName,
-            isFirst && styles.stopNameCurrent,
+            isCurrent && [styles.stopNameCurrent, { color: accentColor }],
             isPass && styles.stopNamePass,
           ]}
         >
@@ -273,10 +395,23 @@ const StopRow = ({
 const PortraitMain: React.FC = () => {
   const commonData = useHeaderCommonData();
   const leftStations = useAtomValue(leftStationsAtom);
+  const arrived = useAtomValue(arrivedAtom);
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
 
   const lineColor = currentLine?.color ?? COLORS.fallbackAccent;
+  const accentColor = useMemo(
+    () => readableAccentColor(lineColor),
+    [lineColor]
+  );
+  const stationSectionTint = useMemo(
+    () => lineTintColor(lineColor),
+    [lineColor]
+  );
+  const trainTypeColor = normalizeTrainTypeColor(trainType?.color ?? undefined);
+  const trainTypeTextColor = getTrainTypeTextColor(
+    trainType?.color ?? undefined
+  );
 
   const lineName = useMemo(
     () =>
@@ -301,6 +436,20 @@ const PortraitMain: React.FC = () => {
     [leftStations]
   );
 
+  // 強調する駅。停車中は先頭駅、発車後はヘッダーの「次は」と同じ次の停車駅。
+  const currentStopIndex = useMemo(
+    () => stops.findIndex((s, i) => (i > 0 || arrived) && !getIsPass(s)),
+    [arrived, stops]
+  );
+
+  // 列車位置の三角(進行方向=下向き)。停車中は現在駅のドット直上、
+  // 発車後は発車済み駅(半透明)と次駅の境目=透明度が切り替わる位置に出す。
+  // 発車後に先頭行へ置くと行ごと半透明になってしまうので次の行の上端に置く。
+  const chevronRowIndex = arrived ? 0 : 1;
+  const chevronPosition: ChevronPosition = arrived
+    ? 'above-dot'
+    : 'segment-top';
+
   if (!commonData) {
     return <View style={styles.root} />;
   }
@@ -316,9 +465,9 @@ const PortraitMain: React.FC = () => {
   return (
     <SafeAreaView style={styles.root}>
       {/* 路線・行き先情報 */}
-      <View style={styles.lineCard}>
+      <View style={styles.lineSection}>
         <View style={[styles.lineColorBar, { backgroundColor: lineColor }]} />
-        <View style={styles.lineCardBody}>
+        <View style={styles.lineSectionBody}>
           <View style={styles.lineNameRow}>
             <Typography numberOfLines={1} style={styles.lineName}>
               {lineName}
@@ -327,14 +476,11 @@ const PortraitMain: React.FC = () => {
               <View
                 style={[
                   styles.trainTypeBadge,
-                  { borderColor: trainType?.color ?? COLORS.textSecondary },
+                  { backgroundColor: trainTypeColor },
                 ]}
               >
                 <Typography
-                  style={[
-                    styles.trainTypeText,
-                    { color: trainType?.color ?? COLORS.textSecondary },
-                  ]}
+                  style={[styles.trainTypeText, { color: trainTypeTextColor }]}
                 >
                   {trainTypeName}
                 </Typography>
@@ -348,19 +494,26 @@ const PortraitMain: React.FC = () => {
       </View>
 
       {/* 駅名表示 */}
-      <View style={styles.stationSection}>
-        <Typography style={styles.stateText}>{stateText}</Typography>
+      <View
+        style={[styles.stationSection, { backgroundColor: stationSectionTint }]}
+      >
+        <Typography
+          numberOfLines={1}
+          style={[styles.stateText, { color: accentColor }]}
+        >
+          {stateText}
+        </Typography>
         <View style={styles.stationNameRow}>
-          {currentStationNumber ? (
-            <View style={styles.numberingContainer}>
+          <View style={styles.numberingColumn}>
+            {currentStationNumber ? (
               <NumberingIcon
                 shape={currentStationNumber.lineSymbolShape || ''}
                 lineColor={numberingColor}
                 stationNumber={currentStationNumber.stationNumber || ''}
                 threeLetterCode={commonData.threeLetterCode}
               />
-            </View>
-          ) : null}
+            ) : null}
+          </View>
           <Typography
             numberOfLines={1}
             adjustsFontSizeToFit
@@ -372,7 +525,7 @@ const PortraitMain: React.FC = () => {
       </View>
 
       {/* 停車駅リスト */}
-      <View style={styles.stopListContainer}>
+      <View style={styles.stopList}>
         <ScrollView contentContainerStyle={styles.stopListContent}>
           {stops.map((station, index) => (
             <StopRow
@@ -380,7 +533,10 @@ const PortraitMain: React.FC = () => {
               station={station}
               isFirst={index === 0}
               isLast={index === stops.length - 1}
-              lineColor={lineColor}
+              isCurrent={index === currentStopIndex}
+              departed={index === 0 && !arrived}
+              chevron={index === chevronRowIndex ? chevronPosition : null}
+              fallbackLineColor={lineColor}
             />
           ))}
         </ScrollView>

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -48,7 +48,9 @@ const readableAccentColor = (color: string): string => {
 // 駅名セクションの背景に敷く路線色の淡いティント。
 const lineTintColor = (color: string): string => {
   try {
-    return rgba(color, 0.08);
+    // 明るい路線色はそのまま透過するとほぼ白に潰れて
+    // 視認できないため、文字色と同じ補正を通してから透過する
+    return rgba(readableAccentColor(color), 0.08);
   } catch {
     return COLORS.background;
   }


### PR DESCRIPTION
## 概要

試験的機能のポートレートモード(`PortraitMain`)のデザインを改善しました。フラットなレイアウトへの刷新に加えて、列車位置マーカー(進行方向の三角)と直通運転時のラインカラー切り替えを追加しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- カードの角丸・浮かせをやめ、全幅セクション + ヘアライン区切りのフラットな構成に変更(画面左右に共通の余白 24px)
- ヘッダーの状態テキストと駅名を左揃えにし、ナンバリング記号は固定幅枠(NumberingIcon LARGE 実寸)で位置を固定
- 言語切り替えタイマーで変わるテキスト(状態・行き先)の高さを固定し、和欧文のフォントメトリクス差による縦のガタつきを解消
- 停車駅リストで発車済みの駅の行を半透明化し、強調(フォント拡大・着色)をヘッダーの「次は」と同じ次の停車駅へ移動
- 縦棒上に列車位置マーカー(進行方向=下向きの三角)を追加。停車中は現在駅のドット直上、発車後は半透明と通常表示の境目に表示
- 直通運転で路線が変わった駅以降は、縦棒・ドット・三角・強調色を直通先のラインカラーで描画
- 種別バッジを種別色の塗りつぶし + コントラスト自動判定の文字色に変更し、駅名セクションに路線色の淡いティント背景を追加(明るい路線色は `polished` の `getLuminance` で暗めに補正)
- 縦棒を 12px に太くし、駅ドット/通過駅マーカーの幾何を整理(円の背後でセグメントを重ね、ピクセル丸めによる白い継ぎ目や棒のはみ出しを構造的に防止)
- 停車駅リストの駅名と駅番号の行間を調整
- 上記のテストを追加(発車後の半透明化と強調移動、列車位置マーカーの位置、直通先ラインカラー)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 発車後/停車中での駅リスト表示を改善（先頭行の半透明化・強調移動・三角表示位置の差分反映）
  * 直通先駅が該当路線の色で表示されるよう改善
  * 駅名セクションや列車バッジの視認性を向上

* **テスト**
  * 到着前後の表示差分（強調位置・半透明・三角位置・直通色）を詳細に検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->