### PR TITLE
Add: ios.bundleIdentifier

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -54,6 +54,7 @@ export default {
   ios: {
     buildNumber: '2715',
     scheme: IS_DEV ? 'CanaryTrainLCD' : 'ProdTrainLCD',
+    bundleIdentifier: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',
     supportsTablet: true,
   },
   android: {


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

EASで `The "ios.bundleIdentifier" is required to be set in app config for builds triggered by GitHub integration. Learn more: https://docs.expo.dev/versions/latest/config/app/#bundleidentifier.` のエラーが発生したので `ios.bundleIdentifier` を再度定義した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->
https://github.com/TrainLCD/MobileApp/pull/6288

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS アプリケーションの識別子設定を開発環境と本番環境で区別するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->