### PR TITLE
LineDotの到着予想分数表示の不具合を修正

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -50,6 +50,26 @@ export enum CompanyType {
   SemiMajor = 'SemiMajor',
 }
 
+export type EstimatedArrivalPage = {
+  __typename: 'EstimatedArrivalPage';
+  routes: Maybe<Array<EstimatedArrivalRoute>>;
+};
+
+export type EstimatedArrivalRoute = {
+  __typename: 'EstimatedArrivalRoute';
+  id: Maybe<Scalars['Int']['output']>;
+  stops: Maybe<Array<EstimatedArrivalStop>>;
+};
+
+export type EstimatedArrivalStop = {
+  __typename: 'EstimatedArrivalStop';
+  cumulativeMinutes: Maybe<Scalars['Float']['output']>;
+  departureCumulativeMinutes: Maybe<Scalars['Float']['output']>;
+  stationGroupId: Maybe<Scalars['Int']['output']>;
+  stationId: Maybe<Scalars['Int']['output']>;
+  stopsHere: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type Line = {
   __typename: 'Line';
   averageDistance: Maybe<Scalars['Float']['output']>;
@@ -137,6 +157,7 @@ export type Query = {
   stations: Array<Station>;
   stationsByName: Array<Station>;
   stationsNearby: Array<Station>;
+  trainRoute: TrainRouteResponse;
 };
 
 export type QueryConnectedRoutesArgs = {
@@ -145,6 +166,7 @@ export type QueryConnectedRoutesArgs = {
 };
 
 export type QueryEstimateArrivalTimesArgs = {
+  directionId: InputMaybe<Scalars['Int']['input']>;
   fromStationId: Scalars['Int']['input'];
   toStationId: Scalars['Int']['input'];
   viaLineIds: InputMaybe<Array<Scalars['Int']['input']>>;
@@ -235,23 +257,10 @@ export type QueryStationsNearbyArgs = {
   transportType: InputMaybe<TransportType>;
 };
 
-export type EstimatedArrivalStop = {
-  __typename: 'EstimatedArrivalStop';
-  cumulativeMinutes: Maybe<Scalars['Float']['output']>;
-  stationGroupId: Maybe<Scalars['Int']['output']>;
-  stationId: Maybe<Scalars['Int']['output']>;
-  stopsHere: Maybe<Scalars['Boolean']['output']>;
-};
-
-export type EstimatedArrivalRoute = {
-  __typename: 'EstimatedArrivalRoute';
-  id: Maybe<Scalars['Int']['output']>;
-  stops: Maybe<Array<EstimatedArrivalStop>>;
-};
-
-export type EstimatedArrivalPage = {
-  __typename: 'EstimatedArrivalPage';
-  routes: Maybe<Array<EstimatedArrivalRoute>>;
+export type QueryTrainRouteArgs = {
+  fromStationGroupId: Scalars['Int']['input'];
+  lineGroupId: InputMaybe<Scalars['Int']['input']>;
+  toStationGroupId: Scalars['Int']['input'];
 };
 
 export type Route = {
@@ -356,6 +365,21 @@ export enum TrainDirection {
   Inbound = 'Inbound',
   Outbound = 'Outbound',
 }
+
+export type TrainRouteResponse = {
+  __typename: 'TrainRouteResponse';
+  segments: Maybe<Array<TrainRouteSegment>>;
+};
+
+export type TrainRouteSegment = {
+  __typename: 'TrainRouteSegment';
+  distanceFromPrevious: Maybe<Scalars['Float']['output']>;
+  maxAcceleration: Maybe<Scalars['Float']['output']>;
+  maxDeceleration: Maybe<Scalars['Float']['output']>;
+  maxSpeed: Maybe<Scalars['Float']['output']>;
+  station: Maybe<StationNested>;
+  stops: Maybe<Scalars['Boolean']['output']>;
+};
 
 export type TrainType = {
   __typename: 'TrainType';
@@ -3847,6 +3871,449 @@ export type GetLineGroupStationsQuery = {
   }>;
 };
 
+export type GetStationsByIdsQueryVariables = Exact<{
+  ids: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
+}>;
+
+export type GetStationsByIdsQuery = {
+  stations: Array<{
+    __typename: 'Station';
+    id: number | null | undefined;
+    groupId: number | null | undefined;
+    name: string | null | undefined;
+    nameKatakana: string | null | undefined;
+    nameRoman: string | null | undefined;
+    nameChinese: string | null | undefined;
+    nameKorean: string | null | undefined;
+    threeLetterCode: string | null | undefined;
+    latitude: number | null | undefined;
+    longitude: number | null | undefined;
+    prefectureId: number | null | undefined;
+    hasTrainTypes: boolean | null | undefined;
+    stopCondition: StopCondition | null | undefined;
+    nameTtsSegments:
+      | Array<{
+          __typename: 'TtsSegment';
+          alphabet: TtsAlphabet | null | undefined;
+          fallbackText: string | null | undefined;
+          lang: string | null | undefined;
+          pronunciation: string | null | undefined;
+          separator: string | null | undefined;
+          surface: string | null | undefined;
+        }>
+      | null
+      | undefined;
+    stationNumbers:
+      | Array<{
+          __typename: 'StationNumber';
+          lineSymbol: string | null | undefined;
+          lineSymbolColor: string | null | undefined;
+          lineSymbolShape: string | null | undefined;
+          stationNumber: string | null | undefined;
+        }>
+      | null
+      | undefined;
+    line:
+      | {
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+    lines:
+      | Array<{
+          __typename: 'LineNested';
+          id: number | null | undefined;
+          color: string | null | undefined;
+          lineType: LineType | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameShort: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          transportType: TransportType | null | undefined;
+          company:
+            | {
+                __typename: 'Company';
+                id: number | null | undefined;
+                nameEnglishShort: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameShort: string | null | undefined;
+              }
+            | null
+            | undefined;
+          lineSymbols:
+            | Array<{
+                __typename: 'LineSymbol';
+                color: string | null | undefined;
+                shape: string | null | undefined;
+                symbol: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          station:
+            | {
+                __typename: 'StationNested';
+                id: number | null | undefined;
+                groupId: number | null | undefined;
+                name: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                hasTrainTypes: boolean | null | undefined;
+                stationNumbers:
+                  | Array<{
+                      __typename: 'StationNumber';
+                      lineSymbol: string | null | undefined;
+                      lineSymbolColor: string | null | undefined;
+                      lineSymbolShape: string | null | undefined;
+                      stationNumber: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+        }>
+      | null
+      | undefined;
+    trainType:
+      | {
+          __typename: 'TrainTypeNested';
+          id: number | null | undefined;
+          typeId: number | null | undefined;
+          groupId: number | null | undefined;
+          name: string | null | undefined;
+          nameKatakana: string | null | undefined;
+          nameRoman: string | null | undefined;
+          nameRomanIpa: string | null | undefined;
+          nameChinese: string | null | undefined;
+          nameKorean: string | null | undefined;
+          color: string | null | undefined;
+          direction: TrainDirection | null | undefined;
+          kind: TrainTypeKind | null | undefined;
+          nameTtsSegments:
+            | Array<{
+                __typename: 'TtsSegment';
+                alphabet: TtsAlphabet | null | undefined;
+                fallbackText: string | null | undefined;
+                lang: string | null | undefined;
+                pronunciation: string | null | undefined;
+                separator: string | null | undefined;
+                surface: string | null | undefined;
+              }>
+            | null
+            | undefined;
+          line:
+            | {
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameRomanIpa: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }
+            | null
+            | undefined;
+          lines:
+            | Array<{
+                __typename: 'LineNested';
+                id: number | null | undefined;
+                color: string | null | undefined;
+                lineType: LineType | null | undefined;
+                nameFull: string | null | undefined;
+                nameKatakana: string | null | undefined;
+                nameRoman: string | null | undefined;
+                nameRomanIpa: string | null | undefined;
+                nameShort: string | null | undefined;
+                nameChinese: string | null | undefined;
+                nameKorean: string | null | undefined;
+                status: OperationStatus | null | undefined;
+                transportType: TransportType | null | undefined;
+                company:
+                  | {
+                      __typename: 'Company';
+                      id: number | null | undefined;
+                      nameEnglishShort: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameShort: string | null | undefined;
+                    }
+                  | null
+                  | undefined;
+                lineSymbols:
+                  | Array<{
+                      __typename: 'LineSymbol';
+                      color: string | null | undefined;
+                      shape: string | null | undefined;
+                      symbol: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+                station:
+                  | {
+                      __typename: 'StationNested';
+                      id: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      hasTrainTypes: boolean | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                      stationNumbers:
+                        | Array<{
+                            __typename: 'StationNumber';
+                            lineSymbol: string | null | undefined;
+                            lineSymbolColor: string | null | undefined;
+                            lineSymbolShape: string | null | undefined;
+                            stationNumber: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                trainType:
+                  | {
+                      __typename: 'TrainTypeNested';
+                      id: number | null | undefined;
+                      typeId: number | null | undefined;
+                      groupId: number | null | undefined;
+                      name: string | null | undefined;
+                      nameKatakana: string | null | undefined;
+                      nameRoman: string | null | undefined;
+                      nameRomanIpa: string | null | undefined;
+                      nameChinese: string | null | undefined;
+                      nameKorean: string | null | undefined;
+                      color: string | null | undefined;
+                      direction: TrainDirection | null | undefined;
+                      kind: TrainTypeKind | null | undefined;
+                      nameTtsSegments:
+                        | Array<{
+                            __typename: 'TtsSegment';
+                            alphabet: TtsAlphabet | null | undefined;
+                            fallbackText: string | null | undefined;
+                            lang: string | null | undefined;
+                            pronunciation: string | null | undefined;
+                            separator: string | null | undefined;
+                            surface: string | null | undefined;
+                          }>
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined;
+                nameTtsSegments:
+                  | Array<{
+                      __typename: 'TtsSegment';
+                      alphabet: TtsAlphabet | null | undefined;
+                      fallbackText: string | null | undefined;
+                      lang: string | null | undefined;
+                      pronunciation: string | null | undefined;
+                      separator: string | null | undefined;
+                      surface: string | null | undefined;
+                    }>
+                  | null
+                  | undefined;
+              }>
+            | null
+            | undefined;
+        }
+      | null
+      | undefined;
+  }>;
+};
+
 export type LineRouteFieldsFragment = {
   __typename: 'LineNested';
   id: number | null | undefined;
@@ -4363,6 +4830,7 @@ export type EstimateArrivalTimesQuery = {
                 stationId: number | null | undefined;
                 stationGroupId: number | null | undefined;
                 cumulativeMinutes: number | null | undefined;
+                departureCumulativeMinutes: number | null | undefined;
                 stopsHere: boolean | null | undefined;
               }>
             | null

--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import type React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import { FONTS } from '~/constants';
 import { useScale } from '~/hooks/useScale';
@@ -24,7 +24,7 @@ const localStyles = StyleSheet.create({
     lineHeight: isTablet ? 32 : 24,
     textAlign: 'center',
     fontFamily: FONTS.RobotoBold,
-    letterSpacing: -1,
+    letterSpacing: Platform.OS === 'ios' ? 0 : -1,
   },
 });
 

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -268,7 +268,7 @@ describe('useEstimateArrivalTimes', () => {
     );
   });
 
-  it('現在駅の到着時刻を基準(0分)とした相対値に変換する', async () => {
+  it('現在駅の出発時刻を基準(0分)とした相対値に変換する', async () => {
     mockUseDisplayCurrentStation.mockReturnValue(stationB);
     setupAtoms({ leftStations: [stationB, stationC] });
     mockGqlRequest.mockResolvedValue({
@@ -278,7 +278,11 @@ describe('useEstimateArrivalTimes', () => {
             id: 100,
             stops: [
               { stationGroupId: stationA.groupId, cumulativeMinutes: 0 },
-              { stationGroupId: stationB.groupId, cumulativeMinutes: 10 },
+              {
+                stationGroupId: stationB.groupId,
+                cumulativeMinutes: 10,
+                departureCumulativeMinutes: 10,
+              },
               { stationGroupId: stationC.groupId, cumulativeMinutes: 22.5 },
             ],
           },
@@ -340,7 +344,11 @@ describe('useEstimateArrivalTimes', () => {
             stops: [
               { stationGroupId: tochomae.groupId, cumulativeMinutes: 1.0 },
               { stationGroupId: stationC.groupId, cumulativeMinutes: 30 },
-              { stationGroupId: tochomae.groupId, cumulativeMinutes: 56.2 },
+              {
+                stationGroupId: tochomae.groupId,
+                cumulativeMinutes: 56.2,
+                departureCumulativeMinutes: 56.2,
+              },
               { stationGroupId: stationA.groupId, cumulativeMinutes: 58.0 },
               { stationGroupId: stationB.groupId, cumulativeMinutes: 59.9 },
             ],

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -130,16 +130,25 @@ export const useEstimateArrivalTimes = () => {
       windowStartIndex !== -1
         ? allStops.slice(windowStartIndex, windowEndIndex)
         : allStops;
-    // 特定した区間内で現在駅の到着時刻を探し、基準（0分）として使う。
+    // 特定した区間内で現在駅の出発時刻を探し、基準（0分）として使う。
+    // 停車時間がある駅では到着時刻ではなく出発時刻を基準にしないと、
+    // 停車中に後続駅のETAがズレて表示されてしまう。
     // 区間内に現在駅が見つからない場合はオフセットせず生の値を返す。
     const baseMinutes =
       windowStops.find((s) => s.stationGroupId === currentStation?.groupId)
-        ?.cumulativeMinutes ?? 0;
+        ?.departureCumulativeMinutes ?? 0;
 
     const visibleGroupIds = new Set(leftStations.map((s) => s.groupId));
+    // 現在駅自身は cumulativeMinutes - baseMinutes が0以下になり通常は下のfilterで
+    // 除外されるが、windowStops内に現在駅のエントリが見つからずbaseMinutesが0に
+    // フォールバックするケースでは生の値が残ってしまう。停車中の駅にはETAを出さない
+    // という表示上の不変条件を計算結果に依存せず保証するため、ここで明示的に除く。
     const relativeStops = windowStops
       .filter(
-        (s) => s.stationGroupId != null && visibleGroupIds.has(s.stationGroupId)
+        (s) =>
+          s.stationGroupId != null &&
+          visibleGroupIds.has(s.stationGroupId) &&
+          s.stationGroupId !== currentStation?.groupId
       )
       .map((s) => ({
         ...s,

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -492,6 +492,7 @@ export const ESTIMATE_ARRIVAL_TIMES = gql`
           stationId
           stationGroupId
           cumulativeMinutes
+          departureCumulativeMinutes
           stopsHere
         }
       }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 到着予想分数（ETA）の基準時刻を、現在駅の到着時刻ではなく出発時刻に変更し、停車中に後続駅のETAがズレて表示される不具合を修正
- 停車中の現在駅自身のLineDotにはETAを表示しないよう、計算結果によらず明示的に除外する処理を追加
- LineDotの到着予想分数テキストについて、iOSでの文字間隔（letterSpacing）を調整
- 上記のETA基準時刻拡張（departureCumulativeMinutes）に伴い、GraphQLの型定義（graphql.d.ts）・クエリ（queries.ts）を再生成

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 経路取得や駅ID一覧取得に対応し、より詳細なルート情報を扱えるようになりました。
* **不具合修正**
  * 到着予測で停車時間を考慮した表示に改善し、後続駅のETAずれを抑えました。
  * 現在駅が一覧に残ってしまう表示不整合を修正しました。
  * iOSでの時刻表示の文字間を調整し、見た目の違和感を軽減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->