### PR TITLE
ポートレートモードのセーフエリア描画調整と駅名の見切れ修正

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -1,6 +1,5 @@
-import { render, within } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
-import type React from 'react';
 import { StyleSheet } from 'react-native';
 import { type Station, StopCondition } from '~/@types/graphql';
 import {
@@ -21,10 +20,6 @@ import PortraitMain from './PortraitMain';
 jest.mock('~/translation', () => ({
   isJapanese: true,
   translate: (key: string) => key,
-}));
-
-jest.mock('react-native-safe-area-context', () => ({
-  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 jest.mock('./NumberingIcon', () => () => null);
@@ -135,6 +130,48 @@ describe('PortraitMain', () => {
     expect(getByTestId('portrait-station-name').props.children).toBe(
       '高輪ゲートウェイ'
     );
+  });
+
+  it('駅名がスロットに収まるときは末尾欠け防止のバッファ分だけ余白を取り横圧縮しない', () => {
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    // スロット幅 300 に対し自然幅 200 ならバッファ込み 208 でも収まる
+    fireEvent(getByTestId('portrait-station-name-slot'), 'layout', {
+      nativeEvent: { layout: { width: 300 } },
+    });
+    fireEvent(getByTestId('portrait-station-name-measure'), 'textLayout', {
+      nativeEvent: { lines: [{ width: 200 }] },
+    });
+
+    const style = StyleSheet.flatten(
+      getByTestId('portrait-station-name').props.style
+    );
+    expect(style.width).toBe(208);
+    expect(style.transform).toEqual([{ scaleX: 1 }]);
+  });
+
+  it('駅名がスロットをはみ出すときはバッファ込みの描画幅を基準に左基準で横圧縮する', () => {
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '高輪ゲートウェイ', StopCondition.All, 'JY-26'),
+    ]);
+
+    // ナンバリングありのスロットは onLayout 値から 8px を差し引く
+    fireEvent(getByTestId('portrait-station-name-slot'), 'layout', {
+      nativeEvent: { layout: { width: 108 } },
+    });
+    fireEvent(getByTestId('portrait-station-name-measure'), 'textLayout', {
+      nativeEvent: { lines: [{ width: 392 }] },
+    });
+
+    const style = StyleSheet.flatten(
+      getByTestId('portrait-station-name').props.style
+    );
+    // 描画幅 = 392 + 8(バッファ) = 400、利用可能幅 = 108 - 8 = 100
+    expect(style.width).toBe(400);
+    expect(style.transform).toEqual([{ scaleX: 100 / 400 }]);
+    expect(style.transformOrigin).toBe('left center');
   });
 
   it('停車駅リストに通過駅も含めて駅名とナンバリングを表示する', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -12,7 +12,6 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Circle, Path, Svg } from 'react-native-svg';
 import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
@@ -847,7 +846,9 @@ const PortraitMain: React.FC = () => {
   const displayStateText = resolveStateText(stateText, headerState);
 
   return (
-    <SafeAreaView style={styles.root}>
+    // ポートレート時は上下のセーフエリアを無視して全画面に描画する。
+    // ステータスバーは非表示のため SafeAreaView は使わず素の View を使う。
+    <View style={styles.root}>
       {/* 路線・行き先情報 */}
       <View style={styles.lineSection}>
         <View style={[styles.lineColorBar, { backgroundColor: lineColor }]} />
@@ -946,7 +947,7 @@ const PortraitMain: React.FC = () => {
           </View>
         </ScrollView>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -3,7 +3,14 @@ import { useAtomValue } from 'jotai';
 import { darken, getLuminance, mix, rgba } from 'polished';
 import type React from 'react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import {
+  type LayoutChangeEvent,
+  type NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  type TextLayoutEventData,
+  View,
+} from 'react-native';
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -115,6 +122,15 @@ const CONTENT_INSET = 24;
 // 描画せず、その分を駅名表示に充てる。行の minHeight にも流用し、
 // ナンバリングの有無で駅名セクションの高さが変わらないようにする。
 const NUMBERING_COLUMN_WIDTH = isTablet ? 72 * 1.5 : 72;
+
+// 日本語グリフでネイティブのテキスト計測幅がわずかに過小評価されると、
+// 表示用 Typography に計測幅ぴったりの width を与えたとき末尾の文字が
+// 欠ける。HeaderStationName と同じく計測幅にこの分を加えて余白を確保する。
+const STATION_NAME_MEASURE_BUFFER = 8;
+
+// 駅名の自然幅を測る非表示コンテナの幅。どんなに長い駅名でも打ち切られない
+// よう十分大きく取る。フォールバック計測でこの値以上なら未確定とみなす。
+const STATION_NAME_MEASURE_WIDTH = 10000;
 
 // トラック列と縦棒の幅。一筋の光(trackLight)を縦棒の x 位置・幅に合わせる
 // ためにも使う。
@@ -231,7 +247,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     top: 0,
-    width: 1000,
+    width: STATION_NAME_MEASURE_WIDTH,
     alignItems: 'flex-start',
     opacity: 0,
   },
@@ -678,11 +694,42 @@ const StationName = ({
   withNumbering: boolean;
 }) => {
   const [availableWidth, setAvailableWidth] = useState(0);
-  const [naturalWidth, setNaturalWidth] = useState(0);
+  // 計測値は対象テキストとセットで保持し、駅名が変わった直後に前の駅名の
+  // 幅で圧縮してしまわないようにする。
+  const [measured, setMeasured] = useState({ text: '', width: 0 });
+  const measuredWidth = measured.text === text ? measured.width : 0;
+  // 末尾欠けを防ぐためのバッファを足した描画幅。スロット幅を超えるぶんだけ
+  // 左基準で横圧縮(長体)して 1 行に収める。
+  const renderWidth =
+    measuredWidth > 0 ? measuredWidth + STATION_NAME_MEASURE_BUFFER : 0;
   const scaleX =
-    availableWidth > 0 && naturalWidth > availableWidth
-      ? availableWidth / naturalWidth
+    availableWidth > 0 && renderWidth > availableWidth
+      ? availableWidth / renderWidth
       : 1;
+
+  const handleTextLayout = (
+    e: NativeSyntheticEvent<TextLayoutEventData>
+  ): void => {
+    const width = e.nativeEvent.lines.reduce(
+      (max, line) => Math.max(max, line.width),
+      0
+    );
+    setMeasured((prev) =>
+      prev.text === text && prev.width === width ? prev : { text, width }
+    );
+  };
+
+  // onTextLayout が発火しない環境向けのフォールバック。計測専用コンテナは
+  // 十分広いので、その幅未満ならテキスト本来の幅とみなす。
+  const handleMeasureLayout = (e: LayoutChangeEvent): void => {
+    const width = e.nativeEvent.layout.width;
+    if (width <= 0 || width >= STATION_NAME_MEASURE_WIDTH) {
+      return;
+    }
+    setMeasured((prev) =>
+      prev.text === text && prev.width >= width ? prev : { text, width }
+    );
+  };
 
   return (
     <View
@@ -700,21 +747,23 @@ const StationName = ({
       <View style={styles.stationNameMeasure} pointerEvents="none">
         <Typography
           numberOfLines={1}
+          testID="portrait-station-name-measure"
           style={styles.stationNameText}
-          onLayout={(e) => setNaturalWidth(e.nativeEvent.layout.width)}
+          onLayout={handleMeasureLayout}
+          onTextLayout={handleTextLayout}
         >
           {text}
         </Typography>
       </View>
-      {/* 表示用。自然幅(width)を与えて省略させず、左基準で横圧縮して
+      {/* 表示用。描画幅(width)を与えて省略させず、左基準で横圧縮して
           スロット内に収める(はみ出しはスロットの overflow:hidden でクリップ)。 */}
       <Typography
         numberOfLines={1}
         testID="portrait-station-name"
         style={[
           styles.stationNameText,
-          naturalWidth > 0 && {
-            width: naturalWidth,
+          renderWidth > 0 && {
+            width: renderWidth,
             transform: [{ scaleX }],
             transformOrigin: 'left center',
           },


### PR DESCRIPTION
## 概要

ポートレートモード（`PortraitMain`）の描画を 2 点修正する。

1. 上下のセーフエリア分の余白が空いてしまっていたため、画面全体に描画されるようにする。
2. 長い駅名の末尾が右端で見切れていたため、横圧縮（長体）が正しく効くようにする。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `PortraitMain` のルート要素を `SafeAreaView` から素の `View` に置き換え、ポートレート時に上下のセーフエリアを無視して全画面に描画するようにした（不要になった `react-native-safe-area-context` の import も削除）。`PortraitMain` は縦向き時のみ描画される専用コンポーネントで、ステータスバーも `index.tsx` で非表示化されているため `SafeAreaView` は不要だった。
- 駅名（`StationName`）の幅計測を `onTextLayout`（行幅）ベースに変更し、`HeaderStationName` と同じく計測幅にバッファ（8px）を加えてから横圧縮の基準幅とした。日本語グリフでネイティブ計測幅がわずかに過小評価されることで、計測幅ぴったりの `width` を与えた表示テキストの末尾が欠けていたのを防ぐ。
- 計測用コンテナ幅を定数化し、長い駅名でも打ち切られないよう拡張した。
- 上記の挙動（収まるときは圧縮しない／はみ出すときはバッファ込みの描画幅を基準に左基準で横圧縮）を検証するテストを追加した。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`PortraitMain.test.tsx`（13 件）すべてパスを確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ポートレート画面の外側レイアウトを調整しました。
  * 駅名表示の計測・描画ロジックを見直し、末尾の欠け防止のための余白反映と、必要時の横圧縮動作を改善しました。
* **Tests**
  * 駅名がスロット内に収まる/収まらない場合のレイアウト挙動を検証するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->