### PR TITLE
LineBoardJOのバーセグメントを右へ1px重ねてピクセル丸めによる白い継ぎ目を解消

### DIFF
--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -320,7 +320,11 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
               style={[
                 styles.barJO,
                 {
-                  width: barWidth,
+                  // barWidthは小数を含むためセグメント境界が物理ピクセルに
+                  // 揃わず、丸めの具合で白い継ぎ目が出ることがある。右へ1px
+                  // 食み出させて隣接セグメントを重ね、継ぎ目が出ないようにする
+                  // (後続セグメントが上に描画されるため境界位置は変わらない)。
+                  width: barWidth + 1,
                   left: barWidth * i,
                   backgroundColor: (() => {
                     if (i <= currentStationIndex) {


### PR DESCRIPTION
## 概要

LineBoardJO の路線カラーバーで、駅ごとのセグメントの間に 1px 幅の白い継ぎ目が見えることがある問題を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/LineBoardJO.tsx`: バーセグメントの幅を `barWidth + 1` にして右へ 1px 食み出させ、隣接セグメント同士を重ねるようにした。
- 原因: `barWidth` は小数（スマホでは `(画面幅 - 96) / 7.835`）を含むため、`left: barWidth * i` / `width: barWidth` で敷き詰めるとセグメント境界が物理ピクセルに揃わず、丸めの具合で背景の白が 1px 覗くことがある。
- 後続セグメントが上に描画されるため、色の境界位置（現在駅の赤・通過済みのグレー・路線色の切り替わり）は見た目上変わらない。`PortraitMain.tsx` の縦棒で採用済みの継ぎ目対策と同じ手法。

### リグレッションリスクと緩和

- 影響範囲は LineBoardJO のバー描画のみ。1px の食み出しは後続セグメントまたは終端の三角形に覆われるため、レイアウト崩れのリスクは低い。
- `LineBoardJO.test.tsx` の既存 12 テストを含む全テストスイートがグリーンであることを確認済み。
- 同じ敷き詰めパターンを持つ `LineBoardWest.tsx` は今回のスコープ外（同様の対策を横展開する場合は別PRで対応可能）。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（185 suites / 1955 tests パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLmPtMci6CXUSuf5z9vGXw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * セグメント表示の境界で発生していた白いすき間を軽減しました。
  * バーの表示幅をわずかに広げ、隣接セグメントが重なるようにして、表示の乱れを抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->