### PR TITLE
Cloudflare移行ドキュメントを英語へ戻し古い記述を修正

### DIFF
--- a/docs/cloudflare-migration-phase3-checklist.md
+++ b/docs/cloudflare-migration-phase3-checklist.md
@@ -35,7 +35,7 @@ cd functions
 # KV / R2 / Queue を作成し wrangler.jsonc の id・bucket 名を差し替え（dev/prod 両方）
 wrangler kv namespace create TTS_KV       # 他 CONFIG_KV / STATE_KV も
 wrangler r2 bucket create trainlcd-tts-dev # 他 uploads も
-wrangler queues create tts-cache-dev       # 他 feedback-triage も
+wrangler queues create feedback-triage-dev # TTS キャッシュはキューを使わず /tts から R2+KV へ直接書き込み
 # シークレット投入
 wrangler secret put SESSION_JWT_SECRET
 wrangler secret put AZURE_SPEECH_KEY
@@ -47,7 +47,7 @@ wrangler secret put DISCORD_REVIEW_WEBHOOK_URL
 # 数値しきい値の初期投入（KV）
 wrangler kv key put --binding CONFIG_KV 'config:remote' '{"max_permit_accuracy":1500,"force_not_arrived_on_low_accuracy":true}'
 wrangler kv key put --binding CONFIG_KV 'config:maintenance' '{"underMaintenance":false}'
-# few-shot を R2 に配置
+# few-shot を CONFIG_KV に配置
 wrangler kv key put --binding CONFIG_KV "config:fewshot" --path fewshot.jsonl
 # デプロイ
 npm run deploy:dev      # / npm run deploy:prod

--- a/docs/cloudflare-migration-plan.md
+++ b/docs/cloudflare-migration-plan.md
@@ -46,7 +46,7 @@ Google Play レビュー取得は Google Play Developer API（Firebase ではな
 | メソッド/パス | 由来 | 認証 | 概要 |
 | --- | --- | --- | --- |
 | `POST /auth/token` | 新規 | なし（ID 受領） | インストール ID を受け、短期セッション JWT（HS256・Worker シークレット署名）を発行。`sub=installId` |
-| `POST /tts` | `tts` onCall | セッション JWT | callable 互換。KV/R2 キャッシュ照会 → ミス時 Azure 合成 → Queue 投函 |
+| `POST /tts` | `tts` onCall | セッション JWT | callable 互換。KV/R2 キャッシュ照会 → ミス時 Azure 合成 → R2+KV へ直接書込 |
 | `POST /postFeedback` | `enqueueFeedback` | セッション JWT | callable 互換。Queue へ投函 |
 | `POST /feedback/upload-image` | Firebase Storage 代替 | セッション JWT | PNG を受け R2 `report-images/{id}.png` に保存し公開 URL を返す |
 | `GET /config/maintenance` | Firestore 代替 | なし | KV `config:maintenance` → `{ underMaintenance: boolean }` |
