### PR TITLE
小田急テーマのLineBoardからETA表示を削除

### DIFF
--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -204,6 +204,31 @@ describe('LineBoardEast', () => {
     );
   });
 
+  it('isOdakyu時はETAクエリをskipして呼び出す', () => {
+    const { useEstimateArrivalTimes } = require('~/hooks');
+    render(
+      <LineBoardEast
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+        isOdakyu
+      />
+    );
+    expect(useEstimateArrivalTimes).toHaveBeenCalledWith({ skip: true });
+  });
+
+  it('isOdakyuでない場合はETAクエリをskipしない', () => {
+    const { useEstimateArrivalTimes } = require('~/hooks');
+    render(
+      <LineBoardEast
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(useEstimateArrivalTimes).toHaveBeenCalledWith({ skip: undefined });
+  });
+
   it('lineがnullの場合、何もレンダリングされない', () => {
     useCurrentLine.mockReturnValue(null);
     const { StationName } = require('./LineBoard/shared/components');

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -489,7 +489,10 @@ const LineBoardEast: React.FC<Props> = ({
   // なったため、バナーの「◯◯のつぎは」側も同じ次駅を参照して整合を保つ
   const nextStation = useDisplayNextStation();
   const afterNextStation = useAfterNextStation();
-  const { route: estimatedRoute } = useEstimateArrivalTimes();
+  // 小田急テーマはETA表示の対象外のためクエリごと実行しない
+  const { route: estimatedRoute } = useEstimateArrivalTimes({
+    skip: isOdakyu,
+  });
   const estimatedMinutesByStationId =
     useEstimatedMinutesByStationId(estimatedRoute);
 

--- a/src/hooks/useEstimateArrivalTimes.test.tsx
+++ b/src/hooks/useEstimateArrivalTimes.test.tsx
@@ -54,11 +54,13 @@ jest.mock('~/lib/gql', () => ({
 }));
 
 type HookResult = ReturnType<typeof useEstimateArrivalTimes> | null;
+type HookOptions = Parameters<typeof useEstimateArrivalTimes>[0];
 
-const HookBridge: React.FC<{ onReady: (v: HookResult) => void }> = ({
-  onReady,
-}) => {
-  onReady(useEstimateArrivalTimes());
+const HookBridge: React.FC<{
+  onReady: (v: HookResult) => void;
+  options?: HookOptions;
+}> = ({ onReady, options }) => {
+  onReady(useEstimateArrivalTimes(options));
   return null;
 };
 
@@ -73,11 +75,12 @@ const createQueryClient = () =>
     },
   });
 
-const renderHook = () => {
+const renderHook = (options?: HookOptions) => {
   const hookRef: { current: HookResult } = { current: null };
   const utils = render(
     <QueryClientProvider client={createQueryClient()}>
       <HookBridge
+        options={options}
         onReady={(v) => {
           hookRef.current = v;
         }}
@@ -143,6 +146,14 @@ describe('useEstimateArrivalTimes', () => {
     mockUseCurrentTrainType.mockReturnValue(null);
 
     const { hookRef } = renderHook();
+
+    expect(mockGqlRequest).not.toHaveBeenCalled();
+    expect(hookRef.current?.route).toBeNull();
+  });
+
+  it('skip オプション指定時はクエリを実行せず route も返さない', () => {
+    // デフォルトの setupAtoms は本来クエリが実行される条件
+    const { hookRef } = renderHook({ skip: true });
 
     expect(mockGqlRequest).not.toHaveBeenCalled();
     expect(hookRef.current?.route).toBeNull();

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -23,7 +23,7 @@ import { useLoopLine } from './useLoopLine';
  * 返す route.stops は LineBoard に表示中の駅（leftStations）に限定し、
  * 現在駅の到着時刻を基準（0分）とした相対時間に変換する。
  */
-export const useEstimateArrivalTimes = () => {
+export const useEstimateArrivalTimes = (options?: { skip?: boolean }) => {
   const stations = useAtomValue(stationsAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
   const selectedDirection = useAtomValue(selectedDirectionAtom);
@@ -73,8 +73,9 @@ export const useEstimateArrivalTimes = () => {
   const directionId =
     selectedDirection != null ? (travelsInStoredOrder ? 0 : 1) : undefined;
 
-  // 方面未選択・始発/終着が不明・フィルタ先が無い場合はクエリを実行しない
+  // 呼び出し側がETA不要な場合・方面未選択・始発/終着が不明・フィルタ先が無い場合はクエリを実行しない
   const skip =
+    !!options?.skip ||
     !selectedBound ||
     fromStationId == null ||
     toStationId == null ||
@@ -97,6 +98,11 @@ export const useEstimateArrivalTimes = () => {
   // stops を LineBoard 表示中の駅（leftStations）だけに絞り込んだ上で、
   // 現在駅の到着時刻を基準（0分）とした相対時間に変換する
   const matchedRoute = useMemo(() => {
+    // skip時でも同一queryKeyのキャッシュがあるとdataは返ってくる(enabledはfetch抑止のみ)
+    // ため、ルートを返さないことをここで保証する
+    if (skip) {
+      return null;
+    }
     const routes = data?.estimateArrivalTimes?.routes;
     if (!routes || filteringId == null) {
       return null;
@@ -142,7 +148,7 @@ export const useEstimateArrivalTimes = () => {
       .filter((s) => s.cumulativeMinutes == null || s.cumulativeMinutes > 0);
 
     return { ...route, stops: relativeStops };
-  }, [data, filteringId, leftStations, currentStation?.id]);
+  }, [data, filteringId, leftStations, currentStation?.id, skip]);
 
   return { route: matchedRoute, loading, error };
 };


### PR DESCRIPTION
## 概要

小田急テーマの LineBoard で到着予想時間（ETA）バッジを表示しないようにしました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `useEstimateArrivalTimes` に `skip` オプションを追加し、skip 時はクエリを実行せず route も返さないことを保証（react-query は `enabled: false` でも同一 queryKey のキャッシュから data を返すため、テーマ切り替え時にキャッシュ経由で ETA が残るのを防ぐ）
- `LineBoardEast` を小田急テーマ（`isOdakyu`）のとき `skip: true` で呼び出し、ETA バッジを非表示化。同コンポーネントを共有する東京メトロ・東急テーマの ETA 表示は従来どおり
- `useEstimateArrivalTimes.test.tsx` / `LineBoardEast.test.tsx` に skip 挙動のテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 小田急テーマでは到着予測の取得を行わないようになり、不要な通信を抑制しました。
  * 取得をスキップした場合は、ルート情報を返さないように改善しました。
  * スキップ設定の有無に応じて、表示結果が正しく切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->