### PR TITLE
iOSのバックグラウンドTTS停止を修正しプレイヤー再利用をAndroid限定にする

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import React from 'react';
+import { Platform } from 'react-native';
 import speechState, { resetFirstSpeechAtom } from '~/store/atoms/speech';
 import { mockFetch } from '~/utils/test/ttsMocks';
 import { clearFetchCache } from '~/utils/ttsSpeechFetcher';
@@ -107,6 +108,14 @@ const mockSuccessfulFetch = () => {
   });
 };
 
+// プレイヤー再利用は Android 限定（iOS は背景再生のため発話ごとに生成・破棄する）。
+// jest-expo の既定 Platform.OS は 'ios' のため、再利用挙動を検証するテストでは
+// 明示的に 'android' へ切り替え、afterEach で必ず元へ戻す。
+const originalPlatformOS = Platform.OS;
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+};
+
 describe('useTTS', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -128,6 +137,7 @@ describe('useTTS', () => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
     jest.clearAllMocks();
+    setPlatformOS(originalPlatformOS);
   });
 
   it('英語のみ有効時は英語音声のみ再生プレイヤーを生成する', async () => {
@@ -349,7 +359,8 @@ describe('useTTS', () => {
     warnSpy.mockRestore();
   });
 
-  it('didJustFinishが届かず再生位置も進まない場合はストール検知で復帰する', async () => {
+  it('[Android] didJustFinishが届かず再生位置も進まない場合はストール検知で復帰する', async () => {
+    setPlatformOS('android');
     const store = createStore();
     store.set(speechState, {
       ...defaultSpeechState,
@@ -382,7 +393,7 @@ describe('useTTS', () => {
       '[ttsAudioPlayer] playback stalled, aborting:',
       '/tmp/tts-id_en.mp3'
     );
-    // ストール時は一時停止して再生パイプラインを解放するが、
+    // Androidはストール時も一時停止して再生パイプラインを解放するが、
     // プレイヤー自体は次の発話で使い回すため破棄しない
     expect(mockPlayer.pause).toHaveBeenCalled();
     expect(mockPlayer.remove).not.toHaveBeenCalled();
@@ -390,7 +401,45 @@ describe('useTTS', () => {
     warnSpy.mockRestore();
   });
 
-  it('2回目以降の発話ではプレイヤーを使い回しreplaceで音源を差し替える', async () => {
+  it('[iOS] ストール検知時はプレイヤーを破棄して再生パイプラインを解放する', async () => {
+    setPlatformOS('ios');
+    const store = createStore();
+    store.set(speechState, {
+      ...defaultSpeechState,
+      ttsEnabledLanguages: ['EN'],
+    });
+
+    const mockPlayer = createMockPlayer({ autoFinish: false, playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mockPlayer);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    jest.advanceTimersByTime(100);
+
+    await waitFor(() => {
+      expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    jest.advanceTimersByTime(11_000);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ttsAudioPlayer] playback stalled, aborting:',
+      '/tmp/tts-id_en.mp3'
+    );
+    // iOSは発話ごとに生成・破棄するため、ストール時もプレイヤーをネイティブごと解放する
+    expect(mockPlayer.remove).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('[Android] 2回目以降の発話ではプレイヤーを使い回しreplaceで音源を差し替える', async () => {
+    setPlatformOS('android');
     const { useTTSText } = jest.requireMock('./useTTSText') as {
       useTTSText: jest.Mock;
     };
@@ -455,6 +504,75 @@ describe('useTTS', () => {
       });
     });
     expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+  });
+
+  it('[iOS] 2回目以降の発話でもプレイヤーを使い回さず毎回新規生成する', async () => {
+    setPlatformOS('ios');
+    const { useTTSText } = jest.requireMock('./useTTSText') as {
+      useTTSText: jest.Mock;
+    };
+
+    const store = createStore();
+    store.set(speechState, {
+      ...defaultSpeechState,
+      ttsEnabledLanguages: ['EN'],
+    });
+
+    // 初回 render で prefetch を走らせないことで、2回目発話の fetch を確実に分離する
+    useTTSText.mockReturnValue({
+      text: ['ja text', 'en text'],
+      nextText: [],
+    });
+
+    const mockPlayer = createMockPlayer({ autoFinish: true });
+    mockCreateAudioPlayer.mockReturnValue(mockPlayer);
+
+    const { rerender } = renderHook(() => useTTS(), {
+      wrapper: createWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+    });
+    const fetchCountAfterFirstSpeak = mockFetch.mock.calls.length;
+
+    // 次の駅のテキストへ変化させて2回目の発話を発火する
+    useTTSText.mockReturnValue({
+      text: ['ja text 2', 'en text 2'],
+      nextText: [],
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: 'tts-id-2',
+          jaAudioContent: 'QQ==',
+          enAudioContent: 'QQ==',
+          jaAudioMimeType: 'audio/mpeg',
+          enAudioMimeType: 'audio/mpeg',
+        },
+      }),
+    });
+    rerender({});
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCountAfterFirstSpeak + 1);
+    });
+    jest.runAllTimers();
+
+    // iOSはreplaceで使い回さず、2回目もcreateAudioPlayerで新規生成する
+    await waitFor(() => {
+      expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(2);
+    });
+    expect(mockCreateAudioPlayer).toHaveBeenLastCalledWith({
+      uri: '/tmp/tts-id-2_en.mp3',
+    });
+    expect(mockPlayer.replace).not.toHaveBeenCalled();
   });
 
   it('resetFirstSpeechAtom変更時にuseTTSTextへfirstSpeech=trueが同期的に渡される', async () => {

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -524,8 +524,12 @@ describe('useTTS', () => {
       nextText: [],
     });
 
-    const mockPlayer = createMockPlayer({ autoFinish: true });
-    mockCreateAudioPlayer.mockReturnValue(mockPlayer);
+    // 1回目/2回目で別インスタンスを返し、使い回しではなく新規生成であることを保証する
+    const firstPlayer = createMockPlayer({ autoFinish: true });
+    const secondPlayer = createMockPlayer({ autoFinish: true });
+    mockCreateAudioPlayer
+      .mockImplementationOnce(() => firstPlayer)
+      .mockImplementationOnce(() => secondPlayer);
 
     const { rerender } = renderHook(() => useTTS(), {
       wrapper: createWrapper(store),
@@ -572,7 +576,12 @@ describe('useTTS', () => {
     expect(mockCreateAudioPlayer).toHaveBeenLastCalledWith({
       uri: '/tmp/tts-id-2_en.mp3',
     });
-    expect(mockPlayer.replace).not.toHaveBeenCalled();
+    // 別インスタンスが生成され、どちらも replace で使い回されていないこと
+    expect(firstPlayer).not.toBe(secondPlayer);
+    expect(firstPlayer.replace).not.toHaveBeenCalled();
+    expect(secondPlayer.replace).not.toHaveBeenCalled();
+    // 1回目のプレイヤーは発話完了時にネイティブごと破棄される
+    expect(firstPlayer.remove).toHaveBeenCalled();
   });
 
   it('resetFirstSpeechAtom変更時にuseTTSTextへfirstSpeech=trueが同期的に渡される', async () => {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,6 +1,7 @@
 import { type AudioPlayer, setAudioModeAsync } from 'expo-audio';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
 import { TransportType } from '~/@types/graphql';
 import { STORAGE_KEYS } from '../constants';
 import { getSessionToken } from '../lib/session';
@@ -76,33 +77,53 @@ export const useTTS = (): void => {
 
   const jaHandleRef = useRef<PlayAudioHandle | null>(null);
   const enHandleRef = useRef<PlayAudioHandle | null>(null);
-  // プレイヤーは使い回す。createAudioPlayerを発話のたびに呼ぶとAndroidの
-  // AudioTrackが枯渇してTTSが停止するため、永続インスタンスをreplace()で再利用する
+  // Androidでは createAudioPlayer を発話のたびに呼ぶと AudioTrack が枯渇して
+  // TTS が停止するため、永続インスタンスを replace() で再利用する。
+  // 一方 iOS では replace() による再利用がバックグラウンド再生を壊す。
+  // ネイティブ(expo-audio AudioPlayer.swift)の replace は「差し替え時点で再生中
+  // だった場合のみ」ロード完了後に再生を再開する実装で、JS から replace 直前に
+  // pause() するため wasPlaying=false となり自動再開されない。直後の play() は
+  // まだ readyToPlay でない差し替え後アイテムに対する呼び出しとなり、
+  // フォアグラウンドでは間に合うがバックグラウンドでは再生が始まらない。
+  // AudioTrack 枯渇は Android 固有の問題のため、再利用は Android に限定し、
+  // iOS は従来どおり発話ごとに生成・破棄して背景再生を維持する。
+  const reusePlayers = Platform.OS === 'android';
   const jaPlayerRef = useRef<AudioPlayer | null>(null);
   const enPlayerRef = useRef<AudioPlayer | null>(null);
   const playingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 現在の再生を止める（リスナー/ウォッチドッグを解放し一時停止）が、
-  // 永続プレイヤー自体は破棄せず次の発話で再利用する
+  // 現在の再生を止める（リスナー/ウォッチドッグを解放）。
+  // Android は永続プレイヤーを破棄せず一時停止して次の発話で再利用し、
+  // iOS は今回再生したプレイヤーをネイティブごと解放する。
   const cleanupAllPlayers = useCallback(() => {
     safeRemoveListener(jaHandleRef.current?.listener ?? null);
     safeRemoveListener(enHandleRef.current?.listener ?? null);
-    try {
-      jaPlayerRef.current?.pause();
-    } catch {}
-    try {
-      enPlayerRef.current?.pause();
-    } catch {}
+    if (reusePlayers) {
+      try {
+        jaPlayerRef.current?.pause();
+      } catch {}
+      try {
+        enPlayerRef.current?.pause();
+      } catch {}
+    } else {
+      safeRemovePlayer(jaHandleRef.current?.player ?? null);
+      safeRemovePlayer(enHandleRef.current?.player ?? null);
+      jaPlayerRef.current = null;
+      enPlayerRef.current = null;
+    }
     jaHandleRef.current = null;
     enHandleRef.current = null;
-  }, []);
+  }, [reusePlayers]);
 
-  // アンマウント時のみ永続プレイヤーをネイティブごと解放する
+  // アンマウント時に全プレイヤーをネイティブごと解放する。
+  // 再利用中の永続プレイヤーと再生中ハンドルのプレイヤー双方を確実に解放する。
   const releaseAllPlayers = useCallback(() => {
     safeRemoveListener(jaHandleRef.current?.listener ?? null);
     safeRemoveListener(enHandleRef.current?.listener ?? null);
     safeRemovePlayer(jaPlayerRef.current);
     safeRemovePlayer(enPlayerRef.current);
+    safeRemovePlayer(jaHandleRef.current?.player ?? null);
+    safeRemovePlayer(enHandleRef.current?.player ?? null);
     jaHandleRef.current = null;
     enHandleRef.current = null;
     jaPlayerRef.current = null;
@@ -197,19 +218,30 @@ export const useTTS = (): void => {
       playingRef.current = true;
       armPlaybackWatchdog();
 
-      // 再生終了/失敗時は永続プレイヤーを破棄せず、リスナーだけ解放して一時停止する
+      // 再生終了/失敗時の停止処理。Android はリスナーだけ解放してプレイヤーを
+      // 一時停止し再利用、iOS はプレイヤーをネイティブごと破棄する。
       const stopEn = () => {
         safeRemoveListener(enHandleRef.current?.listener ?? null);
-        try {
-          enPlayerRef.current?.pause();
-        } catch {}
+        if (reusePlayers) {
+          try {
+            enPlayerRef.current?.pause();
+          } catch {}
+        } else {
+          safeRemovePlayer(enHandleRef.current?.player ?? null);
+          enPlayerRef.current = null;
+        }
         enHandleRef.current = null;
       };
       const stopJa = () => {
         safeRemoveListener(jaHandleRef.current?.listener ?? null);
-        try {
-          jaPlayerRef.current?.pause();
-        } catch {}
+        if (reusePlayers) {
+          try {
+            jaPlayerRef.current?.pause();
+          } catch {}
+        } else {
+          safeRemovePlayer(jaHandleRef.current?.player ?? null);
+          jaPlayerRef.current = null;
+        }
         jaHandleRef.current = null;
       };
 
@@ -221,18 +253,18 @@ export const useTTS = (): void => {
 
         enHandleRef.current = playAudio({
           uri: pathEn,
-          player: enPlayerRef.current,
+          player: reusePlayers ? enPlayerRef.current : null,
           onFinish: enCleanup,
           onError: () => enCleanup(),
         });
-        enPlayerRef.current = enHandleRef.current.player;
+        enPlayerRef.current = reusePlayers ? enHandleRef.current.player : null;
         return;
       }
 
       // JA（+ 任意で EN）再生
       jaHandleRef.current = playAudio({
         uri: pathJa,
-        player: jaPlayerRef.current,
+        player: reusePlayers ? jaPlayerRef.current : null,
         onFinish: () => {
           if (!isLoadableRef.current || !playEnglish) {
             stopJa();
@@ -240,7 +272,8 @@ export const useTTS = (): void => {
             return;
           }
 
-          // プレイヤーを使い回すため、JA完了後すぐに英語へ差し替えて再生する
+          // JA完了後すぐに英語を再生する（Androidは同一プレイヤーをreplace、
+          // iOSは英語用プレイヤーを新規生成する）
           const enCleanup = () => {
             stopEn();
             stopJa();
@@ -251,11 +284,13 @@ export const useTTS = (): void => {
           try {
             enHandleRef.current = playAudio({
               uri: pathEn,
-              player: enPlayerRef.current,
+              player: reusePlayers ? enPlayerRef.current : null,
               onFinish: enCleanup,
               onError: () => enCleanup(),
             });
-            enPlayerRef.current = enHandleRef.current.player;
+            enPlayerRef.current = reusePlayers
+              ? enHandleRef.current.player
+              : null;
           } catch (e) {
             console.warn('[useTTS] EN playback failed to start:', e);
             enCleanup();
@@ -266,12 +301,13 @@ export const useTTS = (): void => {
           finishPlaying();
         },
       });
-      jaPlayerRef.current = jaHandleRef.current.player;
+      jaPlayerRef.current = reusePlayers ? jaHandleRef.current.player : null;
     },
     [
       armPlaybackWatchdog,
       cleanupAllPlayers,
       finishPlaying,
+      reusePlayers,
       shouldSpeakEnglish,
       shouldSpeakJapanese,
     ]


### PR DESCRIPTION
## 概要

iPhone (iOS 26) でバックグラウンド時に TTS が再生されなくなる不具合を修正します。原因は #6235 で導入したプレイヤーの永続再利用 (`replace()`) で、iOS のバックグラウンドでは再生を開始できないためです。プレイヤー再利用を Android 限定にし、iOS は従来どおり発話ごとに生成・破棄して背景再生を維持します。

`expo-audio` ネイティブ実装 (`AudioPlayer.swift` の `replaceCurrentSource`) は「差し替え時点で再生中だった場合のみ」ロード完了後 (`onReady`) に再生を再開します。JS (`ttsAudioPlayer.ts`) は `replace()` の直前に `pause()` するため `wasPlaying = false` となり自動再開されず、直後に呼ぶ `play()` はまだ `readyToPlay` でない差し替え後アイテムへの呼び出しになります。フォアグラウンドでは間に合うものの、バックグラウンドの iOS では再生が始まりません。新規 `createAudioPlayer`（従来の iOS 挙動）はこの問題が無いため、iOS では発話ごとの生成に戻します。AudioTrack 枯渇は Android 固有の問題のため、Android は #6235 の再利用パスを維持します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTTS.ts` に `reusePlayers = Platform.OS === 'android'` を導入し、プレイヤー再利用を Android 限定に変更。
- iOS では `cleanupAllPlayers` / `stopJa` / `stopEn` でプレイヤーをネイティブごと破棄 (`remove`) し、発話ごとに `createAudioPlayer` で新規生成する従来挙動へ復帰。Android は永続インスタンスを一時停止して `replace()` で使い回す挙動を維持。
- `releaseAllPlayers`（アンマウント時）で永続プレイヤーと再生中ハンドルのプレイヤー双方を確実に解放するよう調整。
- テストを Android/iOS 双方の挙動向けに整理（再利用・ストール時の破棄/一時停止の差を検証）し、iOS で 2 回目の発話が `replace` ではなく新規生成されること、ストール時にプレイヤーが破棄されることを追加検証。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

根本原因はネイティブ音声リソースの挙動のため、最終確認は実機 iOS (iOS 26) でのバックグラウンド・オートモード長時間再生での検証を推奨します。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01LDHsud95ANfDLbbCpAJUYz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **Bug Fixes**
  * 音声再生の安定性を向上させました。AndroidとiOSでのプレイヤー制御を最適化し、停止検知や再生中の挙動をより安定させました。

* **Tests**
  * プラットフォーム別（Android/iOS）の音声再生・停止時の呼び出し挙動や、2回目以降の発話でのプレイヤー動作を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->