### PR TITLE
大江戸線都庁前の外回り/内回りをgroupIdで取り違える駅位置特定のバグを修正

### DIFF
--- a/src/hooks/useBounds.test.tsx
+++ b/src/hooks/useBounds.test.tsx
@@ -182,6 +182,42 @@ describe('useBounds フック', () => {
     expect(bounds).toContain('"id":9930121');
   });
 
+  it('groupIdが同じでもidが異なる駅がある場合、id一致で現在地の位置を特定する', () => {
+    setAtomValues({ selectedDirection: 'INBOUND' });
+
+    // 都庁前(内回り: 9930101)が現在駅。groupId(100)は外回り(9930100)と同一だが、
+    // idは別々に採番されている。groupIdだけでstationIndexを求めると、配列中で
+    // 先に出現する外回り(index 0)に固定され、実際には現在地より手前(outbound側)
+    // にあるはずの飯田橋まで inbound(現在地より前方)に含めてしまう。
+    const currentStation = { id: 9930101, groupId: 100 };
+    (useCurrentStation as jest.Mock).mockReturnValue(currentStation);
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: true,
+      inboundStationsForLoopLine: [],
+      outboundStationsForLoopLine: [],
+    });
+    (getIsLocal as jest.Mock).mockReturnValue(true);
+
+    const stations = [
+      { id: 9930100, groupId: 100 }, // 都庁前(外回り) - 現在駅とgroupIdが同じ
+      { id: 9930107, groupId: 9930107 }, // 飯田橋 - 外回りと内回りの間(現在地より手前)
+      { id: 9930101, groupId: 100 }, // 都庁前(内回り) - 現在駅
+      { id: 9930113, groupId: 9930113 }, // 両国 - 現在地より後方
+    ] as unknown as Station[];
+    const { getByTestId } = render(<TestComponent stations={stations} />);
+
+    const bounds = getByTestId('bounds').props.children;
+    const [inboundStops, outboundStops] = JSON.parse(bounds) as {
+      id: number;
+    }[][];
+    // inbound(bounds[0])には現在地(内回り)より後方の両国のみが含まれる
+    expect(inboundStops.map((s) => s.id)).toEqual([9930113]);
+    // 現在地より手前の飯田橋はoutbound(bounds[1])側に含まれるべきで、
+    // inboundに誤って混入してはいけない
+    expect(outboundStops.map((s) => s.id)).toContain(9930107);
+  });
+
   it('大江戸線で currentStation が見つからない場合、空の bounds を返す', () => {
     setAtomValues({ selectedDirection: 'INBOUND' });
 

--- a/src/hooks/useBounds.ts
+++ b/src/hooks/useBounds.ts
@@ -41,8 +41,11 @@ export const useBounds = (
     const outboundStation = stations[0];
 
     if (isOedoLine) {
+      // 都庁前(外回り/内回り)のようにgroupIdが同じでもidが異なる駅があるため、
+      // idで位置を特定する(groupId一致だと配列中で先に見つかる方に固定され、
+      // 実際の現在地と異なる位置を基準に行き先・経由駅の区間を切り出してしまう)。
       const stationIndex = stations.findIndex(
-        (s) => s.groupId === currentStation?.groupId
+        (s) => s.id === currentStation?.id
       );
       if (stationIndex < 0) return [[], []];
 

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -73,8 +73,11 @@ export const useTrainTypeModal = () => {
       const newStations = res.data.lineGroupStations;
 
       if (selectedBound) {
+        // 大江戸線の都庁前(外回り/内回り)のようにgroupIdが同じでもidが異なる駅が
+        // あるため、idで存在チェックする(groupId一致だと無関係な出現を現在駅と
+        // 誤認し、findNearestStationによる位置補正がスキップされてしまう)。
         const currentInNewList = newStations.some(
-          (s) => s.groupId === currentStation?.groupId
+          (s) => s.id === currentStation?.id
         );
 
         setStationState((prev) => {
@@ -85,7 +88,7 @@ export const useTrainTypeModal = () => {
           const nearest = findNearestStation(
             prev.stations,
             newStations,
-            currentStation?.groupId,
+            currentStation?.id,
             selectedDirection
           );
 
@@ -119,7 +122,7 @@ export const useTrainTypeModal = () => {
       setNavigation,
       setResetFirstSpeech,
       selectedBound,
-      currentStation?.groupId,
+      currentStation?.id,
       selectedDirection,
     ]
   );

--- a/src/utils/findNearestStation.test.ts
+++ b/src/utils/findNearestStation.test.ts
@@ -207,5 +207,27 @@ describe('findNearestStation', () => {
 
       expect(result?.id).toBe(after.id);
     });
+
+    it('OUTBOUND方向でも、groupIdが同じでもidが異なる駅がある場合はid一致で現在地を特定する', () => {
+      // INBOUND版と同じ配置。groupIdだけでcurrentIdxを求めると常に先に出現する
+      // outer(index 0)に固定され、OUTBOUND(index減少方向)には駅が無い
+      // (currentIdx-1 = -1)ため誤ってnullを返してしまう。id一致ならinner
+      // (index 2)を起点にでき、手前のbetweenを正しく返せる。
+      const outer = createStation(9930100, { groupId: 100 });
+      const between = createStation(50, { groupId: 50 });
+      const inner = createStation(9930101, { groupId: 100 });
+      const after = createStation(60, { groupId: 60 });
+      const oldStations = [outer, between, inner, after];
+      const newStations = [between, after];
+
+      const result = findNearestStation(
+        oldStations,
+        newStations,
+        inner.id,
+        'OUTBOUND'
+      );
+
+      expect(result?.id).toBe(between.id);
+    });
   });
 });

--- a/src/utils/findNearestStation.test.ts
+++ b/src/utils/findNearestStation.test.ts
@@ -96,7 +96,7 @@ describe('findNearestStation', () => {
   });
 
   describe('エッジケース', () => {
-    it('currentGroupIdがnullの場合、nullを返す', () => {
+    it('currentStationIdがnullの場合、nullを返す', () => {
       const result = findNearestStation(
         localStations,
         expressStations,
@@ -106,7 +106,7 @@ describe('findNearestStation', () => {
       expect(result).toBeNull();
     });
 
-    it('currentGroupIdがundefinedの場合、nullを返す', () => {
+    it('currentStationIdがundefinedの場合、nullを返す', () => {
       const result = findNearestStation(
         localStations,
         expressStations,
@@ -146,37 +146,37 @@ describe('findNearestStation', () => {
       expect(result).toBeNull();
     });
 
-    it('旧リストにgroupIdがnullの駅がある場合、その駅をスキップして探す', () => {
+    it('旧リストにidがnullの駅がある場合、その駅をスキップして探す', () => {
       const stationsWithNull = [
         createStation(1),
         createStation(2),
-        createStation(3, { groupId: null }),
+        createStation(3, { id: null }),
         createStation(4),
         createStation(5),
       ];
       const express = [createStation(1), createStation(5)];
-      // 駅2にいてINBOUND → 駅3はgroupId=nullなのでスキップ → 駅5にマッチ
+      // 駅2にいてINBOUND → 駅3はidがnullなのでスキップ → 駅5にマッチ
       const result = findNearestStation(
         stationsWithNull,
         express,
         2,
         'INBOUND'
       );
-      expect(result?.groupId).toBe(5);
+      expect(result?.id).toBe(5);
     });
 
-    it('新リストにgroupIdがnullの駅がある場合、誤マッチしない', () => {
+    it('新リストにidがnullの駅がある場合、誤マッチしない', () => {
       const stationsWithNull = [
         createStation(1),
         createStation(2),
-        createStation(3, { groupId: null }),
+        createStation(3, { id: null }),
         createStation(4),
       ];
       const expressWithNull = [
-        createStation(10, { groupId: null }),
+        createStation(10, { id: null }),
         createStation(5),
       ];
-      // 駅2にいてINBOUND → 駅3はgroupId=nullなのでスキップ、駅4はexpressに無い → null
+      // 駅2にいてINBOUND → 駅3はidがnullなのでスキップ、駅4はexpressに無い → null
       const result = findNearestStation(
         stationsWithNull,
         expressWithNull,
@@ -184,6 +184,28 @@ describe('findNearestStation', () => {
         'INBOUND'
       );
       expect(result).toBeNull();
+    });
+
+    it('groupIdが同じでもidが異なる駅がある場合、id一致で現在地を特定する(都庁前の外回り/内回り相当)', () => {
+      // 大江戸線の都庁前は外回り/内回りでgroupIdが同一だがidは別々。
+      // groupIdだけで現在地を特定すると配列中で先に見つかる方(outer)に
+      // 固定されてしまい、実際の現在地(inner)より手前の駅を誤って
+      // 「次の停車駅」として返してしまう。
+      const outer = createStation(9930100, { groupId: 100 });
+      const between = createStation(50, { groupId: 50 });
+      const inner = createStation(9930101, { groupId: 100 });
+      const after = createStation(60, { groupId: 60 });
+      const oldStations = [outer, between, inner, after];
+      const newStations = [between, after];
+
+      const result = findNearestStation(
+        oldStations,
+        newStations,
+        inner.id,
+        'INBOUND'
+      );
+
+      expect(result?.id).toBe(after.id);
     });
   });
 });

--- a/src/utils/findNearestStation.ts
+++ b/src/utils/findNearestStation.ts
@@ -5,45 +5,50 @@ import type { LineDirection } from '~/models/Bound';
  * 列車種別変更時に、現在駅が新しい駅リストに存在しない場合、
  * 旧駅リストでの位置を基準に進行方向で最も近い駅を探す。
  *
+ * 大江戸線の都庁前(外回り/内回り)のように、groupIdが同じでもidが異なる駅が
+ * 旧駅リスト中に複数存在しうる。groupIdだけで現在地の位置を特定すると、
+ * 常に配列中で先に見つかる方(必ずしも現在地と同じ出現ではない)に固定されて
+ * しまうため、idで一意に特定する。
+ *
  * @param oldStations 旧駅リスト
  * @param newStations 新しい駅リスト
- * @param currentGroupId 現在駅のgroupId
+ * @param currentStationId 現在駅のid
  * @param direction 進行方向
  * @returns 最寄りの駅（見つからない場合は null）
  */
 export const findNearestStation = (
   oldStations: Station[],
   newStations: Station[],
-  currentGroupId: number | null | undefined,
+  currentStationId: number | null | undefined,
   direction: LineDirection | null
 ): Station | null => {
-  if (currentGroupId == null || !direction) {
+  if (currentStationId == null || !direction) {
     return null;
   }
 
-  const currentIdx = oldStations.findIndex((s) => s.groupId === currentGroupId);
+  const currentIdx = oldStations.findIndex((s) => s.id === currentStationId);
   if (currentIdx === -1) {
     return null;
   }
 
-  const newStationsByGroupId = new Map(
-    newStations.filter((s) => s.groupId != null).map((s) => [s.groupId, s])
+  const newStationsById = new Map(
+    newStations.filter((s) => s.id != null).map((s) => [s.id, s])
   );
 
   if (direction === 'INBOUND') {
     for (let i = currentIdx + 1; i < oldStations.length; i++) {
-      const candidateGroupId = oldStations[i]?.groupId;
-      if (candidateGroupId == null) continue;
-      const found = newStationsByGroupId.get(candidateGroupId);
+      const candidateId = oldStations[i]?.id;
+      if (candidateId == null) continue;
+      const found = newStationsById.get(candidateId);
       if (found) {
         return found;
       }
     }
   } else {
     for (let i = currentIdx - 1; i >= 0; i--) {
-      const candidateGroupId = oldStations[i]?.groupId;
-      if (candidateGroupId == null) continue;
-      const found = newStationsByGroupId.get(candidateGroupId);
+      const candidateId = oldStations[i]?.id;
+      if (candidateId == null) continue;
+      const found = newStationsById.get(candidateId);
       if (found) {
         return found;
       }


### PR DESCRIPTION
## 概要

大江戸線の都庁前(外回り/内回り)のように `groupId` は同一だが `id` は別々に採番されている駅について、`groupId` だけで駅配列内の現在地インデックスを特定していた箇所を `id` 優先のマッチングに修正しました。`groupId` ベースの `findIndex` は常に配列中で先に見つかる方(必ずしも実際の現在地と同じ出現ではない)に固定されてしまうため、行き先表示の区間切り出しや列車種別変更時の現在地補正が誤った位置を基準に行われる不具合がありました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useBounds.ts`: 大江戸線の行き先/経由駅表示区間を切り出すための `stationIndex` を、`groupId` 一致から `id` 一致に変更
- `findNearestStation.ts`: 列車種別変更時に現在駅が新しい駅リストに存在しない場合の位置探索を `id` ベースに変更(シグネチャも `currentGroupId` から `currentStationId` に変更)
- `useTrainTypeModal.ts`: 上記シグネチャ変更に伴う呼び出し元の更新。あわせて、現在駅が新しい駅リストに存在するかの判定(`currentInNewList`)も `id` 一致に変更(`groupId` 一致だと無関係な出現を現在駅と誤認し、位置補正がスキップされてしまうため)
- `useBounds.test.tsx` / `findNearestStation.test.ts`: `groupId` が同一で `id` が異なる駅(都庁前の外回り/内回り相当)がある場合に、正しい方の出現を基準に位置特定できることを検証するリグレッションテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPA7eobZEejKS4Y3MrRuA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 同一のグループに複数の駅がある場合でも、現在地と次の停車駅を正しく判定するよう改善しました（駅ID基準）。
  * 方面・行き先の切り替え時に、誤った駅が混入する可能性を低減しました。
* **Tests**
  * 駅ID/方向ごとの境界ケースを追加・更新し、正しい結果になることを確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->