### PR TITLE
finalize-release に Ruleset 一時緩和つき sync PR マージ手順を追加

### DIFF
--- a/.claude/skills/finalize-release/SKILL.md
+++ b/.claude/skills/finalize-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finalize-release
-description: Run the full post-release finishing flow for TrainLCD MobileApp in one shot — tag origin/master HEAD, publish a GitHub Release with auto-generated notes, and open a dev<-master sync PR. Thin orchestrator over publish-release + sync-dev-from-master that consolidates mid-flow approvals into a single upfront confirmation. Use after a production release PR (release/vX.Y.Z → master) has been merged.
+description: Run the full post-release finishing flow for TrainLCD MobileApp in one shot — tag origin/master HEAD, publish a GitHub Release with auto-generated notes, open a dev<-master sync PR, and merge it as a merge commit (temporarily relaxing the dev branch ruleset, which otherwise allows squash only, then restoring it). Thin orchestrator over publish-release + sync-dev-from-master that consolidates mid-flow approvals into a single upfront confirmation. Use after a production release PR (release/vX.Y.Z → master) has been merged.
 ---
 
 # finalize-release
@@ -12,7 +12,9 @@ description: Run the full post-release finishing flow for TrainLCD MobileApp in 
 1. **publish-release**: master HEAD に annotated tag を打ち、`gh release create --generate-notes --latest` で GitHub Release を即公開。
 2. **sync-dev-from-master**: `chore/dev-from-master` を master から切り出し、`dev<-master` タイトルのマージPRを作成。
 
-各スキル自体の仕様（安全弁・検証・本文テンプレ・squash merge 禁止警告）はそのまま流用する。このスキルは **差分情報の先読み** と **承認の統合** のみを担い、独自の破壊的操作は追加しない。
+各スキル自体の仕様（安全弁・検証・本文テンプレ・squash merge 禁止警告）はそのまま流用する。このスキルは **差分情報の先読み**・**承認の統合** に加え、**sync PR の merge commit マージまで** を担う。
+
+`dev` ブランチには Ruleset（`pull_request` ルール）で `allowed_merge_methods` が `["squash"]` に絞られていることがあり、その状態では `gh pr merge --merge` が `Merge commits are not allowed on this repository.` で弾かれる。一方 sync PR は履歴整合のため **必ず merge commit** でマージする必要がある（squash すると merge commit が潰れる。PR #5838 / #5840 の教訓）。そこでこのスキルは sync PR をマージする際、**dev Ruleset を一時的に緩めて（`merge` を許可方式に追加）merge commit でマージし、直後に元へ戻す**。この緩和は唯一の独自破壊的操作であり、**マージの成否に関わらず Ruleset を必ず復元する**（緩和したまま放置しない）ことを不変条件とする。
 
 ## 入力
 
@@ -62,12 +64,19 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
    - 既存 `chore/dev-from-master` の状態（open PR が無い前提で）:
      - `git ls-remote --heads origin chore/dev-from-master` と `gh pr list --base dev --head chore/dev-from-master --state all --limit 1 --json number,state,url`
      - ローカル未 push コミット有無: `git show-ref --verify --quiet refs/heads/chore/dev-from-master` でローカル枝の存在を確認し、有るなら `git cherry origin/chore/dev-from-master` を実行。出力が空でなければ **中断** してユーザーに確認（自動では削除しない）。
+       - 補足: リモート `origin/chore/dev-from-master` が既に削除済みでローカル枝だけ残るケースでは、`git cherry origin/...` は HEAD 基準で誤射する。実体判定は `git log chore/dev-from-master --not origin/master`・`--not origin/dev` がともに空（＝ master/dev に完全マージ済み・固有コミット無し）かで行い、空なら安全な残骸として削除対象に記録する。
      - 直近 PR が `MERGED` → 承認後に削除・再作成予定としてプランに記録。
      - それ以外（`CLOSED` のみ、PR 無し等）→ 中断してユーザーに確認（自動では削除しない）。
 
