### PR TITLE
山手線内回り/外回りのTTS誤読をスペース挿入で防ぐ

### DIFF
--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -143,7 +143,10 @@ export const useTTSText = (
 
   const yamanoteTrainTypeJa = useMemo(() => {
     if (isBus || !isYamanoteLine || !selectedDirection) return null;
-    return selectedDirection === 'INBOUND' ? '山手線内回り' : '山手線外回り';
+    // 「山手線内回り」を続けて渡すと TTS が「線内」を「せんない」と解釈し
+    // 「やまてせんないまわり」と誤読するため、路線名と方向の間にスペースを挟んで
+    // 語境界を明示する (「山手線 内回り」)。
+    return selectedDirection === 'INBOUND' ? '山手線 内回り' : '山手線 外回り';
   }, [isBus, isYamanoteLine, selectedDirection]);
 
   const yamanoteTrainTypeEn = !isBus && isYamanoteLine ? 'Yamanote Line' : null;


### PR DESCRIPTION
## 概要

山手線テーマの自動アナウンスで、TTS API に「山手線内回り」「山手線外回り」をそのまま渡すと「線内」が「せんない」と解釈され、「やまてせんないまわり」のように誤読される問題を修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTTSText` の `yamanoteTrainTypeJa` で、路線名と方向の間にスペースを挟み「山手線 内回り」「山手線 外回り」として語境界を明示
- この値は `trainTypeJa` / `trainTypeJaPlain` / `trainTypeJaKyushu` / `jrEastTrainDescJa` のフォールバックに使われるため、山手線の各読み上げ経路に反映される

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
