### PR TITLE
npm run android/ios で APP_VARIANT=dev を渡し dev 用バンドルID で起動するようにする

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,6 @@
-import type { ConfigContext } from 'expo/config';
+const IS_DEV = process.env.APP_VARIANT === 'dev';
 
-export default ({ config }: ConfigContext) => ({
+export default {
   name: 'TrainLCD',
   slug: 'trainlcd',
   version: '10.7.1',
@@ -48,28 +48,16 @@ export default ({ config }: ConfigContext) => ({
   ],
   extra: {
     eas: {
-      projectId:
-        process.env.EAS_BUILD_PROJECT_ID ||
-        'dad36dde-0056-4760-8eda-37f05e7c9c6c',
+      projectId: 'dad36dde-0056-4760-8eda-37f05e7c9c6c',
     },
   },
   ios: {
     buildNumber: '2713',
-    bundleIdentifier:
-      process.env.EAS_BUILD_PROFILE === 'production'
-        ? 'me.tinykitten.trainlcd'
-        : 'me.tinykitten.trainlcd.dev',
-    scheme:
-      process.env.EAS_BUILD_PROFILE === 'production'
-        ? 'TrainLCD'
-        : 'CanaryTrainLCD',
+    scheme: IS_DEV ? 'CanaryTrainLCD' : 'ProdTrainLCD',
     supportsTablet: true,
   },
   android: {
-    package:
-      process.env.EAS_BUILD_PROFILE === 'production'
-        ? 'me.tinykitten.trainlcd'
-        : 'me.tinykitten.trainlcd.dev',
+    package: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',
     permissions: [],
     versionCode: 100000500,
   },
@@ -77,4 +65,4 @@ export default ({ config }: ConfigContext) => ({
   experiments: {
     reactCompiler: true,
   },
-});
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "babel-plugin-module-resolver": "^5.0.2",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "babel-preset-expo": "~55.0.9",
+        "cross-env": "^10.1.0",
         "jest": "^29.2.1",
         "jest-expo": "~55.0.18",
         "patch-package": "^8.0.1",
@@ -1833,6 +1834,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@expo-google-fonts/roboto": {
       "version": "0.2.3",
@@ -7540,6 +7548,24 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "start": "expo start",
-    "android": "expo run:android -- --variant devDebug",
-    "ios": "expo run:ios",
+    "android": "cross-env APP_VARIANT=dev expo run:android -- --variant devDebug",
+    "ios": "cross-env APP_VARIANT=dev expo run:ios",
     "web": "expo start --web",
     "lint": "biome check ./src",
     "format": "biome format ./src --write",
@@ -113,6 +113,7 @@
     "babel-plugin-module-resolver": "^5.0.2",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-expo": "~55.0.9",
+    "cross-env": "^10.1.0",
     "jest": "^29.2.1",
     "jest-expo": "~55.0.18",
     "patch-package": "^8.0.1",


### PR DESCRIPTION
## 概要

ローカルの `npm run android` 実行時に、Android アプリが開発用バンドルID (`me.tinykitten.trainlcd.dev`) としてインストール・起動されるようにする。あわせて `npm run ios` も同じ `APP_VARIANT=dev` を渡すよう揃える。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `package.json`: `android` / `ios` の起動スクリプトに `cross-env APP_VARIANT=dev` を付与し、`cross-env` を devDependencies に追加
- `app.config.ts`:
  - バリアント判定を `EAS_BUILD_PROFILE === 'production'` ベースから `APP_VARIANT === 'dev'`（`IS_DEV`）ベースに統一
  - `android.package`: `IS_DEV` のとき `me.tinykitten.trainlcd.dev`、それ以外 `me.tinykitten.trainlcd`
  - iOS の `bundleIdentifier` 指定を app.config から削除（ネイティブ側の設定に委譲）。`scheme` を `IS_DEV ? 'CanaryTrainLCD' : 'ProdTrainLCD'` に変更
  - `extra.eas.projectId` の `EAS_BUILD_PROJECT_ID` フォールバックを削除して定数化。型付き関数 export（`ConfigContext`）からプレーンオブジェクト export に変更
- 結果として、`npm run android` のローカルビルドが本番 (`me.tinykitten.trainlcd`) と並存する形で `.dev` バンドルIDとして起動する

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

<!-- 省略: アプリ本体コード (src/android/ios 等) の変更が無く、ビルド/実行設定 (package.json / app.config.ts) のみのため -->

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
