### PR TITLE
LineBoard(東日本・JR九州・埼京線・都営)に到着予想分数のオーバーレイ表示を追加

### DIFF
--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import type React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import { useScale } from '~/hooks/useScale';
 import getIsPass from '~/utils/isPass';
@@ -9,6 +9,23 @@ import PadLineMarks from '../../../PadLineMarks';
 import PassChevronEast from '../../../PassChevronEast';
 import { commonLineBoardStyles as styles } from '../styles/commonStyles';
 
+const localStyles = StyleSheet.create({
+  estimatedMinutesOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  estimatedMinutesText: {
+    color: '#000',
+    fontSize: isTablet ? 30 : 22,
+    lineHeight: isTablet ? 32 : 24,
+    fontWeight: '900',
+    textAlign: 'center',
+  },
+});
+
 export type LineDotProps = {
   station: Station;
   shouldGrayscale: boolean;
@@ -16,6 +33,7 @@ export type LineDotProps = {
   arrived: boolean;
   passed: boolean;
   isOdakyu?: boolean;
+  estimatedMinutes?: number | null;
 };
 
 export const LineDot: React.FC<LineDotProps> = ({
@@ -25,6 +43,7 @@ export const LineDot: React.FC<LineDotProps> = ({
   arrived,
   passed,
   isOdakyu = false,
+  estimatedMinutes,
 }) => {
   const { widthScale } = useScale();
 
@@ -52,16 +71,22 @@ export const LineDot: React.FC<LineDotProps> = ({
     );
   }
 
+  const dotSizeStyle = isOdakyu
+    ? {
+        width: isTablet ? 36 : 24,
+        height: isTablet ? 36 : 24,
+        borderRadius: isTablet ? 18 : 12,
+      }
+    : null;
+
   return (
     <View style={styles.stationArea}>
       <View style={styles.chevronArea}>
         <LinearGradient
           style={[
             styles.chevronGradient,
+            dotSizeStyle,
             isOdakyu && {
-              width: isTablet ? 36 : 24,
-              height: isTablet ? 36 : 24,
-              borderRadius: isTablet ? 18 : 12,
               borderWidth: 1,
               borderColor: passed && !arrived ? '#bbb' : '#fff',
             },
@@ -75,6 +100,22 @@ export const LineDot: React.FC<LineDotProps> = ({
           }
           {...(isOdakyu && { start: { x: 0, y: 0 }, end: { x: 1, y: 1 } })}
         />
+        {estimatedMinutes != null ? (
+          // 実際に見えるドット（chevronGradient）と同じサイズ・位置に重ねることで、
+          // chevronArea自体の幅(モバイルではドットより狭い)に引きずられず中央に揃える
+          <View
+            style={[
+              styles.chevronGradient,
+              dotSizeStyle,
+              localStyles.estimatedMinutesOverlay,
+            ]}
+            pointerEvents="none"
+          >
+            <Text style={localStyles.estimatedMinutesText}>
+              {Math.round(estimatedMinutes)}
+            </Text>
+          </View>
+        ) : null}
       </View>
       <View style={styles.marksContainer}>
         <PadLineMarks

--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -6,6 +6,7 @@ import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
 } from '~/hooks';
@@ -107,6 +108,7 @@ interface StationNameCellProps {
   hasTerminus: boolean;
   chevronColors: readonly [ChevronColor, ChevronColor];
   isOdakyu?: boolean;
+  estimatedMinutes?: number | null;
 }
 
 // Helper for bar gradients
@@ -305,6 +307,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
   hasTerminus,
   chevronColors,
   isOdakyu,
+  estimatedMinutes,
 }: StationNameCellProps) => {
   const arrived = useAtomValue(arrivedAtom);
   // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
@@ -407,6 +410,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           arrived={arrived}
           passed={passed}
           isOdakyu={isOdakyu}
+          estimatedMinutes={estimatedMinutes}
         />
         {stations.length - 1 === index ? (
           isOdakyu ? (
@@ -484,6 +488,17 @@ const LineBoardEast: React.FC<Props> = ({
   // なったため、バナーの「◯◯のつぎは」側も同じ次駅を参照して整合を保つ
   const nextStation = useDisplayNextStation();
   const afterNextStation = useAfterNextStation();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+
+  const estimatedMinutesByGroupId = useMemo(
+    () =>
+      new Map(
+        estimatedRoute?.stops
+          ?.filter((s) => s.stationGroupId != null)
+          .map((s) => [s.stationGroupId as number, s.cumulativeMinutes]) ?? []
+      ),
+    [estimatedRoute]
+  );
 
   const dim = useLandscapeWindowDimensions();
 
@@ -553,11 +568,24 @@ const LineBoardEast: React.FC<Props> = ({
             hasTerminus={hasTerminus}
             chevronColors={chevronColors}
             isOdakyu={isOdakyu}
+            estimatedMinutes={
+              s.groupId != null
+                ? estimatedMinutesByGroupId.get(s.groupId)
+                : null
+            }
           />
         </React.Fragment>
       );
     },
-    [chevronColors, hasTerminus, line, lineColors, stations, isOdakyu]
+    [
+      chevronColors,
+      hasTerminus,
+      line,
+      lineColors,
+      stations,
+      isOdakyu,
+      estimatedMinutesByGroupId,
+    ]
   );
 
   return (

--- a/src/components/LineBoardJRKyushu.test.tsx
+++ b/src/components/LineBoardJRKyushu.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -6,6 +6,7 @@ import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
 } from '~/hooks';
@@ -65,6 +66,7 @@ interface StationNameCellProps {
   line: Line;
   lineColors: (string | null | undefined)[];
   hasTerminus: boolean;
+  estimatedMinutes?: number | null;
 }
 
 // Helper: Determine if the bar should be split at current station
@@ -255,6 +257,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
   line,
   lineColors,
   hasTerminus,
+  estimatedMinutes,
 }: StationNameCellProps) => {
   const dim = useLandscapeWindowDimensions();
   const {
@@ -352,6 +355,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           transferLines={transferLines}
           arrived={arrived}
           passed={passed}
+          estimatedMinutes={estimatedMinutes}
         />
 
         {stations.length - 1 === index ? (
@@ -405,6 +409,17 @@ const LineBoardJRKyushu: React.FC<Props> = ({
   const dim = useLandscapeWindowDimensions();
   const padCount = Math.max(0, 8 - stations.length);
   const totalStations = stations.length + padCount;
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+
+  const estimatedMinutesByGroupId = useMemo(
+    () =>
+      new Map(
+        estimatedRoute?.stops
+          ?.filter((s) => s.stationGroupId != null)
+          .map((s) => [s.stationGroupId as number, s.cumulativeMinutes]) ?? []
+      ),
+    [estimatedRoute]
+  );
 
   const line = useMemo(
     () => currentLine || selectedLine,
@@ -439,11 +454,23 @@ const LineBoardJRKyushu: React.FC<Props> = ({
             line={line}
             lineColors={lineColors}
             hasTerminus={hasTerminus}
+            estimatedMinutes={
+              s.groupId != null
+                ? estimatedMinutesByGroupId.get(s.groupId)
+                : null
+            }
           />
         </React.Fragment>
       );
     },
-    [hasTerminus, line, lineColors, stations, totalStations]
+    [
+      hasTerminus,
+      line,
+      lineColors,
+      stations,
+      totalStations,
+      estimatedMinutesByGroupId,
+    ]
   );
 
   const stationsWithEmpty = useMemo(

--- a/src/components/LineBoardSaikyo.test.tsx
+++ b/src/components/LineBoardSaikyo.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
   useInterval: jest.fn(),
   useTransferLinesFromStation: jest.fn(() => []),
 }));

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -6,6 +6,7 @@ import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
 } from '~/hooks';
@@ -76,6 +77,7 @@ interface StationNameCellProps {
   line: Line | null;
   lineColors: (string | null | undefined)[];
   hasTerminus: boolean;
+  estimatedMinutes?: number | null;
 }
 
 const useStationCellState = (
@@ -213,6 +215,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
   line,
   lineColors,
   hasTerminus,
+  estimatedMinutes,
 }: StationNameCellProps) => {
   const isEn = useAtomValue(isEnAtom);
   const dim = useLandscapeWindowDimensions();
@@ -268,6 +271,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           transferLines={transferLines}
           arrived={arrived}
           passed={passed}
+          estimatedMinutes={estimatedMinutes}
         />
         {stations.length - 1 === index && (
           <BarTerminalSaikyo
@@ -312,6 +316,17 @@ const LineBoardSaikyo: React.FC<Props> = ({
   const selectedLine = useAtomValue(selectedLineAtom);
   const currentLine = useCurrentLine();
   const dim = useLandscapeWindowDimensions();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+
+  const estimatedMinutesByGroupId = useMemo(
+    () =>
+      new Map(
+        estimatedRoute?.stops
+          ?.filter((s) => s.stationGroupId != null)
+          .map((s) => [s.stationGroupId as number, s.cumulativeMinutes]) ?? []
+      ),
+    [estimatedRoute]
+  );
 
   const line = useMemo(
     () => currentLine || selectedLine,
@@ -333,11 +348,16 @@ const LineBoardSaikyo: React.FC<Props> = ({
             line={line}
             lineColors={lineColors}
             hasTerminus={hasTerminus}
+            estimatedMinutes={
+              s.groupId != null
+                ? estimatedMinutesByGroupId.get(s.groupId)
+                : null
+            }
           />
         </React.Fragment>
       );
     },
-    [hasTerminus, line, lineColors, stations]
+    [hasTerminus, line, lineColors, stations, estimatedMinutesByGroupId]
   );
 
   const stationsWithEmpty = useMemo(

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -14,6 +14,7 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
   useInterval: jest.fn(),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
   useTransferLinesFromStation: jest.fn(() => []),

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -6,6 +6,7 @@ import type { Line, Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
   useLandscapeWindowDimensions,
   useStationNumberIndexFunc,
   useTransferLinesFromStation,
@@ -205,6 +206,7 @@ interface StationNameCellProps {
   line: Line;
   lineColors: (string | null | undefined)[];
   hasTerminus: boolean;
+  estimatedMinutes?: number | null;
 }
 
 // Helper: Check if station is at middle position
@@ -339,6 +341,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
   line,
   lineColors,
   hasTerminus,
+  estimatedMinutes,
 }: StationNameCellProps) => {
   const arrived = useAtomValue(arrivedAtom);
   // 現在地基準の現在駅(到着取りこぼし時はヘッダーの「まもなく」と一致する側へ自己修復)
@@ -460,6 +463,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           transferLines={transferLines}
           arrived={arrived}
           passed={passed}
+          estimatedMinutes={estimatedMinutes}
         />
         {isLastStation ? (
           <BarTerminalEast
@@ -510,6 +514,17 @@ const LineBoardToei: React.FC<Props> = ({
   const currentLine = useCurrentLine();
 
   const dim = useLandscapeWindowDimensions();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+
+  const estimatedMinutesByGroupId = useMemo(
+    () =>
+      new Map(
+        estimatedRoute?.stops
+          ?.filter((s) => s.stationGroupId != null)
+          .map((s) => [s.stationGroupId as number, s.cumulativeMinutes]) ?? []
+      ),
+    [estimatedRoute]
+  );
 
   const line = useMemo(
     () => currentLine || selectedLine,
@@ -547,11 +562,16 @@ const LineBoardToei: React.FC<Props> = ({
             line={line}
             lineColors={lineColors}
             hasTerminus={hasTerminus}
+            estimatedMinutes={
+              s.groupId != null
+                ? estimatedMinutesByGroupId.get(s.groupId)
+                : null
+            }
           />
         </React.Fragment>
       );
     },
-    [hasTerminus, line, lineColors, stations]
+    [hasTerminus, line, lineColors, stations, estimatedMinutesByGroupId]
   );
 
   const stationsWithEmpty = useMemo(


### PR DESCRIPTION
## 概要

LineBoard の東日本・JR九州・埼京線・都営の4テーマに、到着予想分数をドットに重ねて表示する機能を追加します。全テーマへの反映は段階的に進めており、本PRはその一部です。分数表示に対応していないテーマもまだ残っています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `LineDot` に到着予想分数を丸の上に重ねて表示する `estimatedMinutes` prop とオーバーレイ表示を追加
- `LineBoardEast` / `LineBoardJRKyushu` / `LineBoardSaikyo` / `LineBoardToei` にて `useEstimateArrivalTimes` から取得したルート情報を駅グループIDごとの分数マップに変換し、各駅の `LineDot` に受け渡し
- 上記4テーマのテストで `useEstimateArrivalTimes` のモックを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 駅一覧に到着見込み分数を表示できるようになりました。
  * 路線図の駅アイコン上に、推定分数がある場合は数値バッジが重なって表示されます。

* **テスト**
  * 到着見込み情報に関するテスト環境を更新し、表示の安定性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->