### PR TITLE
大江戸線で都庁前通過中に選択中の行き先と異なる終点判定をしていたバグを修正

### DIFF
--- a/src/hooks/useIsTerminus.test.tsx
+++ b/src/hooks/useIsTerminus.test.tsx
@@ -29,6 +29,16 @@ const setAtomValues = ({
   });
 };
 
+const setLoopLine = ({
+  isLoopLine = false,
+  isOedoLine = false,
+}: {
+  isLoopLine?: boolean;
+  isOedoLine?: boolean;
+} = {}) => {
+  (useLoopLine as jest.Mock).mockReturnValue({ isLoopLine, isOedoLine });
+};
+
 const TestComponent: React.FC<{ station?: Station }> = ({ station }) => {
   const isTerminus = useIsTerminus(station);
   return <Text testID="isTerminus">{String(isTerminus)}</Text>;
@@ -41,10 +51,7 @@ describe('useIsTerminus フック', () => {
 
   it('station が未指定なら false を返す', () => {
     setAtomValues({ stations: [] });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: false,
-      isOedoLine: false,
-    });
+    setLoopLine();
 
     const { getByTestId } = render(<TestComponent />);
     expect(getByTestId('isTerminus').props.children).toBe('false');
@@ -56,10 +63,7 @@ describe('useIsTerminus フック', () => {
       { id: 2, groupId: 2 },
     ] as unknown as Station[];
     setAtomValues({ stations });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: true,
-      isOedoLine: false,
-    });
+    setLoopLine({ isLoopLine: true });
 
     const { getByTestId } = render(<TestComponent station={stations[0]} />);
     expect(getByTestId('isTerminus').props.children).toBe('false');
@@ -72,10 +76,7 @@ describe('useIsTerminus フック', () => {
       { id: 3, groupId: 3 },
     ] as unknown as Station[];
     setAtomValues({ stations });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: false,
-      isOedoLine: false,
-    });
+    setLoopLine();
 
     const { getByTestId, rerender } = render(
       <TestComponent station={stations[0]} />
@@ -99,10 +100,7 @@ describe('useIsTerminus フック', () => {
       hikarigaoka, // 光が丘
     ] as unknown as Station[];
     setAtomValues({ stations, selectedBound: hikarigaoka as Station });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: false,
-      isOedoLine: true,
-    });
+    setLoopLine({ isOedoLine: true });
 
     const { getByTestId } = render(
       <TestComponent station={shinjukuTochomaeOuter as Station} />
@@ -122,10 +120,7 @@ describe('useIsTerminus フック', () => {
       tochomaeOuter, // 都庁前(外回り) - 末尾
     ] as unknown as Station[];
     setAtomValues({ stations, selectedBound: hikarigaoka as Station });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: false,
-      isOedoLine: true,
-    });
+    setLoopLine({ isOedoLine: true });
 
     const { getByTestId } = render(
       <TestComponent station={tochomaeOuter as Station} />
@@ -140,14 +135,28 @@ describe('useIsTerminus フック', () => {
       tochomaeOuter,
     ] as unknown as Station[];
     setAtomValues({ stations, selectedBound: tochomaeOuter as Station });
-    (useLoopLine as jest.Mock).mockReturnValue({
-      isLoopLine: false,
-      isOedoLine: true,
-    });
+    setLoopLine({ isOedoLine: true });
 
     const { getByTestId } = render(
       <TestComponent station={tochomaeOuter as Station} />
     );
     expect(getByTestId('isTerminus').props.children).toBe('true');
+  });
+
+  it('大江戸線で selectedBound が未選択(null)の場合は終点扱いしない', () => {
+    // 目的地未選択のまま都庁前を通過するケースで、selectedBound?.id === station.id が
+    // 安全に false を返すことを確認する
+    const tochomaeOuter = { id: 9930100, groupId: 9930100 };
+    const stations = [
+      { id: 9930101, groupId: 9930101 },
+      tochomaeOuter,
+    ] as unknown as Station[];
+    setAtomValues({ stations, selectedBound: null });
+    setLoopLine({ isOedoLine: true });
+
+    const { getByTestId } = render(
+      <TestComponent station={tochomaeOuter as Station} />
+    );
+    expect(getByTestId('isTerminus').props.children).toBe('false');
   });
 });

