### PR TITLE
環状区間の駅重複出現でETAの区間フィルタが無関係な出現を拾ってしまうバグを修正

### DIFF
--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -464,6 +464,51 @@ describe('useEstimateArrivalTimes', () => {
     );
   });
 
+  it('leftStationsに1回しか出現しない駅でも、区間内にAPI側の無関係な重複出現があれば混同しない', async () => {
+    // 都庁前がleftStationsの中間(現在駅ではない)に1回だけ出現するケース。
+    // allStops側は環状区間の影響で都庁前が2回出現し、そのうち1回(58.0)は
+    // stationBへ辿り着くための区間内に紛れ込んだ無関係な出現。
+    // stationGroupIdの集合一致で区間を再フィルタすると両方拾ってしまい、
+    // 後段のMap化で無関係な方(58.0)が後勝ちして誤表示される。
+    const tochomae = createStation(900, { line: { id: 100 } });
+    mockUseDisplayCurrentStation.mockReturnValue(stationA);
+    setupAtoms({ leftStations: [stationA, tochomae, stationB] });
+    mockGqlRequest.mockResolvedValue({
+      estimateArrivalTimes: {
+        routes: [
+          {
+            id: 100,
+            stops: [
+              {
+                stationGroupId: stationA.groupId,
+                cumulativeMinutes: 0,
+                departureCumulativeMinutes: 0,
+              },
+              { stationGroupId: tochomae.groupId, cumulativeMinutes: 3.0 },
+              { stationGroupId: tochomae.groupId, cumulativeMinutes: 58.0 },
+              { stationGroupId: stationB.groupId, cumulativeMinutes: 5.0 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { hookRef } = renderHook();
+
+    await waitFor(() => {
+      expect(hookRef.current?.route?.stops).toHaveLength(2);
+    });
+    expect(hookRef.current?.route?.stops?.map((s) => s.stationGroupId)).toEqual(
+      [tochomae.groupId, stationB.groupId]
+    );
+    expect(hookRef.current?.route?.stops?.[0]?.cumulativeMinutes).toBeCloseTo(
+      3.0
+    );
+    expect(hookRef.current?.route?.stops?.[1]?.cumulativeMinutes).toBeCloseTo(
+      5.0
+    );
+  });
+
   it('viaLineIds に全路線IDが重複なく含まれる', async () => {
     const s1 = createStation(10, { line: { id: 200 } });
     const s2 = createStation(20, { line: { id: 200 } });

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -177,17 +177,14 @@ export const useEstimateArrivalTimes = () => {
     // (例: 都庁前だけ本来より遥かに大きい分数になる)。
     // そのため区間全体を再フィルタするのではなく、leftStations の各要素に対して
     // 一意に特定できた allStops 上のインデックス(bestMatchedIndices)だけを使う。
+    const visibleGroupIds = new Set(leftStations.map((ls) => ls.groupId));
     const matchedStops =
       windowStartIndex !== -1
         ? bestMatchedIndices.map((idx) => allStops[idx])
-        : windowStops.filter((s) => {
-            const visibleGroupIds = new Set(
-              leftStations.map((ls) => ls.groupId)
-            );
-            return (
+        : windowStops.filter(
+            (s) =>
               s.stationGroupId != null && visibleGroupIds.has(s.stationGroupId)
-            );
-          });
+          );
 
     // 現在駅自身は cumulativeMinutes - baseMinutes が0以下になり通常は下のfilterで
     // 除外されるが、windowStops内に現在駅のエントリが見つからずbaseMinutesが0に

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -120,12 +120,18 @@ export const useEstimateArrivalTimes = () => {
     let windowStartIndex = -1;
     let windowEndIndex = -1;
     let bestSpan = Number.POSITIVE_INFINITY;
+    // leftStations の各要素が allStops 中のどのインデックスに一致したかを、
+    // 最良区間の分だけ記録する。区間の再フィルタではなく、この一致インデックスを
+    // 直接使うことで、環状区間内に紛れ込む無関係な重複出現(下記コメント参照)を
+    // relativeStops に混入させない。
+    let bestMatchedIndices: number[] = [];
     if (firstGroupId != null) {
       outer: for (let i = 0; i < allStops.length; i++) {
         if (allStops[i]?.stationGroupId !== firstGroupId) {
           continue;
         }
         let cursor = i;
+        const matchedIndices: number[] = [];
         for (const ls of leftStations) {
           while (
             cursor < allStops.length &&
@@ -136,6 +142,7 @@ export const useEstimateArrivalTimes = () => {
           if (cursor >= allStops.length) {
             continue outer;
           }
+          matchedIndices.push(cursor);
           cursor++;
         }
         const span = cursor - i;
@@ -143,6 +150,7 @@ export const useEstimateArrivalTimes = () => {
           bestSpan = span;
           windowStartIndex = i;
           windowEndIndex = cursor;
+          bestMatchedIndices = matchedIndices;
         }
       }
     }
@@ -155,20 +163,40 @@ export const useEstimateArrivalTimes = () => {
     // 停車時間がある駅では到着時刻ではなく出発時刻を基準にしないと、
     // 停車中に後続駅のETAがズレて表示されてしまう。
     // 区間内に現在駅が見つからない場合はオフセットせず生の値を返す。
+    // windowStops[0] は firstGroupId(= leftStations[0]) との一致地点なので、
+    // currentStation が leftStations[0] と同じ駅である限りこの find() は
+    // 必ず windowStops[0] で短絡し、区間内の後続の重複出現を拾わない。
     const baseMinutes =
       windowStops.find((s) => s.stationGroupId === currentStation?.groupId)
         ?.departureCumulativeMinutes ?? 0;
 
-    const visibleGroupIds = new Set(leftStations.map((s) => s.groupId));
+    // 大江戸線の都庁前のように、環状区間で同じ駅が全stops中に複数回出現する場合、
+    // windowStops を stationGroupId の集合一致で再フィルタすると、leftStationsの
+    // 特定の1要素に対応しない無関係な重複出現まで relativeStops に含まれてしまい、
+    // 後段の Map化(stationGroupId をキーにする)で後勝ちの誤ったETAが表示される
+    // (例: 都庁前だけ本来より遥かに大きい分数になる)。
+    // そのため区間全体を再フィルタするのではなく、leftStations の各要素に対して
+    // 一意に特定できた allStops 上のインデックス(bestMatchedIndices)だけを使う。
+    const matchedStops =
+      windowStartIndex !== -1
+        ? bestMatchedIndices.map((idx) => allStops[idx])
+        : windowStops.filter((s) => {
+            const visibleGroupIds = new Set(
+              leftStations.map((ls) => ls.groupId)
+            );
+            return (
+              s.stationGroupId != null && visibleGroupIds.has(s.stationGroupId)
+            );
+          });
+
     // 現在駅自身は cumulativeMinutes - baseMinutes が0以下になり通常は下のfilterで
     // 除外されるが、windowStops内に現在駅のエントリが見つからずbaseMinutesが0に
     // フォールバックするケースでは生の値が残ってしまう。停車中の駅にはETAを出さない
     // という表示上の不変条件を計算結果に依存せず保証するため、ここで明示的に除く。
-    const relativeStops = windowStops
+    const relativeStops = matchedStops
       .filter(
         (s) =>
           s.stationGroupId != null &&
-          visibleGroupIds.has(s.stationGroupId) &&
           s.stationGroupId !== currentStation?.groupId
       )
       .map((s) => ({


### PR DESCRIPTION
## 概要

環状路線(都営大江戸線など)で同じ駅がETA APIのレスポンスに複数回出現する場合に、無関係な出現を誤って拾ってしまい、都庁前など特定の駅だけ大きく外れたETA(例: 58分)が表示される不具合を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useEstimateArrivalTimes.ts`: leftStations とAPIレスポンス(`allStops`)の区間マッチングで、最良区間探索時に特定済みの一致インデックス(`bestMatchedIndices`)を直接使うよう変更。従来は区間内を `stationGroupId` の集合一致で再フィルタしていたため、環状区間でAPI側に同じ駅が複数回出現すると無関係な出現まで拾ってしまい、LineBoard側の `Map` 構築時に後勝ちで誤ったETAが残っていた
- `useEstimateArrivalTimes.test.tsx`: leftStationsには1回しか出現しない駅が、API側の区間内では2回出現するケースを再現するリグレッションテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPA7eobZEejKS4Y3MrRuA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 同じ駅が複数回現れる路線でも、到達時刻の推定結果がより正確になるよう改善しました。
  * 区間内に同名駅の別の出現が混ざっていても、不要な重複を除外し、正しい停車駅と時刻を採用するようになりました。
  * これにより、環状区間などでも停車駅の並びと累積時間のずれが起きにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->