### PR TITLE
経路検索の種別一覧を乗車路線基準で表示しナンバリングを表示する

### DIFF
--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -1004,6 +1004,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         visible={isTrainTypeModalVisible}
         line={trainTypeModalLine}
         destination={targetDestination ?? wantedDestination}
+        boardingStation={station}
         onClose={() => {
           setIsTrainTypeModalVisible(false);
         }}

--- a/src/components/TrainTypeListModal.tsx
+++ b/src/components/TrainTypeListModal.tsx
@@ -14,7 +14,8 @@ import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import {
   formatLineNames,
-  getOriginLine,
+  getBoardingLine,
+  getBoardingLineStation,
   getViaLines,
 } from '~/utils/trainTypeList';
 import Button from './Button';
@@ -77,6 +78,12 @@ type Props = {
   visible: boolean;
   line: Line | null;
   destination?: Station | null;
+  /**
+   * 乗車駅。起点路線ごとの駅番号（ナンバリング）を引くために使う。
+   * 経路検索の item.lines[].station は API が null を返すため、乗車駅の
+   * 路線別 station からナンバリングを解決する。
+   */
+  boardingStation?: Station | null;
   loading?: boolean;
   onClose: () => void;
   onSelect: (trainType: TrainType) => void;
@@ -86,6 +93,7 @@ export const TrainTypeListModal = ({
   visible,
   line,
   destination,
+  boardingStation,
   loading,
   onClose,
   onSelect,
@@ -115,11 +123,18 @@ export const TrainTypeListModal = ({
 
       const lines = uniqBy(item.lines ?? [], 'id');
 
-      // カードの配色・路線シンボルは種別ごとの起点路線で描画する（選択中の line で
-      // 固定すると東武東上線経由の種別に西武池袋線のデザインが当たってしまう）。
-      const originLine = getOriginLine(lines, line, destination);
+      // カードの配色・路線シンボル・ナンバリングは、種別ごとに乗車駅で実際に乗車する
+      // 路線で統一する（選択中の line で固定すると東武東上線経由の種別に西武池袋線の
+      // デザインが当たってしまう）。経路の途中駅から乗る場合は終端路線ではなく乗車路線
+      // を使うことで、乗車駅に必ず存在する駅番号でナンバリングを安定表示できる。
+      const boardingLine = getBoardingLine(
+        lines,
+        boardingStation,
+        line,
+        destination
+      );
 
-      const viaLines = getViaLines(lines, originLine, destination);
+      const viaLines = getViaLines(lines, boardingLine, destination);
 
       const title = `${isJapanese ? item.name : item.nameRoman}`;
 
@@ -157,11 +172,19 @@ export const TrainTypeListModal = ({
             })
             .join('\n');
 
-      // この一覧では駅番号は出さず路線シンボル（静的画像）を固定表示する仕様のため、
-      // targetStation は渡さない（番号マッチが起きず line のシンボルが描画される）。
+      // 駅番号（ナンバリング）は乗車路線の乗車駅基準で表示する。乗車路線はカードの
+      // デザインと同一なので CommonCard の路線記号一致が必ず成立し、番号が安定して
+      // 描画される。
+      const boardingLineStation = getBoardingLineStation(
+        boardingStation,
+        boardingLine,
+        line
+      );
+
       return (
         <CommonCard
-          line={originLine}
+          targetStation={boardingLineStation ?? undefined}
+          line={boardingLine}
           title={title}
           subtitle={subtitle}
           loading={loading}
@@ -169,7 +192,7 @@ export const TrainTypeListModal = ({
         />
       );
     },
-    [destination, line, loading, onSelect]
+    [boardingStation, destination, line, loading, onSelect]
   );
 
   const keyExtractor = useCallback(

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -706,6 +706,7 @@ const RouteSearchScreen = () => {
         visible={trainTypeListModalVisible}
         line={currentStationLineForTrainTypeModal}
         destination={wantedDestination}
+        boardingStation={station}
         onClose={() => {
           setTrainTypeListModalVisible(false);
         }}

--- a/src/utils/trainTypeList.test.ts
+++ b/src/utils/trainTypeList.test.ts
@@ -1,5 +1,11 @@
 import type { Line, Station } from '~/@types/graphql';
-import { formatLineNames, getOriginLine, getViaLines } from './trainTypeList';
+import {
+  formatLineNames,
+  getBoardingLine,
+  getBoardingLineStation,
+  getOriginLine,
+  getViaLines,
+} from './trainTypeList';
 
 afterEach(() => jest.clearAllMocks());
 
@@ -82,6 +88,101 @@ describe('getOriginLine', () => {
       line: minatomirai,
     } as Station);
     expect(result.id).toBe(seibuIkebukuro.id);
+  });
+});
+
+// 乗車駅(StationNested)を模したヘルパー。lines[].station.stationNumbers から
+// ナンバリングを引くため、各路線に駅番号付きの station を持たせる。
+const createNestedStation = (stationNumber: string, lineSymbol: string) =>
+  ({
+    __typename: 'StationNested',
+    stationNumbers: [{ stationNumber, lineSymbol }],
+  }) as unknown as Line['station'];
+
+const createBoardingStation = (
+  lineEntries: { id: Line['id']; station?: Line['station'] }[]
+): Station =>
+  ({
+    __typename: 'Station',
+    lines: lineEntries,
+  }) as unknown as Station;
+
+describe('getBoardingLine', () => {
+  // 西武秩父線・東急東横線・みなとみらい線は池袋を通らない（乗車駅に含まれない）
+  const seibuChichibu = createLine(6, { nameShort: '西武秩父線' });
+  const ikebukuro = createBoardingStation([
+    { id: seibuIkebukuro.id },
+    { id: tobuTojo.id },
+    { id: fukutoshin.id },
+  ]);
+
+  it('経路順で最初に乗車駅を通る路線を乗車路線とする（S-TRAIN: 終端は西武秩父線でも乗車は西武池袋線）', () => {
+    const lines = [
+      seibuChichibu,
+      seibuIkebukuro,
+      fukutoshin,
+      tokyu,
+      minatomirai,
+    ];
+    const result = getBoardingLine(lines, ikebukuro, seibuIkebukuro, {
+      line: minatomirai,
+    } as Station);
+    expect(result.id).toBe(seibuIkebukuro.id);
+  });
+
+  it('linesが行先始まりの逆順でも乗車駅を通る路線を選ぶ（特急: 副都心線から乗車）', () => {
+    const lines = [minatomirai, tokyu, fukutoshin, seibuChichibu];
+    const result = getBoardingLine(lines, ikebukuro, seibuIkebukuro, {
+      line: minatomirai,
+    } as Station);
+    expect(result.id).toBe(fukutoshin.id);
+  });
+
+  it('乗車駅情報が無い場合は getOriginLine（始発側終端）にフォールバックする', () => {
+    const lines = [tobuTojo, fukutoshin, tokyu, minatomirai];
+    const result = getBoardingLine(lines, null, seibuIkebukuro, {
+      line: minatomirai,
+    } as Station);
+    expect(result.id).toBe(tobuTojo.id);
+  });
+
+  it('乗車駅にどの経路路線も含まれない場合も getOriginLine にフォールバックする', () => {
+    const lines = [tobuTojo, tokyu, minatomirai];
+    const onlyOtherLines = createBoardingStation([{ id: seibuIkebukuro.id }]);
+    const result = getBoardingLine(lines, onlyOtherLines, seibuIkebukuro, {
+      line: minatomirai,
+    } as Station);
+    expect(result.id).toBe(tobuTojo.id);
+  });
+});
+
+describe('getBoardingLineStation', () => {
+  const ikebukuro = createBoardingStation([
+    { id: seibuIkebukuro.id, station: createNestedStation('SI-01', 'SI') },
+    { id: fukutoshin.id, station: createNestedStation('F-09', 'F') },
+  ]);
+
+  it('乗車駅の乗車路線の駅（駅番号付き）を返す', () => {
+    const result = getBoardingLineStation(
+      ikebukuro,
+      fukutoshin,
+      seibuIkebukuro
+    );
+    expect(result?.stationNumbers?.[0]?.stationNumber).toBe('F-09');
+  });
+
+  it('乗車駅情報が無く乗車路線が選択中の路線と同じなら選択路線の駅を返す', () => {
+    const selected = createLine(1, {
+      nameShort: '西武池袋線',
+      station: createNestedStation('SI-01', 'SI'),
+    } as Partial<Line>);
+    const result = getBoardingLineStation(null, selected, selected);
+    expect(result?.stationNumbers?.[0]?.stationNumber).toBe('SI-01');
+  });
+
+  it('乗車駅情報が無く乗車路線が選択中の路線と異なる場合は null を返す', () => {
+    const result = getBoardingLineStation(null, fukutoshin, seibuIkebukuro);
+    expect(result).toBeNull();
   });
 });
 

--- a/src/utils/trainTypeList.ts
+++ b/src/utils/trainTypeList.ts
@@ -1,4 +1,4 @@
-import type { Line, Station } from '~/@types/graphql';
+import type { Line, Station, StationNested } from '~/@types/graphql';
 
 /**
  * 各種別が始発（出発駅）で乗車する起点路線を lines から特定する。
@@ -25,6 +25,40 @@ export const getOriginLine = (
   const originFromStart = destinationLineIndex * 2 >= lines.length - 1;
   return (originFromStart ? lines[0] : lines.at(-1)) ?? selectedLine;
 };
+
+/**
+ * 乗車駅(boardingStation)で実際に乗車する路線を返す。
+ *
+ * 経路順に並ぶ lines のうち、乗車駅を通る最初の路線がその駅で乗車する路線になる。
+ * getOriginLine が返す始発側の終端路線は、乗車駅が経路の途中にある場合（例: 池袋から
+ * S-TRAIN に乗ると終端は西武秩父線だが乗車するのは西武池袋線）に一致しない。
+ * カードの配色・路線記号・ナンバリングはこの乗車路線で統一することで、乗車駅に必ず
+ * 存在する駅番号を使ってナンバリングを安定して表示できる。
+ * 乗車駅情報が無い場合（在来アプリ内利用など）は getOriginLine にフォールバックする。
+ */
+export const getBoardingLine = (
+  lines: Line[],
+  boardingStation: Station | null | undefined,
+  selectedLine: Line,
+  destination?: Station | null
+): Line =>
+  lines.find((l) => boardingStation?.lines?.some((sl) => sl.id === l.id)) ??
+  getOriginLine(lines, selectedLine, destination);
+
+/**
+ * 乗車駅における乗車路線(boardingLine)の駅（駅番号付き）を返す。ナンバリング表示に使う。
+ *
+ * 経路検索では item.lines[].station が API で null になるため、乗車駅の路線別 station
+ * から乗車路線の駅を引く。乗車駅情報が無い場合は、乗車路線が選択中の路線と同じであれば
+ * 選択路線の駅へフォールバックする（在来アプリ内利用など）。
+ */
+export const getBoardingLineStation = (
+  boardingStation: Station | null | undefined,
+  boardingLine: Line,
+  selectedLine: Line
+): StationNested | null =>
+  boardingStation?.lines?.find((l) => l.id === boardingLine.id)?.station ??
+  (boardingLine.id === selectedLine.id ? (selectedLine.station ?? null) : null);
 
 /** 選択された路線と目的地の路線の間にある経由路線を取得する */
 export const getViaLines = (


### PR DESCRIPTION
## 概要

PR #6251 で経路検索の種別一覧モーダルのナンバリング（駅番号）が静的な路線シンボル画像に固定されていた問題を、ナンバリング表示に戻しました。あわせて、カードの配色・路線シンボル・経由・ナンバリングを「種別ごとに乗車駅で実際に乗車する路線」基準で統一し、`getOriginLine`（始発側の終端路線）では乗車駅に駅番号が無く番号が出ない不整合を解消しています。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `CommonCard` はナンバリングを `line` の路線記号一致でしか描画しないため、デザイン用の路線とナンバリングの路線が一致しないと「番号が出るときと出ないとき」が生じていた。原因を staging API で確認したところ、経路検索（`routeTypes`）のレスポンスはネストされた `lines[].station` をすべて `null` で返し、さらに `getOriginLine` が返す始発側の終端路線（例: S-TRAIN なら西武秩父線、特急なら東急東横線など）は乗車駅に存在しないため、駅番号を引けなかった。
- 種別一覧のカードを、種別ごとに「乗車駅で実際に乗車する路線」（経路順で最初に乗車駅を通る路線）基準で描画するように変更。配色・路線シンボル・経由・ナンバリングをこの乗車路線で統一し、乗車駅に必ず存在する駅番号で安定してナンバリングを表示する。
- 乗車路線の解決ロジックを `src/utils/trainTypeList.ts` に `getBoardingLine` / `getBoardingLineStation` として追加（`getOriginLine` は乗車駅情報が無い場合のフォールバックとして存続）。
- `TrainTypeListModal` に乗車駅を渡す `boardingStation` prop を追加し、`RouteSearchScreen` / `SelectBoundModal` から乗車駅を渡すように変更。
- 新規 util のユニットテストを `src/utils/trainTypeList.test.ts` に追加。
- 補足: 経路の途中駅から乗る種別（特急・S-TRAIN 等）では、カードのデザイン路線が PR #6251 の「始発側終端路線」から「乗車路線」に変わる（例: 特急は西武/東急系の終端 → 副都心線）。これはナンバリングとデザインを一致させ常時表示するための必須変更で、PR #6251 のコメントが意図していた「始発側で乗車する路線」とも整合する。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

staging API（池袋→元町・中華街 / みなとみらい線経由）の実データで全 9 種別を検証し、9/9 でナンバリングが表示されることを確認（S-TRAIN は西武池袋線 SI-01、その他は副都心線 F-09 と、それぞれ正しい乗車路線の駅番号）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 経路検索結果の路線番号解決を乗車駅基準に改善し、検索結果がユーザーの乗車駅に合わせてより正確に表示されるようにしました。

* **Tests**
  * 乗車駅ベースの経路表示機能の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->