--- a/src/hooks/useIsTerminus.test.tsx
+++ b/src/hooks/useIsTerminus.test.tsx
@@ -1,0 +1,153 @@
+import { render } from '@testing-library/react-native';
+import type React from 'react';
+import { Text } from 'react-native';
+import type { Station } from '~/@types/graphql';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+jest.mock('./useLoopLine', () => ({ useLoopLine: jest.fn() }));
+
+import { useAtomValue } from 'jotai';
+import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
+import { useIsTerminus } from './useIsTerminus';
+import { useLoopLine } from './useLoopLine';
+
+const setAtomValues = ({
+  stations = [],
+  selectedBound = null,
+}: {
+  stations?: Station[];
+  selectedBound?: Station | null;
+}) => {
+  (useAtomValue as jest.Mock).mockImplementation((atom: unknown) => {
+    if (atom === stationsAtom) return stations;
+    if (atom === selectedBoundAtom) return selectedBound;
+    return undefined;
+  });
+};
+
+const TestComponent: React.FC<{ station?: Station }> = ({ station }) => {
+  const isTerminus = useIsTerminus(station);
+  return <Text testID="isTerminus">{String(isTerminus)}</Text>;
+};
+
+describe('useIsTerminus フック', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('station が未指定なら false を返す', () => {
+    setAtomValues({ stations: [] });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: false,
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+    expect(getByTestId('isTerminus').props.children).toBe('false');
+  });
+
+  it('環状線のときは常に false を返す', () => {
+    const stations = [
+      { id: 1, groupId: 1 },
+      { id: 2, groupId: 2 },
+    ] as unknown as Station[];
+    setAtomValues({ stations });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: true,
+      isOedoLine: false,
+    });
+
+    const { getByTestId } = render(<TestComponent station={stations[0]} />);
+    expect(getByTestId('isTerminus').props.children).toBe('false');
+  });
+
+  it('非環状線・非大江戸線では配列の先頭/末尾一致で終点判定する', () => {
+    const stations = [
+      { id: 1, groupId: 1 },
+      { id: 2, groupId: 2 },
+      { id: 3, groupId: 3 },
+    ] as unknown as Station[];
+    setAtomValues({ stations });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: false,
+    });
+
+    const { getByTestId, rerender } = render(
+      <TestComponent station={stations[0]} />
+    );
+    expect(getByTestId('isTerminus').props.children).toBe('true');
+
+    rerender(<TestComponent station={stations[1]} />);
+    expect(getByTestId('isTerminus').props.children).toBe('false');
+
+    rerender(<TestComponent station={stations[2]} />);
+    expect(getByTestId('isTerminus').props.children).toBe('true');
+  });
+
+  it('大江戸線で都庁前(外回り)を通過するだけの場合は終点扱いしない（新宿→都庁前）', () => {
+    // 新宿→都庁前(外回り)方面へ向かっているが、実際の行き先は光が丘
+    const shinjukuTochomaeOuter = { id: 9930100, groupId: 9930100 };
+    const hikarigaoka = { id: 9930138, groupId: 9930138 };
+    const stations = [
+      { id: 9930101, groupId: 9930101 }, // 都庁前(内回り)
+      shinjukuTochomaeOuter, // 都庁前(外回り)
+      hikarigaoka, // 光が丘
+    ] as unknown as Station[];
+    setAtomValues({ stations, selectedBound: hikarigaoka as Station });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: true,
+    });
+
+    const { getByTestId } = render(
+      <TestComponent station={shinjukuTochomaeOuter as Station} />
+    );
+    // 配列の先頭でも末尾でもないため誤検知の余地はないが、
+    // 大江戸線では selectedBound とのID一致でのみ判定されることを確認
+    expect(getByTestId('isTerminus').props.children).toBe('false');
+  });
+
+  it('大江戸線で都庁前が配列の末尾に位置していても、選択中の行き先と異なれば終点扱いしない（西新宿五丁目→都庁前）', () => {
+    // 都庁前(外回り)がたまたま配列の末尾にあっても、選択中の行き先(光が丘)と一致しない限り終点にしない
+    const tochomaeOuter = { id: 9930100, groupId: 9930100 };
+    const hikarigaoka = { id: 9930138, groupId: 9930138 };
+    const stations = [
+      hikarigaoka,
+      { id: 9930101, groupId: 9930101 }, // 都庁前(内回り)
+      tochomaeOuter, // 都庁前(外回り) - 末尾
+    ] as unknown as Station[];
+    setAtomValues({ stations, selectedBound: hikarigaoka as Station });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: true,
+    });
+
+    const { getByTestId } = render(
+      <TestComponent station={tochomaeOuter as Station} />
+    );
+    expect(getByTestId('isTerminus').props.children).toBe('false');
+  });
+
+  it('大江戸線で都庁前が実際に選択中の行き先と一致する場合は終点扱いする', () => {
+    const tochomaeOuter = { id: 9930100, groupId: 9930100 };
+    const stations = [
+      { id: 9930101, groupId: 9930101 },
+      tochomaeOuter,
+    ] as unknown as Station[];
+    setAtomValues({ stations, selectedBound: tochomaeOuter as Station });
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: true,
+    });
+
+    const { getByTestId } = render(
+      <TestComponent station={tochomaeOuter as Station} />
+    );
+    expect(getByTestId('isTerminus').props.children).toBe('true');
+  });
+});

