### PR TITLE
新宿・代々木など他路線レコードが最寄り駅の場合に大江戸線の方面が選べなくなる不具合をgroupIdフォールバックで修正

### DIFF
--- a/src/hooks/useBounds.test.tsx
+++ b/src/hooks/useBounds.test.tsx
@@ -218,6 +218,40 @@ describe('useBounds フック', () => {
     expect(outboundStops.map((s) => s.id)).toContain(9930107);
   });
 
+  it('大江戸線で現在駅が他路線レコード(JR新宿など)の場合、groupIdで読み替えて bounds を返す', () => {
+    setAtomValues({ selectedDirection: 'INBOUND' });
+
+    // 新宿の最寄り駅としてJR側のレコードが現在駅になっているケース。
+    // idは大江戸線の駅リストに存在しないが、groupIdは大江戸線新宿と共通。
+    const currentStation = { id: 1130224, groupId: 1130224 }; // JR新宿
+    (useCurrentStation as jest.Mock).mockReturnValue(currentStation);
+    (useLoopLine as jest.Mock).mockReturnValue({
+      isLoopLine: false,
+      isOedoLine: true,
+      inboundStationsForLoopLine: [],
+      outboundStationsForLoopLine: [],
+    });
+    (getIsLocal as jest.Mock).mockReturnValue(true);
+
+    const stations = [
+      { id: 9930138, groupId: 9930138 }, // 光が丘（主要駅）
+      { id: 9930100, groupId: 100 }, // 都庁前(外回り)
+      { id: 9930128, groupId: 1130224 }, // 大江戸線新宿 - JR新宿とgroupIdが同じ
+      { id: 9930121, groupId: 9930121 }, // 大門（主要駅）
+      { id: 9930113, groupId: 9930113 }, // 両国（主要駅）
+    ] as unknown as Station[];
+    const { getByTestId } = render(<TestComponent stations={stations} />);
+
+    const bounds = getByTestId('bounds').props.children;
+    const [inboundStops, outboundStops] = JSON.parse(bounds) as {
+      id: number;
+    }[][];
+    // inbound には新宿より後方の主要駅（大門、両国）が含まれる
+    expect(inboundStops.map((s) => s.id)).toEqual([9930121, 9930113]);
+    // outbound には都庁前(外回り)と光が丘が含まれる
+    expect(outboundStops.map((s) => s.id)).toEqual([9930100, 9930138]);
+  });
+
   it('大江戸線で currentStation が見つからない場合、空の bounds を返す', () => {
     setAtomValues({ selectedDirection: 'INBOUND' });
 

--- a/src/hooks/useBounds.ts
+++ b/src/hooks/useBounds.ts
@@ -42,22 +42,27 @@ export const useBounds = (
 
     if (isOedoLine) {
       // 都庁前(外回り/内回り)のようにgroupIdが同じでもidが異なる駅があるため、
-      // idで位置を特定する(groupId一致だと配列中で先に見つかる方に固定され、
+      // まずidで位置を特定する(groupId一致だと配列中で先に見つかる方に固定され、
       // 実際の現在地と異なる位置を基準に行き先・経由駅の区間を切り出してしまう)。
-      const stationIndex = stations.findIndex(
-        (s) => s.id === currentStation?.id
-      );
-      if (stationIndex < 0) return [[], []];
+      // ただし新宿・代々木などでは最寄り駅が他路線(JRなど)のレコードになり
+      // idが大江戸線の駅リストに存在しないため、groupIdで大江戸線側の駅に読み替える。
+      const oedoCurrentStation =
+        stations.find((s) => s.id === currentStation?.id) ??
+        (currentStation?.groupId != null
+          ? stations.find((s) => s.groupId === currentStation.groupId)
+          : undefined);
+      if (!oedoCurrentStation) return [[], []];
+      const stationIndex = stations.indexOf(oedoCurrentStation);
 
       const isTochomaeStation =
-        currentStation?.id === TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_OUTER ||
-        currentStation?.id === TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_INNER;
+        oedoCurrentStation.id === TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_OUTER ||
+        oedoCurrentStation.id === TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_INNER;
 
       const oedoLineInboundStops = stations
         .slice(stationIndex, stations.length)
         .filter(
           (s) =>
-            s.id !== currentStation?.id &&
+            s.id !== oedoCurrentStation.id &&
             s.id !== undefined &&
             s.id !== null &&
             TOEI_OEDO_LINE_MAJOR_STATIONS_ID.includes(s.id)
@@ -70,14 +75,13 @@ export const useBounds = (
           (s) =>
             s.id !== undefined &&
             s.id !== null &&
-            ((s.id !== currentStation?.id &&
+            ((s.id !== oedoCurrentStation.id &&
               TOEI_OEDO_LINE_MAJOR_STATIONS_ID.includes(s.id)) ||
               s.id === TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_OUTER)
         )
         // NOTE: 光が丘~築地市場駅間では「都庁前」案内をしない
         .filter((s) =>
-          currentStation &&
-          (currentStation.id ?? 0) >= TOEI_OEDO_LINE_TSUKIJISHIJO_STATION_ID
+          (oedoCurrentStation.id ?? 0) >= TOEI_OEDO_LINE_TSUKIJISHIJO_STATION_ID
             ? s.id !== TOEI_OEDO_LINE_TOCHOMAE_STATION_ID_INNER
             : true
         );


### PR DESCRIPTION
## 概要

新宿駅・代々木駅などで都営大江戸線を選択した際、行先選択モーダルに方面ボタンが1つも表示されず方向が選べなくなる不具合を修正します。

#6349 (95de837) で `useBounds` の大江戸線分岐の現在駅位置特定が groupId 一致 → id 一致に変更されましたが、行先選択モーダルには選択した路線（大江戸線）の駅リストが渡される一方、現在駅は最寄り駅として検出されたレコードのままです。新宿・代々木ではこれが JR など他路線の駅レコードになるため、その id は大江戸線の駅リストに存在せず `findIndex` が -1 → bounds が `[[], []]`（空）になっていました。都庁前のような大江戸線単独駅では id が一致するため発症しません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useBounds.ts`: 大江戸線分岐で現在駅をまず id 一致で駅リストから探し（都庁前の外回り/内回り区別は維持）、見つからない場合のみ groupId 一致で大江戸線側の駅に読み替えるフォールバックを追加。
- 同分岐内の自駅除外フィルタと「光が丘〜築地市場間では都庁前(内回り)を案内しない」判定も、読み替え後の大江戸線レコードの id を使うよう統一（他路線 id との数値比較になっていた潜在バグも解消）。
- `src/hooks/useBounds.test.tsx`: JR新宿レコードが現在駅の場合に inbound（大門・両国）/ outbound（都庁前外回り・光が丘）が正しく返ることを検証する回帰テストを追加。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 185 スイート / 1959 件すべてパス（新規回帰テスト1件を含む）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kkb6NJLeyzqsMd9QpJi47N)_