### PR TITLE
ポートレートモードのセーフエリア対応と圧縮した駅名(ひらがな表記)が右へ寄る不具合を修正

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -180,7 +180,9 @@ describe('PortraitMain', () => {
     // 描画幅 = 392 + 8(バッファ) = 400、利用可能幅 = 108 - 8 = 100
     expect(style.width).toBe(400);
     expect(style.transform).toEqual([{ scaleX: 100 / 400 }]);
-    expect(style.transformOrigin).toBe('left center');
+    // 左端基準で圧縮する。数値配列形式 [x, y, z] で指定し、New Architecture でも
+    // 確実に左端アンカーになるようにする(2 値キーワード文字列は中央へフォールバックする)。
+    expect(style.transformOrigin).toEqual([0, '50%', 0]);
   });
 
   it('停車駅リストに通過駅も含めて駅名とナンバリングを表示する', () => {

--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -22,6 +22,15 @@ jest.mock('~/translation', () => ({
   translate: (key: string) => key,
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: jest.fn(() => ({
+    top: 59,
+    right: 0,
+    bottom: 34,
+    left: 0,
+  })),
+}));
+
 jest.mock('./NumberingIcon', () => () => null);
 
 jest.mock('~/hooks', () => ({
@@ -357,6 +366,24 @@ describe('PortraitMain', () => {
 
     // translate はモックでキーをそのまま返す
     expect(getByText('nowStoppingAtEn')).toBeTruthy();
+  });
+
+  it('上端は Dynamic Island、下端はホームインジケータと被らないようセーフエリア分の余白を取る', () => {
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    // 上端: 路線セクションが Dynamic Island に潜らないよう root に paddingTop
+    expect(
+      StyleSheet.flatten(getByTestId('portrait-root').props.style).paddingTop
+    ).toBe(59);
+    // 下端: スクロール末尾でも最終駅がホームインジケータに被らないよう
+    // リスト内容に通常の下パディング + セーフエリア下端を足す
+    expect(
+      StyleSheet.flatten(
+        getByTestId('portrait-stop-list').props.contentContainerStyle
+      ).paddingBottom
+    ).toBe(12 + 34);
   });
 
   it('ヘッダーデータが揃っていない間は何も表示しない', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -19,6 +19,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Circle, Path, Svg } from 'react-native-svg';
 import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
@@ -776,6 +777,10 @@ const StationName = ({
 };
 
 const PortraitMain: React.FC = () => {
+  // ステータスバー非表示で全画面描画するため SafeAreaView は使わないが、
+  // Dynamic Island / ノッチやホームインジケータと表示が被らないよう、
+  // 上下のセーフエリア分を padding として確保する。
+  const insets = useSafeAreaInsets();
   const commonData = useHeaderCommonData();
   const allStations = useAtomValue(stationsAtom);
   const selectedDirection = useAtomValue(selectedDirectionAtom);
@@ -895,9 +900,13 @@ const PortraitMain: React.FC = () => {
   const displayStateText = resolveStateText(stateText, headerState);
 
   return (
-    // ポートレート時は上下のセーフエリアを無視して全画面に描画する。
     // ステータスバーは非表示のため SafeAreaView は使わず素の View を使う。
-    <View style={styles.root}>
+    // 上端は Dynamic Island / ノッチと路線セクションが被らないよう、
+    // セーフエリア上端ぶんの padding を確保する。
+    <View
+      testID="portrait-root"
+      style={[styles.root, { paddingTop: insets.top }]}
+    >
       {/* 路線・行き先情報 */}
       <View style={styles.lineSection}>
         <View style={[styles.lineColorBar, { backgroundColor: lineColor }]} />
@@ -959,7 +968,13 @@ const PortraitMain: React.FC = () => {
       <View style={styles.stopList}>
         <ScrollView
           ref={scrollRef}
-          contentContainerStyle={styles.stopListContent}
+          testID="portrait-stop-list"
+          contentContainerStyle={[
+            styles.stopListContent,
+            // スクロール末尾でも最終駅がホームインジケータに被って
+            // 見切れないよう、下端のセーフエリア分を余白として足す。
+            { paddingBottom: STOP_LIST_PADDING_V + insets.bottom },
+          ]}
         >
           {/* 行と光を同じ座標系・スタッキング文脈に置くラッパー。光は縦棒の
               上(zIndex 1)、列車マーカーの行はさらに上(zIndex 2)に重なる。 */}

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -766,7 +766,11 @@ const StationName = ({
           renderWidth > 0 && {
             width: renderWidth,
             transform: [{ scaleX }],
-            transformOrigin: 'left center',
+            // 左端を基準に横圧縮する。2 値のキーワード文字列('left center')は
+            // New Architecture でパースされず中央基準にフォールバックし、圧縮した
+            // 駅名(主に文字数の多いひらがな表記)が右へ寄ってしまう。数値配列形式
+            // [x, y, z] で指定するとパースを介さず確実に左端基準になる。
+            transformOrigin: [0, '50%', 0],
           },
         ]}
       >


### PR DESCRIPTION
## 概要

ポートレートモード（`PortraitMain`）の表示崩れを 2 点修正します。

1. 画面最上部の路線セクションが Dynamic Island／ノッチと重なって表示されていた問題を、セーフエリア分の `padding` を確保することで解消。あわせて、停車駅リストをスクロールした際に最終駅がホームインジケータに被って見切れないよう、下端にもセーフエリア分の余白を足す。
2. 横幅に収まらない駅名（主に文字数の多いひらがな表記）が、横圧縮時に左端ではなく中央基準で縮小され右へ寄ってしまう不具合を修正。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `PortraitMain` で `useSafeAreaInsets` を導入。
- ルート View に `paddingTop: insets.top` を付与し、路線セクションが Dynamic Island／ノッチに潜らないようにした。
- 停車駅リスト（`ScrollView`）の `contentContainerStyle` に `paddingBottom: STOP_LIST_PADDING_V + insets.bottom` を足し、スクロール末尾でも最終駅がホームインジケータに被らないようにした。
- 駅名の横圧縮の `transformOrigin` を 2 値キーワード文字列 `'left center'` から数値配列形式 `[0, '50%', 0]` に変更。New Architecture では 2 値キーワード文字列がパースされず中央基準にフォールバックし、圧縮した駅名（文字数の多いひらがな表記など）が右へ寄っていたため、パースを介さず確実に左端基準になるようにした。
- 上記検証用の testID（`portrait-root` / `portrait-stop-list`）を追加し、セーフエリア余白・左端基準の圧縮が適用されることを確認するテストを追加・更新。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * セーフエリア（Dynamic Island/ノッチ等）を考慮した上部余白を適用し、コンテンツの重なりを回避
  * ホームインジケータ付近での見切れを防ぐため、停車駅リストの下部余白を調整
  * 駅名の横圧縮時の基準を見直し、見た目の不整合を抑制
* **Tests**
  * セーフエリアをモックし、余白計算（上部/下部）とレイアウト前提を検証するテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->