### PR TITLE
LineDotの到着予想分数のフォントウェイトをsemiboldに変更

### DIFF
--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -21,7 +21,7 @@ const localStyles = StyleSheet.create({
     color: '#000',
     fontSize: isTablet ? 30 : 22,
     lineHeight: isTablet ? 32 : 24,
-    fontWeight: '900',
+    fontWeight: '600',
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
## 概要

LineDotの到着予想分数（ETA）の文字が太すぎたため、フォントウェイトをsemibold相当に調整しました。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `LineDot.tsx` の `estimatedMinutesText` の `fontWeight` を `'900'` から `'600'`（semibold）に変更

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
