### PR TITLE
テレメトリ設定を実験的機能画面に移動

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -216,7 +216,7 @@
   "betaNotice": "This TrainLCD is currently in beta release.",
   "canaryNotice": "This TrainLCD is a canary release.",
   "setAsTerminus": "Set as terminus",
-  "optInTelemetryTitle": "Enable telemetry",
+  "optInTelemetryTitle": "Telemetry",
   "showDevOverlay": "Show developer overlay",
   "hideDevOverlay": "Hide developer overlay",
   "telemetrySettingWillPersist": "Enabling telemetry will be persisted.",
@@ -315,5 +315,6 @@
   "experimentalSettingsNotice": "Experimental features are under development and may change or be removed without notice.",
   "portraitModeTitle": "Portrait Mode",
   "portraitModeDescription": "When enabled, the running screen switches to a layout optimized for portrait orientation while you hold your device upright.",
+  "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
   "passStationLabel": "Pass"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -217,7 +217,7 @@
   "betaNotice": "このTrainLCDは現在ベータリリースです。",
   "canaryNotice": "このTrainLCDはカナリアリリースです。",
   "setAsTerminus": "終着駅に設定",
-  "optInTelemetryTitle": "テレメトリを有効にする",
+  "optInTelemetryTitle": "テレメトリ",
   "showDevOverlay": "開発者オーバレイを表示",
   "hideDevOverlay": "開発者オーバレイを非表示",
   "telemetrySettingWillPersist": "テレメトリ有効化は永続的に保持されます。",
@@ -316,5 +316,6 @@
   "experimentalSettingsNotice": "試験的機能は開発中のため、予告なく変更または削除されることがあります。",
   "portraitModeTitle": "ポートレートモード",
   "portraitModeDescription": "有効にすると、走行画面で端末を縦向きにした際に、縦画面に最適化されたデザインで表示します。",
+  "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
   "passStationLabel": "通過"
 }

--- a/src/components/TuningSettings.tsx
+++ b/src/components/TuningSettings.tsx
@@ -154,15 +154,6 @@ const TuningSettings: React.FC = () => {
     storage.set(STORAGE_KEYS.UNTOUCHABLE_MODE_ENABLED, String(nextValue));
   };
 