+   **マージ方式制約の先読み（dev Ruleset）**:
+   - `OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)` を解決し、`gh api "repos/$OWNER_REPO/rules/branches/dev" --jq '.[] | select(.type=="pull_request") | {ruleset_id, allowed: .parameters.allowed_merge_methods}'` を読む。
+     - `allowed_merge_methods` に `merge` が含まれる → 「マージ時の Ruleset 緩和は不要」とプランに記録。
+     - 含まれない（`["squash"]` 等）→ 「マージ時に Ruleset `<id>` を一時緩和（`merge` 追加）→マージ→復元」とプランに記録。`ruleset_id` も控える。
+     - `pull_request` ルール自体が無い（PR 必須でない）→ Ruleset 緩和不要としてプランに記録。
+
 3. **承認ゲート（一括）**
 
-   以下フォーマットで実行計画を要約し、**1 回だけ** ユーザー承認を取る。承認が出たら手順 4〜5 を連続実行し、途中で止めない。
+   以下フォーマットで実行計画を要約し、**1 回だけ** ユーザー承認を取る。承認が出たら手順 4〜6 を連続実行し、途中で止めない。マージと Ruleset 一時緩和もこの 1 回の承認に含める（マージ直前で改めて承認を取らない）。
 
    ```text
    finalize-release 実行計画 (version=v<version>)
@@ -83,12 +92,13 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
      - master→dev 差分: <N> 件
      - 既存 chore/dev-from-master: <有り (直近 PR #<M> MERGED) → 削除・再作成 | 無し → 新規作成>
      - PR: base=dev, head=chore/dev-from-master, title="dev<-master"
-     - ⚠ Squash merge 禁止（マージ時は Create a merge commit）
+     - マージ: 作成後に merge commit でマージ（--delete-branch）
+       - dev Ruleset: <merge 許可済み → 緩和不要 | squash-only (ruleset #<id>) → 一時緩和 ["squash"]→["squash","merge"] → マージ → 復元>
    ```
 
    スキップ判定時は該当セクションを以下に差し替える:
-   - 差分 0 件: `[sync-dev-from-master] skip (master は dev と同期済み)`
-   - 既存 open PR あり: `[sync-dev-from-master] 既存 PR を流用 (URL: <url>)`
+   - 差分 0 件: `[sync-dev-from-master] skip (master は dev と同期済み)`（この場合マージ・Ruleset 緩和も不要）
+   - 既存 open PR あり: `[sync-dev-from-master] 既存 PR を流用 (URL: <url>) → 同 PR を merge commit でマージ`
 
    承認が得られなければ中断。
 
@@ -112,7 +122,42 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
      2. `git switch -c chore/dev-from-master origin/master` → `git push -u origin chore/dev-from-master`
      3. PR 本文をテンプレ準拠で組み立てて `gh pr create`（`release_version` には手順 1 の `version` を渡す）。
 
