### PR TITLE
estimateArrivalTimes GraphQLクエリを叩くカスタムフックを追加

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -121,6 +121,7 @@ export enum OperationStatus {
 export type Query = {
   __typename: 'Query';
   connectedRoutes: Array<Route>;
+  estimateArrivalTimes: EstimatedArrivalPage;
   line: Maybe<Line>;
   lineGroupListStations: Array<Station>;
   lineGroupStations: Array<Station>;
@@ -141,6 +142,12 @@ export type Query = {
 export type QueryConnectedRoutesArgs = {
   fromStationGroupId: Scalars['Int']['input'];
   toStationGroupId: Scalars['Int']['input'];
+};
+
+export type QueryEstimateArrivalTimesArgs = {
+  fromStationId: Scalars['Int']['input'];
+  toStationId: Scalars['Int']['input'];
+  viaLineIds: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type QueryLineArgs = {
@@ -226,6 +233,25 @@ export type QueryStationsNearbyArgs = {
   limit: InputMaybe<Scalars['Int']['input']>;
   longitude: Scalars['Float']['input'];
   transportType: InputMaybe<TransportType>;
+};
+
+export type EstimatedArrivalStop = {
+  __typename: 'EstimatedArrivalStop';
+  cumulativeMinutes: Maybe<Scalars['Float']['output']>;
+  stationGroupId: Maybe<Scalars['Int']['output']>;
+  stationId: Maybe<Scalars['Int']['output']>;
+  stopsHere: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type EstimatedArrivalRoute = {
+  __typename: 'EstimatedArrivalRoute';
+  id: Maybe<Scalars['Int']['output']>;
+  stops: Maybe<Array<EstimatedArrivalStop>>;
+};
+
+export type EstimatedArrivalPage = {
+  __typename: 'EstimatedArrivalPage';
+  routes: Maybe<Array<EstimatedArrivalRoute>>;
 };
 
 export type Route = {
@@ -4314,4 +4340,35 @@ export type GetStationTrainTypesLightQuery = {
       | null
       | undefined;
   }>;
+};
+
+export type EstimateArrivalTimesQueryVariables = Exact<{
+  fromStationId: Scalars['Int']['input'];
+  toStationId: Scalars['Int']['input'];
+  viaLineIds: InputMaybe<
+    Array<Scalars['Int']['input']> | Scalars['Int']['input']
+  >;
+}>;
+
+export type EstimateArrivalTimesQuery = {
+  estimateArrivalTimes: {
+    __typename: 'EstimatedArrivalPage';
+    routes:
+      | Array<{
+          __typename: 'EstimatedArrivalRoute';
+          id: number | null | undefined;
+          stops:
+            | Array<{
+                __typename: 'EstimatedArrivalStop';
+                stationId: number | null | undefined;
+                stationGroupId: number | null | undefined;
+                cumulativeMinutes: number | null | undefined;
+                stopsHere: boolean | null | undefined;
+              }>
+            | null
+            | undefined;
+        }>
+      | null
+      | undefined;
+  };
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,6 +21,7 @@ export { useDeepLink } from './useDeepLink';
 export { useDisplayCurrentStation } from './useDisplayCurrentStation';
 export { useDisplayNextStation } from './useDisplayNextStation';
 export { useDistanceToNextStation } from './useDistanceToNextStation';
+export { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
 export { useFeedback } from './useFeedback';
 export { useFetchCurrentLocationOnce } from './useFetchCurrentLocationOnce';
 export { useFetchNearbyStation } from './useFetchNearbyStation';

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -1,0 +1,248 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import { gqlRequest } from '~/lib/gql';
+import { createLine, createStation } from '~/utils/test/factories';
+import { selectedLineAtom } from '../store/atoms/line';
+import {
+  selectedBoundAtom,
+  selectedDirectionAtom,
+  stationsAtom,
+} from '../store/atoms/station';
+import { useCurrentTrainType } from './useCurrentTrainType';
+import { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  useAtomValue: jest.fn(),
+  atom: jest.fn(),
+}));
+jest.mock('../store/atoms/station', () => ({
+  __esModule: true,
+  stationsAtom: { __atom: 'stations' },
+  selectedBoundAtom: { __atom: 'selectedBound' },
+  selectedDirectionAtom: { __atom: 'selectedDirection' },
+}));
+jest.mock('../store/atoms/line', () => ({
+  __esModule: true,
+  selectedLineAtom: { __atom: 'selectedLine' },
+}));
+jest.mock('./useCurrentTrainType', () => ({
+  useCurrentTrainType: jest.fn(),
+}));
+jest.mock('~/lib/gql', () => ({
+  gqlRequest: jest.fn(),
+  graphqlQueryKey: jest.fn((_document: unknown, variables?: object) => [
+    'EstimateArrivalTimes',
+    variables ?? null,
+  ]),
+}));
+
+type HookResult = ReturnType<typeof useEstimateArrivalTimes> | null;
+
+const HookBridge: React.FC<{ onReady: (v: HookResult) => void }> = ({
+  onReady,
+}) => {
+  onReady(useEstimateArrivalTimes());
+  return null;
+};
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: Number.POSITIVE_INFINITY,
+      },
+    },
+  });
+
+const renderHook = () => {
+  const hookRef: { current: HookResult } = { current: null };
+  const utils = render(
+    <QueryClientProvider client={createQueryClient()}>
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    </QueryClientProvider>
+  );
+  return { hookRef, ...utils };
+};
+
+describe('useEstimateArrivalTimes', () => {
+  const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+    typeof useAtomValue
+  >;
+  const mockUseCurrentTrainType =
+    useCurrentTrainType as jest.MockedFunction<typeof useCurrentTrainType>;
+  const mockGqlRequest = gqlRequest as unknown as jest.Mock;
+
+  const stationA = createStation(1, { line: { id: 100 } });
+  const stationB = createStation(2, { line: { id: 100 } });
+  const stationC = createStation(3, { line: { id: 100 } });
+  const selectedLine = createLine(100);
+
+  const setupAtoms = ({
+    stations = [stationA, stationB, stationC],
+    selectedBound = stationC as Station | null,
+    selectedDirection = 'INBOUND' as string | null,
+    line = selectedLine as Line | null,
+  } = {}) => {
+    mockUseAtomValue.mockImplementation((atom) => {
+      if (atom === stationsAtom) return stations;
+      if (atom === selectedBoundAtom) return selectedBound;
+      if (atom === selectedDirectionAtom) return selectedDirection;
+      if (atom === selectedLineAtom) return line;
+      throw new Error('unknown atom');
+    });
+  };
+
+  beforeEach(() => {
+    setupAtoms();
+    mockUseCurrentTrainType.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selectedBound が null のときクエリを skip する', () => {
+    setupAtoms({ selectedBound: null });
+    mockUseCurrentTrainType.mockReturnValue(null);
+
+    const { hookRef } = renderHook();
+
+    expect(mockGqlRequest).not.toHaveBeenCalled();
+    expect(hookRef.current?.route).toBeNull();
+  });
+
+  it('filteringId が null のときクエリを skip する', () => {
+    setupAtoms({ line: null });
+    mockUseCurrentTrainType.mockReturnValue(null);
+
+    const { hookRef } = renderHook();
+
+    expect(mockGqlRequest).not.toHaveBeenCalled();
+    expect(hookRef.current?.route).toBeNull();
+  });
+
+  it('INBOUND のとき fromStationId=先頭, toStationId=末尾 で送信する', async () => {
+    setupAtoms({ selectedDirection: 'INBOUND' });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [{ id: 100, stops: [] }],
+      },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.fromStationId).toBe(stationA.id);
+    expect(variables.toStationId).toBe(stationC.id);
+  });
+
+  it('OUTBOUND のとき fromStationId=末尾, toStationId=先頭 で送信する', async () => {
+    setupAtoms({ selectedDirection: 'OUTBOUND' });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [{ id: 100, stops: [] }],
+      },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.fromStationId).toBe(stationC.id);
+    expect(variables.toStationId).toBe(stationA.id);
+  });
+
+  it('trainType.groupId でルートをフィルタリングする', async () => {
+    mockUseCurrentTrainType.mockReturnValue({
+      groupId: 42,
+    } as TrainType);
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          { id: 100, stops: [{ stationGroupId: 1, cumulativeMinutes: 0 }] },
+          { id: 42, stops: [{ stationGroupId: 1, cumulativeMinutes: 5 }] },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.id).toBe(42);
+    });
+  });
+
+  it('trainType が null のとき selectedLine.id でフィルタリングする', async () => {
+    mockUseCurrentTrainType.mockReturnValue(null);
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          { id: 100, stops: [{ stationGroupId: 1, cumulativeMinutes: 0 }] },
+          { id: 999, stops: [{ stationGroupId: 1, cumulativeMinutes: 5 }] },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.id).toBe(100);
+    });
+  });
+
+  it('一致するルートがないとき route は null', async () => {
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          { id: 999, stops: [{ stationGroupId: 1, cumulativeMinutes: 0 }] },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.loading).toBe(false);
+    });
+    expect(hookRef.current?.route).toBeNull();
+  });
+
+  it('viaLineIds に全路線IDが重複なく含まれる', async () => {
+    const s1 = createStation(10, { line: { id: 200 } });
+    const s2 = createStation(20, { line: { id: 200 } });
+    const s3 = createStation(30, { line: { id: 300 } });
+    setupAtoms({ stations: [s1, s2, s3], line: createLine(200) });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: { routes: [] },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.viaLineIds).toEqual(
+      expect.arrayContaining([200, 300])
+    );
+    expect(variables.viaLineIds).toHaveLength(2);
+  });
+});

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -6,11 +6,13 @@ import type { Line, Station, TrainType } from '~/@types/graphql';
 import { gqlRequest } from '~/lib/gql';
 import { createLine, createStation } from '~/utils/test/factories';
 import { selectedLineAtom } from '../store/atoms/line';
