### PR TITLE
TTSのsub aliasをひらがな変換せずカタカナのまま渡して都営などのアクセント句分割を防ぐ

### DIFF
--- a/src/hooks/tts/formatters.test.ts
+++ b/src/hooks/tts/formatters.test.ts
@@ -37,9 +37,17 @@ describe('replaceJapaneseText', () => {
     expect(replaceJapaneseText('新宿', undefined)).toBe('新宿');
   });
 
-  it('wraps name with sub alias when both name and nameKatakana are provided', () => {
+  it('wraps name with sub alias using the katakana reading as-is', () => {
+    // alias はカタカナのまま渡す。ひらがな化すると Azure が alias を再解析した際に
+    // 先頭モーラを助詞と誤認してアクセント句が割れる崩れが起きるため (例: 都営)。
     expect(replaceJapaneseText('新宿', 'シンジュク')).toBe(
-      '<sub alias="しんじゅく">新宿</sub>'
+      '<sub alias="シンジュク">新宿</sub>'
+    );
+  });
+
+  it('keeps katakana so 都営 is not split into と・えい', () => {
+    expect(replaceJapaneseText('都営', 'トエイ')).toBe(
+      '<sub alias="トエイ">都営</sub>'
     );
   });
 

--- a/src/hooks/tts/formatters.ts
+++ b/src/hooks/tts/formatters.ts
@@ -1,5 +1,4 @@
 import type { Line, Station, TtsSegment } from '../../@types/graphql';
-import katakanaToHiragana from '../../utils/kanaToHiragana';
 import { escapeXml, escapeXmlAttr, wrapPhoneme } from '../../utils/phoneme';
 
 // 駅名に併記されたカッコ書き (例: 命名権スポンサー名 `電鉄富山(トヨタモビリティ富山)`)
@@ -55,6 +54,12 @@ export const stripStationParensForTTS = (station: Station): Station => ({
  *
  * NOTE: `name` だけ nullish で `nameKatakana` が埋まっているケースでは sub 内に
  * `null` / `undefined` が混入していたため、`name` がない時点で fallback に倒す。
+ *
+ * NOTE: alias にはカタカナの `nameKatakana` をそのまま渡す。以前はひらがなへ
+ * 変換していたが、Azure Speech の日本語フロントエンドは alias 文字列を形態素解析し
+ * 直すため、ひらがなだと「とえい(都営)」の先頭「と」が助詞と誤認されてアクセント句が
+ * 「と・えい」と分割される崩れが起きていた。カタカナは助詞(基本ひらがな)に化けにくく、
+ * 固有名詞を1トークンとして読ませやすいため、先頭が助詞由来モーラの読み全般で安定する (#6276 系)。
  */
 export const replaceJapaneseText = (
   name: string | null | undefined,
@@ -67,7 +72,7 @@ export const replaceJapaneseText = (
   if (!nameKatakana) {
     return escapeXml(name);
   }
-  const alias = escapeXmlAttr(katakanaToHiragana(nameKatakana));
+  const alias = escapeXmlAttr(nameKatakana);
   return `<sub alias="${alias}">${escapeXml(name)}</sub>`;
 };
 

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -128,7 +128,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        '次は<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>はお乗り換えです。',
         'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -141,7 +141,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 公式の東京メトロ到着前放送は乗換案内を含まない
       expect(result.current.text).toEqual([
-        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        'まもなく<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。',
         'Arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
@@ -157,7 +157,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 公式の東急放送は駅名2回読み、「◯◯線ご利用のお客様はお乗り換えです」(「を」なし)
       expect(result.current.text).toEqual([
-        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
+        '次は<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, please transfer at this station.',
       ]);
     });
@@ -169,7 +169,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
+        'まもなく<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>ご利用のお客様はお乗り換えです。',
         'We will soon make a brief stop at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Passengers changing to the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line, please transfer at this station.',
       ]);
     });
@@ -184,7 +184,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        '次は、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -196,7 +196,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        'まもなく、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -212,7 +212,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 公式のJR西日本発車後放送は乗換案内を含まない (乗換案内は到着前のみ)
       expect(result.current.text).toEqual([
-        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        '次は<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。',
         'The next stop is Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
@@ -224,7 +224,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        'まもなく<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>はお乗り換えです。',
         'We will soon be making a brief stop at Shinjuku-sanchome, station number S <say-as interpret-as="cardinal">2</say-as>. Transfer here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -240,7 +240,7 @@ describe('Without trainType & With numbering', () => {
       );
       // SAIKYO は YAMANOTE と同じJR東日本 通勤型共通テンプレートを使う
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        '次は、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -252,7 +252,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        'まもなく、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -268,7 +268,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 公式の都営放送では列車案内は始発時のみ。乗換案内は「◯◯は、お乗り換えです。」
       expect(result.current.text).toEqual([
-        '次は、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>は、お乗り換えです。',
+        '次は、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>は、お乗り換えです。',
         'The next station is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -281,7 +281,7 @@ describe('Without trainType & With numbering', () => {
       );
       // 公式の都営到着前放送は乗換案内を含まない (通過駅がある場合のみ案内)
       expect(result.current.text).toEqual([
-        'まもなく、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>、<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。',
+        'まもなく、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>、<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。',
         'We will soon be arriving at Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>.',
       ]);
     });
@@ -296,7 +296,7 @@ describe('Without trainType & With numbering', () => {
         }
       );
       expect(result.current.text).toEqual([
-        '次は<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。<sub alias="とうきょうめとろまるのうちせん">東京メトロ丸ノ内線</sub>、<sub alias="とうきょうめとろふくとしんせん">東京メトロ副都心線</sub>はお乗り換えです。',
+        '次は<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>はお乗り換えです。',
         'The next stop is Shinjuku-sanchome S <say-as interpret-as="cardinal">2</say-as>. Please change here for the Tokyo Metro Marunouchi Line,<break time="200ms"/> and the Tokyo Metro Fukutoshin Line.',
       ]);
     });
