### PR TITLE
PiP有効時のバックグラウンド移行でWarningPanelトーストをPiPウィンドウへ写り込ませないよう非表示にする

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -36,6 +36,7 @@ import {
   useCheckStoreVersion,
   useCurrentLine,
   useFeedback,
+  useIsAppActive,
   useWarningInfo,
   useWrongDirectionDetectorEffect,
 } from '../hooks';
@@ -74,7 +75,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setNotify = useSetAtom(notifyState);
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
   const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
-  const { active: pictureInPictureActive } = useAtomValue(pictureInPictureAtom);
+  const { enabled: pictureInPictureEnabled, active: pictureInPictureActive } =
+    useAtomValue(pictureInPictureAtom);
+  const isAppActive = useIsAppActive();
   const setTuning = useSetAtom(tuningState);
   const [themePreference, setThemePreference] = useAtom(themePreferenceAtom);
   const [reportModalShow, setReportModalShow] = useAtom(reportModalVisibleAtom);
@@ -632,10 +635,17 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     ]
   );
 
+  // PiP を有効にしている場合、バックグラウンド(PiP 表示含む)へ移行した際は
+  // トーストが PiP ウィンドウへ写り込んでしまうため非表示にする。
+  // PiP 無効時はそもそも写り込まないので、通常どおり表示し続ける。
+  const hideWarningForPictureInPicture =
+    pictureInPictureEnabled && (pictureInPictureActive || !isAppActive);
+
   const warningPanel =
