### PR TITLE
ETA表示をE231・JO・山手線iPad版のLineBoardへ横展開

### DIFF
--- a/src/components/LineBoard/shared/components/EstimatedMinutesBadge.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesBadge.tsx
@@ -1,0 +1,25 @@
+import type React from 'react';
+import { Platform, StyleSheet, Text, type TextStyle } from 'react-native';
+import { FONTS } from '~/constants';
+import isTablet from '~/utils/isTablet';
+
+const styles = StyleSheet.create({
+  text: {
+    color: '#000',
+    fontSize: isTablet ? 30 : 22,
+    lineHeight: isTablet ? 32 : 24,
+    textAlign: 'center',
+    fontFamily: FONTS.RobotoBold,
+    letterSpacing: Platform.OS === 'ios' ? 0 : -1,
+  },
+});
+
+export type EstimatedMinutesBadgeProps = {
+  estimatedMinutes: number;
+  style?: TextStyle;
+};
+
+export const EstimatedMinutesBadge: React.FC<EstimatedMinutesBadgeProps> = ({
+  estimatedMinutes,
+  style,
+}) => <Text style={[styles.text, style]}>{Math.round(estimatedMinutes)}</Text>;

--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -1,14 +1,14 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import type React from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
-import { FONTS } from '~/constants';
 import { useScale } from '~/hooks/useScale';
 import getIsPass from '~/utils/isPass';
 import isTablet from '~/utils/isTablet';
 import PadLineMarks from '../../../PadLineMarks';
 import PassChevronEast from '../../../PassChevronEast';
 import { commonLineBoardStyles as styles } from '../styles/commonStyles';
+import { EstimatedMinutesBadge } from './EstimatedMinutesBadge';
 
 const localStyles = StyleSheet.create({
   estimatedMinutesOverlay: {
@@ -17,14 +17,6 @@ const localStyles = StyleSheet.create({
     left: 0,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  estimatedMinutesText: {
-    color: '#000',
-    fontSize: isTablet ? 30 : 22,
-    lineHeight: isTablet ? 32 : 24,
-    textAlign: 'center',
-    fontFamily: FONTS.RobotoBold,
-    letterSpacing: Platform.OS === 'ios' ? 0 : -1,
   },
 });
 
@@ -113,9 +105,7 @@ export const LineDot: React.FC<LineDotProps> = ({
             ]}
             pointerEvents="none"
           >
-            <Text style={localStyles.estimatedMinutesText}>
-              {Math.round(estimatedMinutes)}
-            </Text>
+            <EstimatedMinutesBadge estimatedMinutes={estimatedMinutes} />
           </View>
         ) : null}
       </View>

--- a/src/components/LineBoard/shared/components/index.ts
+++ b/src/components/LineBoard/shared/components/index.ts
@@ -2,6 +2,8 @@ export type { BlinkingChevronProps } from './BlinkingChevron';
 export { BlinkingChevron } from './BlinkingChevron';
 export type { EmptyStationNameCellProps } from './EmptyStationNameCell';
 export { EmptyStationNameCell } from './EmptyStationNameCell';
+export type { EstimatedMinutesBadgeProps } from './EstimatedMinutesBadge';
+export { EstimatedMinutesBadge } from './EstimatedMinutesBadge';
 export type { LineDotProps } from './LineDot';
 export { LineDot } from './LineDot';
 export type { StationNameProps } from './StationName';

--- a/src/components/LineBoardE231.test.tsx
+++ b/src/components/LineBoardE231.test.tsx
@@ -133,10 +133,26 @@ describe('LineBoardE231', () => {
         hasTerminus={false}
       />
     );
-    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
-      expect.objectContaining({ estimatedMinutes: 5 }),
-      undefined
+    expect(EstimatedMinutesBadge.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ estimatedMinutes: 5 })
     );
