### PR TITLE
ポートレートモードの駅名見切れを修正

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -146,7 +146,7 @@ describe('PortraitMain', () => {
       buildStation(1, '品川', StopCondition.All, 'JY-25'),
     ]);
 
-    // スロット幅 300 に対し自然幅 200 ならバッファ込み 208 でも収まる
+    // スロット幅 300 に対し自然幅 200 ならバッファ込み 216 でも収まる
     fireEvent(getByTestId('portrait-station-name-slot'), 'layout', {
       nativeEvent: { layout: { width: 300 } },
     });
@@ -157,7 +157,7 @@ describe('PortraitMain', () => {
     const style = StyleSheet.flatten(
       getByTestId('portrait-station-name').props.style
     );
-    expect(style.width).toBe(208);
+    expect(style.width).toBe(216);
     expect(style.transform).toEqual([{ scaleX: 1 }]);
   });
 
@@ -177,9 +177,9 @@ describe('PortraitMain', () => {
     const style = StyleSheet.flatten(
       getByTestId('portrait-station-name').props.style
     );
-    // 描画幅 = 392 + 8(バッファ) = 400、利用可能幅 = 108 - 8 = 100
-    expect(style.width).toBe(400);
-    expect(style.transform).toEqual([{ scaleX: 100 / 400 }]);
+    // 描画幅 = 392 + 16(バッファ) = 408、利用可能幅 = 108 - 8 = 100
+    expect(style.width).toBe(408);
+    expect(style.transform).toEqual([{ scaleX: 100 / 408 }]);
     // 左端基準で圧縮する。数値配列形式 [x, y, z] で指定し、New Architecture でも
     // 確実に左端アンカーになるようにする(2 値キーワード文字列は中央へフォールバックする)。
     expect(style.transformOrigin).toEqual([0, '50%', 0]);

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -127,7 +127,8 @@ const NUMBERING_COLUMN_WIDTH = isTablet ? 72 * 1.5 : 72;
 // 日本語グリフでネイティブのテキスト計測幅がわずかに過小評価されると、
 // 表示用 Typography に計測幅ぴったりの width を与えたとき末尾の文字が
 // 欠ける。HeaderStationName と同じく計測幅にこの分を加えて余白を確保する。
-const STATION_NAME_MEASURE_BUFFER = 8;
+// iOS ではフォントメトリクスの誤差が大きめに出ることがあるため余裕を持たせる。
+const STATION_NAME_MEASURE_BUFFER = 16;
 
 // 駅名の自然幅を測る非表示コンテナの幅。どんなに長い駅名でも打ち切られない
 // よう十分大きく取る。フォールバック計測でこの値以上なら未確定とみなす。
@@ -757,21 +758,26 @@ const StationName = ({
         </Typography>
       </View>
       {/* 表示用。描画幅(width)を与えて省略させず、左基準で横圧縮して
-          スロット内に収める(はみ出しはスロットの overflow:hidden でクリップ)。 */}
+          スロット内に収める(はみ出しはスロットの overflow:hidden でクリップ)。
+          計測完了前(renderWidth===0)は opacity:0 にして、スケーリング未適用の
+          テキストが overflow:hidden でクリップされるのを防ぐ。 */}
       <Typography
         numberOfLines={1}
+        ellipsizeMode="clip"
         testID="portrait-station-name"
         style={[
           styles.stationNameText,
-          renderWidth > 0 && {
-            width: renderWidth,
-            transform: [{ scaleX }],
-            // 左端を基準に横圧縮する。2 値のキーワード文字列('left center')は
-            // New Architecture でパースされず中央基準にフォールバックし、圧縮した
-            // 駅名(主に文字数の多いひらがな表記)が右へ寄ってしまう。数値配列形式
-            // [x, y, z] で指定するとパースを介さず確実に左端基準になる。
-            transformOrigin: [0, '50%', 0],
-          },
+          renderWidth > 0
+            ? {
+                width: renderWidth,
+                transform: [{ scaleX }],
+                // 左端を基準に横圧縮する。2 値のキーワード文字列('left center')は
+                // New Architecture でパースされず中央基準にフォールバックし、圧縮した
+                // 駅名(主に文字数の多いひらがな表記)が右へ寄ってしまう。数値配列形式
+                // [x, y, z] で指定するとパースを介さず確実に左端基準になる。
+                transformOrigin: [0, '50%', 0],
+              }
+            : { opacity: 0 },
         ]}
       >
         {text}


### PR DESCRIPTION
## 概要

ポートレートモードの駅名表示がiPhoneで見切れることがある問題を修正

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- テキスト計測バッファ(`STATION_NAME_MEASURE_BUFFER`)を8pxから16pxに拡大し、iOSでの日本語グリフ計測誤差によるクリップを防止
- 計測完了前(`renderWidth === 0`)の表示用Typographyに`opacity: 0`を適用し、スケーリング未適用のテキストが`overflow: hidden`で見切れるのを防止
- 表示用Typographyに`ellipsizeMode="clip"`を追加し、万一クリップが発生しても「…」ではなく自然に切れるように変更

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 駅名の計測バッファを拡張し、表示・スケーリングの安定性を向上しました。
  * 文字描画の準備中は不可視化し、描画幅が確定したときのみ幅・拡大縮小・変形基準を適用するよう調整しました。あわせて長い駅名の末尾挙動も改善しました。
* **テスト**
  * 駅名スロット幅計算の期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->