### PR TITLE
乗換案内の対象駅を表示用次駅に揃えて接近中の駅名と乗換路線の不一致を解消

### DIFF
--- a/src/hooks/useTransferLines.test.tsx
+++ b/src/hooks/useTransferLines.test.tsx
@@ -7,7 +7,7 @@ import { createLine, createStation } from '~/utils/test/factories';
 import stationState from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import { useCurrentStation } from './useCurrentStation';
-import { useNextStation } from './useNextStation';
+import { useDisplayNextStation } from './useDisplayNextStation';
 import { useTransferLines } from './useTransferLines';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 
@@ -19,8 +19,8 @@ jest.mock('jotai', () => ({
 jest.mock('./useCurrentStation', () => ({
   useCurrentStation: jest.fn(),
 }));
-jest.mock('./useNextStation', () => ({
-  useNextStation: jest.fn(),
+jest.mock('./useDisplayNextStation', () => ({
+  useDisplayNextStation: jest.fn(),
 }));
 jest.mock('./useTransferLinesFromStation', () => ({
   useTransferLinesFromStation: jest.fn(),
@@ -44,9 +44,8 @@ describe('useTransferLines', () => {
   const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
     typeof useCurrentStation
   >;
-  const mockUseNextStation = useNextStation as jest.MockedFunction<
-    typeof useNextStation
-  >;
+  const mockUseDisplayNextStation =
+    useDisplayNextStation as jest.MockedFunction<typeof useDisplayNextStation>;
   const mockUseTransferLinesFromStation =
     useTransferLinesFromStation as jest.MockedFunction<
       typeof useTransferLinesFromStation
@@ -68,7 +67,9 @@ describe('useTransferLines', () => {
       throw new Error('unknown atom');
     });
     mockUseCurrentStation.mockImplementation(() => currentStationValue);
-    mockUseNextStation.mockImplementation(() => nextStationValue ?? undefined);
+    mockUseDisplayNextStation.mockImplementation(
+      () => nextStationValue ?? undefined
+    );
     mockUseTransferLinesFromStation.mockReturnValue([]);
     mockGetIsPass.mockReturnValue(false);
   });
@@ -119,16 +120,22 @@ describe('useTransferLines', () => {
     );
   });
 
-  it('未到着時も次駅を対象にする', () => {
-    const nextStation = createStation(20);
+  it('未到着時は表示用の次駅 (接近中はGPS基準の接近駅) を対象にする', () => {
+    // useDisplayNextStation は接近中に路線順の次駅ではなく実際に接近している駅を
+    // 返すことがある。乗換案内はヘッダー・TTS の「まもなく」駅名と同じ駅を
+    // 対象にしなければならない。
+    const displayNextStation = createStation(20);
     stationAtomValue.arrived = false;
-    nextStationValue = nextStation;
+    nextStationValue = displayNextStation;
 
     render(<TestComponent />);
 
-    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(nextStation, {
-      omitRepeatingLine: false,
-      omitJR: false,
-    });
+    expect(mockUseTransferLinesFromStation).toHaveBeenCalledWith(
+      displayNextStation,
+      {
+        omitRepeatingLine: false,
+        omitJR: false,
+      }
+    );
   });
 });

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -4,7 +4,7 @@ import type { Line } from '~/@types/graphql';
 import { arrivedAtom } from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import { useCurrentStation } from './useCurrentStation';
-import { useNextStation } from './useNextStation';
+import { useDisplayNextStation } from './useDisplayNextStation';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
 
 type Option = {
@@ -15,7 +15,11 @@ type Option = {
 export const useTransferLines = (options?: Option): Line[] => {
   const arrived = useAtomValue(arrivedAtom);
   const currentStation = useCurrentStation(false, true);
-  const nextStation = useNextStation();
+  // ヘッダー・TTS が「まもなく」で読み上げる駅 (接近中はGPS基準の接近駅) と
+  // 乗換案内の対象駅を一致させる。useNextStation 起点のままだと、到着判定の
+  // 取りこぼしで stationState が古い場合に「まもなくA、B駅の乗換路線をご案内」
+  // という不整合が起きる。
+  const nextStation = useDisplayNextStation();
   const targetStation = useMemo(
     () =>
       arrived && currentStation && !getIsPass(currentStation)


### PR DESCRIPTION
## 概要

TTS の「まもなく」(ARRIVING) 案内で、駅名は `useDisplayNextStation`(接近中は GPS 基準の接近駅)を読み上げる一方、乗換路線は `useTransferLines` 経由で `useNextStation`(路線順の次駅)を参照しており、到着判定の取りこぼしで stationState が古くなると「まもなく A です。(B 駅の乗換路線)はお乗り換えです」という不整合が起き得た。乗換案内の対象駅を表示用次駅に揃えて解消する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTransferLines` の未到着時の対象駅を `useNextStation()` から `useDisplayNextStation()` に変更し、ヘッダー・TTS が「まもなく」で示す駅と乗換案内の対象駅を一致させた
- 同種のズレは次々駅案内で既に `useAfterNextStation` が `useDisplayNextStation` 起点に修正済みで、`useTransferLines` だけが残っていた
- TTS に加えて、接近中の乗換ボード表示(Transfers / LineBoardLED 等)も同じ駅の乗換路線を表示するようになる
- `useTransferLines.test.tsx` のモックを `useDisplayNextStation` に差し替え、接近中は表示用次駅を対象にする意図をテスト名とコメントで明文化

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 185 suites / 1958 tests 全通過。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01TnDsTfR5WnizgYErzWPo5n)_