### PR TITLE
環状路線のETA取得時のdirectionIdとfrom/toの割り当てが進行方向と逆だった不具合を修正

### DIFF
--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -211,7 +211,7 @@ describe('useEstimateArrivalTimes', () => {
     expect(variables.directionId).toBeUndefined();
   });
 
-  it('環状路線かつ INBOUND のとき directionId=0(格納順) を送信する', async () => {
+  it('環状路線かつ INBOUND(配列逆順)のとき directionId=1 と逆順の from/to を送信する', async () => {
     mockUseLoopLine.mockReturnValue({
       isLoopLine: true,
     } as ReturnType<typeof useLoopLine>);
@@ -227,10 +227,13 @@ describe('useEstimateArrivalTimes', () => {
     });
 
     const variables = mockGqlRequest.mock.calls[0][1];
-    expect(variables.directionId).toBe(0);
+    expect(variables.directionId).toBe(1);
+    // 環状のINBOUNDは配列逆順に進むため、進行方向の始端=末尾駅がfromになる
+    expect(variables.fromStationId).toBe(stationC.id);
+    expect(variables.toStationId).toBe(stationA.id);
   });
 
-  it('環状路線かつ OUTBOUND のとき directionId=1(逆順) を送信する', async () => {
+  it('環状路線かつ OUTBOUND(格納順)のとき directionId=0 と格納順の from/to を送信する', async () => {
     mockUseLoopLine.mockReturnValue({
       isLoopLine: true,
     } as ReturnType<typeof useLoopLine>);
@@ -246,7 +249,10 @@ describe('useEstimateArrivalTimes', () => {
     });
 
     const variables = mockGqlRequest.mock.calls[0][1];
-    expect(variables.directionId).toBe(1);
+    expect(variables.directionId).toBe(0);
+    // 環状のOUTBOUNDは格納順に進むため、先頭駅がfromになる
+    expect(variables.fromStationId).toBe(stationA.id);
+    expect(variables.toStationId).toBe(stationC.id);
   });
 
   it('環状路線でも方面未選択のとき directionId を送信しない', async () => {

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -19,10 +19,12 @@ import { useGraphQLQuery } from './useGraphQLQuery';
 import { useLoopLine } from './useLoopLine';
 
 // StationAPI EstimateArrivalTimesRequest.direction_id (0 = 格納順, 1 = 逆順) に対応。
-// stations 配列は API の格納順なので、先頭→末尾に進む INBOUND が 0、逆の OUTBOUND が 1。
+// 環状路線の進行方向は線形路線と逆の規約で、INBOUND(内回り)は stations 配列の逆順、
+// OUTBOUND(外回り)は格納順に進む (useNextStation の環状分岐・useLoopLine と同じ)。
+// 例: 山手線は 大崎→渋谷→新宿→池袋→上野→東京→品川 の順で格納されており、これは外回り。
 const LOOP_LINE_DIRECTION_ID: Record<LineDirection, number> = {
-  INBOUND: 0,
-  OUTBOUND: 1,
+  INBOUND: 1,
+  OUTBOUND: 0,
 };
 
 /**
@@ -44,11 +46,19 @@ export const useEstimateArrivalTimes = () => {
   const { isLoopLine } = useLoopLine();
 
   // stations 配列は [上り方面の終点, ..., 下り方面の終点] の順。
-  // OUTBOUND は末尾→先頭方向、INBOUND は先頭→末尾方向に進むので from/to を入れ替える。
-  const fromStationId =
-    selectedDirection === 'OUTBOUND' ? stations.at(-1)?.id : stations[0]?.id;
-  const toStationId =
-    selectedDirection === 'OUTBOUND' ? stations[0]?.id : stations.at(-1)?.id;
+  // 線形路線では OUTBOUND は末尾→先頭方向、INBOUND は先頭→末尾方向に進むので from/to を入れ替える。
+  // 環状路線は進行方向の規約が線形と逆 (INBOUND=配列逆順・OUTBOUND=格納順) なので、
+  // from/to も進行方向の始端→終端になるよう逆に割り当てる。こうしないと directionId で
+  // 指定した向きの弧が from→to の全周区間ではなく継ぎ目を跨いだ2駅分に潰れてしまう。
+  const travelsInStoredOrder = isLoopLine
+    ? selectedDirection === 'OUTBOUND'
+    : selectedDirection === 'INBOUND';
+  const fromStationId = travelsInStoredOrder
+    ? stations[0]?.id
+    : stations.at(-1)?.id;
+  const toStationId = travelsInStoredOrder
+    ? stations.at(-1)?.id
+    : stations[0]?.id;
 
   // 経由路線ID: stations に含まれる全路線IDを重複排除して渡す
   const viaLineIds = useMemo(


### PR DESCRIPTION
## 概要

#6334 のフォローアップ。環状路線のETA取得で `directionId` を送るようにしたが、環状路線における INBOUND/OUTBOUND と API 駅格納順の対応が線形路線と逆であることを見落としており、山手線内回り乗車時に逆側（外回り）の弧が返って ETA が一切表示されなかった（canary ビルドの実機で確認された不具合）。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `LOOP_LINE_DIRECTION_ID` のマッピングを反転: `INBOUND（内回り）→ 1（配列逆順）` / `OUTBOUND（外回り）→ 0（格納順）`。環状路線の進行方向規約は線形路線と逆（`useNextStation` の環状分岐 `groupIndex - 1`、`useLoopLine` の inbound が反転配列走査であることに整合）。山手線の格納順（大崎→渋谷→新宿→池袋→上野→東京→品川）は外回りに相当する
- 環状路線では `fromStationId` / `toStationId` も進行方向の始端→終端になるよう線形路線と逆に割り当てる。従来の割り当てのままだと StationAPI の方向指定つき弧選択（TrainLCD/StationAPI#1581）が継ぎ目を跨いだ2駅分の弧に潰れ、ETA 対象駅が返らない
- 線形路線（`isLoopLine === false`）の from/to と directionId 未送信の挙動は従来と同一
- テストを修正後の期待値に更新し、環状路線の INBOUND/OUTBOUND それぞれで `directionId` と `fromStationId` / `toStationId` の両方を検証するようにした

## テスト

ローカルで `npm run lint && npm test && npm run typecheck` を実行し、すべて通過（181 スイート / 1928 テスト）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: #6334 / TrainLCD/StationAPI#1581

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01WpLyvxXSyp54snZ63h5HwS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 環状路線での到着予測時に、方面の選択に応じた駅の並びと方向判定が正しく反映されるようになりました。
  * ループ路線で一部の区間が意図しない扱いになる不具合を修正し、始点・終点の対応が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->