+  });
+
+  it('useEstimateArrivalTimesが返すrouteがuseEstimatedMinutesByStationIdへ渡される', () => {
+    const {
+      useEstimateArrivalTimes,
+      useEstimatedMinutesByStationId,
+    } = require('~/hooks');
+    const mockRoute = { stops: [] };
+    useEstimateArrivalTimes.mockReturnValueOnce({ route: mockRoute });
+    render(
+      <LineBoardE231
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(useEstimatedMinutesByStationId).toHaveBeenCalledWith(mockRoute);
   });
 
   it('estimatedMinutesが無い場合、EstimatedMinutesBadgeは表示されない', () => {

--- a/src/components/LineBoardE231.test.tsx
+++ b/src/components/LineBoardE231.test.tsx
@@ -1,0 +1,153 @@
+import { render } from '@testing-library/react-native';
+import type { Line, Station } from '~/@types/graphql';
+import LineBoardE231 from './LineBoardE231';
+
+// モック設定
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+  useAtom: jest.fn((val) => [val, jest.fn()]),
+  useSetAtom: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('~/hooks', () => ({
+  useCurrentLine: jest.fn(),
+  useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
+  useEstimatedMinutesByStationId: jest.fn(() => new Map()),
+  useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
+  useTransferLinesFromStation: jest.fn(() => []),
+}));
+
+jest.mock('~/hooks/useScale', () => ({
+  useScale: jest.fn(() => ({ widthScale: jest.fn((val) => val) })),
+}));
+
+jest.mock('~/store/selectors/isEn', () => ({
+  isEnAtom: {},
+}));
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+jest.mock('~/utils/isPass', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('./ChevronE231', () => ({
+  ChevronE231: jest.fn(() => null),
+}));
+
+jest.mock('./PadLineMarks', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('./PassChevronEast', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('./LineBoard/shared/components', () => {
+  const { Text } = require('react-native');
+  return {
+    EstimatedMinutesBadge: jest.fn(({ estimatedMinutes }) => (
+      <Text>{estimatedMinutes}</Text>
+    )),
+    StationName: jest.fn(() => null),
+  };
+});
+
+jest.mock('./LineBoard/shared/hooks/useBarStyles', () => ({
+  useBarStyles: jest.fn(() => ({ left: 0, width: 100 })),
+  useChevronPosition: jest.fn(() => ({})),
+  useIncludesLongStationName: jest.fn(() => false),
+}));
+
+describe('LineBoardE231', () => {
+  const { useAtomValue } = require('jotai');
+  const { useCurrentLine, useDisplayCurrentStation } = require('~/hooks');
+  const { selectedLineAtom } = require('~/store/atoms/line');
+  const { arrivedAtom } = require('~/store/atoms/station');
+  const { isEnAtom } = require('~/store/selectors/isEn');
+
+  const mockLine: Line = {
+    __typename: 'Line',
+    id: 1,
+    nameShort: '山手線',
+    color: '#9acd32',
+  } as Line;
+
+  const mockStations: Station[] = [
+    {
+      id: 1,
+      groupId: 1,
+      name: '東京',
+      line: mockLine,
+    } as unknown as Station,
+    {
+      id: 2,
+      groupId: 2,
+      name: '品川',
+      line: mockLine,
+    } as unknown as Station,
+  ];
+
+  beforeEach(() => {
+    useAtomValue.mockImplementation((a: unknown) => {
+      if (a === arrivedAtom) return true;
+      if (a === selectedLineAtom) return null;
+      if (a === isEnAtom) return false;
+      return undefined;
+    });
+    useCurrentLine.mockReturnValue(mockLine);
+    useDisplayCurrentStation.mockReturnValue(mockStations[0]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('正しくレンダリングされる', () => {
+    const result = render(
+      <LineBoardE231
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(result.toJSON()).toBeTruthy();
+  });
+
+  it('stationIdに対応するestimatedMinutesがEstimatedMinutesBadgeへ渡される', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardE231
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: 5 }),
+      undefined
+    );
+  });
+
+  it('estimatedMinutesが無い場合、EstimatedMinutesBadgeは表示されない', () => {
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardE231
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(EstimatedMinutesBadge).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -109,6 +109,8 @@ const localStyles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
+    width: isTablet ? 44 : 36,
+    height: isTablet ? 36 : 24,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -261,12 +263,9 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
                   passed && !arrived && localStyles.dotInnerPassed,
                 ]}
               >
-                {estimatedMinutes != null ? (
+                {estimatedMinutes != null && !(passed && !arrived) ? (
                   <View
-                    style={[
-                      localStyles.dotInner,
-                      localStyles.estimatedMinutesOverlay,
-                    ]}
+                    style={localStyles.estimatedMinutesOverlay}
                     pointerEvents="none"
                   >
                     <EstimatedMinutesBadge

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -5,6 +5,8 @@ import type { Line, Station } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
+  useEstimatedMinutesByStationId,
   useLandscapeWindowDimensions,
   useTransferLinesFromStation,
 } from '~/hooks';
@@ -16,7 +18,10 @@ import { selectedLineAtom } from '../store/atoms/line';
 import getIsPass from '../utils/isPass';
 import isTablet from '../utils/isTablet';
 import { ChevronE231 } from './ChevronE231';
-import { StationName } from './LineBoard/shared/components';
+import {
+  EstimatedMinutesBadge,
+  StationName,
+} from './LineBoard/shared/components';
 import {
   useBarStyles,
   useChevronPosition,
@@ -100,6 +105,13 @@ const localStyles = StyleSheet.create({
     backgroundColor: '#ccc',
     borderColor: '#aaa',
   },
+  estimatedMinutesOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   marksContainer: {
     top: 38,
     position: 'absolute',
@@ -154,6 +166,7 @@ interface StationNameCellProps {
   line: Line | null;
   lineColors: (string | null | undefined)[];
   hasTerminus: boolean;
+  estimatedMinutes?: number | null;
 }
 
 const StationNameCell: React.FC<StationNameCellProps> = ({
@@ -163,6 +176,7 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
   line,
   lineColors,
   hasTerminus,
+  estimatedMinutes,
 }: StationNameCellProps) => {
   const isEn = useAtomValue(isEnAtom);
   const dim = useLandscapeWindowDimensions();
@@ -246,7 +260,21 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
                   localStyles.dotInner,
                   passed && !arrived && localStyles.dotInnerPassed,
                 ]}
-              />
+              >
+                {estimatedMinutes != null ? (
+                  <View
+                    style={[
+                      localStyles.dotInner,
+                      localStyles.estimatedMinutesOverlay,
+                    ]}
+                    pointerEvents="none"
+                  >
+                    <EstimatedMinutesBadge
+                      estimatedMinutes={estimatedMinutes}
+                    />
+                  </View>
+                ) : null}
+              </View>
             )}
             <View style={localStyles.marksContainer}>
               <PadLineMarks
@@ -308,6 +336,9 @@ const LineBoardE231: React.FC<Props> = ({
   const selectedLine = useAtomValue(selectedLineAtom);
   const currentLine = useCurrentLine();
   const dim = useLandscapeWindowDimensions();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+  const estimatedMinutesByStationId =
+    useEstimatedMinutesByStationId(estimatedRoute);
 
   const line = useMemo(
     () => currentLine || selectedLine,
@@ -329,11 +360,14 @@ const LineBoardE231: React.FC<Props> = ({
             line={line}
             lineColors={lineColors}
             hasTerminus={hasTerminus}
+            estimatedMinutes={
+              s.id != null ? estimatedMinutesByStationId.get(s.id) : null
+            }
           />
         </React.Fragment>
       );
     },
-    [hasTerminus, line, lineColors, stations]
+    [hasTerminus, line, lineColors, stations, estimatedMinutesByStationId]
   );
 
   const stationsWithEmpty = useMemo(

--- a/src/components/LineBoardJO.test.tsx
+++ b/src/components/LineBoardJO.test.tsx
@@ -246,9 +246,8 @@ describe('LineBoardJO', () => {
         lineColors={['#9acd32', '#9acd32']}
       />
     );
-    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
-      expect.objectContaining({ estimatedMinutes: 5 }),
-      undefined
+    expect(EstimatedMinutesBadge.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ estimatedMinutes: 5 })
     );
   });
 

--- a/src/components/LineBoardJO.test.tsx
+++ b/src/components/LineBoardJO.test.tsx
@@ -14,6 +14,8 @@ jest.mock('~/hooks', () => ({
   useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
   useCurrentLine: jest.fn(),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
+  useEstimatedMinutesByStationId: jest.fn(() => new Map()),
   useIsPassing: jest.fn(() => false),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
   useTransferLinesFromStation: jest.fn(() => []),
@@ -73,11 +75,17 @@ jest.mock('./Typography', () => {
   };
 });
 
-jest.mock('./LineBoard/shared/components', () => ({
-  EmptyStationNameCell: jest.fn(() => null),
-  LineDot: jest.fn(() => null),
-  StationName: jest.fn(() => null),
-}));
+jest.mock('./LineBoard/shared/components', () => {
+  const { Text } = require('react-native');
+  return {
+    EmptyStationNameCell: jest.fn(() => null),
+    EstimatedMinutesBadge: jest.fn(({ estimatedMinutes }) => (
+      <Text>{estimatedMinutes}</Text>
+    )),
+    LineDot: jest.fn(() => null),
+    StationName: jest.fn(() => null),
+  };
+});
 
 describe('LineBoardJO', () => {
   const { useAtomValue } = require('jotai');
@@ -226,6 +234,22 @@ describe('LineBoardJO', () => {
       />
     );
     expect(result.toJSON()).toBeTruthy();
+  });
+
+  it('stationIdに対応するestimatedMinutesがbarDotへ表示される', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardJO
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+      />
+    );
+    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: 5 }),
+      undefined
+    );
   });
 
   it('通過駅の場合、PassChevronEastが表示される', () => {

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -5,6 +5,8 @@ import type { Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
+  useEstimatedMinutesByStationId,
   useIsPassing,
   useLandscapeWindowDimensions,
   useStationNumberIndexFunc,
@@ -19,6 +21,7 @@ import isTablet from '../utils/isTablet';
 import { getNumberingColor } from '../utils/numbering';
 import { ChevronJO } from './ChevronJO';
 import { JOCurrentArrowEdge } from './JOCurrentArrowEdge';
+import { EstimatedMinutesBadge } from './LineBoard/shared/components';
 import { useIncludesLongStationName } from './LineBoard/shared/hooks/useBarStyles';
 import {
   BAR_BOTTOM_JO,
@@ -233,6 +236,9 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
   const station = useDisplayCurrentStation();
   const currentLine = useCurrentLine();
   const barWidth = useBarWidth();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+  const estimatedMinutesByStationId =
+    useEstimatedMinutesByStationId(estimatedRoute);
 
   const line = useMemo(
     () => currentLine || selectedLine,
@@ -371,9 +377,20 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
                   bottom: getBottom(i),
                   width: i <= currentStationIndex ? 16 : 32,
                   height: i <= currentStationIndex ? 16 : 32,
+                  justifyContent: 'center',
+                  alignItems: 'center',
                 },
               ]}
-            />
+            >
+              {stations[i]?.id != null &&
+              estimatedMinutesByStationId.get(stations[i].id) != null ? (
+                <EstimatedMinutesBadge
+                  estimatedMinutes={
+                    estimatedMinutesByStationId.get(stations[i].id) as number
+                  }
+                />
+              ) : null}
+            </View>
           )}
         </React.Fragment>
       ))}

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -306,94 +306,97 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
 
   return (
     <View style={styles.root}>
-      {[...lineColors, ...emptyArray].map((lc, i) => (
-        <React.Fragment key={`${lc}${i.toString()}`}>
-          <View
-            key={`${lc}${i.toString()}`}
-            style={[
-              styles.barJO,
-              {
-                width: barWidth,
-                left: barWidth * i,
-                backgroundColor: (() => {
-                  if (i <= currentStationIndex) {
-                    if (!arrived) {
+      {[...lineColors, ...emptyArray].map((lc, i) => {
+        const stationId = stations[i]?.id;
+        const estimatedMinutes =
+          stationId != null && i > currentStationIndex
+            ? estimatedMinutesByStationId.get(stationId)
+            : null;
+
+        return (
+          <React.Fragment key={`${lc}${i.toString()}`}>
+            <View
+              key={`${lc}${i.toString()}`}
+              style={[
+                styles.barJO,
+                {
+                  width: barWidth,
+                  left: barWidth * i,
+                  backgroundColor: (() => {
+                    if (i <= currentStationIndex) {
+                      if (!arrived) {
+                        return '#888';
+                      }
+                      if (i === currentStationIndex) {
+                        return '#dc143c';
+                      }
                       return '#888';
                     }
-                    if (i === currentStationIndex) {
-                      return '#dc143c';
-                    }
-                    return '#888';
-                  }
 
-                  return lc ?? '#888';
-                })(),
-              },
-            ]}
-          />
-          <View
-            style={[
-              styles.barJO,
-              {
-                left: barWidth * i,
-                backgroundColor: (() => {
-                  if (i <= currentStationIndex) {
-                    if (!arrived) {
+                    return lc ?? '#888';
+                  })(),
+                },
+              ]}
+            />
+            <View
+              style={[
+                styles.barJO,
+                {
+                  left: barWidth * i,
+                  backgroundColor: (() => {
+                    if (i <= currentStationIndex) {
+                      if (!arrived) {
+                        return '#888';
+                      }
+                      if (i === currentStationIndex) {
+                        return '#dc143c';
+                      }
                       return '#888';
                     }
-                    if (i === currentStationIndex) {
-                      return '#dc143c';
-                    }
-                    return '#888';
-                  }
 
-                  return lc ?? '#888';
-                })(),
-              },
-            ]}
-          />
-          {getIsPass(stations[i]) ? (
-            <View
-              style={[
-                styles.barDotJO,
-                {
-                  left: getLeft(i),
-                  bottom: getBottom(i),
-                  width: i <= currentStationIndex ? 16 : 32,
-                  height: i <= currentStationIndex ? 16 : 32,
+                    return lc ?? '#888';
+                  })(),
                 },
               ]}
-            >
-              <PassChevronEast />
-            </View>
-          ) : (
-            <View
-              style={[
-                styles.barDotJO,
-                {
-                  backgroundColor:
-                    stations.length <= i ? 'transparent' : 'white',
-                  left: getLeft(i),
-                  bottom: getBottom(i),
-                  width: i <= currentStationIndex ? 16 : 32,
-                  height: i <= currentStationIndex ? 16 : 32,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                },
-              ]}
-            >
-              {stations[i]?.id != null &&
-              estimatedMinutesByStationId.get(stations[i].id) != null ? (
-                <EstimatedMinutesBadge
-                  estimatedMinutes={
-                    estimatedMinutesByStationId.get(stations[i].id) as number
-                  }
-                />
-              ) : null}
-            </View>
-          )}
-        </React.Fragment>
-      ))}
+            />
+            {getIsPass(stations[i]) ? (
+              <View
+                style={[
+                  styles.barDotJO,
+                  {
+                    left: getLeft(i),
+                    bottom: getBottom(i),
+                    width: i <= currentStationIndex ? 16 : 32,
+                    height: i <= currentStationIndex ? 16 : 32,
+                  },
+                ]}
+              >
+                <PassChevronEast />
+              </View>
+            ) : (
+              <View
+                style={[
+                  styles.barDotJO,
+                  {
+                    backgroundColor:
+                      stations.length <= i ? 'transparent' : 'white',
+                    left: getLeft(i),
+                    bottom: getBottom(i),
+                    width: i <= currentStationIndex ? 16 : 32,
+                    height: i <= currentStationIndex ? 16 : 32,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                  },
+                ]}
+              >
+                {estimatedMinutes != null ? (
+                  <EstimatedMinutesBadge estimatedMinutes={estimatedMinutes} />
+                ) : null}
+              </View>
+            )}
+          </React.Fragment>
+        );
+      })}
 
       {arrived ? (
         <View

--- a/src/components/LineBoardYamanotePad.test.tsx
+++ b/src/components/LineBoardYamanotePad.test.tsx
@@ -15,6 +15,8 @@ jest.mock('~/hooks', () => ({
   useCurrentLine: jest.fn(),
   useCurrentTrainType: jest.fn(() => null),
   useDisplayCurrentStation: jest.fn(),
+  useEstimateArrivalTimes: jest.fn(() => ({ route: null })),
+  useEstimatedMinutesByStationId: jest.fn(() => new Map()),
   useGetLineMark: jest.fn(() => jest.fn(() => null)),
   useNextStation: jest.fn(() => null),
   useStationNumberIndexFunc: jest.fn(() => jest.fn(() => 0)),
@@ -208,6 +210,20 @@ describe('LineBoardYamanotePad', () => {
     expect(PadArch).toHaveBeenCalled();
     const callArgs = PadArch.mock.calls[0][0];
     expect(callArgs.stations).toHaveLength(6);
+  });
+
+  it('estimatedMinutesByStationIdがPadArchへ渡される', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    const mockMap = new Map([[2, 5]]);
+    useEstimatedMinutesByStationId.mockReturnValueOnce(mockMap);
+
+    render(<LineBoardYamanotePad stations={mockStations} />);
+    expect(PadArch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        estimatedMinutesByStationId: mockMap,
+      }),
+      undefined
+    );
   });
 
   it('transferLinesが正しく渡される', () => {

--- a/src/components/LineBoardYamanotePad.tsx
+++ b/src/components/LineBoardYamanotePad.tsx
@@ -5,6 +5,8 @@ import {
   useCurrentLine,
   useCurrentTrainType,
   useDisplayCurrentStation,
+  useEstimateArrivalTimes,
+  useEstimatedMinutesByStationId,
   useGetLineMark,
   useNextStation,
   useTransferLines,
@@ -31,6 +33,9 @@ const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
   const getLineMarkFunc = useGetLineMark();
   const nextStation = useNextStation();
   const transferLines = useTransferLines();
+  const { route: estimatedRoute } = useEstimateArrivalTimes();
+  const estimatedMinutesByStationId =
+    useEstimatedMinutesByStationId(estimatedRoute);
   const switchedStation = useMemo(
     () =>
       arrived && station && !getIsPass(station)
@@ -118,6 +123,7 @@ const LineBoardYamanotePad: React.FC<Props> = ({ stations }: Props) => {
       lineMarks={lineMarks}
       trainTypeLines={trainType?.lines ?? []}
       isEn={isEn}
+      estimatedMinutesByStationId={estimatedMinutesByStationId}
     />
   );
 };

--- a/src/components/PadArch.test.tsx
+++ b/src/components/PadArch.test.tsx
@@ -1,0 +1,105 @@
+import { render } from '@testing-library/react-native';
+import type { Line, LineNested, Station } from '~/@types/graphql';
+import PadArch from './PadArch';
+
+jest.mock('~/utils/isPass', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('./NumberingIcon', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('./TransferLineDot', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('./TransferLineMark', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('./ChevronYamanote', () => ({
+  ChevronYamanote: jest.fn(() => null),
+}));
+
+jest.mock('./Typography', () => {
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: jest.fn((props) => <Text {...props}>{props.children}</Text>),
+  };
+});
+
+jest.mock('./LineBoard/shared/components', () => {
+  const { Text } = require('react-native');
+  return {
+    EstimatedMinutesBadge: jest.fn(({ estimatedMinutes }) => (
+      <Text>{estimatedMinutes}</Text>
+    )),
+  };
+});
+
+describe('PadArch', () => {
+  const mockLine: Line = {
+    __typename: 'Line',
+    id: 1,
+    nameShort: '山手線',
+    color: '#9acd32',
+  } as Line;
+
+  const mockStations: Station[] = [
+    { id: 1, groupId: 1, name: '東京', line: mockLine } as unknown as Station,
+    { id: 2, groupId: 2, name: '有楽町', line: mockLine } as unknown as Station,
+    { id: 3, groupId: 3, name: '新橋', line: mockLine } as unknown as Station,
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderPadArch = (
+    stations: Station[],
+    estimatedMinutesByStationId?: Map<number, number | null>,
+    arrived = false
+  ) =>
+    render(
+      <PadArch
+        line={mockLine}
+        stations={stations}
+        arrived={arrived}
+        transferLines={[]}
+        station={null}
+        numberingInfo={stations.map(() => null)}
+        lineMarks={[]}
+        trainTypeLines={[] as LineNested[]}
+        isEn={false}
+        estimatedMinutesByStationId={estimatedMinutesByStationId}
+      />
+    );
+
+  it('stationIdに対応するestimatedMinutesがEstimatedMinutesBadgeへ渡される', () => {
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    renderPadArch(mockStations, new Map([[2, 5]]));
+    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: 5 }),
+      undefined
+    );
+  });
+
+  it('estimatedMinutesByStationIdが未指定でもエラーなくレンダリングされる', () => {
+    const result = renderPadArch(mockStations);
+    expect(result.toJSON()).toBeTruthy();
+  });
+
+  it('通過駅にはestimatedMinutesを表示しない', () => {
+    const getIsPass = require('~/utils/isPass').default;
+    getIsPass.mockReturnValue(true);
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    renderPadArch(mockStations, new Map([[2, 5]]));
+    expect(EstimatedMinutesBadge).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PadArch.test.tsx
+++ b/src/components/PadArch.test.tsx
@@ -84,9 +84,8 @@ describe('PadArch', () => {
   it('stationIdに対応するestimatedMinutesがEstimatedMinutesBadgeへ渡される', () => {
     const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
     renderPadArch(mockStations, new Map([[2, 5]]));
-    expect(EstimatedMinutesBadge).toHaveBeenCalledWith(
-      expect.objectContaining({ estimatedMinutes: 5 }),
-      undefined
+    expect(EstimatedMinutesBadge.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ estimatedMinutes: 5 })
     );
   });
 
@@ -100,6 +99,12 @@ describe('PadArch', () => {
     getIsPass.mockReturnValue(true);
     const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
     renderPadArch(mockStations, new Map([[2, 5]]));
+    expect(EstimatedMinutesBadge).not.toHaveBeenCalled();
+  });
+
+  it('到着時の最後から2番目の駅にはestimatedMinutesを表示しない', () => {
+    const { EstimatedMinutesBadge } = require('./LineBoard/shared/components');
+    renderPadArch(mockStations, new Map([[2, 5]]), true);
     expect(EstimatedMinutesBadge).not.toHaveBeenCalled();
   });
 });

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -17,6 +17,7 @@ import {
 import type { LineMark } from '../models/LineMark';
 import getIsPass from '../utils/isPass';
 import { ChevronYamanote } from './ChevronYamanote';
+import { EstimatedMinutesBadge } from './LineBoard/shared/components';
 import NumberingIcon from './NumberingIcon';
 import TransferLineDot from './TransferLineDot';
 import TransferLineMark from './TransferLineMark';
@@ -38,6 +39,7 @@ type Props = {
   lineMarks: (LineMark | null)[];
   trainTypeLines: LineNested[];
   isEn: boolean;
+  estimatedMinutesByStationId?: Map<number, number | null>;
 };
 
 type ColorSegment = {
@@ -213,6 +215,17 @@ const styles = StyleSheet.create({
     height: 18,
     marginLeft: 21,
     marginTop: 25,
+  },
+  estimatedMinutesOverlay: {
+    position: 'absolute',
+    width: 68,
+    height: 68,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  estimatedMinutesText: {
+    fontSize: 28,
+    lineHeight: 30,
   },
   clipViewStyle: {
     overflow: 'hidden',
@@ -405,6 +418,7 @@ const PadArch: React.FC<Props> = ({
   lineMarks,
   trainTypeLines,
   isEn,
+  estimatedMinutesByStationId,
 }: Props) => {
   const { width: windowWidth, height: windowHeight } =
     useLandscapeWindowDimensions();
@@ -641,13 +655,25 @@ const PadArch: React.FC<Props> = ({
           return null;
         }
         const isPass = getIsPass(s);
+        const isSmallCircle = (arrived && i === stations.length - 2) || isPass;
+        const estimatedMinutes =
+          !isSmallCircle && s.id != null
+            ? estimatedMinutesByStationId?.get(s.id)
+            : null;
         return {
           isPass,
           dotStyle: getCustomDotStyle(i, stations, arrived, isPass),
           nameStyle: getCustomStationNameStyle(i),
+          estimatedMinutes,
         };
       }),
-    [stations, arrived, getCustomDotStyle, getCustomStationNameStyle]
+    [
+      stations,
+      arrived,
+      getCustomDotStyle,
+      getCustomStationNameStyle,
+      estimatedMinutesByStationId,
+    ]
   );
 
   return (
@@ -746,7 +772,7 @@ const PadArch: React.FC<Props> = ({
         {stations.map((s, i) => {
           const renderInfo = stationRenderInfos[i];
           if (!s || !renderInfo) return null;
-          const { isPass, dotStyle, nameStyle } = renderInfo;
+          const { isPass, dotStyle, nameStyle, estimatedMinutes } = renderInfo;
           return (
             <React.Fragment key={s.id}>
               <View
@@ -758,6 +784,20 @@ const PadArch: React.FC<Props> = ({
                   dotStyle,
                 ]}
               />
+              {estimatedMinutes != null ? (
+                <View
+                  style={[
+                    styles.estimatedMinutesOverlay,
+                    { left: dotStyle.left, top: dotStyle.top },
+                  ]}
+                  pointerEvents="none"
+                >
+                  <EstimatedMinutesBadge
+                    estimatedMinutes={estimatedMinutes}
+                    style={styles.estimatedMinutesText}
+                  />
+                </View>
+              ) : null}
               <View
                 style={[
                   styles.stationNameContainer,


### PR DESCRIPTION
## 概要

到着予想時刻(ETA)表示を East/Toei/Saikyo/JRKyushu テーマの LineBoard に加え、E231・JO(山手線非iPad含む)・山手線iPad版(PadArch)の LineBoard にも横展開しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `LineBoard/shared/components/EstimatedMinutesBadge` を新設し、既存 `LineDot` の ETA テキスト描画をこのコンポーネントに委譲
- `LineBoardE231` の駅ドット、`LineBoardJO` の barDot、`PadArch`(山手線iPad版アーチ表示) の駅サークルに、それぞれ ETA の数値オーバーレイを追加
- 通過駅・到着中/通過中で縮小表示される駅ドットには ETA を表示しない(既存 `LineDot` の挙動と統一)
- JR西日本テーマ(`LineBoardWest`)は実車に ETA 表示が無いため、今回の対象から明示的に除外
- 各コンポーネントに ETA 描画のユニットテストを追加(`LineBoardE231.test.tsx`, `PadArch.test.tsx` は新規作成)

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

## スクリーンショット（任意）

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAtDgq51QAEey7ZxTK4cNb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 駅ごとの推定所要時間を、路線図の駅アイコン上にバッジ表示できるようになりました。
  * 一部の路線表示で、駅ID別の推定分数が反映されるようになりました（通過・到着条件では非表示）。
* **Tests**
  * 推定所要時間の表示/非表示や、バッジへの値の渡り方を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->