### PR TITLE
Androidで長時間オートモード後にTTSが再生されなくなる不具合を修正

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -401,6 +401,12 @@ describe('useTTS', () => {
       ttsEnabledLanguages: ['EN'],
     });
 
+    // 初回 render で prefetch を走らせないことで、2回目発話の fetch を確実に分離する
+    useTTSText.mockReturnValue({
+      text: ['ja text', 'en text'],
+      nextText: [],
+    });
+
     const mockPlayer = createMockPlayer({ autoFinish: true });
     mockCreateAudioPlayer.mockReturnValue(mockPlayer);
 
@@ -416,6 +422,7 @@ describe('useTTS', () => {
     await waitFor(() => {
       expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
     });
+    const fetchCountAfterFirstSpeak = mockFetch.mock.calls.length;
 
     // 次の駅のテキストへ変化させて2回目の発話を発火する
     useTTSText.mockReturnValue({
@@ -437,7 +444,7 @@ describe('useTTS', () => {
     rerender({});
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCountAfterFirstSpeak + 1);
     });
     jest.runAllTimers();
 

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -321,6 +321,33 @@ describe('useTTS', () => {
     warnSpy.mockRestore();
   });
 
+  it('フェッチがハングしても安全タイムアウトで再生パイプラインが解放される', async () => {
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    // 応答もエラーも返さないリクエストを再現（Androidでネットワーク切替や
+    // ドーズ状態に入ると発生し、これまではplayingRefが解放されず
+    // 以降のTTSが一切再生されなくなっていた）
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    // フェッチ段階でも安全タイムアウトが張られており、ハングしても復帰する
+    jest.advanceTimersByTime(300_000);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useTTS] Playback safety timeout reached, force resetting'
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('didJustFinishが届かず再生位置も進まない場合はストール検知で復帰する', async () => {
     const store = createStore();
     store.set(speechState, {

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -179,7 +179,7 @@ describe('useTTS', () => {
 
     expect(calls[0]).toBe('/tmp/tts-id_ja.mp3');
 
-    // EN_PLAYBACK_DELAY_MS 後に EN プレイヤーが生成される
+    // JA 完了後に続けて EN プレイヤーが生成される
     jest.runAllTimers();
 
     await waitFor(() => {

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -73,6 +73,7 @@ const createMockPlayer = (opts?: {
     }),
     pause: jest.fn(),
     remove: jest.fn(),
+    replace: jest.fn(),
     emitStatus: (status: { didJustFinish?: boolean; error?: string }) => {
       playbackStatusListener?.(status);
     },
@@ -381,11 +382,72 @@ describe('useTTS', () => {
       '[ttsAudioPlayer] playback stalled, aborting:',
       '/tmp/tts-id_en.mp3'
     );
-    // ストールしたプレイヤーは破棄され、再生パイプラインが解放される
+    // ストール時は一時停止して再生パイプラインを解放するが、
+    // プレイヤー自体は次の発話で使い回すため破棄しない
     expect(mockPlayer.pause).toHaveBeenCalled();
-    expect(mockPlayer.remove).toHaveBeenCalled();
+    expect(mockPlayer.remove).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+
+  it('2回目以降の発話ではプレイヤーを使い回しreplaceで音源を差し替える', async () => {
+    const { useTTSText } = jest.requireMock('./useTTSText') as {
+      useTTSText: jest.Mock;
+    };
+
+    const store = createStore();
+    store.set(speechState, {
+      ...defaultSpeechState,
+      ttsEnabledLanguages: ['EN'],
+    });
+
+    const mockPlayer = createMockPlayer({ autoFinish: true });
+    mockCreateAudioPlayer.mockReturnValue(mockPlayer);
+
+    const { rerender } = renderHook(() => useTTS(), {
+      wrapper: createWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    // 次の駅のテキストへ変化させて2回目の発話を発火する
+    useTTSText.mockReturnValue({
+      text: ['ja text 2', 'en text 2'],
+      nextText: [],
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: 'tts-id-2',
+          jaAudioContent: 'QQ==',
+          enAudioContent: 'QQ==',
+          jaAudioMimeType: 'audio/mpeg',
+          enAudioMimeType: 'audio/mpeg',
+        },
+      }),
+    });
+    rerender({});
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+    jest.runAllTimers();
+
+    // 2回目はcreateAudioPlayerを呼ばず、既存プレイヤーのreplaceで差し替える
+    await waitFor(() => {
+      expect(mockPlayer.replace).toHaveBeenCalledWith({
+        uri: '/tmp/tts-id-2_en.mp3',
+      });
+    });
+    expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
   });
 
   it('resetFirstSpeechAtom変更時にuseTTSTextへfirstSpeech=trueが同期的に渡される', async () => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,5 +1,5 @@
 import { getIdToken } from '@react-native-firebase/auth';
-import { setAudioModeAsync } from 'expo-audio';
+import { type AudioPlayer, setAudioModeAsync } from 'expo-audio';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { DEV_TTS_API_URL, PRODUCTION_TTS_API_URL } from 'react-native-dotenv';
@@ -81,15 +81,37 @@ export const useTTS = (): void => {
 
   const jaHandleRef = useRef<PlayAudioHandle | null>(null);
   const enHandleRef = useRef<PlayAudioHandle | null>(null);
+  // プレイヤーは使い回す。createAudioPlayerを発話のたびに呼ぶとAndroidの
+  // AudioTrackが枯渇してTTSが停止するため、永続インスタンスをreplace()で再利用する
+  const jaPlayerRef = useRef<AudioPlayer | null>(null);
+  const enPlayerRef = useRef<AudioPlayer | null>(null);
   const playingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // 現在の再生を止める（リスナー/ウォッチドッグを解放し一時停止）が、
+  // 永続プレイヤー自体は破棄せず次の発話で再利用する
   const cleanupAllPlayers = useCallback(() => {
     safeRemoveListener(jaHandleRef.current?.listener ?? null);
     safeRemoveListener(enHandleRef.current?.listener ?? null);
-    safeRemovePlayer(jaHandleRef.current?.player ?? null);
-    safeRemovePlayer(enHandleRef.current?.player ?? null);
+    try {
+      jaPlayerRef.current?.pause();
+    } catch {}
+    try {
+      enPlayerRef.current?.pause();
+    } catch {}
     jaHandleRef.current = null;
     enHandleRef.current = null;
+  }, []);
+
+  // アンマウント時のみ永続プレイヤーをネイティブごと解放する
+  const releaseAllPlayers = useCallback(() => {
+    safeRemoveListener(jaHandleRef.current?.listener ?? null);
+    safeRemoveListener(enHandleRef.current?.listener ?? null);
+    safeRemovePlayer(jaPlayerRef.current);
+    safeRemovePlayer(enPlayerRef.current);
+    jaHandleRef.current = null;
+    enHandleRef.current = null;
+    jaPlayerRef.current = null;
+    enPlayerRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -173,49 +195,55 @@ export const useTTS = (): void => {
       playingRef.current = true;
       armPlaybackWatchdog();
 
+      // 再生終了/失敗時は永続プレイヤーを破棄せず、リスナーだけ解放して一時停止する
+      const stopEn = () => {
+        safeRemoveListener(enHandleRef.current?.listener ?? null);
+        try {
+          enPlayerRef.current?.pause();
+        } catch {}
+        enHandleRef.current = null;
+      };
+      const stopJa = () => {
+        safeRemoveListener(jaHandleRef.current?.listener ?? null);
+        try {
+          jaPlayerRef.current?.pause();
+        } catch {}
+        jaHandleRef.current = null;
+      };
+
       if (!playJapanese && playEnglish) {
         const enCleanup = () => {
-          safeRemovePlayer(enHandleRef.current?.player ?? null);
-          enHandleRef.current = null;
+          stopEn();
           finishPlaying();
         };
 
         enHandleRef.current = playAudio({
           uri: pathEn,
+          player: enPlayerRef.current,
           onFinish: enCleanup,
           onError: () => enCleanup(),
         });
+        enPlayerRef.current = enHandleRef.current.player;
         return;
       }
 
       // JA（+ 任意で EN）再生
-      const removeSoundJa = () => {
-        const handle = jaHandleRef.current;
-        if (handle) {
-          safeRemovePlayer(handle.player);
-          jaHandleRef.current = null;
-        }
-      };
-
       jaHandleRef.current = playAudio({
         uri: pathJa,
+        player: jaPlayerRef.current,
         onFinish: () => {
-          // 日本語プレイヤーはまだremoveしない
-          // コールバック内でremoveするとオーディオセッションが不安定になり
-          // 直後に生成する英語プレイヤーの再生が開始されないことがある
           if (isLoadableRef.current && playEnglish) {
             // 音声セッションが安定するまで短いディレイを入れてから英語を再生
             setTimeout(() => {
               if (!isLoadableRef.current) {
-                removeSoundJa();
+                stopJa();
                 finishPlaying();
                 return;
               }
 
               const enCleanup = () => {
-                safeRemovePlayer(enHandleRef.current?.player ?? null);
-                enHandleRef.current = null;
-                removeSoundJa();
+                stopEn();
+                stopJa();
                 finishPlaying();
               };
 
@@ -224,24 +252,27 @@ export const useTTS = (): void => {
               try {
                 enHandleRef.current = playAudio({
                   uri: pathEn,
+                  player: enPlayerRef.current,
                   onFinish: enCleanup,
                   onError: () => enCleanup(),
                 });
+                enPlayerRef.current = enHandleRef.current.player;
               } catch (e) {
                 console.warn('[useTTS] EN playback failed to start:', e);
                 enCleanup();
               }
             }, EN_PLAYBACK_DELAY_MS);
           } else {
-            removeSoundJa();
+            stopJa();
             finishPlaying();
           }
         },
         onError: () => {
-          removeSoundJa();
+          stopJa();
           finishPlaying();
         },
       });
+      jaPlayerRef.current = jaHandleRef.current.player;
     },
     [
       armPlaybackWatchdog,
@@ -419,8 +450,8 @@ export const useTTS = (): void => {
         clearTimeout(playingTimeoutRef.current);
         playingTimeoutRef.current = null;
       }
-      cleanupAllPlayers();
+      releaseAllPlayers();
       playingRef.current = false;
     };
-  }, [cleanupAllPlayers]);
+  }, [releaseAllPlayers]);
 };

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -30,10 +30,6 @@ import { useTTSText } from './useTTSText';
 // これはウォッチドッグでも捕捉できない異常系に対する最後の砦
 const PLAYBACK_TIMEOUT_MS = 300_000;
 
-// 日本語再生完了後に英語プレイヤーを生成するまでのディレイ（ミリ秒）
-// ネイティブ音声セッションが安定するまで待機し、英語再生の開始失敗を防ぐ
-const EN_PLAYBACK_DELAY_MS = 100;
-
 export const useTTS = (): void => {
   const { enabled, backgroundEnabled, ttsEnabledLanguages } =
     useAtomValue(speechState);
@@ -232,39 +228,31 @@ export const useTTS = (): void => {
         uri: pathJa,
         player: jaPlayerRef.current,
         onFinish: () => {
-          if (isLoadableRef.current && playEnglish) {
-            // 音声セッションが安定するまで短いディレイを入れてから英語を再生
-            setTimeout(() => {
-              if (!isLoadableRef.current) {
-                stopJa();
-                finishPlaying();
-                return;
-              }
-
-              const enCleanup = () => {
-                stopEn();
-                stopJa();
-                finishPlaying();
-              };
-
-              // setTimeoutコールバック内の例外は誰もキャッチしないため、
-              // プレイヤー生成失敗時もここで確実にfinishPlayingへ到達させる
-              try {
-                enHandleRef.current = playAudio({
-                  uri: pathEn,
-                  player: enPlayerRef.current,
-                  onFinish: enCleanup,
-                  onError: () => enCleanup(),
-                });
-                enPlayerRef.current = enHandleRef.current.player;
-              } catch (e) {
-                console.warn('[useTTS] EN playback failed to start:', e);
-                enCleanup();
-              }
-            }, EN_PLAYBACK_DELAY_MS);
-          } else {
+          if (!isLoadableRef.current || !playEnglish) {
             stopJa();
             finishPlaying();
+            return;
+          }
+
+          // プレイヤーを使い回すため、JA完了後すぐに英語へ差し替えて再生する
+          const enCleanup = () => {
+            stopEn();
+            stopJa();
+            finishPlaying();
+          };
+
+          // playAudioが生成・再生開始に失敗してもfinishPlayingへ確実に到達させる
+          try {
+            enHandleRef.current = playAudio({
+              uri: pathEn,
+              player: enPlayerRef.current,
+              onFinish: enCleanup,
+              onError: () => enCleanup(),
+            });
+            enPlayerRef.current = enHandleRef.current.player;
+          } catch (e) {
+            console.warn('[useTTS] EN playback failed to start:', e);
+            enCleanup();
           }
         },
         onError: () => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -56,6 +56,9 @@ export const useTTS = (): void => {
   // 初回放送後にfirstSpeechRef変更で生じるテキスト変化を無視するフラグ
   const suppressPostFirstSpeechRef = useRef(false);
   const playingRef = useRef(false);
+  // 発話ごとに採番する世代ID。タイムアウト・新規発話で古いfetch継続を破棄し、
+  // 解決の遅れた古い音声が後から割り込んで再生されるのを防ぐ
+  const speechRunIdRef = useRef(0);
   const isLoadableRef = useRef(true);
   const pendingRef = useRef<{ textJa: string; textEn: string } | null>(null);
   const speechWithTextRef = useRef<
@@ -154,19 +157,26 @@ export const useTTS = (): void => {
   // playingRefがtrueになった時点で必ず安全タイムアウトを張る。
   // フェッチやトークン取得がハングしてもplayingRefが解放されずTTS全体が
   // 停止するのを防ぐため、再生開始前のフェッチ段階も含めて監視する。
-  const armPlaybackWatchdog = useCallback(() => {
-    if (playingTimeoutRef.current) {
-      clearTimeout(playingTimeoutRef.current);
-    }
-    playingTimeoutRef.current = setTimeout(() => {
-      if (!playingRef.current) {
-        return;
+  const armPlaybackWatchdog = useCallback(
+    (runId: number = speechRunIdRef.current) => {
+      if (playingTimeoutRef.current) {
+        clearTimeout(playingTimeoutRef.current);
       }
-      console.warn('[useTTS] Playback safety timeout reached, force resetting');
-      cleanupAllPlayers();
-      finishPlaying();
-    }, PLAYBACK_TIMEOUT_MS);
-  }, [cleanupAllPlayers, finishPlaying]);
+      playingTimeoutRef.current = setTimeout(() => {
+        if (!playingRef.current || speechRunIdRef.current !== runId) {
+          return;
+        }
+        console.warn(
+          '[useTTS] Playback safety timeout reached, force resetting'
+        );
+        // 世代を進めて、強制リセット後に古いfetch継続が再生へ進むのを無効化する
+        speechRunIdRef.current += 1;
+        cleanupAllPlayers();
+        finishPlaying();
+      }, PLAYBACK_TIMEOUT_MS);
+    },
+    [cleanupAllPlayers, finishPlaying]
+  );
 
   const speakFromPath = useCallback(
     async (pathJa: string, pathEn: string) => {
@@ -281,12 +291,25 @@ export const useTTS = (): void => {
         return;
       }
 
+      // この発話の世代IDを採番。await の合間にタイムアウトや新規発話で世代が
+      // 進んでいたら、古い継続は再生へ進めず破棄する
+      const runId = speechRunIdRef.current + 1;
+      speechRunIdRef.current = runId;
       playingRef.current = true;
       // フェッチやトークン取得がハングした場合でもplayingRefが確実に解放される
       // よう、再生開始前のこの時点から安全タイムアウトを張る
-      armPlaybackWatchdog();
+      armPlaybackWatchdog(runId);
+      // 世代が進んでいる（=この継続はもう無効）場合は何もしない。
+      // playingRefは新しい発話が所有しているため、ここでリセットしてはならない
+      const isStaleRun = () =>
+        speechRunIdRef.current !== runId ||
+        !playingRef.current ||
+        !isLoadableRef.current;
       try {
         const idToken = user && (await getIdToken(user));
+        if (isStaleRun()) {
+          return;
+        }
         if (!idToken) {
           console.warn('[useTTS] idToken is missing, skipping fetch');
           finishPlaying();
@@ -302,6 +325,9 @@ export const useTTS = (): void => {
           enVoiceName: ttsEnVoiceName,
         });
 
+        if (isStaleRun()) {
+          return;
+        }
         if (!fetched) {
           console.warn('[useTTS] Failed to fetch speech audio');
           finishPlaying();
@@ -310,6 +336,9 @@ export const useTTS = (): void => {
 
         await speakFromPath(fetched.pathJa, fetched.pathEn);
       } catch (error) {
+        if (isStaleRun()) {
+          return;
+        }
         console.error('[useTTS] speech error:', error);
         finishPlaying();
       }

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -133,6 +133,23 @@ export const useTTS = (): void => {
     }
   }, []);
 
+  // playingRefがtrueになった時点で必ず安全タイムアウトを張る。
+  // フェッチやトークン取得がハングしてもplayingRefが解放されずTTS全体が
+  // 停止するのを防ぐため、再生開始前のフェッチ段階も含めて監視する。
+  const armPlaybackWatchdog = useCallback(() => {
+    if (playingTimeoutRef.current) {
+      clearTimeout(playingTimeoutRef.current);
+    }
+    playingTimeoutRef.current = setTimeout(() => {
+      if (!playingRef.current) {
+        return;
+      }
+      console.warn('[useTTS] Playback safety timeout reached, force resetting');
+      cleanupAllPlayers();
+      finishPlaying();
+    }, PLAYBACK_TIMEOUT_MS);
+  }, [cleanupAllPlayers, finishPlaying]);
+
   const speakFromPath = useCallback(
     async (pathJa: string, pathEn: string) => {
       if (!isLoadableRef.current) {
@@ -153,22 +170,8 @@ export const useTTS = (): void => {
 
       cleanupAllPlayers();
 
-      if (playingTimeoutRef.current) {
-        clearTimeout(playingTimeoutRef.current);
-      }
-
       playingRef.current = true;
-
-      playingTimeoutRef.current = setTimeout(() => {
-        if (!playingRef.current) {
-          return;
-        }
-        console.warn(
-          '[useTTS] Playback safety timeout reached, force resetting'
-        );
-        cleanupAllPlayers();
-        finishPlaying();
-      }, PLAYBACK_TIMEOUT_MS);
+      armPlaybackWatchdog();
 
       if (!playJapanese && playEnglish) {
         const enCleanup = () => {
@@ -240,7 +243,13 @@ export const useTTS = (): void => {
         },
       });
     },
-    [cleanupAllPlayers, finishPlaying, shouldSpeakEnglish, shouldSpeakJapanese]
+    [
+      armPlaybackWatchdog,
+      cleanupAllPlayers,
+      finishPlaying,
+      shouldSpeakEnglish,
+      shouldSpeakJapanese,
+    ]
   );
 
   const ttsApiUrl = useMemo(() => {
@@ -254,6 +263,9 @@ export const useTTS = (): void => {
       }
 
       playingRef.current = true;
+      // フェッチやトークン取得がハングした場合でもplayingRefが確実に解放される
+      // よう、再生開始前のこの時点から安全タイムアウトを張る
+      armPlaybackWatchdog();
       try {
         const idToken = user && (await getIdToken(user));
         if (!idToken) {
@@ -284,6 +296,7 @@ export const useTTS = (): void => {
       }
     },
     [
+      armPlaybackWatchdog,
       finishPlaying,
       speakFromPath,
       ttsApiUrl,

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -30,6 +30,7 @@ const createMockPlayer = (opts?: { playing?: boolean }) => {
     play: jest.fn(),
     pause: jest.fn(),
     remove: jest.fn(),
+    replace: jest.fn(),
   };
   return {
     player,
@@ -176,6 +177,29 @@ describe('playAudio', () => {
     expect(mockCreateAudioPlayer).toHaveBeenCalledWith({
       uri: '/path/to/audio.mp3',
     });
+  });
+
+  it('既存プレイヤーを渡すと再生成せず replace で音源を差し替える', () => {
+    const mock = createMockPlayer();
+
+    const handle = playAudio({
+      uri: '/path/to/next.mp3',
+      player: mock.player as unknown as Parameters<
+        typeof playAudio
+      >[0]['player'],
+      onFinish: jest.fn(),
+      onError: jest.fn(),
+    });
+
+    // createAudioPlayer は呼ばれず、既存インスタンスが使い回される
+    expect(mockCreateAudioPlayer).not.toHaveBeenCalled();
+    expect(handle.player).toBe(mock.player);
+    // 前回再生をリセットしてから replace し、再生を開始する
+    expect(mock.player.pause).toHaveBeenCalled();
+    expect(mock.player.replace).toHaveBeenCalledWith({
+      uri: '/path/to/next.mp3',
+    });
+    expect(mock.player.play).toHaveBeenCalledTimes(1);
   });
 
   it('再生位置が進まないままの場合はストールとして onError を呼ぶ', () => {

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -31,11 +31,17 @@ export interface PlayAudioHandle {
 
 export const playAudio = (options: {
   uri: string;
+  // 既存プレイヤーを渡すと再生成せず replace() で音源だけ差し替える。
+  // 再生のたびに createAudioPlayer すると Android の ExoPlayer/AudioTrack が
+  // 解放しきれず蓄積し、AudioFlinger がトラックを作れなくなって
+  // (status -12 / NO_MEMORY) TTS が完全停止するため、プレイヤーは使い回す。
+  player?: AudioPlayer | null;
   onFinish: () => void;
   onError: (error: unknown) => void;
 }): PlayAudioHandle => {
   const { uri, onFinish, onError } = options;
-  const player = createAudioPlayer({ uri });
+  const reusing = Boolean(options.player);
+  const player = options.player ?? createAudioPlayer({ uri });
 
   let settled = false;
   let stalledTicks = 0;
@@ -90,6 +96,11 @@ export const playAudio = (options: {
   }, STALL_CHECK_INTERVAL_MS);
 
   try {
+    if (reusing) {
+      // 前回再生の途中状態を確実にリセットしてから音源を差し替える
+      player.pause();
+      player.replace({ uri });
+    }
     player.play();
   } catch (e) {
     settle(() => onError(e));

--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -104,6 +104,33 @@ describe('fetchSpeechAudio', () => {
     expect(result).toBeNull();
   });
 
+  it('リクエストがハングした場合はタイムアウトで中断して null を返す', async () => {
+    jest.useFakeTimers();
+    try {
+      let capturedSignal: AbortSignal | undefined;
+      // 応答もエラーも返さないリクエストを再現し、abort されたら reject する
+      mockFetch.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new Error('Aborted'));
+            });
+          });
+        }
+      );
+
+      const promise = fetchSpeechAudio({ ...defaultOptions, timeoutMs: 1000 });
+      await jest.advanceTimersByTimeAsync(1000);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(capturedSignal?.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('SSML でテキストをラップしてリクエストする', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -1,5 +1,9 @@
 import { mockFetch } from '~/utils/test/ttsMocks';
-import { clearFetchCache, fetchSpeechAudio } from './ttsSpeechFetcher';
+import {
+  clearFetchCache,
+  fetchSpeechAudio,
+  TTS_FETCH_TIMEOUT_MS,
+} from './ttsSpeechFetcher';
 
 const defaultOptions = {
   textJa: 'こんにちは',
@@ -122,6 +126,36 @@ describe('fetchSpeechAudio', () => {
 
       const promise = fetchSpeechAudio({ ...defaultOptions, timeoutMs: 1000 });
       await jest.advanceTimersByTimeAsync(1000);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(capturedSignal?.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('timeoutMs に不正値が渡されてもデフォルトのタイムアウトに正規化する', async () => {
+    jest.useFakeTimers();
+    try {
+      let capturedSignal: AbortSignal | undefined;
+      mockFetch.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new Error('Aborted'));
+            });
+          });
+        }
+      );
+
+      // timeoutMs: 0 は無効値。即座に abort せず既定値まで待つことを検証する
+      const promise = fetchSpeechAudio({ ...defaultOptions, timeoutMs: 0 });
+      await jest.advanceTimersByTimeAsync(0);
+      expect(capturedSignal?.aborted).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(TTS_FETCH_TIMEOUT_MS);
       const result = await promise;
 
       expect(result).toBeNull();

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -125,6 +125,12 @@ export const fetchSpeechAudio = async (
     enVoiceName,
     timeoutMs = TTS_FETCH_TIMEOUT_MS,
   } = options;
+  // 0・負値・NaN・Infinity が明示的に渡された場合もタイムアウト保護が
+  // 効くよう、正の有限値に正規化する
+  const effectiveTimeoutMs =
+    Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : TTS_FETCH_TIMEOUT_MS;
 
   if (!textJa.length || !textEn.length) {
     return null;
@@ -149,7 +155,7 @@ export const fetchSpeechAudio = async (
   };
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort(), effectiveTimeoutMs);
 
   try {
     const response = await fetch(apiUrl, {

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -2,6 +2,11 @@ import { fetch } from 'expo/fetch';
 import { File, Paths } from 'expo-file-system';
 import { base64ToUint8Array } from './base64ToUint8Array';
 
+// ネットワーク切り替えやドーズ状態に入るとリクエストが応答もエラーも返さず
+// 永久にハングすることがある。その場合に呼び出し側(useTTS)のplayingRefが
+// 解放されずTTS全体が停止してしまうため、AbortControllerで上限時間を設ける。
+export const TTS_FETCH_TIMEOUT_MS = 20_000;
+
 export interface FetchSpeechOptions {
   textJa: string;
   textEn: string;
@@ -9,6 +14,7 @@ export interface FetchSpeechOptions {
   idToken: string;
   jaVoiceName?: string;
   enVoiceName?: string;
+  timeoutMs?: number;
 }
 
 const getSampleRateFromMimeType = (mimeType: string): number => {
@@ -110,7 +116,15 @@ export const clearFetchCache = (): void => {
 export const fetchSpeechAudio = async (
   options: FetchSpeechOptions
 ): Promise<{ id: string; pathJa: string; pathEn: string } | null> => {
-  const { textJa, textEn, apiUrl, idToken, jaVoiceName, enVoiceName } = options;
+  const {
+    textJa,
+    textEn,
+    apiUrl,
+    idToken,
+    jaVoiceName,
+    enVoiceName,
+    timeoutMs = TTS_FETCH_TIMEOUT_MS,
+  } = options;
 
   if (!textJa.length || !textEn.length) {
     return null;
@@ -134,6 +148,9 @@ export const fetchSpeechAudio = async (
     },
   };
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
   try {
     const response = await fetch(apiUrl, {
       headers: {
@@ -142,6 +159,7 @@ export const fetchSpeechAudio = async (
       },
       body: JSON.stringify(reqBody),
       method: 'POST',
+      signal: controller.signal,
     });
 
     if (!response.ok) {
@@ -190,5 +208,7 @@ export const fetchSpeechAudio = async (
   } catch (error) {
     console.error('[ttsSpeechFetcher] fetchSpeech error:', error);
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 };


### PR DESCRIPTION
## 概要

Android でオートモードなどを使い TTS を長時間再生し続けると、ある時点から音声がアプリ再起動まで一切再生されなくなる不具合を修正します。ネイティブログで `AudioTrack init failed` / `AudioFlinger could not create track, status: -12`（NO_MEMORY）を確認し、発話のたびに `createAudioPlayer` で新規プレイヤー（ExoPlayer/AudioTrack）を生成していたことによるネイティブ音声トラックの枯渇が主因と特定しました。あわせて、音声フェッチのハングで再生パイプラインが固着するデッドロックも修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- TTS プレイヤーを発話ごとに生成せず、日本語/英語用の永続インスタンスを `replace()` で使い回すよう変更し、AudioTrack 枯渇による再生停止を解消（`ttsAudioPlayer.ts` / `useTTS.ts`）。ネイティブ解放（`remove()`）はアンマウント時のみに限定。
- 音声フェッチ（`ttsSpeechFetcher.ts`）に `AbortController` ベースのタイムアウト（20 秒）を追加。通信切替やドーズ状態でリクエストが応答もエラーも返さずハングしても、`playingRef` が固着して以降の TTS が止まるのを防止。`timeoutMs` は `0`・負値・`NaN`・`Infinity` が渡されても正の有限値に正規化。
- `playingRef` の安全タイムアウトをフェッチ段階から張るよう変更（`armPlaybackWatchdog`）。トークン取得・フェッチのハングでも再生パイプラインが確実に復帰する。
- 発話ごとの世代 ID（`speechRunIdRef`）を導入。各 `await` の後に世代が進んでいれば継続を破棄し、タイムアウト・新規発話の後に解決の遅れた古いフェッチが stale な音声を割り込ませて再生する事故を防止。
- プレイヤー再利用により根拠が消滅した日本語→英語間の 100ms 再生ディレイ（`EN_PLAYBACK_DELAY_MS`）を削除し、日本語の再生完了後すぐ英語を再生。
- 上記に対応するユニットテストを追加・更新（プレイヤー再利用 / フェッチタイムアウト / `timeoutMs` 正規化 / ハング復帰 / ストール時はプレイヤーを破棄せず一時停止）。

### 回帰リスクと対策

- 影響範囲は TTS 再生パイプラインに限定。音声フォーカス喪失や通信ハングからの復帰用ウォッチドッグ（ストール検知・再生セーフティタイムアウト）は別の失敗ケースの保険として維持しています。
- 根本原因はネイティブ音声リソースの枯渇のため、最終確認は実機での長時間オートモード（`AudioTrack init failed` がログに出ず、日本語の直後に英語が続けて再生されること）の検証を推奨します。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
