### PR TITLE
ポートレートモードを全駅表示に刷新し列車位置マーカー・自動スクロール・配色を改善

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -5,12 +5,16 @@ import { StyleSheet } from 'react-native';
 import { type Station, StopCondition } from '~/@types/graphql';
 import {
   useCurrentLine,
+  useCurrentStation,
   useCurrentTrainType,
   useHeaderCommonData,
   useTransferLinesFromStation,
 } from '~/hooks';
-import { leftStationsAtom } from '~/store/atoms/navigation';
-import { arrivedAtom } from '~/store/atoms/station';
+import {
+  arrivedAtom,
+  selectedDirectionAtom,
+  stationsAtom,
+} from '~/store/atoms/station';
 import { RFValue } from '~/utils/rfValue';
 import PortraitMain from './PortraitMain';
 
@@ -26,7 +30,9 @@ jest.mock('react-native-safe-area-context', () => ({
 jest.mock('./NumberingIcon', () => () => null);
 
 jest.mock('~/hooks', () => ({
+  useBoundText: jest.fn(() => ({ JA: '品川・大崎方面' })),
   useCurrentLine: jest.fn(),
+  useCurrentStation: jest.fn(),
   useCurrentTrainType: jest.fn(),
   useHeaderCommonData: jest.fn(),
   useStationNumberIndexFunc: jest.fn(() => () => 0),
@@ -35,6 +41,7 @@ jest.mock('~/hooks', () => ({
 
 const mockedUseHeaderCommonData = useHeaderCommonData as jest.Mock;
 const mockedUseCurrentLine = useCurrentLine as jest.Mock;
+const mockedUseCurrentStation = useCurrentStation as jest.Mock;
 const mockedUseCurrentTrainType = useCurrentTrainType as jest.Mock;
 const mockedUseTransferLinesFromStation =
   useTransferLinesFromStation as jest.Mock;
@@ -69,6 +76,7 @@ const buildStation = (
 ): Station =>
   ({
     id,
+    groupId: id,
     name,
     nameRoman: `${name}-roman`,
     stopCondition,
@@ -79,11 +87,17 @@ const buildStation = (
 
 const renderWithStations = (
   stations: Station[],
-  { arrived = true }: { arrived?: boolean } = {}
+  {
+    arrived = true,
+    currentStation = stations[0],
+  }: { arrived?: boolean; currentStation?: Station } = {}
 ) => {
   const store = createStore();
-  store.set(leftStationsAtom, stations);
+  // 全駅表示。INBOUND は反転しないので渡した順がそのまま表示順になる。
+  store.set(stationsAtom, stations);
+  store.set(selectedDirectionAtom, 'INBOUND');
   store.set(arrivedAtom, arrived);
+  mockedUseCurrentStation.mockReturnValue(currentStation);
 
   return render(
     <Provider store={store}>
@@ -109,7 +123,7 @@ describe('PortraitMain', () => {
   });
 
   it('路線名・種別・行き先・状態テキスト・駅名を表示する', () => {
-    const { getByText } = renderWithStations([
+    const { getByText, getByTestId } = renderWithStations([
       buildStation(1, '品川', StopCondition.All, 'JY-25'),
     ]);
 
@@ -117,22 +131,26 @@ describe('PortraitMain', () => {
     expect(getByText('各駅停車')).toBeTruthy();
     expect(getByText('品川・大崎方面')).toBeTruthy();
     expect(getByText('nextKana')).toBeTruthy();
-    expect(getByText('高輪ゲートウェイ')).toBeTruthy();
+    // 駅名は表示用と測定用の2つがあるため testID で表示用を取得
+    expect(getByTestId('portrait-station-name').props.children).toBe(
+      '高輪ゲートウェイ'
+    );
   });
 
-  it('停車駅リストに駅名とナンバリングを表示し通過駅には通過ラベルを付ける', () => {
-    const { getByText, getAllByText } = renderWithStations([
+  it('停車駅リストに通過駅も含めて駅名とナンバリングを表示する', () => {
+    const { getByText, queryByText } = renderWithStations([
       buildStation(1, '品川', StopCondition.All, 'JY-25'),
-      buildStation(2, '高輪ゲートウェイ', StopCondition.Not, 'JY-26'),
+      buildStation(2, '新橋', StopCondition.Not, 'JY-26'),
       buildStation(3, '田町', StopCondition.All, 'JY-27'),
     ]);
 
     expect(getByText('品川')).toBeTruthy();
+    expect(getByText('新橋')).toBeTruthy();
     expect(getByText('田町')).toBeTruthy();
     expect(getByText('JY-25')).toBeTruthy();
     expect(getByText('JY-27')).toBeTruthy();
-    // 通過駅は1駅だけなので通過ラベルも1つ
-    expect(getAllByText('passStationLabel')).toHaveLength(1);
+    // 「通過」ラベルは表示しない
+    expect(queryByText('passStationLabel')).toBeNull();
   });
 
   it('発車後は先頭駅の行が半透明になり強調が次の停車駅へ移る', () => {
@@ -145,12 +163,13 @@ describe('PortraitMain', () => {
       { arrived: false }
     );
 
+    // 発車済みの先頭駅は縦棒・ドットが淡い色になり、次駅以降は通常色のまま
     expect(
-      StyleSheet.flatten(getByTestId('stop-row-1').props.style).opacity
-    ).toBe(0.4);
+      StyleSheet.flatten(getByTestId('stop-dot-1').props.style).borderColor
+    ).not.toBe(yamanoteLine.color);
     expect(
-      StyleSheet.flatten(getByTestId('stop-row-2').props.style).opacity
-    ).toBeUndefined();
+      StyleSheet.flatten(getByTestId('stop-dot-2').props.style).borderColor
+    ).toBe(yamanoteLine.color);
     // 強調(フォント拡大)は発車済みの品川ではなく次の停車駅の田町に付く
     expect(StyleSheet.flatten(getByText('田町').props.style).fontSize).toBe(
       RFValue(18)
@@ -188,6 +207,28 @@ describe('PortraitMain', () => {
     ).toBeTruthy();
   });
 
+  it('停車中も現在駅より前の駅(過ぎた線路)は半透明になる', () => {
+    const { getByTestId } = renderWithStations(
+      [
+        buildStation(1, '品川', StopCondition.All, 'JY-25'),
+        buildStation(2, '田町', StopCondition.All, 'JY-27'),
+        buildStation(3, '浜松町', StopCondition.All, 'JY-28'),
+      ],
+      {
+        arrived: true,
+        currentStation: buildStation(2, '田町', StopCondition.All),
+      }
+    );
+
+    // 現在駅(田町)より前の品川は淡色、現在駅と以降は通常色
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-1').props.style).borderColor
+    ).not.toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-2').props.style).borderColor
+    ).toBe(yamanoteLine.color);
+  });
+
   it('直通先の駅は直通先のラインカラーで描画される', () => {
     const keihinTohokuLine = {
       id: 11332,
@@ -214,6 +255,11 @@ describe('PortraitMain', () => {
     ]);
 
     expect(getByTestId('numbering-column')).toBeTruthy();
+    // ナンバリングありのときは駅名スロットに記号との間隔パディングが付く
+    expect(
+      StyleSheet.flatten(getByTestId('portrait-station-name-slot').props.style)
+        .paddingLeft
+    ).toBe(8);
   });
 
   it('現在駅にナンバリングがないときは枠を確保せず駅名表示に充てる', () => {
@@ -222,15 +268,58 @@ describe('PortraitMain', () => {
       currentStationNumber: null,
     });
 
-    const { queryByTestId, getByText } = renderWithStations([
+    const { queryByTestId, getByTestId } = renderWithStations([
       buildStation(1, '品川', StopCondition.All),
     ]);
 
     expect(queryByTestId('numbering-column')).toBeNull();
-    // 記号との間隔用パディングも付かず、駅名が左端から始まる
+    // 記号との間隔用パディングも付かず、駅名スロットが左端から始まる
     expect(
-      StyleSheet.flatten(getByText('高輪ゲートウェイ').props.style).paddingLeft
+      StyleSheet.flatten(getByTestId('portrait-station-name-slot').props.style)
+        .paddingLeft
     ).toBeUndefined();
+  });
+
+  it('ピンより前の駅は淡色になり、ピンの行とそれ以降は通常色のまま', () => {
+    const { getByTestId } = renderWithStations(
+      [
+        buildStation(1, '光が丘', StopCondition.All, 'E-38'),
+        buildStation(2, '練馬春日町', StopCondition.All, 'E-37'),
+        buildStation(3, '豊島園', StopCondition.All, 'E-36'),
+      ],
+      // 光が丘を発車し練馬春日町へ走行中(ピンは練馬春日町の行)
+      {
+        arrived: false,
+        currentStation: buildStation(1, '光が丘', StopCondition.All),
+      }
+    );
+
+    // ピンより前(光が丘)は上下とも淡色。ピンの行(練馬春日町)は通常色のまま。
+    expect(
+      StyleSheet.flatten(getByTestId('track-top-1').props.style).backgroundColor
+    ).not.toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('track-bottom-1').props.style)
+        .backgroundColor
+    ).not.toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('track-top-2').props.style).backgroundColor
+    ).toBe(yamanoteLine.color);
+  });
+
+  it('停車中(CURRENT)の英中韓 state は各言語の「ただいま停車中」を補完表示する', () => {
+    mockedUseHeaderCommonData.mockReturnValue({
+      ...commonData,
+      stateText: '',
+      headerState: 'CURRENT_EN',
+    });
+
+    const { getByText } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    // translate はモックでキーをそのまま返す
+    expect(getByText('nowStoppingAtEn')).toBeTruthy();
   });
 
   it('ヘッダーデータが揃っていない間は何も表示しない', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -819,18 +819,17 @@ const PortraitMain: React.FC = () => {
   const [rowYs, setRowYs] = useState<Record<number, number>>({});
   const chevronRowY = rowYs[chevronRowIndex] ?? 0;
 
-  // 駅が変わるたびにスクロールする。現在駅の1つ前の駅が見える程度の余白
-  // (1行分)を上に残し、現在駅をその下に置く。
+  // 到着(ピン=現在駅)・出発(ピン=次駅)のたびに、ピンの行を表示領域の上
+  // (1つ前の駅が見える程度に1行分の余白を残した位置)へスクロールする。
   const scrollRef = useRef<ScrollView>(null);
   useEffect(() => {
-    const y = rowYs[currentIndex];
-    if (y != null) {
+    if (chevronRowY > 0) {
       scrollRef.current?.scrollTo({
-        y: Math.max(0, STOP_LIST_PADDING_V + y - STOP_ROW_HEIGHT),
+        y: Math.max(0, STOP_LIST_PADDING_V + chevronRowY - STOP_ROW_HEIGHT),
         animated: true,
       });
     }
-  }, [rowYs, currentIndex]);
+  }, [chevronRowY]);
 
   if (!commonData) {
     return <View style={styles.root} />;

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1,21 +1,37 @@
+import { LinearGradient } from 'expo-linear-gradient';
 import { useAtomValue } from 'jotai';
-import { darken, getLuminance, rgba } from 'polished';
+import { darken, getLuminance, mix, rgba } from 'polished';
 import type React from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Circle, Path, Svg } from 'react-native-svg';
 import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
 import {
+  useBoundText,
   useCurrentLine,
+  useCurrentStation,
   useCurrentTrainType,
   useHeaderCommonData,
   useStationNumberIndexFunc,
   useTransferLinesFromStation,
 } from '~/hooks';
-import { leftStationsAtom } from '~/store/atoms/navigation';
-import { arrivedAtom } from '~/store/atoms/station';
+import {
+  arrivedAtom,
+  selectedDirectionAtom,
+  stationsAtom,
+} from '~/store/atoms/station';
 import { isJapanese, translate } from '~/translation';
+import dropEitherJunctionStation from '~/utils/dropJunctionStation';
 import getIsPass from '~/utils/isPass';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
@@ -32,6 +48,9 @@ const COLORS = {
   background: '#FFFFFF',
   textPrimary: '#212121',
   textSecondary: '#8B8B8B',
+  // 通過駅の駅名・記号用。停車駅(textSecondary)よりさらに薄くして
+  // 「停まらない駅」であることを色の淡さで示す。
+  textPass: '#C2C2C2',
   divider: '#E0E0E0',
   fallbackAccent: '#888888',
 } as const;
@@ -42,6 +61,37 @@ const readableAccentColor = (color: string): string => {
     return getLuminance(color) > 0.5 ? darken(0.25, color) : color;
   } catch {
     return COLORS.fallbackAccent;
+  }
+};
+
+// 発車済み駅のトラック(縦棒・ドット)用に白へ寄せた淡い色。
+// opacity で半透明フェードすると縦棒とリングの重なり部分だけ二重合成で
+// 濃くなって不自然なので、不透明のままフェードした色を使い、同色の
+// 重なりが目立たないようにする。
+const departedTrackColor = (color: string): string => {
+  try {
+    return mix(0.4, color, COLORS.background);
+  } catch {
+    return COLORS.divider;
+  }
+};
+
+// 停車中(CURRENT)の state は共有の useHeaderStateText では日本語以外が空になる
+// (ヘッダーは駅名のみ表示する仕様)。ポートレートでは各言語の「ただいま停車中」を
+// 補完して、停車中でも英中韓の state を表示する。
+const resolveStateText = (stateText: string, headerState: string): string => {
+  if (stateText) {
+    return stateText;
+  }
+  switch (headerState) {
+    case 'CURRENT_EN':
+      return translate('nowStoppingAtEn');
+    case 'CURRENT_ZH':
+      return translate('nowStoppingAtZh');
+    case 'CURRENT_KO':
+      return translate('nowStoppingAtKo');
+    default:
+      return stateText;
   }
 };
 
@@ -67,6 +117,22 @@ const CONTENT_INSET = 24;
 // ナンバリングの有無で駅名セクションの高さが変わらないようにする。
 const NUMBERING_COLUMN_WIDTH = isTablet ? 72 * 1.5 : 72;
 
+// トラック列と縦棒の幅。一筋の光(trackLight)を縦棒の x 位置・幅に合わせる
+// ためにも使う。
+const TRACK_COLUMN_WIDTH = 36;
+const TRACK_LINE_WIDTH = 22;
+
+// 縦棒を流れる光の帯の高さ(px)。
+const TRACK_LIGHT_HEIGHT = 28;
+
+// 停車駅リストの上下パディング。光の開始位置(行の y)を stopList 座標へ
+// 変換するのにも使う。
+const STOP_LIST_PADDING_V = 12;
+
+// 停車駅リストの1行の高さ(stopRow の minHeight)。スクロール時に現在駅の
+// 1つ前の駅が見える程度の余白を残すために使う。
+const STOP_ROW_HEIGHT = 72;
+
 const styles = StyleSheet.create({
   root: {
     flex: 1,
@@ -81,7 +147,7 @@ const styles = StyleSheet.create({
   },
   // 停車駅リストの縦棒(trackLine)と同じ太さに揃える
   lineColorBar: {
-    width: 12,
+    width: TRACK_LINE_WIDTH,
   },
   lineSectionBody: {
     flex: 1,
@@ -144,49 +210,54 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  stationName: {
+  // 駅名スロット。長い駅名はフォントを縮小せず横方向に圧縮(長体)して
+  // 1行に収めるため、はみ出しをクリップする。
+  stationNameSlot: {
     flex: 1,
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  // ナンバリング記号と駅名の間隔。記号がないときは付けず左端を揃える
+  stationNameSlotWithNumbering: {
+    paddingLeft: 8,
+  },
+  stationNameText: {
     color: COLORS.textPrimary,
     fontSize: RFValue(32),
     fontWeight: 'bold',
   },
-  // ナンバリング記号と駅名の間隔。記号がないときは付けず左端を揃える
-  stationNameWithNumbering: {
-    paddingLeft: 8,
+  // 自然幅の測定専用(非表示)。絶対配置 + 十分広い固定幅 + 左寄せで、親スロットの
+  // 幅制約を受けずテキストを省略させずに本来の幅を測る。描画には出さない。
+  stationNameMeasure: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: 1000,
+    alignItems: 'flex-start',
+    opacity: 0,
   },
   stopList: {
     flex: 1,
+    overflow: 'hidden',
   },
   stopListContent: {
-    paddingVertical: 12,
+    paddingVertical: STOP_LIST_PADDING_V,
     paddingHorizontal: CONTENT_INSET,
   },
   stopRow: {
     flexDirection: 'row',
     alignItems: 'stretch',
-    minHeight: 56,
-  },
-  stopRowDeparted: {
-    opacity: 0.4,
+    // 駅名の下に番号・乗換ドットを絶対配置するぶん、行間を広めに確保する。
+    minHeight: STOP_ROW_HEIGHT,
   },
   trackColumn: {
-    width: 32,
+    width: TRACK_COLUMN_WIDTH,
     alignItems: 'center',
   },
   trackSegment: {
     flex: 1,
     alignSelf: 'stretch',
     alignItems: 'center',
-  },
-  // 発車後: 上の行(発車済み駅)との境目=透明度が切り替わる位置に寄せる
-  trackSegmentChevronTop: {
-    justifyContent: 'flex-start',
-  },
-  // 停車中: 現在駅のドットのすぐ上に寄せる。セグメント終端(中心から6px)は
-  // ドット上端(中心から11px)より円側に食い込んでいるため、その差分を逃がす
-  trackSegmentChevronBottom: {
-    justifyContent: 'flex-end',
-    paddingBottom: 5,
   },
   // 行高は小数を含むためセグメント境界が物理ピクセルに揃わず、丸めの
   // 具合で白い継ぎ目が出ることがある。上下1pxずつ食み出させて隣接する
@@ -195,26 +266,52 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: -1,
     bottom: -1,
-    width: 12,
+    width: TRACK_LINE_WIDTH,
   },
-  chevronTriangle: {
-    width: 0,
-    height: 0,
-    borderLeftWidth: 11,
-    borderRightWidth: 11,
-    borderTopWidth: 13,
-    borderLeftColor: 'transparent',
-    borderRightColor: 'transparent',
+  // 停車駅リストの縦棒の上を1本だけ流す光。ScrollView コンテンツ内に置き、
+  // 縦棒の x 位置・幅に合わせて重ねる。zIndex は縦棒・ドット(=0)より上、
+  // 列車マーカーの行(=2)より下に置き、光がピンの裏を通るようにする。
+  trackLight: {
+    position: 'absolute',
+    top: 0,
+    left: (TRACK_COLUMN_WIDTH - TRACK_LINE_WIDTH) / 2,
+    width: TRACK_LINE_WIDTH,
+    height: TRACK_LIGHT_HEIGHT,
+    zIndex: 1,
   },
-  // 負マージンで上下セグメントを円の背後まで重ねる。セグメント終端は
-  // 中心から±6px: 棒の途切れ矩形の角(6,6)=8.5px も棒の先端(±6px、
-  // その高さの円の輪郭半幅は9.2px)も半径11の円に余裕を持って収まり、
-  // ピクセル丸めで白い隙間や棒のはみ出しが出ない。
+  // 列車マーカーの行。光(zIndex 1)より上に出してピンの裏を光が通るようにする。
+  stopRowElevated: {
+    zIndex: 2,
+  },
+  // 列車位置マーカー(丸い頭+下向きの尖り)のコンテナ。絶対配置でセグメントの
+  // フロー高さに影響させず、ドット位置を chevron 種別に依らず一定に保つ。
+  trainMarker: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 2,
+  },
+  // 発車後: 上の行との境目(=半透明と通常色の境界)にピンの円中心を合わせる。
+  // ピンは高さ37・円中心 cy14 なので、円中心がセグメント上端(=境界)に来るよう
+  // top を -14 にする。これで半透明はピンの中央を超えない。
+  trainMarkerSegmentTop: {
+    top: -14,
+  },
+  // 停車中: マーカーの尖り(下端)を現在駅のドットのすぐ上に寄せる。
+  trainMarkerAboveDot: {
+    bottom: 2,
+  },
+  // 白抜きの穴(内径 28-6*2=16px)を縦棒(幅22px)より狭くして、縦棒が穴を
+  // またいでリング(ボーダー)の内側へ潜り込むようにする。これで縦棒と
+  // リングの間に白い隙間が生じず、縦棒が駅の丸にシームレスに連結する。
+  // 外径(28px)は縦棒(22px)より太く、駅の丸が縦棒から膨らんで見える。
+  // 負マージンで上下セグメントを円の背後まで重ね、継ぎ目を出さない。
   stopDot: {
-    width: 22,
-    height: 22,
-    borderRadius: 11,
-    borderWidth: 4,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 6,
     backgroundColor: COLORS.background,
     marginVertical: -5,
     zIndex: 1,
@@ -223,18 +320,31 @@ const styles = StyleSheet.create({
   // 円からはみ出した棒の直線エッジが見えてしまうため、穴を棒の内側に収める。
   // 高さぶんの負マージンでフロー占有を0にし、上下のセグメントを背後で連結する。
   passDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
     backgroundColor: COLORS.background,
-    marginVertical: -4,
+    marginVertical: -5,
     zIndex: 1,
   },
   stopBody: {
     flex: 1,
     marginLeft: 16,
     justifyContent: 'center',
-    paddingVertical: 8,
+  },
+  stopBodyDeparted: {
+    opacity: 0.4,
+  },
+  // 駅名のラップ。高さは駅名のみ(サブ情報は absolute で含めない)なので、
+  // stopBody の justifyContent:center で駅名が行の縦中央=丸の真横に来る。
+  stopLabel: {
+    alignSelf: 'flex-start',
+  },
+  // 番号・乗換ドットを駅名の真下に絶対配置。行の高さに影響させない。
+  stopSubInfo: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
   },
   stopName: {
     color: COLORS.textPrimary,
@@ -245,7 +355,7 @@ const styles = StyleSheet.create({
     fontSize: RFValue(18),
   },
   stopNamePass: {
-    color: COLORS.textSecondary,
+    color: COLORS.textPass,
     fontWeight: 'normal',
   },
   stopNumbering: {
@@ -253,11 +363,17 @@ const styles = StyleSheet.create({
     color: COLORS.textSecondary,
     fontSize: RFValue(11),
     lineHeight: RFValue(13),
+    fontWeight: 'bold',
+  },
+  stopNumberingPass: {
+    color: COLORS.textPass,
+    fontWeight: 'normal',
   },
   transferDotsRow: {
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: 6,
+    height: 10,
   },
   transferDot: {
     width: 10,
@@ -265,42 +381,157 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     marginRight: 6,
   },
-  passLabel: {
-    alignSelf: 'center',
-    color: COLORS.textSecondary,
-    fontSize: RFValue(12),
-  },
 });
 
 type ChevronPosition = 'above-dot' | 'segment-top' | null;
+
+// 列車位置マーカー(下向きのティアドロップ型ピン)。丸い頭(円)と下の尖りを
+// 1つのシルエットとして描く。塗りはラインカラー、白い縁取りを付けることで
+// 同色の縦棒(trackLine)に尖りが埋もれず、線路上に乗ったピンとして読める。
+// 円(head)と尖り(tail)はそれぞれ「白い大きめ図形→塗りの図形」の2層構成にし、
+// 同色図形の重なりで継ぎ目なく融合させつつ、外周だけ白を覗かせて縁取りにする。
+// 座標は viewBox 28x37・中心(14,14)・頭半径11、尖り先端を下に伸ばした接線三角形。
+const TrainMarkerPin = ({ color }: { color: string }) => (
+  <Svg width={28} height={37} viewBox="0 0 28 37">
+    {/* 白い縁取り層(頭半径13・尖りを一回り大きく) */}
+    <Circle cx={14} cy={14} r={13} fill={COLORS.background} />
+    <Path d="M3.51 21.68 L14 36 L24.49 21.68 Z" fill={COLORS.background} />
+    {/* ラインカラーの本体層(頭半径11) */}
+    <Circle cx={14} cy={14} r={11} fill={color} />
+    <Path d="M4.81 20.05 L14 34 L23.19 20.05 Z" fill={color} />
+  </Svg>
+);
+
+// 列車位置ピンを軽く拍動(パルス)させ、「いまここを走っている」生きた感じを出す。
+// moving(走行中・通過中)のときは上下にバウンスさせ、停車中との違いを動きで示す。
+const PULSE_DURATION = 850;
+const BOUNCE_DURATION = 500;
+const TrainMarker = ({ color, moving }: { color: string; moving: boolean }) => {
+  const pulse = useSharedValue(0);
+  const bounce = useSharedValue(0);
+
+  // 停車中はパルス(拡大縮小)で「いまここ」を示す。走行中・通過中はパルスを
+  // 止めて上下バウンスのみにする。
+  useEffect(() => {
+    if (moving) {
+      cancelAnimation(pulse);
+      pulse.value = withTiming(0, { duration: 200 });
+      bounce.value = withRepeat(
+        withSequence(
+          withTiming(1, { duration: BOUNCE_DURATION }),
+          withTiming(0, { duration: BOUNCE_DURATION })
+        ),
+        -1,
+        false
+      );
+    } else {
+      cancelAnimation(bounce);
+      bounce.value = withTiming(0, { duration: 200 });
+      // easing は指定せず Reanimated 既定(inOut quad)に任せる。滑らかな拍動。
+      pulse.value = withRepeat(
+        withSequence(
+          withTiming(1, { duration: PULSE_DURATION }),
+          withTiming(0, { duration: PULSE_DURATION })
+        ),
+        -1,
+        false
+      );
+    }
+    return () => {
+      cancelAnimation(pulse);
+      cancelAnimation(bounce);
+    };
+  }, [moving, pulse, bounce]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateY: bounce.value * -5 },
+      { scale: 1 + pulse.value * 0.12 },
+    ],
+  }));
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <TrainMarkerPin color={color} />
+    </Animated.View>
+  );
+};
+
+// 縦棒の上を下方向へ流れる一筋の光。半透明の白いグラデーション帯を、
+// 列車位置(透明度が切り替わる境界 startY)からリスト下端まで translateY で
+// スライドさせる。帯は縦棒の x 位置・幅に合わせて重ね、色のある縦棒上でだけ
+// 光って見える(白いドット上では同化して消える)。発車済み(半透明)区間より
+// 手前=列車の進行方向側だけを流れる。
+// 所要時間は駅数(距離)に依らず固定。リストが長いほど速く流れる。
+const LIGHT_DURATION = 3000; // ms(始点→下端の1往復にかかる時間)
+const TrackLight = ({ startY, height }: { startY: number; height: number }) => {
+  const translateY = useSharedValue(startY);
+
+  useEffect(() => {
+    translateY.value = startY;
+    translateY.value = withRepeat(
+      withTiming(height, { duration: LIGHT_DURATION }),
+      -1,
+      false
+    );
+    return () => cancelAnimation(translateY);
+  }, [startY, height, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[styles.trackLight, animatedStyle]}
+    >
+      <LinearGradient
+        colors={['transparent', 'rgba(255,255,255,0.55)', 'transparent']}
+        style={StyleSheet.absoluteFill}
+      />
+    </Animated.View>
+  );
+};
 
 const TrackSegment = ({
   color,
   hidden,
   chevron = null,
+  lineTestID,
+  // ピン(列車)の色。縦棒(color)が通過中などで淡色化されても、列車そのものを
+  // 表すピンは通常の路線色のままにしたいので別に受け取る。
+  markerColor,
+  markerMoving = false,
 }: {
   color: string;
   hidden: boolean;
   chevron?: ChevronPosition;
+  lineTestID?: string;
+  markerColor?: string;
+  markerMoving?: boolean;
 }) => (
-  <View
-    style={[
-      styles.trackSegment,
-      chevron === 'segment-top' && styles.trackSegmentChevronTop,
-      chevron === 'above-dot' && styles.trackSegmentChevronBottom,
-    ]}
-  >
+  <View style={styles.trackSegment}>
     <View
+      testID={lineTestID}
       style={[
         styles.trackLine,
         { backgroundColor: color, opacity: hidden ? 0 : 1 },
       ]}
     />
+    {/* ピンは絶対配置にしてセグメントのフロー高さに影響させない。これにより
+        chevron の位置(segment-top/above-dot)が変わってもドット位置は不変。 */}
     {chevron ? (
       <View
-        style={[styles.chevronTriangle, { borderTopColor: color }]}
+        style={[
+          styles.trainMarker,
+          chevron === 'segment-top' && styles.trainMarkerSegmentTop,
+          chevron === 'above-dot' && styles.trainMarkerAboveDot,
+        ]}
         testID="train-chevron"
-      />
+      >
+        <TrainMarker color={markerColor ?? color} moving={markerMoving} />
+      </View>
     ) : null}
   </View>
 );
@@ -312,7 +543,10 @@ const StopRow = ({
   isCurrent,
   departed,
   chevron,
+  markerMoving,
   fallbackLineColor,
+  elevated,
+  onLayoutTop,
 }: {
   station: Station;
   isFirst: boolean;
@@ -320,7 +554,10 @@ const StopRow = ({
   isCurrent: boolean;
   departed: boolean;
   chevron: ChevronPosition;
+  markerMoving: boolean;
   fallbackLineColor: string;
+  elevated?: boolean;
+  onLayoutTop?: (y: number) => void;
 }) => {
   const isPass = getIsPass(station);
   // 直通運転で路線が変わったら縦棒も直通先のラインカラーで塗る
@@ -328,6 +565,13 @@ const StopRow = ({
   const accentColor = useMemo(
     () => readableAccentColor(lineColor),
     [lineColor]
+  );
+  // 列車が過ぎた線路(departed)だけを不透明の淡い色でフェードする(半透明だと
+  // 縦棒とリングの重なりが濃くなるため不透明のままフェード)。テキストは
+  // stopBody の opacity でフェードする。
+  const trackColor = useMemo(
+    () => (departed ? departedTrackColor(lineColor) : lineColor),
+    [departed, lineColor]
   );
   const getStationNumberIndex = useStationNumberIndexFunc();
   const transferLines = useTransferLinesFromStation(station, {
@@ -344,68 +588,155 @@ const StopRow = ({
 
   return (
     <View
-      style={[styles.stopRow, departed && styles.stopRowDeparted]}
+      style={[styles.stopRow, elevated && styles.stopRowElevated]}
       testID={`stop-row-${station.id}`}
+      onLayout={
+        onLayoutTop ? (e) => onLayoutTop(e.nativeEvent.layout.y) : undefined
+      }
     >
       <View style={styles.trackColumn}>
-        <TrackSegment color={lineColor} hidden={isFirst} chevron={chevron} />
+        {/* 全駅表示なので上側は始発駅(isFirst)、下側は終点(isLast)でのみ
+            隠す。中間駅は前後の駅と線が繋がる。 */}
+        <TrackSegment
+          color={trackColor}
+          markerColor={lineColor}
+          markerMoving={markerMoving}
+          hidden={isFirst}
+          chevron={chevron}
+          lineTestID={`track-top-${station.id}`}
+        />
         {isPass ? (
-          <View style={[styles.passDot, { borderColor: lineColor }]} />
+          <View style={[styles.passDot, { borderColor: trackColor }]} />
         ) : (
           <View
-            style={[
-              styles.stopDot,
-              { borderColor: lineColor },
-              isCurrent && { backgroundColor: lineColor },
-            ]}
+            style={[styles.stopDot, { borderColor: trackColor }]}
             testID={`stop-dot-${station.id}`}
           />
         )}
-        <TrackSegment color={lineColor} hidden={isLast} />
+        <TrackSegment
+          color={trackColor}
+          hidden={isLast}
+          lineTestID={`track-bottom-${station.id}`}
+        />
       </View>
-      <View style={styles.stopBody}>
+      <View
+        style={[styles.stopBody, departed && styles.stopBodyDeparted]}
+        testID={`stop-body-${station.id}`}
+      >
+        {/* 駅名を行の縦中央に置き、丸(縦棒の中央)と真横に揃える。
+            番号・乗換ドットは駅名の下に絶対配置して行の高さに影響させない。 */}
+        <View style={styles.stopLabel}>
+          <Typography
+            numberOfLines={1}
+            style={[
+              styles.stopName,
+              isCurrent && [styles.stopNameCurrent, { color: accentColor }],
+              isPass && styles.stopNamePass,
+            ]}
+          >
+            {stationName}
+          </Typography>
+          <View style={styles.stopSubInfo}>
+            {stationNumber ? (
+              <Typography
+                style={[
+                  styles.stopNumbering,
+                  isPass && styles.stopNumberingPass,
+                ]}
+              >
+                {stationNumber}
+              </Typography>
+            ) : null}
+            {/* 乗り換えドットの行は常に同じ高さを確保する(ドットは有るときだけ描画)。 */}
+            <View style={styles.transferDotsRow}>
+              {!isPass &&
+                transferLines.slice(0, 8).map((line) => (
+                  <View
+                    key={line.id}
+                    style={[
+                      styles.transferDot,
+                      {
+                        backgroundColor: line.color ?? COLORS.fallbackAccent,
+                      },
+                    ]}
+                  />
+                ))}
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+// ヘッダーの駅名。長い駅名はフォントサイズを縮小せず、横方向に圧縮(長体)して
+// 1行に収める。自然幅を非表示テキストで測り、スロット幅に収まる scaleX を当てる。
+const StationName = ({
+  text,
+  withNumbering,
+}: {
+  text: string;
+  withNumbering: boolean;
+}) => {
+  const [availableWidth, setAvailableWidth] = useState(0);
+  const [naturalWidth, setNaturalWidth] = useState(0);
+  const scaleX =
+    availableWidth > 0 && naturalWidth > availableWidth
+      ? availableWidth / naturalWidth
+      : 1;
+
+  return (
+    <View
+      testID="portrait-station-name-slot"
+      style={[
+        styles.stationNameSlot,
+        withNumbering && styles.stationNameSlotWithNumbering,
+      ]}
+      onLayout={(e) =>
+        setAvailableWidth(e.nativeEvent.layout.width - (withNumbering ? 8 : 0))
+      }
+    >
+      {/* 自然幅の測定用(非表示)。幅無制限のコンテナでラップして、親スロットの
+          幅制約による省略を避け、テキスト本来の幅を測る。 */}
+      <View style={styles.stationNameMeasure} pointerEvents="none">
         <Typography
           numberOfLines={1}
-          style={[
-            styles.stopName,
-            isCurrent && [styles.stopNameCurrent, { color: accentColor }],
-            isPass && styles.stopNamePass,
-          ]}
+          style={styles.stationNameText}
+          onLayout={(e) => setNaturalWidth(e.nativeEvent.layout.width)}
         >
-          {stationName}
+          {text}
         </Typography>
-        {stationNumber ? (
-          <Typography style={styles.stopNumbering}>{stationNumber}</Typography>
-        ) : null}
-        {!isPass && transferLines.length > 0 ? (
-          <View style={styles.transferDotsRow}>
-            {transferLines.slice(0, 8).map((line) => (
-              <View
-                key={line.id}
-                style={[
-                  styles.transferDot,
-                  { backgroundColor: line.color ?? COLORS.fallbackAccent },
-                ]}
-              />
-            ))}
-          </View>
-        ) : null}
       </View>
-      {isPass ? (
-        <Typography style={styles.passLabel}>
-          {translate('passStationLabel')}
-        </Typography>
-      ) : null}
+      {/* 表示用。自然幅(width)を与えて省略させず、左基準で横圧縮して
+          スロット内に収める(はみ出しはスロットの overflow:hidden でクリップ)。 */}
+      <Typography
+        numberOfLines={1}
+        testID="portrait-station-name"
+        style={[
+          styles.stationNameText,
+          naturalWidth > 0 && {
+            width: naturalWidth,
+            transform: [{ scaleX }],
+            transformOrigin: 'left center',
+          },
+        ]}
+      >
+        {text}
+      </Typography>
     </View>
   );
 };
 
 const PortraitMain: React.FC = () => {
   const commonData = useHeaderCommonData();
-  const leftStations = useAtomValue(leftStationsAtom);
+  const allStations = useAtomValue(stationsAtom);
+  const selectedDirection = useAtomValue(selectedDirectionAtom);
+  const currentStation = useCurrentStation();
   const arrived = useAtomValue(arrivedAtom);
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
+  // 行先は言語切り替えタイマーで多言語化せず日本語固定で表示する
+  const boundText = useBoundText().JA;
 
   const lineColor = currentLine?.color ?? COLORS.fallbackAccent;
   const accentColor = useMemo(
@@ -439,24 +770,67 @@ const PortraitMain: React.FC = () => {
     [trainType?.name, trainType?.nameRoman]
   );
 
-  const stops = useMemo(
-    () => leftStations.filter((s): s is Station => !!s),
-    [leftStations]
+  // ポートレートでは路線の全駅を進行方向順(上から下)に表示する。
+  // 2路線の接続駅の重複を dropEitherJunctionStation で除いたうえで、
+  // INBOUND は index 増加方向へ進むので昇順のまま、OUTBOUND は index 減少
+  // 方向へ進むので反転する(useRefreshLeftStations と同じ向き)。
+  const stops = useMemo(() => {
+    const list = allStations.filter((s): s is Station => !!s);
+    const dropped = dropEitherJunctionStation(list, selectedDirection);
+    return selectedDirection === 'OUTBOUND' ? [...dropped].reverse() : dropped;
+  }, [allStations, selectedDirection]);
+
+  // 現在の最寄り駅(列車位置)の index。
+  const currentIndex = useMemo(
+    () => stops.findIndex((s) => s.groupId === currentStation?.groupId),
+    [stops, currentStation]
   );
 
-  // 強調する駅。停車中は先頭駅、発車後はヘッダーの「次は」と同じ次の停車駅。
+  // 強調する停車駅。停車中は現在駅(停車駅)、発車後・通過中は次の停車駅。
   const currentStopIndex = useMemo(
-    () => stops.findIndex((s, i) => (i > 0 || arrived) && !getIsPass(s)),
-    [arrived, stops]
+    () =>
+      stops.findIndex((s, i) => {
+        if (i < currentIndex) {
+          return false;
+        }
+        if (i === currentIndex && !arrived) {
+          return false;
+        }
+        return !getIsPass(s);
+      }),
+    [stops, currentIndex, arrived]
   );
 
   // 列車位置の三角(進行方向=下向き)。停車中は現在駅のドット直上、
-  // 発車後は発車済み駅(半透明)と次駅の境目=透明度が切り替わる位置に出す。
-  // 発車後に先頭行へ置くと行ごと半透明になってしまうので次の行の上端に置く。
-  const chevronRowIndex = arrived ? 0 : 1;
+  // 発車後は現在駅と次駅の境目=透明度が切り替わる位置(次駅行の上端)に出す。
+  const chevronRowIndex = arrived ? currentIndex : currentIndex + 1;
   const chevronPosition: ChevronPosition = arrived
     ? 'above-dot'
     : 'segment-top';
+
+  // 走行中(!arrived)または通過中(現在駅が通過駅)はピンを上下にバウンスさせて
+  // 停車中との違いを示す。
+  const markerMoving = !arrived || getIsPass(stops[currentIndex] ?? undefined);
+
+  // listHeight はコンテンツ(全駅)の高さで光のスライド用。rowYs は各行の上端 y を
+  // 記録する(onLayout は行のレイアウト時にしか発火しないので、currentIndex 変更で
+  // コールバックが別行に移っても再取得できない。全行を記録しておき index で引く)。
+  const [listHeight, setListHeight] = useState(0);
+  const [rowYs, setRowYs] = useState<Record<number, number>>({});
+  const chevronRowY = rowYs[chevronRowIndex] ?? 0;
+
+  // 駅が変わるたびにスクロールする。現在駅の1つ前の駅が見える程度の余白
+  // (1行分)を上に残し、現在駅をその下に置く。
+  const scrollRef = useRef<ScrollView>(null);
+  useEffect(() => {
+    const y = rowYs[currentIndex];
+    if (y != null) {
+      scrollRef.current?.scrollTo({
+        y: Math.max(0, STOP_LIST_PADDING_V + y - STOP_ROW_HEIGHT),
+        animated: true,
+      });
+    }
+  }, [rowYs, currentIndex]);
 
   if (!commonData) {
     return <View style={styles.root} />;
@@ -465,10 +839,13 @@ const PortraitMain: React.FC = () => {
   const {
     stateText,
     stationText,
-    boundText,
     currentStationNumber,
     numberingColor,
+    headerState,
   } = commonData;
+
+  // 停車中の英中韓 state を補完する
+  const displayStateText = resolveStateText(stateText, headerState);
 
   return (
     <SafeAreaView style={styles.root}>
@@ -509,7 +886,7 @@ const PortraitMain: React.FC = () => {
           numberOfLines={1}
           style={[styles.stateText, { color: accentColor }]}
         >
-          {stateText}
+          {displayStateText}
         </Typography>
         <View style={styles.stationNameRow}>
           {currentStationNumber ? (
@@ -522,34 +899,52 @@ const PortraitMain: React.FC = () => {
               />
             </View>
           ) : null}
-          <Typography
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            style={[
-              styles.stationName,
-              currentStationNumber && styles.stationNameWithNumbering,
-            ]}
-          >
-            {stationText}
-          </Typography>
+          <StationName
+            text={stationText}
+            withNumbering={!!currentStationNumber}
+          />
         </View>
       </View>
 
       {/* 停車駅リスト */}
       <View style={styles.stopList}>
-        <ScrollView contentContainerStyle={styles.stopListContent}>
-          {stops.map((station, index) => (
-            <StopRow
-              key={station.id}
-              station={station}
-              isFirst={index === 0}
-              isLast={index === stops.length - 1}
-              isCurrent={index === currentStopIndex}
-              departed={index === 0 && !arrived}
-              chevron={index === chevronRowIndex ? chevronPosition : null}
-              fallbackLineColor={lineColor}
-            />
-          ))}
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={styles.stopListContent}
+        >
+          {/* 行と光を同じ座標系・スタッキング文脈に置くラッパー。光は縦棒の
+              上(zIndex 1)、列車マーカーの行はさらに上(zIndex 2)に重なる。 */}
+          <View onLayout={(e) => setListHeight(e.nativeEvent.layout.height)}>
+            {stops.map((station, index) => {
+              // 列車位置のピンより前の行(過ぎた線路)を半透明にする。停車中・
+              // 走行中とも、ピンの行とそれ以降は通常色のまま(ピンの位置から
+              // 先は薄くしない)。
+              const departed = index < chevronRowIndex;
+              return (
+                <StopRow
+                  key={station.id}
+                  station={station}
+                  isFirst={index === 0}
+                  isLast={index === stops.length - 1}
+                  isCurrent={index === currentStopIndex}
+                  departed={departed}
+                  chevron={index === chevronRowIndex ? chevronPosition : null}
+                  markerMoving={markerMoving}
+                  fallbackLineColor={lineColor}
+                  elevated={index === chevronRowIndex}
+                  onLayoutTop={(y) =>
+                    setRowYs((prev) =>
+                      prev[index] === y ? prev : { ...prev, [index]: y }
+                    )
+                  }
+                />
+              );
+            })}
+            {/* 列車位置(透明度の境界)から下端まで流れる一筋の光 */}
+            {listHeight > 0 ? (
+              <TrackLight startY={chevronRowY} height={listHeight} />
+            ) : null}
+          </View>
         </ScrollView>
       </View>
     </SafeAreaView>

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -606,7 +606,7 @@ const StopRow = ({
           lineTestID={`track-top-${station.id}`}
         />
         {isPass ? (
-          <View style={[styles.passDot, { borderColor: trackColor }]} />
+          <View style={styles.passDot} />
         ) : (
           <View
             style={[styles.stopDot, { borderColor: trackColor }]}


### PR DESCRIPTION
## 概要

試験的機能のポートレートモード(`PortraitMain`)を、次の停車駅までの表示から路線の全駅表示へ刷新しました。あわせて列車位置マーカー(地図ピン型)、現在駅への自動スクロール、路線色を活かした配色、走行/停車状態の表現などを追加・改善しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `leftStations`(次の停車駅まで)ベースから `stationsAtom`(路線の全駅)ベースへ変更し、進行方向順に全駅を表示。接続駅の重複は `dropEitherJunctionStation` で除去
- 列車位置マーカーを下向きの地図ピン型(`react-native-svg` で描画、白縁取り付き)で実装。直通先のラインカラーにも追従
- 駅到着のたびに現在駅を表示領域の上(1駅前が見える位置)へ自動スクロール
- ピンより前(過ぎた線路)を半透明にし、ピンの中央を境界に過去/未来を表現。停車中はピンの位置から先を薄くしない
- 走行中・通過中はピンを上下にバウンス、停車中はパルス(拡大縮小)で「いまここ」を表現
- 縦棒に沿って光が一筋流れるアニメーションを追加(ピンの位置から下端へ)
- 配色を刷新: 状態テキスト・現在駅名を路線色アクセントに、種別バッジを種別色塗りに、駅名セクションに路線色の淡いティント、通過駅をより淡い色に
- 停車中の英中韓の状態テキスト(「ただいま停車中」)を補完表示、行先は日本語固定に
- 駅名はフォント縮小ではなく横圧縮(長体)で1行に収めるよう変更
- 縦棒を太く(22px)し、駅の丸・通過駅マーカーの幾何を整理。駅名リストの丸を駅名の真横に揃え、乗換の有無で行高が変わらないよう調整
- 上記に対応するテストを追加・更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ポートレート駅リストを全面刷新：駅名は縮小せず横方向に圧縮して1行表示、レイアウトと重なりを見直し
  * 列車マーカーを再設計：停車は脈動、走行/通過はバウンス、縦棒上の光の流れを行位置に合わせて制御
  * 停車／通過の視覚表現を統一（色・ドット・縦棒の強調）、ナンバリング有無での余白も調整

* **テスト**
  * 表示・強調・レイアウト・多言語表記・ピン前の淡色表示などのUI検証を拡張・調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->