### PR TITLE
山陽本線(姫路～岡山)・赤穂線の路線記号画像を修正

### DIFF
--- a/src/lineSymbolImage.ts
+++ b/src/lineSymbolImage.ts
@@ -172,7 +172,7 @@ const LINE_SYMBOL_IMAGE_WITH_COLOR: Record<number, LineSymbolImage> = {
   11602: { signPath: require('../assets/marks/jrw/a.webp') }, // 京都線
   11603: { signPath: require('../assets/marks/jrw/a.webp') }, // 神戸線
   11608: { signPath: require('../assets/marks/jrw/a.webp') }, // 山陽線
-  11609: { signPath: require('../assets/marks/jrw/s2.webp') }, // JR山陽本線(姫路～岡山)
+  11609: { signPath: require('../assets/marks/jrw/a.webp') }, // JR山陽本線(姫路～岡山)
   11610: {
     signPath: require('../assets/marks/jrw/w.webp'),
     subSignPath: require('../assets/marks/jrw/x.webp'),

--- a/src/lineSymbolImage.ts
+++ b/src/lineSymbolImage.ts
@@ -221,8 +221,8 @@ const LINE_SYMBOL_IMAGE_WITH_COLOR: Record<number, LineSymbolImage> = {
   11720: { signPath: require('../assets/marks/jrw/z.webp') }, // 福塩線
   11710: { signPath: require('../assets/marks/jrw/m.webp') }, // 瀬戸大橋線
   11631: {
-    signPath: require('../assets/marks/jrw/n.webp'),
-    subSignPath: require('../assets/marks/jrw/a.webp'),
+    signPath: require('../assets/marks/jrw/a.webp'),
+    subSignPath: require('../assets/marks/jrw/n.webp'),
   }, // 赤穂線
   11704: { signPath: require('../assets/marks/jrw/b2.webp') }, // 因美線
   11717: { signPath: require('../assets/marks/jrw/b3.webp') }, // 可部線

--- a/src/lineSymbolImage.ts
+++ b/src/lineSymbolImage.ts
@@ -504,7 +504,7 @@ const LINE_SYMBOL_IMAGE_GRAYSCALE: Record<number, LineSymbolImageWithImage> = {
   11602: { signPath: require('../assets/marks/jrw/a_g.webp') }, // 京都線
   11603: { signPath: require('../assets/marks/jrw/a_g.webp') }, // 神戸線
   11608: { signPath: require('../assets/marks/jrw/a_g.webp') }, // 山陽線
-  11609: { signPath: require('../assets/marks/jrw/s2_g.webp') }, // JR山陽本線(姫路～岡山)
+  11609: { signPath: require('../assets/marks/jrw/a_g.webp') }, // JR山陽本線(姫路～岡山)
   11610: {
     signPath: require('../assets/marks/jrw/w_g.webp'),
     subSignPath: require('../assets/marks/jrw/x_g.webp'),
@@ -553,8 +553,8 @@ const LINE_SYMBOL_IMAGE_GRAYSCALE: Record<number, LineSymbolImageWithImage> = {
   11720: { signPath: require('../assets/marks/jrw/z_g.webp') }, // 福塩線
   11710: { signPath: require('../assets/marks/jrw/m_g.webp') }, // 瀬戸大橋線
   11631: {
-    signPath: require('../assets/marks/jrw/n_g.webp'),
-    subSignPath: require('../assets/marks/jrw/a_g.webp'),
+    signPath: require('../assets/marks/jrw/a_g.webp'),
+    subSignPath: require('../assets/marks/jrw/n_g.webp'),
   }, // 赤穂線
   11704: { signPath: require('../assets/marks/jrw/b2_g.webp') }, // 因美線
   11717: { signPath: require('../assets/marks/jrw/b3_g.webp') }, // 可部線


### PR DESCRIPTION
## 概要

山陽本線(姫路～岡山)区間・赤穂線の路線記号画像の参照を修正（カラー・グレースケール両方）

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 路線ID `11609`（JR山陽本線 姫路～岡山）のシンボル画像参照を `s2` → `a` に変更（カラー・グレースケール両方）
- 路線ID `11631`（赤穂線）の `signPath` と `subSignPath` を入れ替え（メイン: `a`、サブ: `n`）（カラー・グレースケール両方）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