+import { leftStationsAtom } from '../store/atoms/navigation';
 import {
   selectedBoundAtom,
   selectedDirectionAtom,
   stationsAtom,
 } from '../store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
 
@@ -29,8 +31,15 @@ jest.mock('../store/atoms/line', () => ({
   __esModule: true,
   selectedLineAtom: { __atom: 'selectedLine' },
 }));
+jest.mock('../store/atoms/navigation', () => ({
+  __esModule: true,
+  leftStationsAtom: { __atom: 'leftStations' },
+}));
 jest.mock('./useCurrentTrainType', () => ({
   useCurrentTrainType: jest.fn(),
+}));
+jest.mock('./useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
 }));
 jest.mock('~/lib/gql', () => ({
   gqlRequest: jest.fn(),
@@ -81,6 +90,9 @@ describe('useEstimateArrivalTimes', () => {
   const mockUseCurrentTrainType = useCurrentTrainType as jest.MockedFunction<
     typeof useCurrentTrainType
   >;
+  const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
+    typeof useCurrentStation
+  >;
   const mockGqlRequest = gqlRequest as unknown as jest.Mock;
 
   const stationA = createStation(1, { line: { id: 100 } });
@@ -93,12 +105,14 @@ describe('useEstimateArrivalTimes', () => {
     selectedBound = stationC as Station | null,
     selectedDirection = 'INBOUND' as string | null,
     line = selectedLine as Line | null,
+    leftStations = [stationA, stationB, stationC] as Station[],
   } = {}) => {
     mockUseAtomValue.mockImplementation((atom) => {
       if (atom === stationsAtom) return stations;
       if (atom === selectedBoundAtom) return selectedBound;
       if (atom === selectedDirectionAtom) return selectedDirection;
       if (atom === selectedLineAtom) return line;
+      if (atom === leftStationsAtom) return leftStations;
       throw new Error('unknown atom');
     });
   };
@@ -106,6 +120,7 @@ describe('useEstimateArrivalTimes', () => {
   beforeEach(() => {
     setupAtoms();
     mockUseCurrentTrainType.mockReturnValue(null);
+    mockUseCurrentStation.mockReturnValue(stationA);
   });
 
   afterEach(() => {
@@ -223,6 +238,130 @@ describe('useEstimateArrivalTimes', () => {
       expect(hookRef.current?.loading).toBe(false);
     });
     expect(hookRef.current?.route).toBeNull();
+  });
+
+  it('leftStations に含まれない駅は stops から除外される', async () => {
+    setupAtoms({ leftStations: [stationB, stationC] });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          {
+            id: 100,
+            stops: [
+              { stationGroupId: stationA.groupId, cumulativeMinutes: 0 },
+              { stationGroupId: stationB.groupId, cumulativeMinutes: 10 },
+              { stationGroupId: stationC.groupId, cumulativeMinutes: 20 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.stops).toHaveLength(2);
+    });
+    expect(hookRef.current?.route?.stops?.map((s) => s.stationGroupId)).toEqual(
+      [stationB.groupId, stationC.groupId]
+    );
+  });
+
+  it('現在駅の到着時刻を基準(0分)とした相対値に変換する', async () => {
+    mockUseCurrentStation.mockReturnValue(stationB);
+    setupAtoms({ leftStations: [stationB, stationC] });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          {
+            id: 100,
+            stops: [
+              { stationGroupId: stationA.groupId, cumulativeMinutes: 0 },
+              { stationGroupId: stationB.groupId, cumulativeMinutes: 10 },
+              { stationGroupId: stationC.groupId, cumulativeMinutes: 22.5 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.stops).toHaveLength(1);
+    });
+    expect(hookRef.current?.route?.stops?.[0]?.stationGroupId).toBe(
+      stationC.groupId
+    );
+    expect(hookRef.current?.route?.stops?.[0]?.cumulativeMinutes).toBe(12.5);
+  });
+
+  it('現在駅自身（0分）とそれより前（マイナス値）の stop は除外される', async () => {
+    mockUseCurrentStation.mockReturnValue(stationB);
+    setupAtoms({ leftStations: [stationA, stationB, stationC] });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          {
+            id: 100,
+            stops: [
+              { stationGroupId: stationA.groupId, cumulativeMinutes: 0 },
+              { stationGroupId: stationB.groupId, cumulativeMinutes: 10 },
+              { stationGroupId: stationC.groupId, cumulativeMinutes: 22.5 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.stops).toHaveLength(1);
+    });
+    expect(hookRef.current?.route?.stops?.map((s) => s.stationGroupId)).toEqual(
+      [stationC.groupId]
+    );
+  });
+
+  it('環状路線で同じ駅(都庁前)が2回出現しても現在地に近い出現を基準にする', async () => {
+    // 大江戸線: 都庁前が全stops中に2回出現するケース。
+    // 1回目(cumulativeMinutes=1.0)は現在地と無関係な別区間の出現、
+    // 2回目(cumulativeMinutes=56.2)が実際に現在地として使うべき出現。
+    const tochomae = createStation(900, { line: { id: 100 } });
+    mockUseCurrentStation.mockReturnValue(tochomae);
+    setupAtoms({ leftStations: [tochomae, stationA, stationB] });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          {
+            id: 100,
+            stops: [
+              { stationGroupId: tochomae.groupId, cumulativeMinutes: 1.0 },
+              { stationGroupId: stationC.groupId, cumulativeMinutes: 30 },
+              { stationGroupId: tochomae.groupId, cumulativeMinutes: 56.2 },
+              { stationGroupId: stationA.groupId, cumulativeMinutes: 58.0 },
+              { stationGroupId: stationB.groupId, cumulativeMinutes: 59.9 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.stops).toHaveLength(2);
+    });
+    expect(hookRef.current?.route?.stops?.map((s) => s.stationGroupId)).toEqual(
+      [stationA.groupId, stationB.groupId]
+    );
+    expect(hookRef.current?.route?.stops?.[0]?.cumulativeMinutes).toBeCloseTo(
+      1.8
+    );
+    expect(hookRef.current?.route?.stops?.[1]?.cumulativeMinutes).toBeCloseTo(
+      3.7
+    );
   });
 
   it('viaLineIds に全路線IDが重複なく含まれる', async () => {

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -78,8 +78,9 @@ describe('useEstimateArrivalTimes', () => {
   const mockUseAtomValue = useAtomValue as jest.MockedFunction<
     typeof useAtomValue
   >;
-  const mockUseCurrentTrainType =
-    useCurrentTrainType as jest.MockedFunction<typeof useCurrentTrainType>;
+  const mockUseCurrentTrainType = useCurrentTrainType as jest.MockedFunction<
+    typeof useCurrentTrainType
+  >;
   const mockGqlRequest = gqlRequest as unknown as jest.Mock;
 
   const stationA = createStation(1, { line: { id: 100 } });
@@ -240,9 +241,7 @@ describe('useEstimateArrivalTimes', () => {
     });
 
     const variables = mockGqlRequest.mock.calls[0][1];
-    expect(variables.viaLineIds).toEqual(
-      expect.arrayContaining([200, 300])
-    );
+    expect(variables.viaLineIds).toEqual(expect.arrayContaining([200, 300]));
     expect(variables.viaLineIds).toHaveLength(2);
   });
 });

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -64,7 +64,6 @@ export const useEstimateArrivalTimes = () => {
     skip,
   });
 
-
   // レスポンスの routes から filteringId に一致するルートを1件取り出す
   const matchedRoute = useMemo(() => {
     const routes = data?.estimateArrivalTimes?.routes;

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -14,6 +14,10 @@ import {
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useGraphQLQuery } from './useGraphQLQuery';
 
+/**
+ * 選択中の路線・駅情報から estimateArrivalTimes クエリの変数を組み立て、
+ * 現在の種別 (groupId) または選択中の路線 ID に一致するルートを返すフック。
+ */
 export const useEstimateArrivalTimes = () => {
   const stations = useAtomValue(stationsAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
@@ -21,11 +25,14 @@ export const useEstimateArrivalTimes = () => {
   const selectedLine = useAtomValue(selectedLineAtom);
   const trainType = useCurrentTrainType();
 
+  // stations 配列は [上り方面の終点, ..., 下り方面の終点] の順。
+  // OUTBOUND は末尾→先頭方向、INBOUND は先頭→末尾方向に進むので from/to を入れ替える。
   const fromStationId =
     selectedDirection === 'OUTBOUND' ? stations.at(-1)?.id : stations[0]?.id;
   const toStationId =
     selectedDirection === 'OUTBOUND' ? stations[0]?.id : stations.at(-1)?.id;
 
+  // 経由路線ID: stations に含まれる全路線IDを重複排除して渡す
   const viaLineIds = useMemo(
     () => [
       ...new Set(
@@ -35,7 +42,15 @@ export const useEstimateArrivalTimes = () => {
     [stations]
   );
 
-  const skip = !selectedBound || fromStationId == null || toStationId == null;
+  // routes.id は種別選択時は trainType.groupId、未選択時は路線IDに対応する
+  const filteringId = trainType?.groupId ?? selectedLine?.id;
+
+  // 方面未選択・始発/終着が不明・フィルタ先が無い場合はクエリを実行しない
+  const skip =
+    !selectedBound ||
+    fromStationId == null ||
+    toStationId == null ||
+    filteringId == null;
 
   const { data, loading, error } = useGraphQLQuery<
     EstimateArrivalTimesQuery,
@@ -49,19 +64,15 @@ export const useEstimateArrivalTimes = () => {
     skip,
   });
 
+  // レスポンスの routes から filteringId に一致するルートを1件取り出す
   const matchedRoute = useMemo(() => {
     const routes = data?.estimateArrivalTimes?.routes;
-    if (!routes) {
-      return null;
-    }
-
-    const filteringId = trainType?.groupId ?? selectedLine?.id;
-    if (filteringId == null) {
+    if (!routes || filteringId == null) {
       return null;
     }
 
     return routes.find((r) => r.id === filteringId) ?? null;
-  }, [data, trainType?.groupId, selectedLine?.id]);
+  }, [data, filteringId]);
 
   return { route: matchedRoute, loading, error };
 };

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -1,0 +1,60 @@
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import type {
+  EstimateArrivalTimesQuery,
+  EstimateArrivalTimesQueryVariables,
+} from '~/@types/graphql';
+import { ESTIMATE_ARRIVAL_TIMES } from '~/lib/graphql/queries';
+import { selectedLineAtom } from '../store/atoms/line';
+import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
+import { useCurrentTrainType } from './useCurrentTrainType';
+import { useGraphQLQuery } from './useGraphQLQuery';
+
+export const useEstimateArrivalTimes = () => {
+  const stations = useAtomValue(stationsAtom);
+  const selectedBound = useAtomValue(selectedBoundAtom);
+  const selectedLine = useAtomValue(selectedLineAtom);
+  const trainType = useCurrentTrainType();
+
+  const fromStationId = stations[0]?.id;
+  const toStationId = stations.at(-1)?.id;
+
+  const viaLineIds = useMemo(
+    () => [
+      ...new Set(
+        stations.map((s) => s.line?.id).filter((id): id is number => id != null)
+      ),
+    ],
+    [stations]
+  );
+
+  const skip = !selectedBound || fromStationId == null || toStationId == null;
+
+  const { data, loading, error } = useGraphQLQuery<
+    EstimateArrivalTimesQuery,
+    EstimateArrivalTimesQueryVariables
+  >(ESTIMATE_ARRIVAL_TIMES, {
+    variables: {
+      fromStationId: fromStationId ?? 0,
+      toStationId: toStationId ?? 0,
+      viaLineIds,
+    },
+    skip,
+  });
+
+  const matchedRoute = useMemo(() => {
+    const routes = data?.estimateArrivalTimes?.routes;
+    if (!routes) {
+      return null;
+    }
+
+    const filteringId = trainType?.groupId ?? selectedLine?.id;
+    if (filteringId == null) {
+      return null;
+    }
+
+    return routes.find((r) => r.id === filteringId) ?? null;
+  }, [data, trainType?.groupId, selectedLine?.id]);
+
+  return { route: matchedRoute, loading, error };
+};

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -6,18 +6,25 @@ import type {
 } from '~/@types/graphql';
 import { ESTIMATE_ARRIVAL_TIMES } from '~/lib/graphql/queries';
 import { selectedLineAtom } from '../store/atoms/line';
-import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
+import {
+  selectedBoundAtom,
+  selectedDirectionAtom,
+  stationsAtom,
+} from '../store/atoms/station';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useGraphQLQuery } from './useGraphQLQuery';
 
 export const useEstimateArrivalTimes = () => {
   const stations = useAtomValue(stationsAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
+  const selectedDirection = useAtomValue(selectedDirectionAtom);
   const selectedLine = useAtomValue(selectedLineAtom);
   const trainType = useCurrentTrainType();
 
-  const fromStationId = stations[0]?.id;
-  const toStationId = stations.at(-1)?.id;
+  const fromStationId =
+    selectedDirection === 'OUTBOUND' ? stations.at(-1)?.id : stations[0]?.id;
+  const toStationId =
+    selectedDirection === 'OUTBOUND' ? stations[0]?.id : stations.at(-1)?.id;
 
   const viaLineIds = useMemo(
     () => [

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -6,23 +6,29 @@ import type {
 } from '~/@types/graphql';
 import { ESTIMATE_ARRIVAL_TIMES } from '~/lib/graphql/queries';
 import { selectedLineAtom } from '../store/atoms/line';
+import { leftStationsAtom } from '../store/atoms/navigation';
 import {
   selectedBoundAtom,
   selectedDirectionAtom,
   stationsAtom,
 } from '../store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useGraphQLQuery } from './useGraphQLQuery';
 
 /**
  * 選択中の路線・駅情報から estimateArrivalTimes クエリの変数を組み立て、
  * 現在の種別 (groupId) または選択中の路線 ID に一致するルートを返すフック。
+ * 返す route.stops は LineBoard に表示中の駅（leftStations）に限定し、
+ * 現在駅の到着時刻を基準（0分）とした相対時間に変換する。
  */
 export const useEstimateArrivalTimes = () => {
   const stations = useAtomValue(stationsAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
   const selectedDirection = useAtomValue(selectedDirectionAtom);
   const selectedLine = useAtomValue(selectedLineAtom);
+  const leftStations = useAtomValue(leftStationsAtom);
+  const currentStation = useCurrentStation();
   const trainType = useCurrentTrainType();
 
   // stations 配列は [上り方面の終点, ..., 下り方面の終点] の順。
@@ -64,15 +70,86 @@ export const useEstimateArrivalTimes = () => {
     skip,
   });
 
-  // レスポンスの routes から filteringId に一致するルートを1件取り出す
+  // レスポンスの routes から filteringId に一致するルートを1件取り出し、
+  // stops を LineBoard 表示中の駅（leftStations）だけに絞り込んだ上で、
+  // 現在駅の到着時刻を基準（0分）とした相対時間に変換する
   const matchedRoute = useMemo(() => {
     const routes = data?.estimateArrivalTimes?.routes;
     if (!routes || filteringId == null) {
       return null;
     }
 
-    return routes.find((r) => r.id === filteringId) ?? null;
-  }, [data, filteringId]);
+    const route = routes.find((r) => r.id === filteringId) ?? null;
+    if (!route) {
+      return null;
+    }
+
+    const allStops = route.stops ?? [];
+
+    // 大江戸線の都庁前のように、環状区間で同じ駅が全stops中に複数回
+    // 出現することがある（例: 新宿→光が丘は都庁前を1回だけ通るはずだが、
+    // 環状部分を含む都庁前は他の時点でも別途出現する）。
+    // 単純な find() / filter() だと現在地と無関係な出現（別時点の都庁前）を
+    // 拾ってしまうため、leftStations の並び順をそのまま部分列として
+    // 辿れる区間を stops 内から探す。開始位置の候補が複数ある場合は、
+    // 最も範囲が短い（＝現在地に最も近い）候補を採用する。
+    const firstGroupId = leftStations[0]?.groupId;
+    let windowStartIndex = -1;
+    let windowEndIndex = -1;
+    let bestSpan = Number.POSITIVE_INFINITY;
+    if (firstGroupId != null) {
+      outer: for (let i = 0; i < allStops.length; i++) {
+        if (allStops[i]?.stationGroupId !== firstGroupId) {
+          continue;
+        }
+        let cursor = i;
+        for (const ls of leftStations) {
+          while (
+            cursor < allStops.length &&
+            allStops[cursor]?.stationGroupId !== ls.groupId
+          ) {
+            cursor++;
+          }
+          if (cursor >= allStops.length) {
+            continue outer;
+          }
+          cursor++;
+        }
+        const span = cursor - i;
+        if (span < bestSpan) {
+          bestSpan = span;
+          windowStartIndex = i;
+          windowEndIndex = cursor;
+        }
+      }
+    }
+
+    const windowStops =
+      windowStartIndex !== -1
+        ? allStops.slice(windowStartIndex, windowEndIndex)
+        : allStops;
+    // 特定した区間内で現在駅の到着時刻を探し、基準（0分）として使う。
+    // 区間内に現在駅が見つからない場合はオフセットせず生の値を返す。
+    const baseMinutes =
+      windowStops.find((s) => s.stationGroupId === currentStation?.groupId)
+        ?.cumulativeMinutes ?? 0;
+
+    const visibleGroupIds = new Set(leftStations.map((s) => s.groupId));
+    const relativeStops = windowStops
+      .filter(
+        (s) => s.stationGroupId != null && visibleGroupIds.has(s.stationGroupId)
+      )
+      .map((s) => ({
+        ...s,
+        cumulativeMinutes:
+          s.cumulativeMinutes == null
+            ? null
+            : s.cumulativeMinutes - baseMinutes,
+      }))
+      .filter((s) => s.cumulativeMinutes == null || s.cumulativeMinutes > 0);
+
+    return { ...route, stops: relativeStops };
+  }, [data, filteringId, leftStations, currentStation?.groupId]);
 
   return { route: matchedRoute, loading, error };
 };

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -64,6 +64,7 @@ export const useEstimateArrivalTimes = () => {
     skip,
   });
 
+
   // レスポンスの routes から filteringId に一致するルートを1件取り出す
   const matchedRoute = useMemo(() => {
     const routes = data?.estimateArrivalTimes?.routes;

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -473,3 +473,28 @@ export const GET_STATION_TRAIN_TYPES_LIGHT = gql`
     }
   }
 `;
+
+// Query for estimating arrival times between two stations
+export const ESTIMATE_ARRIVAL_TIMES = gql`
+  query EstimateArrivalTimes(
+    $fromStationId: Int!
+    $toStationId: Int!
+    $viaLineIds: [Int!]
+  ) {
+    estimateArrivalTimes(
+      fromStationId: $fromStationId
+      toStationId: $toStationId
+      viaLineIds: $viaLineIds
+    ) {
+      routes {
+        id
+        stops {
+          stationId
+          stationGroupId
+          cumulativeMinutes
+          stopsHere
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## 概要

`estimateArrivalTimes` GraphQL クエリを呼び出すカスタムフック `useEstimateArrivalTimes` を追加。始発駅〜終着駅間の経由路線 ID を渡し、レスポンスの `routes` を列車種別の `groupId`（種別指定時）または選択中の路線 ID でフィルタリングして返す。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/graphql/queries.ts`: `ESTIMATE_ARRIVAL_TIMES` クエリ定義を追加
- `src/@types/graphql.d.ts`: `EstimatedArrivalStop` / `EstimatedArrivalRoute` / `EstimatedArrivalPage` 型、`Query.estimateArrivalTimes` フィールド、オペレーション型を追加
- `src/hooks/useEstimateArrivalTimes.ts`: 新規カスタムフック
  - `stations` 配列から `fromStationId`・`toStationId`・`viaLineIds`（重複排除した全路線 ID）を算出
  - `selectedDirection` に応じて `fromStationId` / `toStationId` の前後を切り替え（OUTBOUND: 末尾→先頭、INBOUND: 先頭→末尾）
  - `filteringId`（`trainType.groupId` ?? `selectedLine.id`）を `skip` 条件に含め、フィルタ先が無い場合の不要なフェッチを防止
  - `useCurrentTrainType()` が非 null なら `routes.id === groupId`、null なら `routes.id === selectedLine.id` でフィルタリング
  - docstring・コード内コメントを追加
- `src/hooks/useEstimateArrivalTimes.test.tsx`: 単体テスト（skip 条件、方向切り替え、フィルタリング、viaLineIds 重複排除など 8 ケース）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 駅間の推定到着時刻を取得・表示できるようになりました。
  * 選択中の駅・路線・方向（必要に応じて現在の車種）に合う到着ルートを自動で絞り込みます。
  * 条件がそろっていない場合は予測取得を行いません。
* **テスト**
  * 条件分岐、ルートの絞り込み、経由路線指定、到着時刻の相対化と除外処理を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->