### PR TITLE
日本語駅名のTTS読み上げをnameIpaから漢字＋カタカナ方式に戻す

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -22,12 +22,9 @@ describe('replaceJapaneseText', () => {
   });
 
   it('returns the provided fallback when both args are nullish', () => {
-    expect(replaceJapaneseText(null, null, undefined, '各駅停車')).toBe(
-      '各駅停車'
-    );
+    expect(replaceJapaneseText(null, null, '各駅停車')).toBe('各駅停車');
     expect(
       replaceJapaneseText(
-        undefined,
         undefined,
         undefined,
         '<sub alias="かくえきていしゃ">各駅停車</sub>'
@@ -46,38 +43,6 @@ describe('replaceJapaneseText', () => {
     );
   });
 
-  it('wraps name with ipa phoneme when nameIpa carries an accent nucleus (ˈ)', () => {
-    // アクセント核を含む IPA がある場合は <phoneme alphabet="ipa"> で読ませる。
-    expect(
-      replaceJapaneseText(
-        '練馬春日町',
-        'ネリマカスガチョウ',
-        'neɾimaˈkasɯɡat͡ɕoː'
-      )
-    ).toBe(
-      '<phoneme alphabet="ipa" ph="neɾimaˈkasɯɡat͡ɕoː">練馬春日町</phoneme>'
-    );
-  });
-
-  it('falls back to sub alias when nameIpa has no accent nucleus', () => {
-    // 核が無い IPA（StationAPI 未対応 or 平板）は従来どおり読みに倒す＝無リグレッション。
-    expect(replaceJapaneseText('新宿', 'シンジュク', 'ɕindʑɯkɯ')).toBe(
-      '<sub alias="しんじゅく">新宿</sub>'
-    );
-  });
-
-  it('escapes XML special characters in the ipa phoneme output', () => {
-    expect(replaceJapaneseText('A&B', 'エービー', 'ˈeːbiː')).toBe(
-      '<phoneme alphabet="ipa" ph="ˈeːbiː">A&amp;B</phoneme>'
-    );
-  });
-
-  it('returns fallback when name is nullish even if nameIpa has an accent nucleus', () => {
-    expect(replaceJapaneseText(null, null, 'ˈabc', '各駅停車')).toBe(
-      '各駅停車'
-    );
-  });
-
   it('does not fall back to 各駅停車 implicitly (#5917)', () => {
     // 駅名・路線名のヘルパとして使われるため、誤って `各駅停車` を返してはならない。
     expect(replaceJapaneseText(null, null)).not.toContain('各駅停車');
@@ -87,7 +52,7 @@ describe('replaceJapaneseText', () => {
     // 以前は sub 内に `null` / `undefined` が混入していた。
     expect(replaceJapaneseText(null, 'シンジュク')).toBe('');
     expect(replaceJapaneseText(undefined, 'シンジュク')).toBe('');
-    expect(replaceJapaneseText(null, 'シンジュク', undefined, '各駅停車')).toBe(
+    expect(replaceJapaneseText(null, 'シンジュク', '各駅停車')).toBe(
       '各駅停車'
     );
 

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -2,10 +2,6 @@ import type { Line, Station, TtsSegment } from '../../@types/graphql';
 import katakanaToHiragana from '../../utils/kanaToHiragana';
 import { escapeXml, escapeXmlAttr, wrapPhoneme } from '../../utils/phoneme';
 
-// IPA のアクセント核（下げ核）マーカー。Azure は <phoneme alphabet="ipa"> 経由で
-// この記号を尊重することを実機確認済み。StationAPI が nameIpa に付与する。
-const ACCENT_NUCLEUS_MARK = 'ˈ';
-
 // 駅名に併記されたカッコ書き (例: 命名権スポンサー名 `電鉄富山(トヨタモビリティ富山)`)
 // を TTS で読み上げないために、半角・全角のカッコと中身を取り除く。
 // 既存の `parenthesisRegexp` は半角のみで駅 API が全角を返すケースをカバー
@@ -63,18 +59,10 @@ export const stripStationParensForTTS = (station: Station): Station => ({
 export const replaceJapaneseText = (
   name: string | null | undefined,
   nameKatakana: string | null | undefined,
-  nameIpa?: string | null | undefined,
   fallback = ''
 ): string => {
   if (!name) {
     return fallback;
-  }
-  // アクセント核(ˈ)を含む IPA がある場合のみ <phoneme> で読ませ、固有名詞の
-  // ピッチアクセントを明示する。核が無い場合（StationAPI 未対応 or 平板）は
-  // 従来どおり読み(<sub>)に倒すことで、アクセントデータ投入前は挙動を一切
-  // 変えず（無リグレッション）、データ投入と同時に自動で有効化される。
-  if (nameIpa?.includes(ACCENT_NUCLEUS_MARK)) {
-    return `<phoneme alphabet="ipa" ph="${escapeXmlAttr(nameIpa)}">${escapeXml(name)}</phoneme>`;
   }
   if (!nameKatakana) {
     return escapeXml(name);
@@ -83,13 +71,12 @@ export const replaceJapaneseText = (
   return `<sub alias="${alias}">${escapeXml(name)}</sub>`;
 };
 
-const replaceLineNameJa = (
-  line: Pick<Line, 'nameShort' | 'nameKatakana' | 'nameIpa'>
-) => replaceJapaneseText(line.nameShort, line.nameKatakana, line.nameIpa);
+const replaceLineNameJa = (line: Pick<Line, 'nameShort' | 'nameKatakana'>) =>
+  replaceJapaneseText(line.nameShort, line.nameKatakana);
 
 const replaceStationNameJa = (
-  station: Pick<Station, 'name' | 'nameKatakana' | 'nameIpa'>
-) => replaceJapaneseText(station.name, station.nameKatakana, station.nameIpa);
+  station: Pick<Station, 'name' | 'nameKatakana'>
+) => replaceJapaneseText(station.name, station.nameKatakana);
 
 /** 路線名を sub alias 付きで `、` 連結する。 */
 export const formatLinesListJa = (lines: Line[]): string =>

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -395,7 +395,6 @@ export const useDeepLink = () => {
         ttnamekatakana,
         ttnamechinese,
         ttnamekorean,
-        ttnameipa,
         ttnameromanipa,
       } = parsed.queryParams;
 
@@ -461,7 +460,6 @@ export const useDeepLink = () => {
         nameKatakana: ttnamekatakana,
         nameChinese: ttnamechinese,
         nameKorean: ttnamekorean,
-        nameIpa: ttnameipa,
         nameRomanIpa: ttnameromanipa,
       });
       if (trainTypeResult.status === 'invalid') {

--- a/src/hooks/useTTSText.ts
+++ b/src/hooks/useTTSText.ts
@@ -369,8 +369,7 @@ export const useTTSText = (
 
     const currentLineJa = replaceJapaneseText(
       currentLine.nameShort,
-      currentLine.nameKatakana,
-      currentLine.nameIpa
+      currentLine.nameKatakana
     );
     const currentLineEn = ph(
       currentLine.nameTtsSegments,
@@ -379,8 +378,7 @@ export const useTTSText = (
     const currentTrainTypeJa = currentTrainType
       ? replaceJapaneseText(
           currentTrainType.name,
-          currentTrainType.nameKatakana,
-          currentTrainType.nameIpa
+          currentTrainType.nameKatakana
         )
       : '';
     const currentTrainTypeEn = currentTrainType
@@ -423,8 +421,7 @@ export const useTTSText = (
       // 日本語
       nextStationJa: replaceJapaneseText(
         nextStation?.name,
-        nextStation?.nameKatakana,
-        nextStation?.nameIpa
+        nextStation?.nameKatakana
       ),
       currentLineJa,
       currentLineShortJa: currentLine.nameShort ?? '',
@@ -456,32 +453,22 @@ export const useTTSText = (
       afterNextStationJa: afterNextStation
         ? replaceJapaneseText(
             afterNextStation.name,
-            afterNextStation.nameKatakana,
-            afterNextStation.nameIpa
+            afterNextStation.nameKatakana
           )
         : '',
       viaStationJa: viaStation
-        ? replaceJapaneseText(
-            viaStation.name,
-            viaStation.nameKatakana,
-            viaStation.nameIpa
-          )
+        ? replaceJapaneseText(viaStation.name, viaStation.nameKatakana)
         : '',
       jrWestStopsListJa: formatJrWestStopsListJa(allStops, isBoundStop),
       lastAnnouncedStopJa: lastAnnouncedStop
         ? replaceJapaneseText(
             lastAnnouncedStop.name,
-            lastAnnouncedStop.nameKatakana,
-            lastAnnouncedStop.nameIpa
+            lastAnnouncedStop.nameKatakana
           )
         : '',
       // 直通境界駅で案内する直通先路線
       nextLineJa: isNextStopThroughBoundary
-        ? replaceJapaneseText(
-            throughLine?.nameShort,
-            throughLine?.nameKatakana,
-            throughLine?.nameIpa
-          )
+        ? replaceJapaneseText(throughLine?.nameShort, throughLine?.nameKatakana)
         : '',
 
       // 英語

--- a/src/lib/deepLinkTrainType.test.ts
+++ b/src/lib/deepLinkTrainType.test.ts
@@ -191,7 +191,6 @@ describe('parseTrainTypeOverride', () => {
         nameKatakana: 'カイソク',
         nameChinese: '快速',
         nameKorean: '쾌속',
-        nameIpa: 'kaisoku',
         nameRomanIpa: 'ɾæpɪd',
       });
       expect(result.status).toBe('valid');
@@ -201,7 +200,8 @@ describe('parseTrainTypeOverride', () => {
           nameKatakana: 'カイソク',
           nameChinese: '快速',
           nameKorean: '쾌속',
-          nameIpa: 'kaisoku',
+          // nameIpa は deep link で運ばないため、常に null になる。
+          nameIpa: null,
           nameRomanIpa: 'ɾæpɪd',
         });
       }

--- a/src/lib/deepLinkTrainType.ts
+++ b/src/lib/deepLinkTrainType.ts
@@ -18,7 +18,6 @@ export type TrainTypeOverrideInput = {
   nameKatakana?: unknown;
   nameChinese?: unknown;
   nameKorean?: unknown;
-  nameIpa?: unknown;
   nameRomanIpa?: unknown;
 };
 
@@ -135,7 +134,6 @@ export const parseTrainTypeOverride = (
   const nameKatakana = optionalName(raw.nameKatakana);
   const nameChinese = optionalName(raw.nameChinese);
   const nameKorean = optionalName(raw.nameKorean);
-  const nameIpa = optionalName(raw.nameIpa);
   const nameRomanIpa = optionalName(raw.nameRomanIpa);
 
   if (
@@ -143,7 +141,6 @@ export const parseTrainTypeOverride = (
     !nameKatakana.ok ||
     !nameChinese.ok ||
     !nameKorean.ok ||
-    !nameIpa.ok ||
     !nameRomanIpa.ok
   ) {
     return { status: 'invalid' };
@@ -159,8 +156,11 @@ export const parseTrainTypeOverride = (
     nameKatakana: nameKatakana.value,
     nameChinese: nameChinese.value,
     nameKorean: nameKorean.value,
-    nameIpa: nameIpa.value,
     nameRomanIpa: nameRomanIpa.value,
+    // nameIpa is no longer carried by deep links: Japanese TTS reads names from
+    // kanji + nameKatakana, so an IPA override would have no effect. It remains a
+    // required schema field, so it is explicitly null.
+    nameIpa: null,
     // Server-owned identity / structural fields are explicitly null so the
     // override never carries stale or fabricated lineGroupId / typeId.
     id: null,

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -48,7 +48,6 @@ export const TINY_TRAIN_TYPE_FRAGMENT = gql`
     groupId
     name
     nameKatakana
-    nameIpa
     nameRoman
     nameRomanIpa
     nameChinese
@@ -98,7 +97,6 @@ export const LINE_NESTED_FRAGMENT = gql`
     lineType
     nameFull
     nameKatakana
-    nameIpa
     nameRoman
     nameRomanIpa
     nameShort
@@ -140,7 +138,6 @@ export const LINE_IN_STATION_FRAGMENT = gql`
     }
     lineType
     nameKatakana
-    nameIpa
     nameRoman
     nameShort
     nameChinese
@@ -160,7 +157,6 @@ export const TRAIN_TYPE_NESTED_FRAGMENT = gql`
     groupId
     name
     nameKatakana
-    nameIpa
     nameRoman
     nameRomanIpa
     nameChinese
@@ -189,7 +185,6 @@ export const STATION_FRAGMENT = gql`
     groupId
     name
     nameKatakana
-    nameIpa
     nameRoman
     nameChinese
     nameKorean


### PR DESCRIPTION
## 概要

日本語駅名・路線名・種別の TTS 読み上げを、`nameIpa` のアクセント核付き `<phoneme alphabet="ipa">` 方式（#6243 で導入）から、従来の漢字＋カタカナによる `<sub alias="ひらがな読み">漢字</sub>` 方式へ戻します。あわせて、TTS 用途が無くなったことで不要になったディープリンクの `nameIpa` 取り回し（#6019 で追加）も削除します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `src/hooks/tts/formatters.ts`: `replaceJapaneseText` から `nameIpa` 引数とアクセント核ゲート付き `<phoneme>` 分岐を撤去し、`<sub alias>` のカナ読み方式に戻す（`& < " '` を防ぐ XML エスケープは方式と独立した防御として維持）。`replaceLineNameJa` / `replaceStationNameJa` も `nameIpa` を渡さないよう更新。
- `src/hooks/useTTSText.ts`: 日本語各案内（次駅・路線・種別・経由駅・直通先など）の `replaceJapaneseText` 呼び出しから `nameIpa` 引数を削除。
- `src/lib/graphql/queries.ts`: TTS 用に追加していた各 fragment の `nameIpa` 取得を削除（英語用の `nameRomanIpa` は維持）。
- `src/lib/deepLinkTrainType.ts` / `src/hooks/useDeepLink.ts`: ディープリンクのカスタム列車種別から `nameIpa` の入力・パース・受け渡しを削除。`TrainTypeNested` の必須フィールドのため、構築結果は `nameIpa: null` を明示。
- 各テスト: `nameIpa` の `<phoneme>` 出力を検証するケースとディープリンクの `nameIpa` 入力検証を更新。
- 補足: `nameIpa` は GraphQL スキーマ（自動生成型）の必須フィールドのため、fixtures / mocks 等の `nameIpa: null` placeholder と `src/@types/graphql.d.ts` は据え置き。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Deep linkでのTrainType名指定がカタカナ・中国語・韓国語表記に対応しました。

* **Refactor**
  * 日本語テキスト処理を最適化し、音声合成テンプレートの生成ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->