### PR TITLE
ヘッダーの路線カラーバーの太さを停車駅リストの縦棒と揃える

### DIFF
--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -77,8 +77,9 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: COLORS.divider,
   },
+  // 停車駅リストの縦棒(trackLine)と同じ太さに揃える
   lineColorBar: {
-    width: 8,
+    width: 12,
   },
   lineSectionBody: {
     flex: 1,


### PR DESCRIPTION
## 概要

ポートレートモード(`PortraitMain`)で、ヘッダー左端の路線カラーバー(8px)と停車駅リストの縦棒(12px)の太さが揃っていなかったため、カラーバーを 12px に統一しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `lineColorBar` の幅を 8px → 12px に変更し、停車駅リストの縦棒(`trackLine`)と同じ太さに統一

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 駅情報表示画面のビジュアルデザイン要素を調整しました。表示部分の視覚要素の幅を最適化し、UI全体のデザイン統一性を向上させています。これに伴い、画面上の要素間の視覚的バランスがより改善された状態になっています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->