-6. **完了報告**
+6. **sync PR を merge commit でマージ（dev Ruleset 一時緩和つき）**
+
+   sync が **スキップ**（差分 0 件）された場合はこの手順を飛ばす。新規作成・流用いずれかで dev<-master PR が存在する場合のみ実行する。**緩和→マージ→復元は 1 つの bash 呼び出しにまとめ、`set +e` でマージ失敗を握って復元を無条件実行する**（途中で関数が分かれて復元が飛ぶ事故を防ぐ）。
+
+   1. マージ対象 PR 番号を確定（手順 5 で新規作成 or 流用した PR）。ローカルが `chore/dev-from-master` に居るとブランチ削除で支障が出るため `git switch dev`（または安全な枝）へ退避する。
+   2. `OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)` を解決。プレフライトの「マージ方式制約」記録を使う:
+      - dev が `merge` を許可済み → **緩和不要**。そのまま手順 6-5 のマージへ。
+      - squash-only 等で `merge` 不許可 → 手順 6-3 の一時緩和を行う。
+   3. **一時緩和**（フル定義をバックアップしてから PUT）。`RS_ID` はプレフライトで控えた `ruleset_id`:
+      ```bash
+      RS_ID=<プレフライトで控えた ruleset_id>
+      gh api "repos/$OWNER_REPO/rulesets/$RS_ID" > ruleset_backup.json   # 復元用。リポジトリ直下の相対パス（/tmp は Git Bash と Windows python で別解決になり read に失敗するため使わない）
+      ```
+      `ruleset_backup.json` から `name,target,enforcement,conditions,bypass_actors,rules` を取り出し、`pull_request` ルールの `allowed_merge_methods` にのみ `merge` を追加した `ruleset_relaxed.json` を生成（他は一切変えない。既存方式 `squash` は残す）。
+      ```bash
+      gh api -X PUT "repos/$OWNER_REPO/rulesets/$RS_ID" --input ruleset_relaxed.json \
+        --jq '.rules[] | select(.type=="pull_request") | .parameters.allowed_merge_methods'   # ["squash","merge"] を確認
+      ```
+   4. **マージ（merge commit）**:
+      ```bash
+      gh pr merge <n> --merge --delete-branch
+      ```
+      - `--squash` / `--rebase` は使わない。
+      - required check 不成立・コンフリクト等で弾かれても **force/admin マージしない**。マージ失敗は握って次の復元へ進む（PR は open のまま残す）。なお `mergeStateStatus=UNSTABLE`（必須でない失敗チェックがあるだけ）は通常マージ可能。
+   5. **復元（緩和した場合は必ず実行）**:
+      ```bash
+      gh api -X PUT "repos/$OWNER_REPO/rulesets/$RS_ID" --input ruleset_backup.json \
+        --jq '.rules[] | select(.type=="pull_request") | .parameters.allowed_merge_methods'   # 元の値（例 ["squash"]）に戻ったことを確認
+      ```
+      **マージが失敗していても Ruleset は必ず復元する。** 復元の PUT 自体が失敗した場合は最優先でユーザーに知らせる（Ruleset を緩めたまま放置しない）。
+   6. **検証**: `git fetch origin dev master` 後、
+      - dev HEAD が **2 親を持つ merge commit**（squash されていない）であること: `git rev-list --parents -n 1 origin/dev` の親が 2 つ。
+      - `git rev-list --count origin/dev..origin/master` が `0`（dev が master を完全包含）。
+   7. 一時ファイル `ruleset_backup.json` / `ruleset_relaxed.json` を削除し、ローカル `dev` を `git pull --ff-only origin dev` で追従させる。
+
+7. **完了報告**
 
    1 レスポンスで以下を報告する:
 
@@ -121,12 +166,16 @@ sync 側の走行は **必須**。master→dev 差分が 0 件の場合のみ自
      - 通常実行時: PR URL、取り込みコミット件数、変更の種類・テスト欄チェック状態
      - スキップ時: `skip (差分なし)`
      - 流用時: `既存 PR を流用: <url>`
-   - **⚠ 警告**: sync の PR が新規作成または流用された場合のみ、以下を太字で明示:
-     > **sync の PR は必ず「Create a merge commit」でマージしてください。Squash / Rebase は禁止です。** （PR #5838 の教訓）
+   - **マージ結果**（sync PR が存在した場合）:
+     - 成功時: マージコミット SHA（**2 親の merge commit** である旨）、`origin/dev..origin/master = 0`、dev Ruleset を `<一時緩和して merge commit でマージ→復元（["squash"] に復帰）| 緩和不要（merge 許可済み）>`
+     - 失敗時: PR は open のまま・**Ruleset は復元済み**である旨を明示し、`sync-dev-from-master` 単独再実行ではなく手当ての方針（CI 修正後に手動 or 再マージ）を案内
+   - **⚠ 補足**: sync PR を **merge commit でマージした**（squash していない）ことを明示。squash すると merge commit 構造が潰れて dev/master 履歴が壊れる（PR #5838 / #5840 の教訓）。手動でマージし直す状況になった場合も必ず「Create a merge commit」を使うこと。
 
 ## 注意事項
 
