### PR TITLE
未使用になった Firebase 関連コードと設定を撤去

### DIFF
--- a/.eas/workflows/create-development-builds.yml
+++ b/.eas/workflows/create-development-builds.yml
@@ -32,13 +32,6 @@ jobs:
             exit 1
           fi
           printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > android/sentry.properties
-      - name: Decode google-services.json
-        run: |
-          if [ -z "${GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "Environment variable GOOGLE_SERVICES_JSON_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json
       - name: Restore android/app/release.jks
         run: |
           if [ -z "${ANDROID_RELEASE_JKS_BASE64:-}" ]; then
@@ -93,13 +86,6 @@ jobs:
             exit 1
           fi
           printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > ios/sentry.properties
-      - name: Decode GoogleService-Info.plist
-        run: |
-          if [ -z "${GOOGLE_SERVICE_INFO_PLIST_BASE64:-}" ]; then
-            echo "Environment variable GOOGLE_SERVICE_INFO_PLIST_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$GOOGLE_SERVICE_INFO_PLIST_BASE64" | base64 --decode > ios/Schemes/Dev/GoogleService-Info.plist
       - uses: eas/build
 
   submit_ios:

--- a/.eas/workflows/create-production-builds.yml
+++ b/.eas/workflows/create-production-builds.yml
@@ -32,13 +32,6 @@ jobs:
             exit 1
           fi
           printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > android/sentry.properties
-      - name: Decode google-services.json
-        run: |
-          if [ -z "${GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "Environment variable GOOGLE_SERVICES_JSON_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json
       - name: Restore android/app/release.jks
         run: |
           if [ -z "${ANDROID_RELEASE_JKS_BASE64:-}" ]; then
@@ -93,13 +86,6 @@ jobs:
             exit 1
           fi
           printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > ios/sentry.properties
-      - name: Decode GoogleService-Info.plist
-        run: |
-          if [ -z "${GOOGLE_SERVICE_INFO_PLIST_BASE64:-}" ]; then
-            echo "Environment variable GOOGLE_SERVICE_INFO_PLIST_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$GOOGLE_SERVICE_INFO_PLIST_BASE64" | base64 --decode > ios/Schemes/Prod/GoogleService-Info.plist
       - uses: eas/build
 
   submit_ios:

--- a/.gitignore
+++ b/.gitignore
@@ -84,14 +84,6 @@ ios/CanaryTrainLCD.app.dSYM.zip
 .expo/*
 web-build/
 
-# Firebase
-google-services.json
-GoogleService-Info.plist
-*.rules.json
-firestore.indexes.json
-.firebaserc
-*debug.log
-
 # Sentry
 sentry.properties
 

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -1,7 +1,6 @@
 internal import Expo
 import React
 import ReactAppDependencyProvider
-import Firebase
 
 @UIApplicationMain
 internal class AppDelegate: ExpoAppDelegate {
@@ -28,8 +27,6 @@ internal class AppDelegate: ExpoAppDelegate {
       in: window,
       launchOptions: launchOptions)
 #endif
-
-    FirebaseApp.configure()
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/CanaryAppClip/AppDelegate.m
+++ b/ios/CanaryAppClip/AppDelegate.m
@@ -10,7 +10,6 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
-#import <Firebase.h>
 
 @implementation AppDelegate
 
@@ -21,8 +20,6 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-  
-  [FIRApp configure];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/ios/ProdAppClip/AppDelegate.m
+++ b/ios/ProdAppClip/AppDelegate.m
@@ -10,7 +10,6 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
-#import <Firebase.h>
 
 @implementation AppDelegate
 
@@ -21,8 +20,6 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-  
-  [FIRApp configure];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -56,8 +56,6 @@
 		942CB6102A32AAB4008339D2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 944C2C6B28DB0DD10004DA72 /* Localizable.strings */; };
 		942CB6162A32AAE3008339D2 /* CanaryWatchApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 942CB5E72A32AA9E008339D2 /* CanaryWatchApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		942CB6192A32AAE9008339D2 /* CanaryRideSessionActivityExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 942CB6142A32AAB4008339D2 /* CanaryRideSessionActivityExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		942CB6232A32AC77008339D2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 942CB6212A32AC77008339D2 /* GoogleService-Info.plist */; };
