### PR TITLE
TTS再生が途中で打ち切られ英語に飛ぶ不具合を修正（iOS早期didJustFinishガード／再生中の時間制限撤廃）

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -294,15 +294,16 @@ describe('useTTS', () => {
     expect(mockCreateAudioPlayer).not.toHaveBeenCalled();
   });
 
-  it('タイムアウト後に強制リセットされる', async () => {
+  it('再生が始まった後は時間が経過しても打ち切られない', async () => {
     const store = createStore();
     store.set(speechState, {
       ...defaultSpeechState,
       ttsEnabledLanguages: ['EN'],
     });
 
-    // didJustFinish を発火しないが再生中(playing=true)であり続けるプレイヤー
-    // （ストール検知に掛からず最終タイムアウトまで到達するケース）
+    // didJustFinish を発火しないが再生中(playing=true)であり続ける長尺プレイヤー。
+    // 準備段階の安全タイムアウトは再生開始時に解除されるため、何分経過しても
+    // 強制リセットされず、進行停止検知はttsAudioPlayerのストール監視に委ねられる。
     mockCreateAudioPlayer.mockImplementation(() =>
       createMockPlayer({ autoFinish: false, playing: true })
     );
@@ -322,10 +323,10 @@ describe('useTTS', () => {
       expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
     });
 
-    // 300秒のタイムアウトを発火
+    // 再生開始後に長時間（300秒）経過させても強制リセットは起きない
     jest.advanceTimersByTime(300_000);
 
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(warnSpy).not.toHaveBeenCalledWith(
       '[useTTS] Playback safety timeout reached, force resetting'
     );
 

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -23,10 +23,12 @@ import { usePrevious } from './usePrevious';
 import { useStoppingState } from './useStoppingState';
 import { useTTSText } from './useTTSText';
 
-// 再生が完了しない場合の最終フォールバックタイムアウト（ミリ秒）
-// 通常のストール（Androidでのネイティブエラーや音声フォーカス喪失など）は
-// ttsAudioPlayerのストール検知ウォッチドッグが先に打ち切って復帰させるため、
-// これはウォッチドッグでも捕捉できない異常系に対する最後の砦
+// 再生開始前（フェッチ・トークン取得など）のハングに対する安全タイムアウト（ミリ秒）
+// プレイヤー未生成の準備段階はttsAudioPlayerのストール検知ウォッチドッグが効かないため、
+// この区間がハングしてもplayingRefを確実に解放してTTS全体の停止を防ぐ。
+// 実際の音声再生が始まった時点でこのタイムアウトは解除し（armPlaybackWatchdogを参照）、
+// 以降の再生中の進行停止検知はttsAudioPlayerのストール監視に委ねる。
+// これにより健全な長尺再生が一定時間で打ち切られることはなくなる。
 const PLAYBACK_TIMEOUT_MS = 300_000;
 
 export const useTTS = (): void => {
@@ -171,9 +173,11 @@ export const useTTS = (): void => {
     }
   }, []);
 
-  // playingRefがtrueになった時点で必ず安全タイムアウトを張る。
+  // playingRefがtrueになった時点で安全タイムアウトを張る。
   // フェッチやトークン取得がハングしてもplayingRefが解放されずTTS全体が
-  // 停止するのを防ぐため、再生開始前のフェッチ段階も含めて監視する。
+  // 停止するのを防ぐための、再生開始前の準備段階専用の監視。
+  // 実際の再生が始まったらclearPlaybackWatchdogで解除し、以降は再生時間に
+  // よらず打ち切らない（進行停止はttsAudioPlayerのストール監視が担う）。
   const armPlaybackWatchdog = useCallback(
     (runId: number = speechRunIdRef.current) => {
       if (playingTimeoutRef.current) {
@@ -194,6 +198,16 @@ export const useTTS = (): void => {
     },
     [cleanupAllPlayers, finishPlaying]
   );
+
+  // 実際の音声再生が始まったら準備段階の安全タイムアウトを解除する。
+  // これ以降は再生が何分続いても打ち切らず、進行停止の検知は
+  // ttsAudioPlayerのストール監視（STALL_TIMEOUT_MS）に委ねる。
+  const clearPlaybackWatchdog = useCallback(() => {
+    if (playingTimeoutRef.current) {
+      clearTimeout(playingTimeoutRef.current);
+      playingTimeoutRef.current = null;
+    }
+  }, []);
 
   const speakFromPath = useCallback(
     async (pathJa: string, pathEn: string) => {
@@ -216,7 +230,6 @@ export const useTTS = (): void => {
       cleanupAllPlayers();
 
       playingRef.current = true;
-      armPlaybackWatchdog();
 
       // 再生終了/失敗時の停止処理。Android はリスナーだけ解放してプレイヤーを
       // 一時停止し再利用、iOS はプレイヤーをネイティブごと破棄する。
@@ -258,6 +271,8 @@ export const useTTS = (): void => {
           onError: () => enCleanup(),
         });
         enPlayerRef.current = reusePlayers ? enHandleRef.current.player : null;
+        // 再生が始まったので準備段階の安全タイムアウトを解除する
+        clearPlaybackWatchdog();
         return;
       }
 
@@ -302,10 +317,12 @@ export const useTTS = (): void => {
         },
       });
       jaPlayerRef.current = reusePlayers ? jaHandleRef.current.player : null;
+      // 再生が始まったので準備段階の安全タイムアウトを解除する
+      clearPlaybackWatchdog();
     },
     [
-      armPlaybackWatchdog,
       cleanupAllPlayers,
+      clearPlaybackWatchdog,
       finishPlaying,
       reusePlayers,
       shouldSpeakEnglish,

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -26,7 +26,7 @@ import { useTTSText } from './useTTSText';
 // 再生開始前（フェッチ・トークン取得など）のハングに対する安全タイムアウト（ミリ秒）
 // プレイヤー未生成の準備段階はttsAudioPlayerのストール検知ウォッチドッグが効かないため、
 // この区間がハングしてもplayingRefを確実に解放してTTS全体の停止を防ぐ。
-// 実際の音声再生が始まった時点でこのタイムアウトは解除し（armPlaybackWatchdogを参照）、
+// 実際の音声再生が始まった時点でこのタイムアウトは解除し（clearPlaybackWatchdogを参照）、
 // 以降の再生中の進行停止検知はttsAudioPlayerのストール監視に委ねる。
 // これにより健全な長尺再生が一定時間で打ち切られることはなくなる。
 const PLAYBACK_TIMEOUT_MS = 300_000;

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -1,4 +1,6 @@
 import {
+  FINISH_END_EPSILON_SEC,
+  MAX_RESUME_ATTEMPTS,
   playAudio,
   STALL_CHECK_INTERVAL_MS,
   STALL_TIMEOUT_MS,
@@ -12,17 +14,24 @@ jest.mock('expo-audio', () => ({
   createAudioPlayer: (...args: unknown[]) => mockCreateAudioPlayer(...args),
 }));
 
-type StatusCallback = (status: {
+type EmittedStatus = {
   didJustFinish?: boolean;
   error?: string;
-}) => void;
+  currentTime?: number;
+  duration?: number;
+  playbackState?: string;
+  reasonForWaitingToPlay?: string;
+};
 
-const createMockPlayer = (opts?: { playing?: boolean }) => {
+type StatusCallback = (status: EmittedStatus) => void;
+
+const createMockPlayer = (opts?: { playing?: boolean; duration?: number }) => {
   let statusCallback: StatusCallback | null = null;
   const listenerRemove = jest.fn();
   const player = {
     playing: opts?.playing ?? false,
     currentTime: 0,
+    duration: opts?.duration ?? 0,
     addListener: jest.fn((_event: string, callback: StatusCallback) => {
       statusCallback = callback;
       return { remove: listenerRemove };
@@ -31,11 +40,12 @@ const createMockPlayer = (opts?: { playing?: boolean }) => {
     pause: jest.fn(),
     remove: jest.fn(),
     replace: jest.fn(),
+    seekTo: jest.fn().mockResolvedValue(undefined),
   };
   return {
     player,
     listenerRemove,
-    emitStatus: (status: { didJustFinish?: boolean; error?: string }) => {
+    emitStatus: (status: EmittedStatus) => {
       statusCallback?.(status);
     },
   };
@@ -272,6 +282,89 @@ describe('playAudio', () => {
 
     expect(onFinish).toHaveBeenCalledTimes(1);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('終端付近の didJustFinish は正常完了として扱う', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'complete.mp3', onFinish, onError });
+
+    // 終端(30s)付近で完了 → そのまま完了扱い
+    mock.emitStatus({ didJustFinish: true, currentTime: 29.9, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+  });
+
+  it('終端手前の didJustFinish は早期完了とみなしその位置から再開する', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'long.mp3', onFinish, onError });
+
+    // 本来30sあるのに10sで完了報告（iOSの早期 didJustFinish 誤報を再現）
+    mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+
+    // 完了扱いせず、10sの位置から再生を継続する
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+    // 初回 play() に続く再開の play()
+    expect(mock.player.play).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
+  it('位置が0の早期 didJustFinish は再開せず完了として扱う', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'reset.mp3', onFinish, onError });
+
+    // 位置が0にリセットされて報告された場合は頭から再生し直しを避け、完了として進む
+    mock.emitStatus({ didJustFinish: true, currentTime: 0, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('早期 didJustFinish が続いても最大回数で完了として打ち切る', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'stuck.mp3', onFinish, onError });
+
+    // 上限回数までは再開を試み、それを超えたら完了として進む（無限ループ防止）
+    for (let i = 0; i < MAX_RESUME_ATTEMPTS; i++) {
+      mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+    }
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledTimes(MAX_RESUME_ATTEMPTS);
+
+    // 上限超過の早期完了は通常完了として扱う
+    mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('FINISH_END_EPSILON_SEC は正の有限値', () => {
+    expect(Number.isFinite(FINISH_END_EPSILON_SEC)).toBe(true);
+    expect(FINISH_END_EPSILON_SEC).toBeGreaterThan(0);
   });
 
   it('listener.remove() 後はウォッチドッグが停止する', () => {

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -299,7 +299,7 @@ describe('playAudio', () => {
     expect(mock.player.seekTo).not.toHaveBeenCalled();
   });
 
-  it('終端手前の didJustFinish は早期完了とみなしその位置から再開する', () => {
+  it('終端手前の didJustFinish は早期完了とみなしその位置から再開する', async () => {
     const mock = createMockPlayer({ playing: true, duration: 30 });
     mockCreateAudioPlayer.mockReturnValue(mock.player);
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -311,11 +311,17 @@ describe('playAudio', () => {
     // 本来30sあるのに10sで完了報告（iOSの早期 didJustFinish 誤報を再現）
     mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
 
-    // 完了扱いせず、10sの位置から再生を継続する
+    // 完了扱いせず、10sの位置へ seek してから再生を継続する
     expect(onFinish).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
     expect(mock.player.seekTo).toHaveBeenCalledWith(10);
-    // 初回 play() に続く再開の play()
+
+    // seekTo の Promise チェーン（.catch → .finally → play）を消化する
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+
+    // seek 完了後に再開の play() が呼ばれる（初回 play と合わせて 2 回）
     expect(mock.player.play).toHaveBeenCalledTimes(2);
 
     warnSpy.mockRestore();

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -87,9 +87,19 @@ export const playAudio = (options: {
         stalledTicks = 0;
         lastCurrentTime = -1;
         try {
-          // didJustFinish で位置が末尾/0 へ移動する実装に備え、明示的に戻してから再生
-          player.seekTo(position).catch(() => {});
-          player.play();
+          // didJustFinish で位置が末尾/0 へ移動する実装に備え、明示的に戻してから再生。
+          // seekTo は非同期のため、完了を待ってから play() しないと古い位置から
+          // 再生が始まりうる。エラー時も含め確実に再生を開始する。
+          player
+            .seekTo(position)
+            .catch(() => {})
+            .finally(() => {
+              try {
+                player.play();
+              } catch (e) {
+                settle(() => onError(e));
+              }
+            });
         } catch (e) {
           settle(() => onError(e));
         }

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -9,6 +9,15 @@ export const STALL_TIMEOUT_MS = 10_000;
 // ストール監視のポーリング間隔
 export const STALL_CHECK_INTERVAL_MS = 1_000;
 
+// didJustFinish 受信時、再生位置がこの秒数以内まで終端へ達していれば正常終了とみなす。
+// iOS は長尺音声で、音声セッションの一時中断やデコード境界などにより本来の終端より
+// 手前で didJustFinish を誤報することがある。これをそのまま「完了」と扱うと、日本語
+// アナウンスが途中で打ち切られて次（英語）へ飛んでしまうため、終端付近に達していない
+// 完了報告は早期完了とみなして再生を継続する。
+export const FINISH_END_EPSILON_SEC = 0.5;
+// 早期 didJustFinish からの再開を試みる最大回数（誤検知時の無限ループを防ぐ安全弁）
+export const MAX_RESUME_ATTEMPTS = 5;
+
 export const safeRemoveListener = (
   listener: { remove: () => void } | null
 ): void => {
@@ -46,13 +55,55 @@ export const playAudio = (options: {
   let settled = false;
   let stalledTicks = 0;
   let lastCurrentTime = -1;
+  let resumeAttempts = 0;
   const maxStalledTicks = Math.ceil(STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS);
+
+  // 終端付近に達していない didJustFinish（iOS の早期完了誤報）を「正常終了」と
+  // 扱わないためのガード。位置が取れる場合はその位置から再開して打ち切りを防ぎ、
+  // 位置が取れない/終端付近の場合は従来どおり完了として進む（=最悪でも現状維持）。
+  const handleDidJustFinish = (status: {
+    currentTime?: number;
+    duration?: number;
+    playbackState?: string;
+    reasonForWaitingToPlay?: string;
+  }) => {
+    const duration = status.duration || player.duration || 0;
+    const position = status.currentTime ?? player.currentTime ?? 0;
+    const reachedEnd =
+      duration <= 0 || position >= duration - FINISH_END_EPSILON_SEC;
+
+    if (!reachedEnd) {
+      // 早期完了の実測値をログに残す（実機での原因特定と再開判定の検証用）
+      console.warn(
+        `[ttsAudioPlayer] early didJustFinish at ${position.toFixed(2)}/${duration.toFixed(2)}s ` +
+          `(state=${status.playbackState ?? 'n/a'}, waiting=${status.reasonForWaitingToPlay ?? 'n/a'}):`,
+        uri
+      );
+      // 位置が取れていれば、その位置から再開して途中打ち切りを防ぐ。
+      // 位置が 0（=リセット報告）だと頭から再生し直しになるため再開しない。
+      if (position > 0 && resumeAttempts < MAX_RESUME_ATTEMPTS) {
+        resumeAttempts += 1;
+        // 再開直後はストール監視を誤発火させないようカウンタを戻す
+        stalledTicks = 0;
+        lastCurrentTime = -1;
+        try {
+          // didJustFinish で位置が末尾/0 へ移動する実装に備え、明示的に戻してから再生
+          player.seekTo(position).catch(() => {});
+          player.play();
+        } catch (e) {
+          settle(() => onError(e));
+        }
+        return;
+      }
+    }
+    settle(onFinish);
+  };
 
   const statusListener = player.addListener(
     'playbackStatusUpdate',
     (status) => {
       if (status.didJustFinish) {
-        settle(onFinish);
+        handleDidJustFinish(status);
       } else if ('error' in status && status.error) {
         console.warn('[ttsAudioPlayer] playback error:', status.error);
         settle(() => onError(status.error));


### PR DESCRIPTION
## 概要

長い日本語アナウンスがiOSで途中で打ち切られ、英語アナウンスに飛んでしまう不具合を修正する。

調査の結果、JA→ENの切り替えトリガーはJAプレイヤーの `didJustFinish`（再生完了報告）のみであることが分かった（`useTTS.ts`）。iOSは長尺音声で、音声セッションの一時中断やデコード境界などにより**本来の終端より手前で `didJustFinish` を誤報**することがあり、これをそのまま「完了」と扱うため、日本語が途中で打ち切られて英語へ進んでしまっていた。`ttsAudioPlayer.ts` に終端到達判定ガードを追加し、終端付近に達していない完了報告は早期完了とみなして再生を継続するようにした。

あわせて、当初の `PLAYBACK_TIMEOUT_MS`（5分）は再生中でも強制的に打ち切る設計だったため、再生開始時に解除して健全な再生を時間で打ち切らないようにした（フェッチ・トークン取得段階のハング保護としては維持）。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/ttsAudioPlayer.ts`:
  - `didJustFinish` 受信時に再生位置（`status.currentTime`）と長さ（`status.duration`）を確認し、終端付近（`FINISH_END_EPSILON_SEC` 以内）に達していない完了報告を「早期完了」とみなすガードを追加。
  - 早期完了時、位置が取れる（`> 0`）場合はその位置へ `seekTo` してから `play()` で再開し、途中打ち切り（=次言語への早期遷移）を防止。位置が0（リセット報告）や終端付近の場合は従来どおり完了として進めるため、**最悪でも現状維持**で劣化しない。
  - 無限ループ防止に再開回数の上限 `MAX_RESUME_ATTEMPTS` を設定。実機での原因特定用に早期完了時の `currentTime`/`duration`/`playbackState` を `console.warn` に記録。
- `src/hooks/useTTS.ts`:
  - `PLAYBACK_TIMEOUT_MS`（5分）を「再生開始前（フェッチ・トークン取得）のハング保護」専用に役割変更し、実際の再生開始時に `clearPlaybackWatchdog` で解除。再生中は時間によらず打ち切らない（進行停止検知は `ttsAudioPlayer` のストール監視に委ねる）。
  - コメント内の関数名参照を修正（`armPlaybackWatchdog` → `clearPlaybackWatchdog`、CodeRabbit指摘）。
- テスト追加・更新:
  - `src/utils/ttsAudioPlayer.test.ts`: 終端付近の完了は正常完了、終端手前の完了は `seekTo` で再開、位置0の完了は再開せず完了、上限超過で完了として打ち切る、を検証。
  - `src/hooks/useTTS.test.ts`: 再生開始後は時間が経過しても打ち切られないことを検証。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npx jest src/utils/ttsAudioPlayer.test.ts src/hooks/useTTS.test.ts` → 37 passed
- `npx tsc --noEmit` → エラーなし
- `npx biome check`（対象3ファイル）→ 問題なし

> 注: iOSが早期完了時に `currentTime` を「途中位置」で報告するか「0」で報告するかは実機未検証。前者なら本ガードで打ち切りが解消し、後者でも追加した `console.warn` のログで実機の実測値を確認でき、必要なら精緻化する。いずれの場合も既存挙動より悪化しない設計。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * TTSの再生完了判定を見直し、終了直前の誤判定や早期完了に起因する不自然な動作を抑制しました。
  * 再生開始前の安全タイムアウトを、再生開始時に確実に解除するよう改善し、長尺コンテンツでの不要な強制リセットを防ぎます。
* **テスト**
  * 終端付近・早期完了・長時間経過などの境界ケースを追加／更新して確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->