### PR TITLE
LineDotの到着予想分数のフォントを他要素と統一(RobotoBold)に変更

### DIFF
--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -2,6 +2,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import type React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
+import { FONTS } from '~/constants';
 import { useScale } from '~/hooks/useScale';
 import getIsPass from '~/utils/isPass';
 import isTablet from '~/utils/isTablet';
@@ -21,8 +22,9 @@ const localStyles = StyleSheet.create({
     color: '#000',
     fontSize: isTablet ? 30 : 22,
     lineHeight: isTablet ? 32 : 24,
-    fontWeight: '600',
     textAlign: 'center',
+    fontFamily: FONTS.RobotoBold,
+    letterSpacing: -1,
   },
 });
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

LineDotの到着予想分数のテキストで使用するフォントを、他要素と同じ `FONTS.RobotoBold` に統一しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `estimatedMinutesText` の `fontWeight: '600'` 指定をやめ、`FONTS.RobotoBold` を指定するよう変更
- 見た目を整えるため `letterSpacing: -1` を追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
