### PR TITLE
環状路線に限らず進行方向が判明していればETA取得時にdirectionIdを送信するよう修正

### DIFF
--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -158,7 +158,7 @@ describe('useEstimateArrivalTimes', () => {
     expect(hookRef.current?.route).toBeNull();
   });
 
-  it('INBOUND のとき fromStationId=先頭, toStationId=末尾 で送信する', async () => {
+  it('INBOUND のとき fromStationId=先頭, toStationId=末尾, directionId=0 で送信する', async () => {
     setupAtoms({ selectedDirection: 'INBOUND' });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: {
@@ -175,9 +175,10 @@ describe('useEstimateArrivalTimes', () => {
     const variables = mockGqlRequest.mock.calls[0][1];
     expect(variables.fromStationId).toBe(stationA.id);
     expect(variables.toStationId).toBe(stationC.id);
+    expect(variables.directionId).toBe(0);
   });
 
-  it('OUTBOUND のとき fromStationId=末尾, toStationId=先頭 で送信する', async () => {
+  it('OUTBOUND のとき fromStationId=末尾, toStationId=先頭, directionId=1 で送信する', async () => {
     setupAtoms({ selectedDirection: 'OUTBOUND' });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: {
@@ -194,9 +195,11 @@ describe('useEstimateArrivalTimes', () => {
     const variables = mockGqlRequest.mock.calls[0][1];
     expect(variables.fromStationId).toBe(stationC.id);
     expect(variables.toStationId).toBe(stationA.id);
+    expect(variables.directionId).toBe(1);
   });
 
-  it('環状路線でないとき directionId を送信しない', async () => {
+  it('方面未選択のとき directionId を送信しない', async () => {
+    setupAtoms({ selectedDirection: null });
     mockGqlRequest.mockResolvedValue({
       estimateArrivalTimes: { routes: [] },
     });

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -5,7 +5,6 @@ import type {
   EstimateArrivalTimesQueryVariables,
 } from '~/@types/graphql';
 import { ESTIMATE_ARRIVAL_TIMES } from '~/lib/graphql/queries';
-import type { LineDirection } from '../models/Bound';
 import { selectedLineAtom } from '../store/atoms/line';
 import { leftStationsAtom } from '../store/atoms/navigation';
 import {
@@ -17,15 +16,6 @@ import { useCurrentTrainType } from './useCurrentTrainType';
 import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useGraphQLQuery } from './useGraphQLQuery';
 import { useLoopLine } from './useLoopLine';
-
-// StationAPI EstimateArrivalTimesRequest.direction_id (0 = 格納順, 1 = 逆順) に対応。
-// 環状路線の進行方向は線形路線と逆の規約で、INBOUND(内回り)は stations 配列の逆順、
-// OUTBOUND(外回り)は格納順に進む (useNextStation の環状分岐・useLoopLine と同じ)。
-// 例: 山手線は 大崎→渋谷→新宿→池袋→上野→東京→品川 の順で格納されており、これは外回り。
-const LOOP_LINE_DIRECTION_ID: Record<LineDirection, number> = {
-  INBOUND: 1,
-  OUTBOUND: 0,
-};
 
 /**
  * 選択中の路線・駅情報から estimateArrivalTimes クエリの変数を組み立て、
@@ -73,14 +63,15 @@ export const useEstimateArrivalTimes = () => {
   // routes.id は種別選択時は trainType.groupId、未選択時は路線IDに対応する
   const filteringId = trainType?.groupId ?? selectedLine?.id;
 
+  // StationAPI EstimateArrivalTimesRequest.direction_id (0 = 格納順, 1 = 逆順) に対応。
   // 環状路線は from/to 駅だけでは周回方向が一意に定まらず、directionId 未指定だと
   // バックエンドは直線距離が短い方の弧を選ぶヒューリスティックにフォールバックする
-  // (TrainLCD/StationAPI#1581)。逆回り方向の ETA が返るのを防ぐため、環状路線の
-  // ときだけ進行方向を明示的に指定する。undefined はシリアライズ時に落ちるので送信されない。
+  // (TrainLCD/StationAPI#1581)。この曖昧さは環状路線に限らないため、路線種別を問わず
+  // 進行方向が判明していれば常に directionId を明示的に指定する。travelsInStoredOrder は
+  // 路線種別ごとの進行方向規約を織り込み済みなので、そのまま 格納順=0 / 逆順=1 に
+  // 変換すればよい。undefined はシリアライズ時に落ちるので方面未選択時は送信されない。
   const directionId =
-    isLoopLine && selectedDirection != null
-      ? LOOP_LINE_DIRECTION_ID[selectedDirection]
-      : undefined;
+    selectedDirection != null ? (travelsInStoredOrder ? 0 : 1) : undefined;
 
   // 方面未選択・始発/終着が不明・フィルタ先が無い場合はクエリを実行しない
   const skip =


### PR DESCRIPTION
## 概要

環状路線かどうかに関わらず、ETA（到着時刻概算）取得APIへのリクエストで、進行方向が判明している場合は`directionId`を送信するように修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useEstimateArrivalTimes`の`directionId`算出を、環状路線限定の`LOOP_LINE_DIRECTION_ID`マップによる分岐から、`travelsInStoredOrder`（格納順=0 / 逆順=1）を使った路線種別に依存しない統一的な計算に変更
- 線形路線でも`selectedDirection`が判明していれば`directionId`を送信するように修正（従来は環状路線のときのみ送信し、線形路線では常に未送信だった）
- 上記の挙動変更に合わせて`useEstimateArrivalTimes.test.tsx`のテストケースを更新し、線形路線でもdirectionIdが送信されることを検証するアサーションを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGaMXpeN4RyXrK9aoycq6q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 方面を選択している場合、到着時刻の取得に必要な方向情報が常に正しく送信されるようになりました。
  * 環状路線・非環状路線のどちらでも、進行方向に応じた値が反映されるよう改善しました。
  * 方面未選択時は、方向情報を送信しない挙動を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->