-		942CB6252A32AC8B008339D2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 942CB6242A32AC8B008339D2 /* GoogleService-Info.plist */; };
 		942CB62B2A32B01D008339D2 /* CanaryWatchApp Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 942CB6022A32AAA6008339D2 /* CanaryWatchApp Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9438A5A22DDD82D8008D2796 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9438A5A12DDD8222008D2796 /* AppDelegate.swift */; };
 		9438A5A32DDD82E8008D2796 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9438A5A12DDD8222008D2796 /* AppDelegate.swift */; };
@@ -128,8 +126,6 @@
 		94D3F4572E22C0F300B0F4CB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 944C2C6B28DB0DD10004DA72 /* Localizable.strings */; };
 		94E2C8432D64E1AA0090392E /* ProdAppClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 94E2C82A2D64E1A90090392E /* ProdAppClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		94E2C8662D64E1CB0090392E /* CanaryAppClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 94E2C84D2D64E1CA0090392E /* CanaryAppClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		94E2CB522D6575DE0090392E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 942CB6242A32AC8B008339D2 /* GoogleService-Info.plist */; };
-		94E2CB532D6575E50090392E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 942CB6212A32AC77008339D2 /* GoogleService-Info.plist */; };
 		94E2CB5A2D65775A0090392E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94FF39FE24710B8B00528ED8 /* InfoPlist.strings */; };
 		94E2CB5B2D65775A0090392E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94FF39FE24710B8B00528ED8 /* InfoPlist.strings */; };
 		94E2CB5C2D6577610090392E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94FF39F624710AE800528ED8 /* InfoPlist.strings */; };
@@ -374,8 +370,6 @@
 		942CB5E72A32AA9E008339D2 /* CanaryWatchApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanaryWatchApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		942CB6022A32AAA6008339D2 /* CanaryWatchApp Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CanaryWatchApp Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		942CB6142A32AAB4008339D2 /* CanaryRideSessionActivityExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CanaryRideSessionActivityExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		942CB6212A32AC77008339D2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Schemes/Dev/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		942CB6242A32AC8B008339D2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Schemes/Prod/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		942CB62F2A32B34E008339D2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Schemes/Dev/Info.plist; sourceTree = "<group>"; };
 		942CB6312A32B35C008339D2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Schemes/Prod/Info.plist; sourceTree = "<group>"; };
 		942CB63C2A32B69B008339D2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = TrainLCD/Schemes/Dev/Info.plist; sourceTree = "<group>"; };
@@ -618,8 +612,6 @@
 				9485EFF42A33613800382D09 /* SplashScreen.storyboard */,
 				942CB63C2A32B69B008339D2 /* Info.plist */,
 				942CB63E2A32B6A6008339D2 /* Info.plist */,
-				942CB6212A32AC77008339D2 /* GoogleService-Info.plist */,
-				942CB6242A32AC8B008339D2 /* GoogleService-Info.plist */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				0731D3B524204D62009CAE85 /* Expo.plist */,
@@ -1269,7 +1261,6 @@
 				9495DB062D65F31B0070E96B /* verdana-bold.ttf in Resources */,
 				9495DB072D65F31B0070E96B /* JF-Dot-jiskan24h.ttf in Resources */,
 				947471FB28E29E0200374B81 /* Localizable.strings in Resources */,
