### PR TITLE
ポートレートモードでナンバリングがない駅では固定幅の枠を確保せず駅名表示に充てるよう修正

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -208,6 +208,31 @@ describe('PortraitMain', () => {
     ).toBe(keihinTohokuLine.color);
   });
 
+  it('現在駅にナンバリングがあるときは駅名の左に固定幅の枠を確保する', () => {
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    expect(getByTestId('numbering-column')).toBeTruthy();
+  });
+
+  it('現在駅にナンバリングがないときは枠を確保せず駅名表示に充てる', () => {
+    mockedUseHeaderCommonData.mockReturnValue({
+      ...commonData,
+      currentStationNumber: null,
+    });
+
+    const { queryByTestId, getByText } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All),
+    ]);
+
+    expect(queryByTestId('numbering-column')).toBeNull();
+    // 記号との間隔用パディングも付かず、駅名が左端から始まる
+    expect(
+      StyleSheet.flatten(getByText('高輪ゲートウェイ').props.style).paddingLeft
+    ).toBeUndefined();
+  });
+
   it('ヘッダーデータが揃っていない間は何も表示しない', () => {
     mockedUseHeaderCommonData.mockReturnValue(null);
 

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -61,8 +61,10 @@ const lineTintColor = (color: string): string => {
 const CONTENT_INSET = 24;
 
 // NumberingIcon の LARGE サイズ実寸(NumberingIconRound 基準)に合わせた固定幅。
-// 駅名の長さやナンバリングの有無で記号の表示位置が動かないよう、
-// 駅名行の左端に固定幅の枠を確保する。
+// ナンバリングがある駅では駅名の長さで記号の表示位置が動かないよう
+// 駅名行の左端に固定幅の枠を確保する。ナンバリングがない駅では枠ごと
+// 描画せず、その分を駅名表示に充てる。行の minHeight にも流用し、
+// ナンバリングの有無で駅名セクションの高さが変わらないようにする。
 const NUMBERING_COLUMN_WIDTH = isTablet ? 72 * 1.5 : 72;
 
 const styles = StyleSheet.create({
@@ -147,6 +149,9 @@ const styles = StyleSheet.create({
     color: COLORS.textPrimary,
     fontSize: RFValue(32),
     fontWeight: 'bold',
+  },
+  // ナンバリング記号と駅名の間隔。記号がないときは付けず左端を揃える
+  stationNameWithNumbering: {
     paddingLeft: 8,
   },
   stopList: {
@@ -507,20 +512,23 @@ const PortraitMain: React.FC = () => {
           {stateText}
         </Typography>
         <View style={styles.stationNameRow}>
-          <View style={styles.numberingColumn}>
-            {currentStationNumber ? (
+          {currentStationNumber ? (
+            <View style={styles.numberingColumn} testID="numbering-column">
               <NumberingIcon
                 shape={currentStationNumber.lineSymbolShape || ''}
                 lineColor={numberingColor}
                 stationNumber={currentStationNumber.stationNumber || ''}
                 threeLetterCode={commonData.threeLetterCode}
               />
-            ) : null}
-          </View>
+            </View>
+          ) : null}
           <Typography
             numberOfLines={1}
             adjustsFontSizeToFit
-            style={styles.stationName}
+            style={[
+              styles.stationName,
+              currentStationNumber && styles.stationNameWithNumbering,
+            ]}
           >
             {stationText}
           </Typography>


### PR DESCRIPTION
## 概要

ポートレートモードの駅名表示で、ナンバリングがない駅では左端の固定幅枠を確保せず、その領域を駅名表示に充てるようにしました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `PortraitMain` で `currentStationNumber` がない場合はナンバリング枠の `View` 自体を描画せず、駅名（`flex: 1`）がその領域まで広がるようにした。
- 駅名の `paddingLeft: 8`（記号と駅名の間隔用）を `stationNameWithNumbering` スタイルへ分離し、ナンバリングがあるときだけ付与するようにした。ない場合は駅名が他コンテンツと同じ左端（`CONTENT_INSET`）から始まる。
- 駅名行の `minHeight` は従来どおり `NUMBERING_COLUMN_WIDTH` を使い続け、ナンバリングの有無でセクションの高さが変わらないようにした。
- `PortraitMain.test.tsx` に、ナンバリングあり時は枠が描画され、なし時は枠が描画されず駅名にパディングも付かないことを検証するテストを追加した。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdE7HbMMd1rZamKDB157Qn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 駅ナンバリング表示時の駅名位置ズレを修正しました。ナンバリング有無に応じて適切なレイアウトが表示されるようになります。

* **テスト**
  * ナンバリング表示状態に応じたレイアウト挙動の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->