### PR TITLE
環状路線のETA取得時にdirectionIdを明示的に指定して進行方向の弧を確定させる

### DIFF
--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -4815,6 +4815,7 @@ export type EstimateArrivalTimesQueryVariables = Exact<{
   viaLineIds: InputMaybe<
     Array<Scalars['Int']['input']> | Scalars['Int']['input']
   >;
+  directionId: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type EstimateArrivalTimesQuery = {

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -15,6 +15,7 @@ import {
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
+import { useLoopLine } from './useLoopLine';
 
 jest.mock('jotai', () => ({
   __esModule: true,
@@ -40,6 +41,9 @@ jest.mock('./useCurrentTrainType', () => ({
 }));
 jest.mock('./useDisplayCurrentStation', () => ({
   useDisplayCurrentStation: jest.fn(),
+}));
+jest.mock('./useLoopLine', () => ({
+  useLoopLine: jest.fn(),
 }));
 jest.mock('~/lib/gql', () => ({
   gqlRequest: jest.fn(),
@@ -94,6 +98,9 @@ describe('useEstimateArrivalTimes', () => {
     useDisplayCurrentStation as jest.MockedFunction<
       typeof useDisplayCurrentStation
     >;
+  const mockUseLoopLine = useLoopLine as jest.MockedFunction<
+    typeof useLoopLine
+  >;
   const mockGqlRequest = gqlRequest as unknown as jest.Mock;
 
   const stationA = createStation(1, { line: { id: 100 } });
@@ -122,6 +129,9 @@ describe('useEstimateArrivalTimes', () => {
     setupAtoms();
     mockUseCurrentTrainType.mockReturnValue(null);
     mockUseDisplayCurrentStation.mockReturnValue(stationA);
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine: false,
+    } as ReturnType<typeof useLoopLine>);
   });
 
   afterEach(() => {
@@ -184,6 +194,59 @@ describe('useEstimateArrivalTimes', () => {
     const variables = mockGqlRequest.mock.calls[0][1];
     expect(variables.fromStationId).toBe(stationC.id);
     expect(variables.toStationId).toBe(stationA.id);
+  });
+
+  it('環状路線でないとき directionId を送信しない', async () => {
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: { routes: [] },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.directionId).toBeUndefined();
+  });
+
+  it('環状路線かつ INBOUND のとき directionId=0(格納順) を送信する', async () => {
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine: true,
+    } as ReturnType<typeof useLoopLine>);
+    setupAtoms({ selectedDirection: 'INBOUND' });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: { routes: [] },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.directionId).toBe(0);
+  });
+
+  it('環状路線かつ OUTBOUND のとき directionId=1(逆順) を送信する', async () => {
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine: true,
+    } as ReturnType<typeof useLoopLine>);
+    setupAtoms({ selectedDirection: 'OUTBOUND' });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: { routes: [] },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.directionId).toBe(1);
   });
 
   it('trainType.groupId でルートをフィルタリングする', async () => {

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -249,6 +249,25 @@ describe('useEstimateArrivalTimes', () => {
     expect(variables.directionId).toBe(1);
   });
 
+  it('環状路線でも方面未選択のとき directionId を送信しない', async () => {
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine: true,
+    } as ReturnType<typeof useLoopLine>);
+    setupAtoms({ selectedDirection: null });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: { routes: [] },
+    });
+
+    renderHook();
+
+    await waitFor(() => {
+      expect(mockGqlRequest).toHaveBeenCalled();
+    });
+
+    const variables = mockGqlRequest.mock.calls[0][1];
+    expect(variables.directionId).toBeUndefined();
+  });
+
   it('trainType.groupId でルートをフィルタリングする', async () => {
     mockUseCurrentTrainType.mockReturnValue({
       groupId: 42,

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -5,6 +5,7 @@ import type {
   EstimateArrivalTimesQueryVariables,
 } from '~/@types/graphql';
 import { ESTIMATE_ARRIVAL_TIMES } from '~/lib/graphql/queries';
+import type { LineDirection } from '../models/Bound';
 import { selectedLineAtom } from '../store/atoms/line';
 import { leftStationsAtom } from '../store/atoms/navigation';
 import {
@@ -15,6 +16,14 @@ import {
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useGraphQLQuery } from './useGraphQLQuery';
+import { useLoopLine } from './useLoopLine';
+
+// StationAPI EstimateArrivalTimesRequest.direction_id (0 = 格納順, 1 = 逆順) に対応。
+// stations 配列は API の格納順なので、先頭→末尾に進む INBOUND が 0、逆の OUTBOUND が 1。
+const LOOP_LINE_DIRECTION_ID: Record<LineDirection, number> = {
+  INBOUND: 0,
+  OUTBOUND: 1,
+};
 
 /**
  * 選択中の路線・駅情報から estimateArrivalTimes クエリの変数を組み立て、
@@ -32,6 +41,7 @@ export const useEstimateArrivalTimes = () => {
   // 前方補正(healed)が効いた際に基準駅がずれ、出発済み駅にETAが残るのを防ぐ。
   const currentStation = useDisplayCurrentStation();
   const trainType = useCurrentTrainType();
+  const { isLoopLine } = useLoopLine();
 
   // stations 配列は [上り方面の終点, ..., 下り方面の終点] の順。
   // OUTBOUND は末尾→先頭方向、INBOUND は先頭→末尾方向に進むので from/to を入れ替える。
@@ -53,6 +63,15 @@ export const useEstimateArrivalTimes = () => {
   // routes.id は種別選択時は trainType.groupId、未選択時は路線IDに対応する
   const filteringId = trainType?.groupId ?? selectedLine?.id;
 
+  // 環状路線は from/to 駅だけでは周回方向が一意に定まらず、directionId 未指定だと
+  // バックエンドは直線距離が短い方の弧を選ぶヒューリスティックにフォールバックする
+  // (TrainLCD/StationAPI#1581)。逆回り方向の ETA が返るのを防ぐため、環状路線の
+  // ときだけ進行方向を明示的に指定する。undefined はシリアライズ時に落ちるので送信されない。
+  const directionId =
+    isLoopLine && selectedDirection != null
+      ? LOOP_LINE_DIRECTION_ID[selectedDirection]
+      : undefined;
+
   // 方面未選択・始発/終着が不明・フィルタ先が無い場合はクエリを実行しない
   const skip =
     !selectedBound ||
@@ -68,6 +87,7 @@ export const useEstimateArrivalTimes = () => {
       fromStationId: fromStationId ?? 0,
       toStationId: toStationId ?? 0,
       viaLineIds,
+      directionId,
     },
     skip,
   });

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -480,11 +480,13 @@ export const ESTIMATE_ARRIVAL_TIMES = gql`
     $fromStationId: Int!
     $toStationId: Int!
     $viaLineIds: [Int!]
+    $directionId: Int
   ) {
     estimateArrivalTimes(
       fromStationId: $fromStationId
       toStationId: $toStationId
       viaLineIds: $viaLineIds
+      directionId: $directionId
     ) {
       routes {
         id


### PR DESCRIPTION
## 概要

環状路線（山手線・大阪環状線・名城線など）でETAを取得する際、`EstimateArrivalTimes` クエリに `directionId` を明示的に指定するようにする。

StationAPI 側の TrainLCD/StationAPI#1581 で環状路線の弧選択が実装され、`direction_id` 未指定時は「直線距離が短い方の弧」を選ぶヒューリスティックにフォールバックするため、遠回り方向に乗車中は逆回りのETAが返ることがある。同PRで推奨されているとおり、クライアントから進行方向を明示して送ることでこれを防ぐ。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ESTIMATE_ARRIVAL_TIMES` クエリに `$directionId: Int` 変数を追加（`src/lib/graphql/queries.ts`）
- `useEstimateArrivalTimes` で `useLoopLine()` の `isLoopLine` が true かつ方面選択済みのときだけ `directionId` を送信するように変更。非環状路線では `undefined` のためシリアライズ時に落ち、従来どおり未指定で送信される（`src/hooks/useEstimateArrivalTimes.ts`）
- マッピングは StationAPI の proto 定義（`EstimateArrivalTimesRequest.direction_id`: `0 = default order, 1 = reverse order`）に基づき、stations 配列の格納順に進む `INBOUND → 0`、逆順に進む `OUTBOUND → 1`。INBOUND でも `0` を明示的に送らないとバックエンドが短い弧ヒューリスティックに落ちるため、環状路線では両方向とも必ず送信する
- 生成型 `EstimateArrivalTimesQueryVariables` に `directionId` を追加（`src/@types/graphql.d.ts`。環境に `GQL_API_URL` が無く `npm run gql:codegen` を実行できないため、codegen の出力形式に合わせて手動反映。次回 codegen 実行で同一内容が再生成される想定）
- テスト4本追加: 非環状路線では `directionId` を送信しない / 環状路線かつ INBOUND で `0` / OUTBOUND で `1` / 環状路線でも方面未選択なら送信しない（`src/hooks/useEstimateArrivalTimes.test.tsx`）

## テスト

ローカルで `npm run lint && npm test && npm run typecheck` を実行し、すべて通過。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: TrainLCD/StationAPI#1581

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 推定到着時刻の取得で、進行方向IDを任意に指定できるようになりました。
  * 環状路線では、選択中の方向に応じて適切な値が自動で送信されます（未選択時は送信されません）。
* **バグ修正**
  * 環状路線で逆回り方向の予測が返る可能性を低減しました。
* **テスト**
  * 進行方向の有無と、環状路線（INBOUND/OUTBOUND/未選択）の送信内容を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->