--- a/src/hooks/useIsTerminus.ts
+++ b/src/hooks/useIsTerminus.ts
@@ -1,14 +1,23 @@
 import { useAtomValue } from 'jotai';
 import type { Station } from '~/@types/graphql';
-import { stationsAtom } from '../store/atoms/station';
+import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
 import { useLoopLine } from './useLoopLine';
 
 export const useIsTerminus = (station: Station | undefined) => {
   const stations = useAtomValue(stationsAtom);
-  const { isLoopLine } = useLoopLine();
+  const selectedBound = useAtomValue(selectedBoundAtom);
+  const { isLoopLine, isOedoLine } = useLoopLine();
 
   if (!station || isLoopLine) {
     return false;
+  }
+
+  if (isOedoLine) {
+    // 都庁前は環状区間と光が丘方面直通区間の接続点として駅配列内に2回
+    // 出現する（外回り/内回り）。配列の先頭・末尾一致だけで終点判定すると、
+    // 環状区間を通過するだけの都庁前を誤って終点扱いしてしまうため、
+    // 実際に選択されている行き先(selectedBound)と一致する場合のみ終点とする。
+    return selectedBound?.id === station.id;
   }
 
   return (


### PR DESCRIPTION
## 概要

都営大江戸線で新宿・西新宿五丁目から都庁前へ向かう際、実際は環状区間を通過するだけ（光が丘方面などへ運行継続）であるにもかかわらず、終点として誤案内されるバグを修正しました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 大江戸線は都庁前が駅配列内に2回出現する（外回り側/内回り側の接続点）ため、`src/hooks/useIsTerminus.ts` の「配列の先頭/末尾一致」による終点判定が誤検知を起こしていました。
- 大江戸線の場合のみ、実際に選択されている行き先（`selectedBoundAtom`）と現在の駅IDが一致する場合にのみ終点と判定するよう変更しました。
- `src/hooks/useIsTerminus.test.tsx` を新規追加し、バグ再現ケースを含む終点判定のテストを網羅しました。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_018TC6hwvs5sLS2xHB5HDZGS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 終点判定の精度を改善しました。
  * 環状線は引き続き終点を表示しません。
  * 大江戸線は駅の位置だけでなく、選択中の行き先（選択された行き先ID）に基づいて終点判定するよう変更しました。
* **Tests**
  * 終点表示の挙動（駅未指定、環状線、非環状線、大江戸線の条件など）を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->