@@ -66,12 +66,13 @@ callable 互換: リクエスト `{data:{…}}` を読み、成功は `{result:{
 - クライアント SSML `<speak>…</speak>` の外殻を剥がし `<speak version="1.0" xml:lang="<ja-JP|en-US>"><voice name="<voiceName>">…</voice></speak>` で包み直す。
 - **流用**: `funcs/tts.ts` の `stripSsml`（byte 数検証）、id ハッシュ生成（version=11・キーソート維持。`node:crypto` → `crypto.subtle.digest('SHA-256')` に置換し**入力不変**）、`normalizeRomanText`（`utils/normalize.ts`）。`synthesizeSpeech` は Azure 呼び出しへ全面差替え、出力は常に `audio/mpeg`（`sniffAudioMimeType` 不要）。
 - ボイス名は **Azure ニューラルボイス**（既定例 ja=`ja-JP-NanamiNeural` / en=`en-US-JennyNeural`、vars で可変）。`utils/ttsVoice.ts` は優先順位ロジック（クライアント指定→config→既定）は流用しつつ Google の `-Standard-` ガードを撤去/Azure 妥当性チェックに置換。config は KV `config:tts`（5 分 isolate キャッシュ）。
-- 処理: JWT 検証 → 入力検証（空・SSML 除去後空・4000byte 上限）→ ボイス解決 → id 算出 → KV メタ照会（ヒット時 R2 から ja/en 取得し base64 返却、既存フォールバック踏襲）→ ミス時 Azure 合成 → `ctx.waitUntil(env.TTS_CACHE_QUEUE.send(...))` → `{result:{…}}`。
+- 処理: JWT 検証 → 入力検証（空・SSML 除去後空・4000byte 上限）→ ボイス解決 → id 算出 → KV メタ照会（ヒット時 R2 から ja/en 取得し base64 返却、既存フォールバック踏襲）→ ミス時 Azure 合成 → `ctx.waitUntil(...)` で R2+KV へ直接キャッシュ書込 → `{result:{…}}`。
+
+> **実装上の変更**: 当初は TTS キャッシュ書込も Queue 経由を想定したが、音声が Queues の 128KB 上限に収まらないため、`/tts` ハンドラから R2+KV へ直接書き込む方式に変更した（tts-cache キューは新設しない）。
 
 ### キュー consumer（queue ハンドラ、`batch.queue` で分岐）
 
-- **tts-cache**（`funcs/ttsCachePubSub.ts` 由来）: base64 音声を R2 `caches/tts/{ja,en}/{id}.{ext}` に保存、KV `voice:{id}` にメタ書込。`getCacheFileExtension` 流用。
-- **feedback-triage**（`workers/feedback.ts` 由来）: few-shot を R2（`fewshot.jsonl`）から読み、`SYSTEM_PROMPT`+few-shot を `env.AI.run(<model>, { messages, response_format: json })` に渡す。出力 JSON を既存正規表現で抽出 → `coerceReport` → `looksLikeSpam` 補正 → GitHub Issue 作成（`OCTOKIT_PAT`）→ Discord 通知。**`coerceReport`/`looksLikeSpam`/Issue・Discord 生成ロジックは流用**、AI 呼び出しのみ差替え。Queues は orderingKey 非対応（reporterUid 単位順序は喪失するがトリアージでは許容）。
+- **feedback-triage**（`workers/feedback.ts` 由来）: few-shot を CONFIG_KV（`config:fewshot`）から読み、`SYSTEM_PROMPT`+few-shot を `env.AI.run(<model>, { messages, response_format: json })` に渡す。出力 JSON を既存正規表現で抽出 → `coerceReport` → `looksLikeSpam` 補正 → GitHub Issue 作成（`OCTOKIT_PAT`）→ Discord 通知。**`coerceReport`/`looksLikeSpam`/Issue・Discord 生成ロジックは流用**、AI 呼び出しのみ差替え。Queues は orderingKey 非対応（reporterUid 単位順序は喪失するがトリアージでは許容）。
 
 ### Cron（scheduled ハンドラ、`0 * * * *`）
 
@@ -99,7 +100,7 @@ functions/
     lib/azure/tts.ts        # Azure Speech 合成
     lib/google/accessToken.ts # SA JWT → OAuth(androidpublisher)
     routes/{tts,feedback,uploadImage,config}.ts
-    consumers/{ttsCache,feedbackTriage}.ts
+    consumers/feedbackTriage.ts            # tts-cache は廃止。TTS は /tts から直接書込
     scheduled/{appStoreReviews,googlePlayReviews}.ts
     models/{ai,common,feedback}.ts   # ほぼ無変更で流用
     utils/{normalize,removeMacron,ttsVoice}.ts  # 流用(ttsVoice は Azure 向け微調整)
@@ -108,8 +109,8 @@ functions/
 ### wrangler.jsonc（bindings）
 
 - **KV**: `TTS_KV`（`voice:*` / `config:tts`）、`CONFIG_KV`（`config:maintenance` / `config:remote`）、`STATE_KV`（`state:*`）
-- **R2**: `TTS_BUCKET`（音声 + `fewshot.jsonl`）、`UPLOAD_BUCKET`（`report-images/*`、公開ドメイン必要 → `imageUrl` 用）
-- **Queues**: producers/consumers = `tts-cache`, `feedback-triage`
+- **R2**: `TTS_BUCKET`（音声バイナリ）、`UPLOAD_BUCKET`（`report-images/*`、公開ドメイン必要 → `imageUrl` 用）。few-shot は CONFIG_KV `config:fewshot` に配置
+- **Queues**: producers/consumers = `feedback-triage`（tts-cache は廃止。TTS キャッシュは `/tts` から R2+KV へ直接書込）
 - **AI**: `AI`（Workers AI）
 - **Cron**: `["0 * * * *"]`
 - **vars（非機密）**: `GOOGLE_PLAY_PACKAGE_NAME`, `AZURE_SPEECH_REGION`, AI model 名, 既定 Azure voice 名(ja/en), few-shot 制御値, `UPLOAD_PUBLIC_BASE_URL`

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,46 +1,48 @@
 # TrainLCD Worker (Cloudflare)
 
-TrainLCD のバックエンドを担う Cloudflare Worker。旧 Firebase Cloud Functions を置き換えたもので、
-1 つの Worker に HTTP / キュー / Cron の 3 ハンドラを集約している。
+The Cloudflare Worker that powers the TrainLCD backend. It replaces the former
+Firebase Cloud Functions, consolidating the HTTP, queue, and Cron handlers into a
+single Worker.
 
-## 提供機能
+## Features
 
-- **TTS 合成** (`POST /tts`): Azure Speech で SSML を音声合成し、KV/R2 でキャッシュ
-- **セッション発行** (`POST /auth/token`): インストール ID から短期セッション JWT を発行（Firebase 匿名認証の代替）
-- **フィードバック受付** (`POST /postFeedback`): トリアージキューへ投函
-- **画像アップロード** (`POST /feedback/upload-image`): フィードバック画像を R2 に保存し公開 URL を返す
-- **アプリ設定配信** (`GET /config/maintenance`, `GET /config/remote`): メンテナンス状態と GPS しきい値（Remote Config 代替）
-- **フィードバックトリアージ** (queue `feedback-triage`): Workers AI で要約・分類し、GitHub Issue 作成と Discord 通知
-- **TTS キャッシュ書き込み**: 合成音声を `/tts` ハンドラから R2 + KV へ直接保存（Queues の 128KB 上限に音声が収まらないためキューは使わない）
-- **レビュー通知** (Cron 毎時): App Store / Google Play の新着レビューを Discord へ通知
+- **TTS synthesis** (`POST /tts`): synthesizes SSML into audio via Azure Speech and caches it in KV/R2.
+- **Session issuance** (`POST /auth/token`): issues a short-lived session JWT from an install ID (the replacement for Firebase anonymous auth).
+- **Feedback intake** (`POST /postFeedback`): enqueues feedback onto the triage queue.
+- **Image upload** (`POST /feedback/upload-image`): stores feedback images in R2 and returns a public URL.
+- **App config delivery** (`GET /config/maintenance`, `GET /config/remote`): maintenance status and GPS thresholds (the replacement for Remote Config).
+- **Feedback triage** (queue `feedback-triage`): summarizes and classifies feedback with Workers AI, then creates a GitHub Issue and notifies Discord.
+- **TTS cache writes**: synthesized audio is written directly from the `/tts` handler to R2 + KV (no queue is used, because audio does not fit within the 128 KB Queues limit).
+- **Review notifications** (Cron, hourly): notifies Discord of new App Store / Google Play reviews.
 
-## 技術スタック
+## Tech stack
 
-- **Cloudflare Workers** — `fetch` / `queue` / `scheduled` ハンドラ
-- **Workers KV** — TTS キャッシュメタ・設定・レビュー既読状態
-- **R2** — 音声バイナリ・フィードバック画像・few-shot データ
+- **Cloudflare Workers** — `fetch` / `queue` / `scheduled` handlers
+- **Workers KV** — TTS cache metadata, config, and review read-state
+- **R2** — audio binaries and feedback images
 - **Cloudflare Queues** — `feedback-triage`
-- **Workers AI** — フィードバックトリアージ
-- **Azure Speech** — TTS 合成（SSML）
-- **Google Android Publisher API** — Google Play レビュー取得（サービスアカウント JWT）
+- **Workers AI** — feedback triage
+- **Azure Speech** — TTS synthesis (SSML)
+- **Google Android Publisher API** — Google Play review retrieval (service-account JWT)
 - **TypeScript / Biome / Jest / Wrangler**
 
-## 前提
+## Prerequisites
 
 - Node.js 22.x / npm
-- Wrangler（`npm install` で devDependency として導入）
-- Cloudflare アカウント（KV/R2/Queues/Workers AI を有効化）
+- Wrangler (installed as a devDependency via `npm install`)
+- A Cloudflare account (with KV/R2/Queues/Workers AI enabled)
 
-## セットアップ
+## Setup
 
 ```bash
 cd functions
 npm install
 ```
 
-### バインディングの作成
+### Creating bindings
 
-`wrangler.jsonc` の `id` / `bucket_name` プレースホルダを、以下で発行した実値に置き換える（dev/prod それぞれ）。
+Replace the `id` / `bucket_name` placeholders in `wrangler.jsonc` with the real
+values issued by the commands below (for both dev and prod).
 
 ```bash
 # KV
@@ -54,92 +56,101 @@ wrangler r2 bucket create trainlcd-uploads-dev
 wrangler queues create feedback-triage-dev
 ```
 
-### シークレット投入
+### Setting secrets
 
 ```bash
-wrangler secret put SESSION_JWT_SECRET          # セッション JWT 署名鍵（任意の長い乱数）
-wrangler secret put AZURE_SPEECH_KEY            # Azure Speech のサブスクリプションキー
-wrangler secret put GOOGLE_SA_KEY              # Android Publisher 用 SA 鍵 JSON（1 行文字列）
+wrangler secret put SESSION_JWT_SECRET          # signing key for session JWTs (any long random string)
+wrangler secret put AZURE_SPEECH_KEY            # Azure Speech subscription key
+wrangler secret put GOOGLE_SA_KEY              # Android Publisher SA key JSON (single-line string)
 wrangler secret put OCTOKIT_PAT
 wrangler secret put DISCORD_CS_WEBHOOK_URL
 wrangler secret put DISCORD_CRASH_WEBHOOK_URL
 wrangler secret put DISCORD_REVIEW_WEBHOOK_URL
 ```
 
-ローカル開発では同じキーを `.dev.vars`（gitignore 済み）に記述する。
+For local development, put the same keys in `.dev.vars` (gitignored).
 
-### 非機密の設定（vars）
+You can also bulk-load secrets with the helper scripts: copy
+`.secrets.env.example` to `.secrets.env`, fill in the values, then run
+`./scripts/put-secrets.sh` (or `./scripts/put-secrets.ps1` on Windows).
 
-`wrangler.jsonc` の `vars` を参照。Azure リージョン・ボイス名・AI モデル名・パッケージ名・
-公開アップロード URL（R2 の公開ドメイン）などを環境ごとに設定する。
+### Non-secret configuration (vars)
 
-## 開発・デプロイ
+See `vars` in `wrangler.jsonc`. Configure the Azure region, voice names, AI model
+name, package name, public upload URL (the R2 public domain), and so on per
+environment.
+
+## Develop & deploy
 
 ```bash
-npm run dev            # wrangler dev（ローカル）
+npm run dev            # wrangler dev (local)
 npm run typecheck      # tsc --noEmit
 npm run lint           # biome check
-npm test               # jest（純粋関数）
-npm run deploy:dev     # wrangler deploy（dev）
+npm test               # jest (pure functions)
+npm run deploy:dev     # wrangler deploy (dev)
 npm run deploy:prod    # wrangler deploy --env production
-npm run tail           # ログ追尾
+npm run tail           # follow logs
 ```
 
-## クライアント通信規約
+## Client wire protocol
 
-`POST /tts` と `POST /postFeedback` は Firebase callable 互換のワイヤ形式を維持している。
+`POST /tts` and `POST /postFeedback` keep the Firebase callable-compatible wire
+format.
 
-- リクエスト: `{ "data": { ... } }`、`Authorization: Bearer <session JWT>`
-- 成功: `{ "result": { ... } }`
-- 失敗: HTTP ステータス + `{ "error": { "message", "status" } }`
+- Request: `{ "data": { ... } }` with `Authorization: Bearer <session JWT>`
+- Success: `{ "result": { ... } }`
+- Failure: an HTTP status plus `{ "error": { "message", "status" } }`
 
-セッション JWT は `POST /auth/token`（body `{ "installId": "<uuid>" }`）で取得する。
+A session JWT is obtained from `POST /auth/token` (body `{ "installId": "<uuid>" }`).
 
-## テスト方針
+## Testing strategy
 
-ユニットテストは純粋関数（SSML 整形・ボイス名解決・トリアージ JSON の正規化・レビュー
-パース）を Jest で検証する。HTTP/キュー/Cron のランタイム結合は `wrangler dev` /
-`wrangler dev --test-scheduled` で確認する。
+Unit tests cover pure functions (SSML formatting, voice-name resolution, triage
+JSON normalization, review parsing) with Jest. Runtime integration for HTTP /
+queue / Cron is verified with `wrangler dev` / `wrangler dev --test-scheduled`.
 
-## few-shot データ
+## few-shot data
 
-フィードバックトリアージは `CONFIG_KV` の `config:fewshot`（`FEW_SHOT_KV_KEY`）を読み込む。
-few-shot は TTS とは無関係なので、設定用 KV に置く（`config:maintenance`/`config:remote` と同じ namespace）。
-フォーマットは 1 行 1 例の JSONL（`fewshot.example.jsonl` 参照）:
+Feedback triage reads `config:fewshot` (`FEW_SHOT_KV_KEY`) from `CONFIG_KV`.
+The few-shot data is unrelated to TTS, so it lives in the config KV (the same
+namespace as `config:maintenance` / `config:remote`). The format is JSONL, one
+example per line (see `fewshot.example.jsonl`):
 
 ```json
-{"input": "ユーザーの本文", "output": "{\"title\":...,\"isSpam\":false,...}"}
+{"input": "user body text", "output": "{\"title\":...,\"isSpam\":false,...}"}
 ```
 
-アップロード（ファイルをそのまま 1 つの KV 値として投入）:
+Upload (the file is stored verbatim as a single KV value):
 
 ```bash
-# dev（--local を付けなければ本番 KV に書き込む）
+# dev (without --local it writes to the production KV)
 wrangler kv key put --binding CONFIG_KV "config:fewshot" --path fewshot.jsonl
 # prod
 wrangler kv key put --binding CONFIG_KV "config:fewshot" --path fewshot.jsonl --env production
 ```
 
-未配置だとトリアージは `FEW_SHOT_NOT_AVAILABLE` で失敗する（誤学習防止のフェイルハード）。
+If it is not present, triage fails hard with `FEW_SHOT_NOT_AVAILABLE` (a
+fail-hard guard that prevents mis-training).
 
-## メンテナンス CLI
+## Maintenance CLI
 
-KV(TTS_KV) と R2(音声バケット) を直接操作する保守ツール。Cloudflare REST API(KV) と
-S3 互換 API(R2) を使う。接続情報は環境変数で渡す:
+Maintenance tools that operate directly on KV (TTS_KV) and R2 (the audio bucket).
+They use the Cloudflare REST API (KV) and the S3-compatible API (R2). Connection
+details are passed via environment variables:
 
 ```bash
-export CF_ACCOUNT_ID=...          # Cloudflare アカウント ID
-export CF_API_TOKEN=...           # KV 読み書き権限の API トークン
-export CF_KV_NAMESPACE_ID=...     # 対象環境の TTS_KV ネームスペース ID
-export R2_ACCESS_KEY_ID=...       # R2 の S3 アクセスキー
+export CF_ACCOUNT_ID=...          # Cloudflare account ID
+export CF_API_TOKEN=...           # API token with KV read/write permission
+export CF_KV_NAMESPACE_ID=...     # TTS_KV namespace ID for the target environment
+export R2_ACCESS_KEY_ID=...       # R2 S3 access key
 export R2_SECRET_ACCESS_KEY=...
-export R2_BUCKET=trainlcd-tts-dev # 対象環境の音声バケット名
+export R2_BUCKET=trainlcd-tts-dev # audio bucket name for the target environment
 
-# SSML 本文で TTS キャッシュを検索（必要なら削除）
+# Search the TTS cache by SSML body (delete if needed)
 npm run find-tts-cache -- "東京" --field ssmlJa
 npm run find-tts-cache -- "東京" --delete
 
-# R2 にあるが KV メタの無い孤立音声を検出（必要なら削除）
+# Detect orphaned audio that exists in R2 but has no KV metadata (delete if needed)
 npm run find-orphaned-tts
 npm run find-orphaned-tts -- --delete
 ```


### PR DESCRIPTION
## 概要

PR #6238（Cloudflare 全面移行）で混入したドキュメントの問題を修正する。`functions/README.md` がプロジェクト規約（root `README.md` は英語）に反して日本語へ書き換えられていたため英語へ戻し、あわせて移行ドキュメントに残っていた古い記述（廃止済みの `tts-cache` キューなど）を現状のコード・`wrangler.jsonc` に合わせて修正する。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `functions/README.md` を日本語から**英語へ書き直し**（PR #6238 以前の README は英語で、root `README.md` も英語というプロジェクト規約に合わせる）。内容は Cloudflare 移行後の構成（Workers / KV / R2 / Queues / Workers AI / Azure Speech）を反映し、`put-secrets.sh` / `.ps1` での一括投入手順への言及も追記。
- `docs/cloudflare-migration-plan.md` の古い記述を修正:
  - `/tts` ルートの「Queue 投函 / `TTS_CACHE_QUEUE.send`」→ R2+KV へ直接書込に修正
  - キュー consumer の `tts-cache` 項目を削除（実構成は `feedback-triage` のみ）、few-shot 読込元を R2 → `CONFIG_KV` に修正
  - ディレクトリ構成・bindings 記述を実構成に合わせて修正、当初プランからの変更点を注記
- `docs/cloudflare-migration-phase3-checklist.md` の古い記述を修正:
  - `wrangler queues create tts-cache-dev` → `feedback-triage-dev`
  - few-shot のコメント「R2 に配置」→「CONFIG_KV に配置」（コマンドと矛盾していた）

## テスト

<!-- ドキュメントのみの変更のため省略（コード変更なし） -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント更新

* **Documentation**
  * Cloudflare 移行計画の Phase 1・3 チェックリストを更新
  * TTS キャッシュ処理の仕様変更に対応する説明に修正
  * 開発者向けドキュメントを英語化し、セットアップ手順・開発方法・テスト方針・環境変数設定を充実

<!-- end of auto-generated comment: release notes by coderabbit.ai -->