### PR TITLE
起動時エラー時にスプラッシュを閉じてエラー画面を前面に出す

### DIFF
--- a/src/components/FatalErrorScreen.test.tsx
+++ b/src/components/FatalErrorScreen.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react-native';
+import * as SplashScreen from 'expo-splash-screen';
+import FatalErrorScreen from './FatalErrorScreen';
+
+jest.mock('expo-splash-screen', () => ({
+  hideAsync: jest.fn(() => Promise.resolve()),
+}));
+
+describe('FatalErrorScreen', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('マウント時にスプラッシュスクリーンを閉じてエラーを前面に出す', () => {
+    render(<FatalErrorScreen title="エラー" text="本文" />);
+
+    expect(SplashScreen.hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('hideAsync が reject してもクラッシュしない', () => {
+    (SplashScreen.hideAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('already hidden')
+    );
+
+    expect(() =>
+      render(<FatalErrorScreen title="エラー" text="本文" />)
+    ).not.toThrow();
+  });
+});

--- a/src/components/FatalErrorScreen.tsx
+++ b/src/components/FatalErrorScreen.tsx
@@ -1,7 +1,8 @@
 // ErrorScreenのnavigationない版
 import * as Linking from 'expo-linking';
+import * as SplashScreen from 'expo-splash-screen';
 import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { isDevApp } from '~/utils/isDevApp';
@@ -63,6 +64,15 @@ const FatalErrorScreen: React.FC<Props> = ({
   reason,
   stacktrace,
 }: Props) => {
+  // index.tsx で preventAutoHideAsync 済みのため、AppContent 到達前に例外が出ると
+  // スプラッシュが閉じられずエラー画面が裏に隠れてしまう。エラー画面表示時は
+  // 必ずスプラッシュを閉じてエラーを前面に出す（既に閉じていれば no-op）。
+  useEffect(() => {
+    SplashScreen.hideAsync().catch(() => {
+      // 既に非表示の場合などは無視してよい
+    });
+  }, []);
+
   const openStatusPage = useCallback(() => Linking.openURL(STATUS_URL), []);
   const showStacktrace = useCallback(() => {
     if (!isDevApp || !stacktrace) {


### PR DESCRIPTION
## 概要

EAS でビルドした iOS の release では、`AppContent` に到達する前（プロバイダー初期化など）で例外が発生すると `CustomErrorBoundary` が `FatalErrorScreen` に切り替わるが、`index.tsx` で `SplashScreen.preventAutoHideAsync()` 済みのためスプラッシュが閉じられず、エラー画面がスプラッシュの裏に隠れて「スプラッシュで固まった」ように見えていた。エラー時は必ずスプラッシュを閉じ、エラー画面を前面に表示するよう修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `FatalErrorScreen` のマウント時に `SplashScreen.hideAsync()` を呼び、エラー画面を必ず前面に出すよう修正（既に非表示なら no-op、reject は握りつぶし）。
- `FatalErrorScreen.test.tsx` を新規追加し、マウント時に `hideAsync` が1回呼ばれること・`hideAsync` の reject でクラッシュしないことを検証。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVz6pUCYMcsB3zfSFwk1jD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * エラー画面表示時にスプラッシュスクリーンが確実に非表示になるようになりました。エラー処理の失敗時にも適切に対応します。

* **Tests**
  * エラー画面のスプラッシュスクリーン処理に関するテストが追加され、正常系およびエラー時の動作が検証されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->