-				942CB6252A32AC8B008339D2 /* GoogleService-Info.plist in Resources */,
 				944C2C7328DB0E030004DA72 /* Localizable.strings in Resources */,
 				94FF39FC24710B8B00528ED8 /* InfoPlist.strings in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
@@ -1299,7 +1290,6 @@
 				942CB5C92A32AA96008339D2 /* Localizable.strings in Resources */,
 				942CB5CA2A32AA96008339D2 /* InfoPlist.strings in Resources */,
 				942CB5CB2A32AA96008339D2 /* Images.xcassets in Resources */,
-				942CB6232A32AC77008339D2 /* GoogleService-Info.plist in Resources */,
 				942CB5CD2A32AA96008339D2 /* InfoPlist.strings in Resources */,
 				01AEECF10F37882B9811E6C7 /* PrivacyInfo.xcprivacy in Resources */,
 				94E2CBB32D659DBB0090392E /* myriadpro-bold.ttf in Resources */,
@@ -1399,7 +1389,6 @@
 				94E2CB5E2D65777F0090392E /* Images.xcassets in Resources */,
 				94E2CB5C2D6577610090392E /* InfoPlist.strings in Resources */,
 				94E2CB5A2D65775A0090392E /* InfoPlist.strings in Resources */,
-				94E2CB522D6575DE0090392E /* GoogleService-Info.plist in Resources */,
 				94E2CBC52D659E8C0090392E /* myriadpro-bold.ttf in Resources */,
 				57286F592EB491F60052DF44 /* SplashScreenAppClip.storyboard in Resources */,
 				94E2CBCA2D65AEE50090392E /* FuturaLTPro-Bold.ttf in Resources */,
@@ -1416,7 +1405,6 @@
 				94E2CB5D2D6577610090392E /* InfoPlist.strings in Resources */,
 				94E2CB5B2D65775A0090392E /* InfoPlist.strings in Resources */,
 				57286F572EB4906D0052DF44 /* SplashScreenAppClip.storyboard in Resources */,
-				94E2CB532D6575E50090392E /* GoogleService-Info.plist in Resources */,
 				94E2CBC22D659E800090392E /* myriadpro-bold.ttf in Resources */,
 				94E2CBC82D65AEE50090392E /* FuturaLTPro-Bold.ttf in Resources */,
 				94E2CBC32D659E800090392E /* verdana-bold.ttf in Resources */,


### PR DESCRIPTION
## 概要

Cloudflare 全面移行により Firebase は使用しなくなったため、各所に残っていた Firebase 関連のコード・設定を撤去します。AppClip ターゲットで `#import <Firebase.h>` が見つからずビルドが失敗していた問題も解消します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- iOS ネイティブから Firebase 初期化を撤去
  - `ios/AppDelegate.swift`: `import Firebase` と `FirebaseApp.configure()` を削除
  - `ios/CanaryAppClip/AppDelegate.m` / `ios/ProdAppClip/AppDelegate.m`: `#import <Firebase.h>` と `[FIRApp configure]` を削除（ビルドエラーの直接原因）
- `ios/TrainLCD.xcodeproj/project.pbxproj` から `GoogleService-Info.plist` の参照を全撤去（実ファイルは削除済みで宙に浮いた参照になっていた）
- EAS ワークフロー（`.eas/workflows/create-production-builds.yml` / `create-development-builds.yml`）から `google-services.json`・`GoogleService-Info.plist` のデコードステップを削除
- `.gitignore` の `# Firebase` ブロックを削除

CocoaPods 生成の `Podfile.lock` / `[CP] Copy Pods Resources` 内 Firebase エントリは `@react-native-firebase/*` が依存から外れているため、Mac/CI で `pod install` を実行すれば自動で再生成・除去される。

## テスト

JS（`src/**`）への変更がないため、`npm run lint` / `npm test` / `npm run typecheck` は省略。

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Firebase統合をSentry統合に置き換えました。EASビルドワークフロー、iOSプロジェクト設定、およびアプリケーション初期化処理からFirebase関連の処理を削除し、Sentryのプロパティファイル処理に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->