### PR TITLE
出発済み駅にLineDotの到着予想分数が残る不具合を修正

### DIFF
--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -12,8 +12,8 @@ import {
   selectedDirectionAtom,
   stationsAtom,
 } from '../store/atoms/station';
-import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
+import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
 
 jest.mock('jotai', () => ({
@@ -38,8 +38,8 @@ jest.mock('../store/atoms/navigation', () => ({
 jest.mock('./useCurrentTrainType', () => ({
   useCurrentTrainType: jest.fn(),
 }));
-jest.mock('./useCurrentStation', () => ({
-  useCurrentStation: jest.fn(),
+jest.mock('./useDisplayCurrentStation', () => ({
+  useDisplayCurrentStation: jest.fn(),
 }));
 jest.mock('~/lib/gql', () => ({
   gqlRequest: jest.fn(),
@@ -90,9 +90,10 @@ describe('useEstimateArrivalTimes', () => {
   const mockUseCurrentTrainType = useCurrentTrainType as jest.MockedFunction<
     typeof useCurrentTrainType
   >;
-  const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
-    typeof useCurrentStation
-  >;
+  const mockUseDisplayCurrentStation =
+    useDisplayCurrentStation as jest.MockedFunction<
+      typeof useDisplayCurrentStation
+    >;
   const mockGqlRequest = gqlRequest as unknown as jest.Mock;
 
   const stationA = createStation(1, { line: { id: 100 } });
@@ -120,7 +121,7 @@ describe('useEstimateArrivalTimes', () => {
   beforeEach(() => {
     setupAtoms();
     mockUseCurrentTrainType.mockReturnValue(null);
-    mockUseCurrentStation.mockReturnValue(stationA);
+    mockUseDisplayCurrentStation.mockReturnValue(stationA);
   });
 
   afterEach(() => {
@@ -268,7 +269,7 @@ describe('useEstimateArrivalTimes', () => {
   });
 
   it('現在駅の到着時刻を基準(0分)とした相対値に変換する', async () => {
-    mockUseCurrentStation.mockReturnValue(stationB);
+    mockUseDisplayCurrentStation.mockReturnValue(stationB);
     setupAtoms({ leftStations: [stationB, stationC] });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: {
@@ -297,7 +298,7 @@ describe('useEstimateArrivalTimes', () => {
   });
 
   it('現在駅自身（0分）とそれより前（マイナス値）の stop は除外される', async () => {
-    mockUseCurrentStation.mockReturnValue(stationB);
+    mockUseDisplayCurrentStation.mockReturnValue(stationB);
     setupAtoms({ leftStations: [stationA, stationB, stationC] });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: {
@@ -329,7 +330,7 @@ describe('useEstimateArrivalTimes', () => {
     // 1回目(cumulativeMinutes=1.0)は現在地と無関係な別区間の出現、
     // 2回目(cumulativeMinutes=56.2)が実際に現在地として使うべき出現。
     const tochomae = createStation(900, { line: { id: 100 } });
-    mockUseCurrentStation.mockReturnValue(tochomae);
+    mockUseDisplayCurrentStation.mockReturnValue(tochomae);
     setupAtoms({ leftStations: [tochomae, stationA, stationB] });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: {

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -12,8 +12,8 @@ import {
   selectedDirectionAtom,
   stationsAtom,
 } from '../store/atoms/station';
-import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
+import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useGraphQLQuery } from './useGraphQLQuery';
 
 /**
@@ -28,7 +28,9 @@ export const useEstimateArrivalTimes = () => {
   const selectedDirection = useAtomValue(selectedDirectionAtom);
   const selectedLine = useAtomValue(selectedLineAtom);
   const leftStations = useAtomValue(leftStationsAtom);
-  const currentStation = useCurrentStation();
+  // LineBoard 側の passed/グレーアウト判定と同じ基準駅を使うことで、取りこぼし時の
+  // 前方補正(healed)が効いた際に基準駅がずれ、出発済み駅にETAが残るのを防ぐ。
+  const currentStation = useDisplayCurrentStation();
   const trainType = useCurrentTrainType();
 
   // stations 配列は [上り方面の終点, ..., 下り方面の終点] の順。


### PR DESCRIPTION
## 概要

出発済みの駅にLineBoardの到着予想分数(ETA)オーバーレイが残ってしまう不具合を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useEstimateArrivalTimes` でETAの基準駅(0分の起点)に使っていた `useCurrentStation()`(記録上の生の現在駅)を、LineBoard各コンポーネントの `passed`/グレーアウト判定と同じ `useDisplayCurrentStation()`(到着取りこぼし時に前方補正された表示用現在駅)に変更
- 取りこぼし補正で表示上「出発済み」扱いになった駅について、ETA計算側の基準もそこまで進むようにし、LineDotに残留ETAが表示されないようにした
- `useEstimateArrivalTimes.test.tsx` のモック対象を `useCurrentStation` から `useDisplayCurrentStation` に更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 到着時刻の表示基準を、画面表示と同じ現在駅に合わせるよう改善しました。
  * これにより、環状線や一部の補正ケースで、出発済みの駅に ETA が残る不自然な表示を抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->