-  const toggleTelemetryEnabled = () => {
-    const nextValue = !settings.telemetryEnabled;
-    setSettings((prev) => ({
-      ...prev,
-      telemetryEnabled: nextValue,
-    }));
-    storage.set(STORAGE_KEYS.TELEMETRY_ENABLED, String(nextValue));
-  };
-
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -289,31 +280,6 @@ const TuningSettings: React.FC = () => {
             accessibilityRole="button"
           >
             {translate('enableUntouchableMode')}
-          </Typography>
-        </View>
-
-        <View style={styles.switchSettingItem}>
-          {isLEDTheme ? (
-            <LEDThemeSwitch
-              value={settings.telemetryEnabled}
-              onValueChange={toggleTelemetryEnabled}
-              accessibilityLabel={translate('optInTelemetryTitle')}
-            />
-          ) : (
-            <Switch
-              value={settings.telemetryEnabled}
-              onValueChange={toggleTelemetryEnabled}
-              ios_backgroundColor={'#fff'}
-              accessibilityLabel={translate('optInTelemetryTitle')}
-            />
-          )}
-
-          <Typography
-            style={styles.switchSettingItemText}
-            onPress={toggleTelemetryEnabled}
-            accessibilityRole="button"
-          >
-            {translate('optInTelemetryTitle')}
           </Typography>
         </View>
       </ScrollView>

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -4,6 +4,7 @@ import { Alert } from 'react-native';
 import { STORAGE_KEYS } from '~/constants';
 import { storage } from '~/lib/storage';
 import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import tuningState from '~/store/atoms/tuning';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
 
 jest.mock('@react-navigation/native', () => ({
@@ -21,9 +22,13 @@ jest.mock('~/translation', () => ({
   translate: (key: string) => key,
 }));
 
-const renderWithStore = (portraitModeEnabled: boolean) => {
+const renderWithStore = (
+  portraitModeEnabled: boolean,
+  telemetryEnabled = false
+) => {
   const store = createStore();
   store.set(portraitModeEnabledAtom, portraitModeEnabled);
+  store.set(tuningState, (prev) => ({ ...prev, telemetryEnabled }));
 
   const screen = render(
     <Provider store={store}>
@@ -76,6 +81,53 @@ describe('ExperimentalSettingsScreen', () => {
     // エラーログとユーザーへのアラート表示を検証
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Failed to save portrait mode setting',
+      expect.any(Error)
+    );
+    expect(alertSpy).toHaveBeenCalledWith(
+      'errorTitle',
+      'failedToSavePreference'
+    );
+
+    setSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  it('テレメトリをONにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('optInTelemetryTitle'));
+
+    expect(store.get(tuningState).telemetryEnabled).toBe(true);
+    expect(storage.getString(STORAGE_KEYS.TELEMETRY_ENABLED)).toBe('true');
+  });
+
+  it('テレメトリをOFFにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false, true);
+
+    fireEvent.press(getByLabelText('optInTelemetryTitle'));
+
+    expect(store.get(tuningState).telemetryEnabled).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.TELEMETRY_ENABLED)).toBe('false');
+  });
+
+  it('テレメトリのストレージ保存に失敗した場合はatom状態をロールバックしエラーを通知する', () => {
+    const setSpy = jest.spyOn(storage, 'set').mockImplementationOnce(() => {
+      throw new Error('storage failure');
+    });
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('optInTelemetryTitle'));
+
+    expect(store.get(tuningState).telemetryEnabled).toBe(false);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to save telemetry setting',
       expect.any(Error)
     );
     expect(alertSpy).toHaveBeenCalledWith(

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -18,6 +18,7 @@ import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
 import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
 import { STORAGE_KEYS } from '../constants';
 import { storage } from '../lib/storage';
@@ -34,6 +35,9 @@ const styles = StyleSheet.create({
     marginTop: 16,
     color: '#8B8B8B',
     lineHeight: 21,
+  },
+  toggleSpacer: {
+    marginTop: 16,
   },
   notice: {
     marginTop: 32,
@@ -91,6 +95,7 @@ const ExperimentalSettingsScreen: React.FC = () => {
   const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
     portraitModeEnabledAtom
   );
+  const [tuning, setTuning] = useAtom(tuningState);
 
   const navigation = useNavigation();
 
@@ -107,6 +112,18 @@ const ExperimentalSettingsScreen: React.FC = () => {
       Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }
   }, [portraitModeEnabled, setPortraitModeEnabled]);
+
+  const handleToggleTelemetry = useCallback(() => {
+    const flag = !tuning.telemetryEnabled;
+    setTuning((prev) => ({ ...prev, telemetryEnabled: flag }));
+    try {
+      storage.set(STORAGE_KEYS.TELEMETRY_ENABLED, flag ? 'true' : 'false');
+    } catch (error) {
+      setTuning((prev) => ({ ...prev, telemetryEnabled: !flag }));
+      console.error('Failed to save telemetry setting', error);
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [tuning.telemetryEnabled, setTuning]);
 
   const handleScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -134,6 +151,16 @@ const ExperimentalSettingsScreen: React.FC = () => {
           />
           <Typography style={styles.description}>
             {translate('portraitModeDescription')}
+          </Typography>
+          <View style={styles.toggleSpacer}>
+            <ToggleItem
+              title={translate('optInTelemetryTitle')}
+              state={tuning.telemetryEnabled}
+              onToggle={handleToggleTelemetry}
+            />
+          </View>
+          <Typography style={styles.description}>
+            {translate('telemetryDescription')}
           </Typography>
           <Typography style={styles.notice}>
             {translate('experimentalSettingsNotice')}


### PR DESCRIPTION
## 概要

テレメトリのオン/オフ設定をチューニング画面（TuningSettings）から実験的機能画面（ExperimentalSettings）に移動し、説明文を追加した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- テレメトリトグルを `TuningSettings` から `ExperimentalSettings` に移動
- テレメトリの説明文を追加（日本語・英語）
- ラベルテキストを「テレメトリを有効にする」から「テレメトリ」に簡略化
- ストレージ保存失敗時のエラーハンドリングとロールバックを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 翻訳ファイルと設定画面の更新

* **New Features**
  * 実験設定画面にテレメトリ opt-in のON/OFF切り替えを追加し、保存に成功/失敗で反映を制御します。
  * 端末の位置情報座標が解析用途として送信されることを説明する文言を表示します。
* **Documentation**
  * 英語・日本語のテレメトリ関連表記を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->