@@ -313,7 +313,7 @@ describe('Without trainType & With numbering', () => {
 
       // 日本語: 期待される日本語SSML出力を検証 (公式のメトロ到着前放送は乗換案内なし)
       expect(jaSSML).toBe(
-        'まもなく<sub alias="しんじゅくさんちょうめ">新宿三丁目</sub>です。'
+        'まもなく<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。'
       );
       // 日本語: 期待される英語SSML出力を検証
       expect(en).toBe(


### PR DESCRIPTION
## 概要

駅名・路線名・会社名の TTS 読み上げで、`<sub alias>` に渡す読みをカタカナからひらがなへ変換していたために、Azure Speech の日本語フロントエンドが alias 文字列を再解析した際に先頭モーラを助詞と誤認し、アクセント句が分割される読み崩れが起きていた（例: 「都営(トエイ)」が「と・えい」と切れて読まれる）。alias をカタカナのまま渡すよう変更してこれを防ぐ。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/tts/formatters.ts`: `replaceJapaneseText` で `nameKatakana` をひらがな変換（`katakanaToHiragana`）せずカタカナのまま `<sub alias>` に渡すよう変更。意図をコメントで明記。
- 先頭が助詞由来モーラ（と / は / に / を / で / も …）で始まる読み全般で、アクセント句の不自然な分割を防止（都営に限らず効く）。
- 変更は TTS パスのみ。ヘッダー表示用のひらがな変換（`useHeaderStationText.ts`）は対象外で変更なし。
- テスト更新: `formatters.test.ts` をカタカナ alias 仕様に合わせ、「都営 → トエイ」の回帰テストを追加。`useTTSText.test.tsx` の alias 期待値（属性内のひらがなのみ）をカタカナへ更新。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

備考: Azure Speech をこの環境から直接叩けないため、実機での読み上げ聴き比べは未実施。主要な駅名・社名（都営／東京メトロ／各社直通名など）の実機確認を推奨。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01YWL18WqYAGmTBkmApCfFtR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 駅名・路線名の日本語音声合成における読み表記を改善しました。
  * テキスト音声合成機能で複数の路線テーマにおけるカタカナ表記の処理が正確に動作するよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->