### PR TITLE
日本語TTSの固有名詞を nameIpa のアクセント核付き <phoneme> で読ませる

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -22,9 +22,12 @@ describe('replaceJapaneseText', () => {
   });
 
   it('returns the provided fallback when both args are nullish', () => {
-    expect(replaceJapaneseText(null, null, '各駅停車')).toBe('各駅停車');
+    expect(replaceJapaneseText(null, null, undefined, '各駅停車')).toBe(
+      '各駅停車'
+    );
     expect(
       replaceJapaneseText(
+        undefined,
         undefined,
         undefined,
         '<sub alias="かくえきていしゃ">各駅停車</sub>'
@@ -43,6 +46,38 @@ describe('replaceJapaneseText', () => {
     );
   });
 
+  it('wraps name with ipa phoneme when nameIpa carries an accent nucleus (ˈ)', () => {
+    // アクセント核を含む IPA がある場合は <phoneme alphabet="ipa"> で読ませる。
+    expect(
+      replaceJapaneseText(
+        '練馬春日町',
+        'ネリマカスガチョウ',
+        'neɾimaˈkasɯɡat͡ɕoː'
+      )
+    ).toBe(
+      '<phoneme alphabet="ipa" ph="neɾimaˈkasɯɡat͡ɕoː">練馬春日町</phoneme>'
+    );
+  });
+
+  it('falls back to sub alias when nameIpa has no accent nucleus', () => {
+    // 核が無い IPA（StationAPI 未対応 or 平板）は従来どおり読みに倒す＝無リグレッション。
+    expect(replaceJapaneseText('新宿', 'シンジュク', 'ɕindʑɯkɯ')).toBe(
+      '<sub alias="しんじゅく">新宿</sub>'
+    );
+  });
+
+  it('escapes XML special characters in the ipa phoneme output', () => {
+    expect(replaceJapaneseText('A&B', 'エービー', 'ˈeːbiː')).toBe(
+      '<phoneme alphabet="ipa" ph="ˈeːbiː">A&amp;B</phoneme>'
+    );
+  });
+
+  it('returns fallback when name is nullish even if nameIpa has an accent nucleus', () => {
+    expect(replaceJapaneseText(null, null, 'ˈabc', '各駅停車')).toBe(
+      '各駅停車'
+    );
+  });
+
   it('does not fall back to 各駅停車 implicitly (#5917)', () => {
     // 駅名・路線名のヘルパとして使われるため、誤って `各駅停車` を返してはならない。
     expect(replaceJapaneseText(null, null)).not.toContain('各駅停車');
@@ -52,7 +87,7 @@ describe('replaceJapaneseText', () => {
     // 以前は sub 内に `null` / `undefined` が混入していた。
     expect(replaceJapaneseText(null, 'シンジュク')).toBe('');
     expect(replaceJapaneseText(undefined, 'シンジュク')).toBe('');
-    expect(replaceJapaneseText(null, 'シンジュク', '各駅停車')).toBe(
+    expect(replaceJapaneseText(null, 'シンジュク', undefined, '各駅停車')).toBe(
       '各駅停車'
     );
 

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -77,9 +77,10 @@ export const replaceJapaneseText = (
     return `<phoneme alphabet="ipa" ph="${escapeXmlAttr(nameIpa)}">${escapeXml(name)}</phoneme>`;
   }
   if (!nameKatakana) {
-    return name;
+    return escapeXml(name);
   }
-  return `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`;
+  const alias = escapeXmlAttr(katakanaToHiragana(nameKatakana));
+  return `<sub alias="${alias}">${escapeXml(name)}</sub>`;
 };
 
 const replaceLineNameJa = (

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -1,6 +1,10 @@
 import type { Line, Station, TtsSegment } from '../../@types/graphql';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
-import { wrapPhoneme } from '../../utils/phoneme';
+import { escapeXml, escapeXmlAttr, wrapPhoneme } from '../../utils/phoneme';
+
+// IPA のアクセント核（下げ核）マーカー。Azure は <phoneme alphabet="ipa"> 経由で
+// この記号を尊重することを実機確認済み。StationAPI が nameIpa に付与する。
+const ACCENT_NUCLEUS_MARK = 'ˈ';
 
 // 駅名に併記されたカッコ書き (例: 命名権スポンサー名 `電鉄富山(トヨタモビリティ富山)`)
 // を TTS で読み上げないために、半角・全角のカッコと中身を取り除く。
@@ -59,10 +63,18 @@ export const stripStationParensForTTS = (station: Station): Station => ({
 export const replaceJapaneseText = (
   name: string | null | undefined,
   nameKatakana: string | null | undefined,
+  nameIpa?: string | null | undefined,
   fallback = ''
 ): string => {
   if (!name) {
     return fallback;
+  }
+  // アクセント核(ˈ)を含む IPA がある場合のみ <phoneme> で読ませ、固有名詞の
+  // ピッチアクセントを明示する。核が無い場合（StationAPI 未対応 or 平板）は
+  // 従来どおり読み(<sub>)に倒すことで、アクセントデータ投入前は挙動を一切
+  // 変えず（無リグレッション）、データ投入と同時に自動で有効化される。
+  if (nameIpa?.includes(ACCENT_NUCLEUS_MARK)) {
+    return `<phoneme alphabet="ipa" ph="${escapeXmlAttr(nameIpa)}">${escapeXml(name)}</phoneme>`;
   }
   if (!nameKatakana) {
     return name;
@@ -70,12 +82,13 @@ export const replaceJapaneseText = (
   return `<sub alias="${katakanaToHiragana(nameKatakana)}">${name}</sub>`;
 };
 
-const replaceLineNameJa = (line: Pick<Line, 'nameShort' | 'nameKatakana'>) =>
-  replaceJapaneseText(line.nameShort, line.nameKatakana);
+const replaceLineNameJa = (
+  line: Pick<Line, 'nameShort' | 'nameKatakana' | 'nameIpa'>
+) => replaceJapaneseText(line.nameShort, line.nameKatakana, line.nameIpa);
 
 const replaceStationNameJa = (
-  station: Pick<Station, 'name' | 'nameKatakana'>
-) => replaceJapaneseText(station.name, station.nameKatakana);
+  station: Pick<Station, 'name' | 'nameKatakana' | 'nameIpa'>
+) => replaceJapaneseText(station.name, station.nameKatakana, station.nameIpa);
 
 /** 路線名を sub alias 付きで `、` 連結する。 */
 export const formatLinesListJa = (lines: Line[]): string =>

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -366,7 +366,8 @@ export const useTTSText = (
 
     const currentLineJa = replaceJapaneseText(
       currentLine.nameShort,
-      currentLine.nameKatakana
+      currentLine.nameKatakana,
+      currentLine.nameIpa
     );
     const currentLineEn = ph(
       currentLine.nameTtsSegments,
@@ -375,7 +376,8 @@ export const useTTSText = (
     const currentTrainTypeJa = currentTrainType
       ? replaceJapaneseText(
           currentTrainType.name,
-          currentTrainType.nameKatakana
+          currentTrainType.nameKatakana,
+          currentTrainType.nameIpa
         )
       : '';
     const currentTrainTypeEn = currentTrainType
@@ -418,7 +420,8 @@ export const useTTSText = (
       // 日本語
       nextStationJa: replaceJapaneseText(
         nextStation?.name,
-        nextStation?.nameKatakana
+        nextStation?.nameKatakana,
+        nextStation?.nameIpa
       ),
       currentLineJa,
       currentLineShortJa: currentLine.nameShort ?? '',
@@ -450,22 +453,32 @@ export const useTTSText = (
       afterNextStationJa: afterNextStation
         ? replaceJapaneseText(
             afterNextStation.name,
-            afterNextStation.nameKatakana
+            afterNextStation.nameKatakana,
+            afterNextStation.nameIpa
           )
         : '',
       viaStationJa: viaStation
-        ? replaceJapaneseText(viaStation.name, viaStation.nameKatakana)
+        ? replaceJapaneseText(
+            viaStation.name,
+            viaStation.nameKatakana,
+            viaStation.nameIpa
+          )
         : '',
       jrWestStopsListJa: formatJrWestStopsListJa(allStops, isBoundStop),
       lastAnnouncedStopJa: lastAnnouncedStop
         ? replaceJapaneseText(
             lastAnnouncedStop.name,
-            lastAnnouncedStop.nameKatakana
+            lastAnnouncedStop.nameKatakana,
+            lastAnnouncedStop.nameIpa
           )
         : '',
       // 直通境界駅で案内する直通先路線
       nextLineJa: isNextStopThroughBoundary
-        ? replaceJapaneseText(throughLine?.nameShort, throughLine?.nameKatakana)
+        ? replaceJapaneseText(
+            throughLine?.nameShort,
+            throughLine?.nameKatakana,
+            throughLine?.nameIpa
+          )
         : '',
 
       // 英語

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -48,6 +48,7 @@ export const TINY_TRAIN_TYPE_FRAGMENT = gql`
     groupId
     name
     nameKatakana
+    nameIpa
     nameRoman
     nameRomanIpa
     nameChinese
@@ -97,6 +98,7 @@ export const LINE_NESTED_FRAGMENT = gql`
     lineType
     nameFull
     nameKatakana
+    nameIpa
     nameRoman
     nameRomanIpa
     nameShort
@@ -138,6 +140,7 @@ export const LINE_IN_STATION_FRAGMENT = gql`
     }
     lineType
     nameKatakana
+    nameIpa
     nameRoman
     nameShort
     nameChinese
@@ -157,6 +160,7 @@ export const TRAIN_TYPE_NESTED_FRAGMENT = gql`
     groupId
     name
     nameKatakana
+    nameIpa
     nameRoman
     nameRomanIpa
     nameChinese
@@ -185,6 +189,7 @@ export const STATION_FRAGMENT = gql`
     groupId
     name
     nameKatakana
+    nameIpa
     nameRoman
     nameChinese
     nameKorean

--- a/src/utils/phoneme.ts
+++ b/src/utils/phoneme.ts
@@ -1,9 +1,9 @@
 import { TtsAlphabet, type TtsSegment } from '~/@types/graphql';
 
-const escapeXml = (s: string): string =>
+export const escapeXml = (s: string): string =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-const escapeXmlAttr = (s: string): string =>
+export const escapeXmlAttr = (s: string): string =>
   escapeXml(s).replace(/"/g, '&quot;').replace(/'/g, '&apos;');
 
 type IpaGroup = {


### PR DESCRIPTION
## 概要

駅名など固有名詞のピッチアクセントが Azure TTS のフロントエンド推定で体系的に外れる問題への受け皿。日本語の読み上げを `<sub alias>`（読みのみ）から、StationAPI の `nameIpa` を使った `<phoneme alphabet="ipa">` へ張り替える。

`nameIpa` にアクセント核 `ˈ` が含まれる時だけ `<phoneme>` を使い、無ければ従来の `<sub alias>` に倒すゲートを設けたため、StationAPI 側（`TrainLCD/StationAPI#1534`）がアクセントを出力するまで挙動は一切変わらず（無リグレッション）、データ投入と同時に駅ごとへ自動適用される。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `queries`: 駅 / 路線 / 列車種別の各 fragment で `nameIpa` を取得
- `formatters`: `replaceJapaneseText` をアクセント核（`ˈ`）ゲート付きの `<phoneme alphabet="ipa">` 優先に変更。`nameIpa` が無い / 核を含まない場合は従来の `<sub alias>` にフォールバック
- `useTTSText`: 次駅・現路線・列車種別・次々駅・経由駅・JR西停車駅・直通先路線の日本語案内で `nameIpa` を渡す（会社名・複合的な行先は据え置き）
- `phoneme`: XML エスケープヘルパ（`escapeXml` / `escapeXmlAttr`）を再利用のため export
- テスト: `<phoneme>` 経路と核ゲートのケースを追加

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 日本語のアクセント核記号を含むIPA（国際音声記号）表記に対応し、より自然な音声読み上げが可能になりました。
  * 駅名・路線名・列車種別など各種表記でIPA表記の活用が拡大されました。

* **Tests**
  * IPA表記のフォールバック処理と XML特殊文字エスケープ処理の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->