-    warningInfo?.text && warningInfo?.level ? (
+    !hideWarningForPictureInPicture &&
+    warningInfo?.text &&
+    warningInfo?.level ? (
       <WarningPanel
-        behindContent={pictureInPictureActive}
         onPress={clearWarningInfo}
         text={warningInfo.text}
         warningLevel={warningInfo.level}
@@ -649,9 +659,8 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
         minDurationMs={LONG_PRESS_DURATION}
       >
         <View style={styles.container}>
-          {pictureInPictureActive && warningPanel}
           {children}
-          {!pictureInPictureActive && warningPanel}
+          {warningPanel}
         </View>
       </LongPressGestureHandler>
       <SelectBoundSettingListModal

--- a/src/components/WarningPanel.tsx
+++ b/src/components/WarningPanel.tsx
@@ -14,14 +14,12 @@ import { RFValue } from '~/utils/rfValue';
 import Typography from './Typography';
 
 interface Props {
-  behindContent?: boolean;
   onPress: (event: GestureResponderEvent) => void;
   text: string;
   warningLevel: 'URGENT' | 'WARNING' | 'INFO';
 }
 
 const WarningPanel: React.FC<Props> = ({
-  behindContent = false,
   text,
   onPress,
   warningLevel,
@@ -48,7 +46,7 @@ const WarningPanel: React.FC<Props> = ({
       right: 24,
       bottom: 24,
       padding: 16,
-      zIndex: behindContent ? 0 : 9999,
+      zIndex: 9999,
       opacity: 0.9,
     },
     message: {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -37,6 +37,7 @@ export { useHeaderStationText } from './useHeaderStationText';
 export { useInitialNearbyStation } from './useInitialNearbyStation';
 export { useInRadiusStation } from './useInRadiusStation';
 export { useInterval } from './useInterval';
+export { useIsAppActive } from './useIsAppActive';
 export { useIsDifferentStationName } from './useIsDifferentStationName';
 export { useIsNextLastStop } from './useIsNextLastStop';
 export { useIsPassing } from './useIsPassing';

--- a/src/hooks/useIsAppActive.test.tsx
+++ b/src/hooks/useIsAppActive.test.tsx
@@ -1,0 +1,70 @@
+import { act, render } from '@testing-library/react-native';
+import type React from 'react';
+import { AppState, Text } from 'react-native';
+import { useIsAppActive } from './useIsAppActive';
+
+const mockAddEventListener = jest.fn();
+const mockRemove = jest.fn();
+
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_, handler) => {
+  mockAddEventListener(handler);
+  return { remove: mockRemove };
+});
+
+let latestValue: boolean | null = null;
+
+const TestComponent: React.FC = () => {
+  latestValue = useIsAppActive();
+  return <Text testID="test">{String(latestValue)}</Text>;
+};
+
+describe('useIsAppActive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    latestValue = null;
+    (AppState as { currentState: string }).currentState = 'active';
+  });
+
+  it('マウント時点でAppStateがactiveならtrueを返す', () => {
+    (AppState as { currentState: string }).currentState = 'active';
+    render(<TestComponent />);
+    expect(latestValue).toBe(true);
+  });
+
+  it('マウント時点でAppStateがbackgroundならfalseを返す', () => {
+    (AppState as { currentState: string }).currentState = 'background';
+    render(<TestComponent />);
+    expect(latestValue).toBe(false);
+  });
+
+  it('backgroundへ移行するとfalse、activeへ復帰するとtrueになる', () => {
+    render(<TestComponent />);
+    const handler = mockAddEventListener.mock.calls[0][0];
+
+    act(() => {
+      handler('background');
+    });
+    expect(latestValue).toBe(false);
+
+    act(() => {
+      handler('active');
+    });
+    expect(latestValue).toBe(true);
+  });
+
+  it('inactiveへ移行するとfalseになる', () => {
+    render(<TestComponent />);
+    const handler = mockAddEventListener.mock.calls[0][0];
+
+    act(() => {
+      handler('inactive');
+    });
+    expect(latestValue).toBe(false);
+  });
+
+  it('アンマウント時にリスナーが解除される', () => {
+    const { unmount } = render(<TestComponent />);
+    unmount();
+    expect(mockRemove).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useIsAppActive.test.tsx
+++ b/src/hooks/useIsAppActive.test.tsx
@@ -25,6 +25,10 @@ describe('useIsAppActive', () => {
     (AppState as { currentState: string }).currentState = 'active';
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('マウント時点でAppStateがactiveならtrueを返す', () => {
     (AppState as { currentState: string }).currentState = 'active';
     render(<TestComponent />);

--- a/src/hooks/useIsAppActive.ts
+++ b/src/hooks/useIsAppActive.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+// アプリがフォアグラウンドでアクティブかどうかを返す。
+// バックグラウンドや PiP への移行時に、PiP ウィンドウへ写り込ませたくない
+// 表示要素を出し分ける用途で使用する。
+export const useIsAppActive = (): boolean => {
+  const [isActive, setIsActive] = useState(AppState.currentState === 'active');
+
+  useEffect(() => {
+    const handleChange = (state: AppStateStatus): void => {
+      setIsActive(state === 'active');
+    };
+
+    const sub = AppState.addEventListener('change', handleChange);
+
+    return () => {
+      sub.remove();
+    };
+  }, []);
+
+  return isActive;
+};


### PR DESCRIPTION
## 概要

Android の Picture-in-Picture(PiP)を有効にしている状態で、`WarningPanel` のトーストが表示されたままバックグラウンド(PiP)へ移行すると、トーストが PiP ウィンドウへ写り込んでしまう不具合を修正します。PiP を有効にしているときに限り、バックグラウンド/PiP 移行中はトーストを非表示にします。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useIsAppActive` フックを追加し、`AppState` を購読してアプリがフォアグラウンドでアクティブかどうかを返すようにした。PiP へ遷移する前のバックグラウンド移行も即座に検知でき、`active` 化を待たずに写り込みを防げる。
- `Permitted.tsx` で `pictureInPictureAtom` の `enabled`(PiP 設定)をゲートに、`PiP 有効 かつ (PiP 表示中 または 非アクティブ)` のときだけ `WarningPanel` を非表示にした。PiP 無効時はそもそも写り込まないため従来どおり表示し続ける。
- PiP 時に裏側へ描画していたトーストの二重レンダリングを整理し、`WarningPanel` から使われなくなった `behindContent` prop を削除した。
- `useIsAppActive` の挙動を検証するユニットテストを追加した。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01FraGGZ2Ve6Ydt2dGVr1iq9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * アプリがアクティブ/バックグラウンドかを検知し、状態変化に追従するようにしました
* **Refactor**
  * Picture-in-Picture 利用時などに、警告パネルの表示/非表示を条件に応じて最適化しました（場合によっては非表示）
* **Tests**
  * アプリ状態検知の挙動を検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->