-- **承認の統合** がこのスキルの付加価値。プレフライトで危ない状態（タグ重複・version 不一致・未マージブランチ残存等）は **承認ゲートに到達させない** ことで、「承認したら止まらない」契約を守る。
-- 操作順は **タグ先・PR 後** で固定。publish-release 成功後に sync 側が失敗しても、タグと Release は既に公開済みで巻き戻さない。sync 失敗時は原因を修正して `sync-dev-from-master` を単独呼び直しで補完する（その旨を完了報告で案内する）。
+- **承認の統合** がこのスキルの付加価値。プレフライトで危ない状態（タグ重複・version 不一致・未マージブランチ残存等）は **承認ゲートに到達させない** ことで、「承認したら止まらない」契約を守る。マージと Ruleset 緩和も同じ 1 回の承認に含め、マージ直前で追加承認を取らない。
+- 操作順は **タグ → sync PR 作成 → マージ** で固定。publish-release 成功後に sync 作成やマージが失敗しても、タグと Release は既に公開済みで巻き戻さない。sync の PR 作成自体が失敗した場合は原因を修正して `sync-dev-from-master` を単独呼び直しで補完する（その旨を完了報告で案内する）。マージのみ失敗した場合は PR を open のまま残す。
 - `git push --delete` や annotated tag push は破壊的に見えるが、プレフライトで重複ガードと `MERGED` 確認を済ませた上で実行する前提。
-- Squash merge 禁止警告は sync 側 PR が絡んだ場合（新規作成 or 既存流用）のみ出す。スキップ時は不要。
+- **dev Ruleset の一時緩和は不変条件つき**: ①既存の `allowed_merge_methods` を削らず `merge` を**追加するだけ**（広げる方向のみ）、②**マージの成否に関わらず必ず元へ復元**する、③復元は緩和と同一 bash 呼び出し内で `set +e` により無条件実行、④バックアップ/緩和用 JSON はリポジトリ直下の相対パスに置き完了後に削除（`/tmp` は使わない）。復元 PUT 自体が失敗したら最優先で報告する。
+- マージは **必ず merge commit**（`gh pr merge --merge`）。`--squash` / `--rebase` は使わない。required check や branch protection で弾かれても **force/admin マージはしない**（PR を残して報告）。
+- sync が **スキップ**（差分 0 件）のときはマージも Ruleset 緩和も行わない。`merge` が既に許可されている dev では緩和をスキップして素直にマージする。


### PR DESCRIPTION
## 概要

`finalize-release` スキルに、`dev` ブランチの Ruleset が squash マージのみ許可（`allowed_merge_methods: ["squash"]`）の場合に sync PR（`dev<-master`）を **merge commit でマージできない**問題への対処手順を組み込みました。sync PR は履歴整合のため merge commit が必須（squash すると merge commit が潰れる。PR #5838 / #5840 の教訓）ですが、Ruleset がそれを阻むため、**Ruleset を一時的に緩めて merge commit でマージし、成否に関わらず必ず元へ復元する**フローを追加しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

`.claude/skills/finalize-release/SKILL.md` を更新:

- スキルの役割を「差分先読み・承認統合」に加え **sync PR の merge commit マージまで** 担うよう拡張。冒頭に dev Ruleset（squash-only）と merge commit 必須の衝突という背景を明記。
- **手順2 プレフライト**: dev Ruleset の `allowed_merge_methods` と `ruleset_id` を先読みし、「マージ時に緩和が必要か」をプランに記録。リモート削除済み＋ローカル枝残存時の安全判定の補足も追加。
- **手順3 承認ゲート**: マージと Ruleset 一時緩和を同じ 1 回の承認に統合（連続実行範囲を手順 4〜6 に拡張）。プラン雛形に Ruleset 緩和方針の行を追加。
- **手順6（新規）**: 「Ruleset 一時緩和 → `gh pr merge --merge` → 必ず復元」を規定。緩和→マージ→復元を 1 つの bash 呼び出しに束ね `set +e` で復元を無条件実行、2 親 merge commit の検証、一時ファイル削除、ローカル dev の ff 追従まで明記。
- **手順7 完了報告 / 注意事項**: マージ結果の報告項目と、「緩和は追加方向のみ・成否によらず必ず復元・`/tmp` 不使用・force/admin マージ禁止」を不変条件として明文化。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: コード変更なし（`.claude/` 配下のスキル文書のみの変更で、アプリ挙動・コード本体パスに影響しないため lint / test / typecheck は対象外）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * finalize-release スキルのドキュメントを更新し、sync PR の merge commit マージ処理を明確化しました。
  * dev ブランチのルール制限下でも確実にマージできるよう、一時的なルール緩和と復元プロセスを記載しました。
  * マージ失敗時の安全な状態復元メカニズムを文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->