### PR TITLE
地下でETAが現在地を独占駆動して勝手に動くデグレを解消しETAをGPSの到着判定補助(R1)に限定、設定に手動A/Bトグルを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -327,5 +327,7 @@
   "portraitModeTitle": "Portrait Mode",
   "portraitModeDescription": "When enabled, the running screen switches to a layout optimized for portrait orientation while you hold your device upright.",
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
+  "etaAssistTitle": "ETA-assisted arrival detection",
+  "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid. This is a toggle for manual A/B testing and enables the feature regardless of the server setting.",
   "passStationLabel": "Pass"
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -327,7 +327,7 @@
   "portraitModeTitle": "Portrait Mode",
   "portraitModeDescription": "When enabled, the running screen switches to a layout optimized for portrait orientation while you hold your device upright.",
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
-  "etaAssistTitle": "ETA-assisted arrival detection",
-  "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid. This is a toggle for manual A/B testing and enables the feature regardless of the server setting.",
+  "etaAssistTitle": "Improve arrival detection",
+  "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid.",
   "passStationLabel": "Pass"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -328,5 +328,7 @@
   "portraitModeTitle": "ポートレートモード",
   "portraitModeDescription": "有効にすると、走行画面で端末を縦向きにした際に、縦画面に最適化されたデザインで表示します。",
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
+  "etaAssistTitle": "ETAによる到着判定の補助",
+  "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。手動A/Bテスト用のトグルで、サーバー設定より優先して有効化します。",
   "passStationLabel": "通過"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -328,7 +328,7 @@
   "portraitModeTitle": "ポートレートモード",
   "portraitModeDescription": "有効にすると、走行画面で端末を縦向きにした際に、縦画面に最適化されたデザインで表示します。",
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
-  "etaAssistTitle": "ETAによる到着判定の補助",
-  "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。手動A/Bテスト用のトグルで、サーバー設定より優先して有効化します。",
+  "etaAssistTitle": "到着判定の改善",
+  "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。",
   "passStationLabel": "通過"
 }

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -193,19 +193,18 @@ describe('DevOverlay', () => {
       expect(getByTestId('dev-overlay-landscape')).toBeTruthy();
     });
 
-    it('ETAフォールバック非稼働時は IDLE と有効フラグを表示する', () => {
+    it('機能が無効(isEtaAssistEnabled=false)なら ETA FALLBACK / ANCHOR カードを表示しない', () => {
       jest
         .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
         .mockReturnValue(false);
-      setupAtomValues({ etaPhase: null });
+      setupAtomValues({
+        etaPhase: null,
+        etaAnchor: { stationId: 5, kind: 'DEPARTED', observedAtMs: 88_000 },
+      });
 
-      const { getByTestId } = render(<DevOverlay />);
-      expect(getByTestId('dev-overlay-eta-fallback-value')).toHaveTextContent(
-        'IDLE'
-      );
-      expect(getByTestId('dev-overlay-eta-fallback-meta')).toHaveTextContent(
-        'assist OFF'
-      );
+      const { queryByTestId } = render(<DevOverlay />);
+      expect(queryByTestId('dev-overlay-eta-fallback-value')).toBeNull();
+      expect(queryByTestId('dev-overlay-eta-anchor-value')).toBeNull();
     });
 
     it('ETA推定フェーズがあるときは現在フェーズと対象駅・有効フラグを表示する', () => {
@@ -244,6 +243,9 @@ describe('DevOverlay', () => {
     });
 
     it('アンカー未設定時は ETA ANCHOR に no anchor を表示する', () => {
+      jest
+        .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
+        .mockReturnValue(true);
       setupAtomValues({ etaAnchor: null });
 
       const { getByTestId } = render(<DevOverlay />);
@@ -256,6 +258,9 @@ describe('DevOverlay', () => {
     });
 
     it('アンカー設定時は種別・起点駅ID・経過秒を表示する', () => {
+      jest
+        .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
+        .mockReturnValue(true);
       jest.spyOn(Date, 'now').mockReturnValue(100_000);
       setupAtomValues({
         etaAnchor: {

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -6,11 +6,7 @@ import type { Station } from '~/@types/graphql';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import * as remoteConfigModule from '~/lib/remoteConfig';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-  etaPhaseAtom,
-} from '~/store/atoms/etaFallback';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
@@ -86,7 +82,6 @@ describe('DevOverlay', () => {
     },
     backgroundLocationTracking = false,
     autoModeEnabled = false,
-    etaFallbackActive = false,
     etaPhase = null,
     etaAnchor = null,
   }: {
@@ -94,7 +89,6 @@ describe('DevOverlay', () => {
     rawLocation?: unknown;
     backgroundLocationTracking?: boolean;
     autoModeEnabled?: boolean;
-    etaFallbackActive?: boolean;
     etaPhase?: unknown;
     etaAnchor?: unknown;
   } = {}) => {
@@ -110,9 +104,6 @@ describe('DevOverlay', () => {
       }
       if (atom === autoModeEnabledAtom) {
         return autoModeEnabled as never;
-      }
-      if (atom === etaFallbackActiveAtom) {
-        return etaFallbackActive as never;
       }
       if (atom === etaPhaseAtom) {
         return etaPhase as never;
@@ -206,7 +197,7 @@ describe('DevOverlay', () => {
       jest
         .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
         .mockReturnValue(false);
-      setupAtomValues({ etaFallbackActive: false, etaPhase: null });
+      setupAtomValues({ etaPhase: null });
 
       const { getByTestId } = render(<DevOverlay />);
       expect(getByTestId('dev-overlay-eta-fallback-value')).toHaveTextContent(
@@ -217,12 +208,11 @@ describe('DevOverlay', () => {
       );
     });
 
-    it('ETAフォールバック稼働時は現在フェーズと対象駅・有効フラグを表示する', () => {
+    it('ETA推定フェーズがあるときは現在フェーズと対象駅・有効フラグを表示する', () => {
       jest
         .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
         .mockReturnValue(true);
       setupAtomValues({
-        etaFallbackActive: true,
         etaPhase: { kind: 'APPROACHING', targetStationId: 42 },
       });
 
@@ -235,13 +225,12 @@ describe('DevOverlay', () => {
       );
     });
 
-    it('ETAフォールバック稼働時(DWELLING)は停車駅IDを表示する', () => {
+    it('ETA推定フェーズが DWELLING のときは停車駅IDを表示する', () => {
       // DWELLINGは targetStationId ではなく stationId を参照するため別途検証する。
       jest
         .spyOn(remoteConfigModule, 'isEtaAssistEnabled')
         .mockReturnValue(true);
       setupAtomValues({
-        etaFallbackActive: true,
         etaPhase: { kind: 'DWELLING', stationId: 7 },
       });
 

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -825,33 +825,37 @@ const DevOverlay: React.FC = () => {
                   />
                 </View>
 
-                <View style={styles.landscapeSubGrid}>
-                  <MetricCard
-                    label="ETA FALLBACK"
-                    value={etaFallbackValue}
-                    meta={etaFallbackMeta}
-                    style={[{ width: leftMetricWidth }, metricCardStyle]}
-                    valueTestID="dev-overlay-eta-fallback-value"
-                    metaTestID="dev-overlay-eta-fallback-meta"
-                    labelStyle={metricLabelStyle}
-                    valueStyle={[
-                      metricValueStyle,
-                      etaPhase != null && styles.metricValueWarning,
-                    ]}
-                    metaStyle={metricMetaStyle}
-                  />
-                  <MetricCard
-                    label="ETA ANCHOR"
-                    value={etaAnchorValue}
-                    meta={etaAnchorMeta}
-                    style={[{ width: leftMetricWidth }, metricCardStyle]}
-                    valueTestID="dev-overlay-eta-anchor-value"
-                    metaTestID="dev-overlay-eta-anchor-meta"
-                    labelStyle={metricLabelStyle}
-                    valueStyle={metricValueStyle}
-                    metaStyle={metricMetaStyle}
-                  />
-                </View>
+                {etaAssistEnabled ? (
+                  <View style={styles.landscapeSubGrid}>
+                    <MetricCard
+                      label="ETA FALLBACK"
+                      value={etaFallbackValue}
+                      meta={etaFallbackMeta}
+                      style={[{ width: leftMetricWidth }, metricCardStyle]}
+                      valueTestID="dev-overlay-eta-fallback-value"
+                      metaTestID="dev-overlay-eta-fallback-meta"
+                      labelStyle={metricLabelStyle}
+                      valueStyle={[
+                        metricValueStyle,
+                        etaPhase != null &&
+                          isAccuracyWarning &&
+                          styles.metricValueWarning,
+                      ]}
+                      metaStyle={metricMetaStyle}
+                    />
+                    <MetricCard
+                      label="ETA ANCHOR"
+                      value={etaAnchorValue}
+                      meta={etaAnchorMeta}
+                      style={[{ width: leftMetricWidth }, metricCardStyle]}
+                      valueTestID="dev-overlay-eta-anchor-value"
+                      metaTestID="dev-overlay-eta-anchor-meta"
+                      labelStyle={metricLabelStyle}
+                      valueStyle={metricValueStyle}
+                      metaStyle={metricMetaStyle}
+                    />
+                  </View>
+                ) : null}
 
                 <Typography style={[styles.footerText, footerTextStyle]}>
                   LIVE SENSOR TRACE / INTERNAL BUILD
@@ -921,31 +925,37 @@ const DevOverlay: React.FC = () => {
                     valueStyle={metricValueStyle}
                     metaStyle={metricMetaStyle}
                   />
-                  <MetricCard
-                    label="ETA FALLBACK"
-                    value={etaFallbackValue}
-                    meta={etaFallbackMeta}
-                    style={[{ width: metricWidth }, metricCardStyle]}
-                    valueTestID="dev-overlay-eta-fallback-value"
-                    metaTestID="dev-overlay-eta-fallback-meta"
-                    labelStyle={metricLabelStyle}
-                    valueStyle={[
-                      metricValueStyle,
-                      etaPhase != null && styles.metricValueWarning,
-                    ]}
-                    metaStyle={metricMetaStyle}
-                  />
-                  <MetricCard
-                    label="ETA ANCHOR"
-                    value={etaAnchorValue}
-                    meta={etaAnchorMeta}
-                    style={[{ width: metricWidth }, metricCardStyle]}
-                    valueTestID="dev-overlay-eta-anchor-value"
-                    metaTestID="dev-overlay-eta-anchor-meta"
-                    labelStyle={metricLabelStyle}
-                    valueStyle={metricValueStyle}
-                    metaStyle={metricMetaStyle}
-                  />
+                  {etaAssistEnabled ? (
+                    <>
+                      <MetricCard
+                        label="ETA FALLBACK"
+                        value={etaFallbackValue}
+                        meta={etaFallbackMeta}
+                        style={[{ width: metricWidth }, metricCardStyle]}
+                        valueTestID="dev-overlay-eta-fallback-value"
+                        metaTestID="dev-overlay-eta-fallback-meta"
+                        labelStyle={metricLabelStyle}
+                        valueStyle={[
+                          metricValueStyle,
+                          etaPhase != null &&
+                            isAccuracyWarning &&
+                            styles.metricValueWarning,
+                        ]}
+                        metaStyle={metricMetaStyle}
+                      />
+                      <MetricCard
+                        label="ETA ANCHOR"
+                        value={etaAnchorValue}
+                        meta={etaAnchorMeta}
+                        style={[{ width: metricWidth }, metricCardStyle]}
+                        valueTestID="dev-overlay-eta-anchor-value"
+                        metaTestID="dev-overlay-eta-anchor-meta"
+                        labelStyle={metricLabelStyle}
+                        valueStyle={metricValueStyle}
+                        metaStyle={metricMetaStyle}
+                      />
+                    </>
+                  ) : null}
                 </View>
               </View>
             )}

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -21,11 +21,7 @@ import {
 } from '~/hooks';
 import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import { getMaxPermitAccuracy, isEtaAssistEnabled } from '~/lib/remoteConfig';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-  etaPhaseAtom,
-} from '~/store/atoms/etaFallback';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
@@ -358,10 +354,9 @@ const DevOverlay: React.FC = () => {
   const isBackgroundLocationTracking = useAtomValue(
     backgroundLocationTrackingAtom
   );
-  // ETAフォールバックの診断表示。有効フラグ(リモート設定)は非リアクティブなgetter、
-  // R2の稼働状態・推定フェーズ・アンカーはatomから購読する。
+  // ETA補助の診断表示。有効フラグ(リモート設定/手動トグル)は非リアクティブなgetter、
+  // 推定フェーズ・アンカーはatomから購読する。
   const etaAssistEnabled = isEtaAssistEnabled();
-  const isEtaFallbackActive = useAtomValue(etaFallbackActiveAtom);
   const etaPhase = useAtomValue(etaPhaseAtom);
   const etaAnchor = useAtomValue(etaAnchorAtom);
 
@@ -415,10 +410,8 @@ const DevOverlay: React.FC = () => {
   const versionLabel = `TrainLCD DO ${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`;
   const telemetryValue = isTelemetryEnabled ? 'ON' : 'OFF';
   const backgroundValue = isBackgroundLocationTracking ? 'ON' : 'OFF';
-  // 稼働中は現在フェーズ(RUNNING/APPROACHING/DWELLING)を、非稼働時は IDLE を表示する。
-  const etaFallbackValue = isEtaFallbackActive
-    ? (etaPhase?.kind ?? 'ACTIVE')
-    : 'IDLE';
+  // ETA推定フェーズ(RUNNING/APPROACHING/DWELLING)を表示。フェーズ未推定時は IDLE。
+  const etaFallbackValue = etaPhase?.kind ?? 'IDLE';
   // 推定対象の駅ID(走行/接近中は目標駅、停車中は当該駅)。
   const etaPhaseTargetId =
     etaPhase == null
@@ -843,7 +836,7 @@ const DevOverlay: React.FC = () => {
                     labelStyle={metricLabelStyle}
                     valueStyle={[
                       metricValueStyle,
-                      isEtaFallbackActive && styles.metricValueWarning,
+                      etaPhase != null && styles.metricValueWarning,
                     ]}
                     metaStyle={metricMetaStyle}
                   />
@@ -938,7 +931,7 @@ const DevOverlay: React.FC = () => {
                     labelStyle={metricLabelStyle}
                     valueStyle={[
                       metricValueStyle,
-                      isEtaFallbackActive && styles.metricValueWarning,
+                      etaPhase != null && styles.metricValueWarning,
                     ]}
                     metaStyle={metricMetaStyle}
                   />

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -43,7 +43,10 @@ import {
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import { storage } from '../lib/storage';
 import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
-import { portraitModeEnabledAtom } from '../store/atoms/experimental';
+import {
+  etaAssistManualEnabledAtom,
+  portraitModeEnabledAtom,
+} from '../store/atoms/experimental';
 import navigationState, {
   autoModeEnabledAtom,
   isAppLatestAtom,
@@ -75,6 +78,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setNotify = useSetAtom(notifyState);
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
   const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
+  const setEtaAssistManualEnabled = useSetAtom(etaAssistManualEnabledAtom);
   const { enabled: pictureInPictureEnabled, active: pictureInPictureActive } =
     useAtomValue(pictureInPictureAtom);
   const isAppActive = useIsAppActive();
@@ -436,6 +440,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       const portraitModeEnabledStr = storage.getString(
         STORAGE_KEYS.PORTRAIT_MODE_ENABLED
       );
+      const etaAssistManualEnabledStr = storage.getString(
+        STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED
+      );
 
       if (themePreferenceKey) {
         setThemePreference(themePreferenceKey as ThemePreference);
@@ -545,6 +552,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       if (portraitModeEnabledStr) {
         setPortraitModeEnabled(portraitModeEnabledStr === 'true');
       }
+      if (etaAssistManualEnabledStr) {
+        setEtaAssistManualEnabled(etaAssistManualEnabledStr === 'true');
+      }
     };
 
     loadSettings();
@@ -556,6 +566,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     setNotify,
     setPictureInPicture,
     setPortraitModeEnabled,
+    setEtaAssistManualEnabled,
   ]);
 
   useEffect(() => {

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -36,6 +36,7 @@ export const STORAGE_KEYS = {
   WRONG_DIRECTION_NOTIFY_ENABLED: '@TrainLCD:wrongDirectionNotifyEnabled',
   PICTURE_IN_PICTURE_ENABLED: '@TrainLCD:pictureInPictureEnabled',
   PORTRAIT_MODE_ENABLED: '@TrainLCD:portraitModeEnabled',
+  ETA_ASSIST_MANUAL_ENABLED: '@TrainLCD:etaAssistManualEnabled',
 } as const;
 
 export type StorageKeys = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -3,6 +3,7 @@ import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
 import { store as globalStore } from '~/store';
+import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import { createStation } from '~/utils/test/factories';
 import {
   etaAnchorAtom,
@@ -132,6 +133,28 @@ describe('useEtaAnchor', () => {
       stationId: stationA.id,
       kind: 'AT_STATION',
       observedAtMs: 5_000_000,
+    });
+  });
+
+  it('実移動はあったが MOVING_RECENCY_MS を超えて古い場合は DEPARTED を記録しない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(6_000_000);
+    // 実移動の観測はあるが有効期間(90秒)より前=期限切れ。発車判定の時間しきい値を跨いだ
+    // 直後に強制未到着で false へ倒れても、偽発車として記録しないことを検証する。
+    globalStore.set(lastMovingAtMsAtom, 6_000_000 - MOVING_RECENCY_MS - 1_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
+
+    jest.spyOn(Date, 'now').mockReturnValue(6_001_000);
+    act(() => {
+      store.set(arrivedAtom, false);
+    });
+
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'AT_STATION',
+      observedAtMs: 6_000_000,
     });
   });
 

--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -2,11 +2,13 @@ import { act, renderHook } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
+import { store as globalStore } from '~/store';
 import { createStation } from '~/utils/test/factories';
 import {
   etaAnchorAtom,
   etaFallbackActiveAtom,
 } from '../store/atoms/etaFallback';
+import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -46,6 +48,8 @@ describe('useEtaAnchor', () => {
   });
 
   afterEach(() => {
+    // useEtaAnchor は lastMovingAtMs をシングルトンストアから読むためリセットする。
+    globalStore.set(lastMovingAtMsAtom, null);
     jest.clearAllMocks();
     jest.useRealTimers();
   });
@@ -75,8 +79,10 @@ describe('useEtaAnchor', () => {
     });
   });
 
-  it('arrived が true→false に遷移すると DEPARTED が一発記録され、その後falseのままでは上書きされない', () => {
+  it('直近に実移動があれば arrived true→false で DEPARTED が一発記録され、その後falseのままでは上書きされない', () => {
     jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
+    // 直近に実移動を観測済み(=電車が動いていた)。これがないと発車とみなさない。
+    globalStore.set(lastMovingAtMsAtom, 2_000_000);
     const store = createStore();
 
     renderWithStore(store, { arrived: true, station: stationA });
@@ -103,6 +109,29 @@ describe('useEtaAnchor', () => {
       stationId: stationA.id,
       kind: 'DEPARTED',
       observedAtMs: 2_001_000,
+    });
+  });
+
+  it('実移動が無い(静止中に精度悪化で arrived が false)場合は DEPARTED を記録しない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(5_000_000);
+    // lastMovingAtMs は未設定(null)=直近に実移動なし。駅で待機中に強制未到着で
+    // arrived が false に倒れただけの状況を模す。
+    globalStore.set(lastMovingAtMsAtom, null);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
+
+    jest.spyOn(Date, 'now').mockReturnValue(5_001_000);
+    act(() => {
+      store.set(arrivedAtom, false);
+    });
+
+    // 偽発車は記録されず、直前の AT_STATION アンカーが保持される。
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'AT_STATION',
+      observedAtMs: 5_000_000,
     });
   });
 

--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -2,11 +2,8 @@ import { act, renderHook } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
-import { store as globalStore } from '~/store';
-import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import { createStation } from '~/utils/test/factories';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
-import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -44,8 +41,6 @@ describe('useEtaAnchor', () => {
   });
 
   afterEach(() => {
-    // useEtaAnchor は lastMovingAtMs をシングルトンストアから読むためリセットする。
-    globalStore.set(lastMovingAtMsAtom, null);
     jest.clearAllMocks();
     jest.useRealTimers();
   });
@@ -75,10 +70,8 @@ describe('useEtaAnchor', () => {
     });
   });
 
-  it('直近に実移動があれば arrived true→false で DEPARTED が一発記録され、その後falseのままでは上書きされない', () => {
+  it('arrived true→false 遷移で DEPARTED が一発記録され、その後falseのままでは上書きされない', () => {
     jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
-    // 直近に実移動を観測済み(=電車が動いていた)。これがないと発車とみなさない。
-    globalStore.set(lastMovingAtMsAtom, 2_000_000);
     const store = createStore();
 
     renderWithStore(store, { arrived: true, station: stationA });
@@ -105,51 +98,6 @@ describe('useEtaAnchor', () => {
       stationId: stationA.id,
       kind: 'DEPARTED',
       observedAtMs: 2_001_000,
-    });
-  });
-
-  it('実移動が無い(静止中に精度悪化で arrived が false)場合は DEPARTED を記録しない', () => {
-    jest.spyOn(Date, 'now').mockReturnValue(5_000_000);
-    // lastMovingAtMs は未設定(null)=直近に実移動なし。駅で待機中に強制未到着で
-    // arrived が false に倒れただけの状況を模す。
-    globalStore.set(lastMovingAtMsAtom, null);
-    const store = createStore();
-
-    renderWithStore(store, { arrived: true, station: stationA });
-    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
-
-    jest.spyOn(Date, 'now').mockReturnValue(5_001_000);
-    act(() => {
-      store.set(arrivedAtom, false);
-    });
-
-    // 偽発車は記録されず、直前の AT_STATION アンカーが保持される。
-    expect(store.get(etaAnchorAtom)).toEqual({
-      stationId: stationA.id,
-      kind: 'AT_STATION',
-      observedAtMs: 5_000_000,
-    });
-  });
-
-  it('実移動はあったが MOVING_RECENCY_MS を超えて古い場合は DEPARTED を記録しない', () => {
-    jest.spyOn(Date, 'now').mockReturnValue(6_000_000);
-    // 実移動の観測はあるが有効期間(90秒)より前=期限切れ。発車判定の時間しきい値を跨いだ
-    // 直後に強制未到着で false へ倒れても、偽発車として記録しないことを検証する。
-    globalStore.set(lastMovingAtMsAtom, 6_000_000 - MOVING_RECENCY_MS - 1_000);
-    const store = createStore();
-
-    renderWithStore(store, { arrived: true, station: stationA });
-    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
-
-    jest.spyOn(Date, 'now').mockReturnValue(6_001_000);
-    act(() => {
-      store.set(arrivedAtom, false);
-    });
-
-    expect(store.get(etaAnchorAtom)).toEqual({
-      stationId: stationA.id,
-      kind: 'AT_STATION',
-      observedAtMs: 6_000_000,
     });
   });
 

--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -5,10 +5,7 @@ import type { Station } from '~/@types/graphql';
 import { store as globalStore } from '~/store';
 import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import { createStation } from '~/utils/test/factories';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-} from '../store/atoms/etaFallback';
+import { etaAnchorAtom } from '../store/atoms/etaFallback';
 import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
@@ -29,13 +26,11 @@ const renderWithStore = (
     arrived = true,
     station = stationA as Station | null,
     selectedBound = boundStation as Station | null,
-    etaFallbackActive = false,
   } = {}
 ) => {
   store.set(arrivedAtom, arrived);
   store.set(stationAtom, station);
   store.set(selectedBoundAtom, selectedBound);
-  store.set(etaFallbackActiveAtom, etaFallbackActive);
 
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <Provider store={store}>{children}</Provider>
@@ -156,32 +151,6 @@ describe('useEtaAnchor', () => {
       kind: 'AT_STATION',
       observedAtMs: 6_000_000,
     });
-  });
-
-  it('etaFallbackActiveAtom が true の間は記録されない', () => {
-    jest.spyOn(Date, 'now').mockReturnValue(3_000_000);
-    const store = createStore();
-
-    renderWithStore(store, {
-      arrived: true,
-      station: stationA,
-      etaFallbackActive: true,
-    });
-
-    expect(store.get(etaAnchorAtom)).toBeNull();
-
-    jest.spyOn(Date, 'now').mockReturnValue(3_005_000);
-    act(() => {
-      jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
-    });
-
-    expect(store.get(etaAnchorAtom)).toBeNull();
-
-    // 発車遷移が起きても、フォールバック活性中は記録しない
-    act(() => {
-      store.set(arrivedAtom, false);
-    });
-    expect(store.get(etaAnchorAtom)).toBeNull();
   });
 
   it('selectedBound が null になると anchor が null にクリアされる', () => {

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -1,9 +1,12 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
+import { store } from '~/store';
+import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import {
   etaAnchorAtom,
   etaFallbackActiveAtom,
 } from '../store/atoms/etaFallback';
+import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -56,12 +59,20 @@ export const useEtaAnchor = (): void => {
         observedAtMs: Date.now(),
       });
     } else if (prevArrived && !arrived && prevStation?.id != null) {
-      // 到着中→非到着への遷移(=発車)を検出した瞬間にだけ一発記録する
-      setAnchor({
-        stationId: prevStation.id,
-        kind: 'DEPARTED',
-        observedAtMs: Date.now(),
-      });
+      // 到着中→非到着への遷移。ただし精度悪化(強制未到着)で静止のまま arrived が
+      // false に倒れただけの場合は「発車」ではない。直近に実移動が観測された時だけ
+      // DEPARTED として記録し、駅で待機中の偽発車→位置前進を防ぐ(motion gate)。
+      const lastMovingAtMs = store.get(lastMovingAtMsAtom);
+      const recentlyMoving =
+        lastMovingAtMs != null &&
+        Date.now() - lastMovingAtMs < MOVING_RECENCY_MS;
+      if (recentlyMoving) {
+        setAnchor({
+          stationId: prevStation.id,
+          kind: 'DEPARTED',
+          observedAtMs: Date.now(),
+        });
+      }
     }
 
     prevArrivedRef.current = arrived;

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -2,10 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
 import { store } from '~/store';
 import { isRecentlyMoving } from '~/utils/etaFallback';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-} from '../store/atoms/etaFallback';
+import { etaAnchorAtom } from '../store/atoms/etaFallback';
 import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
@@ -20,15 +17,13 @@ const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
 
 /**
  * GPSで最後に確定した駅イベント(到着中/発車)を etaAnchorAtom へ記録するフック。
- * ETAフォールバック(GPS精度劣化・喪失時にETAデータで接近/到着状態を推定する機能)の
- * 仮想時計の起点として使われるため、フォールバック活性中(ETA由来の推定状態を
- * 誤って観測してしまう間)は記録を止め、直近のGPS実測アンカーを保持し続ける。
+ * このアンカーは ETA 推定フェーズ(etaPhaseAtom)の仮想時計の起点として使われ、
+ * 精度劣化時の到着しきい値緩和(R1)の対象駅判定に用いられる。
  */
 export const useEtaAnchor = (): void => {
   const arrived = useAtomValue(arrivedAtom);
   const station = useAtomValue(stationAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
-  const etaFallbackActive = useAtomValue(etaFallbackActiveAtom);
   const setAnchor = useSetAtom(etaAnchorAtom);
 
   // 直前レンダー時点の arrived/station を保持し、true→false 遷移(=発車)の検出に使う。
@@ -42,9 +37,8 @@ export const useEtaAnchor = (): void => {
     const prevArrived = prevArrivedRef.current;
     const prevStation = prevStationRef.current;
 
-    if (etaFallbackActive || selectedBound == null) {
-      // フォールバック活性中(ETA由来の状態を観測してしまう)・行き先未選択中は
-      // 記録しない。行き先未選択中に記録すると、下の clear effect と競合して
+    if (selectedBound == null) {
+      // 行き先未選択中は記録しない。記録すると、下の clear effect と競合して
       // 古いアンカーが復活し、次回選択時のETA推定起点が汚染される。
       // ただし遷移検出用のrefは更新し、ガード解除後に古い遷移を誤検出しないようにする。
       prevArrivedRef.current = arrived;
@@ -77,17 +71,12 @@ export const useEtaAnchor = (): void => {
 
     prevArrivedRef.current = arrived;
     prevStationRef.current = station;
-  }, [arrived, station, selectedBound, etaFallbackActive, setAnchor]);
+  }, [arrived, station, selectedBound, setAnchor]);
 
   // arrived/station が変化しない間も経過時間だけは進むため、数秒おきに
   // observedAtMsを更新し続ける(仮想時計の基準時刻を最新に保つ)
   useInterval(() => {
-    if (
-      selectedBound != null &&
-      !etaFallbackActive &&
-      arrived &&
-      station?.id != null
-    ) {
+    if (selectedBound != null && arrived && station?.id != null) {
       setAnchor({
         stationId: station.id,
         kind: 'AT_STATION',

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
 import { store } from '~/store';
-import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
+import { isRecentlyMoving } from '~/utils/etaFallback';
 import {
   etaAnchorAtom,
   etaFallbackActiveAtom,
@@ -62,10 +62,10 @@ export const useEtaAnchor = (): void => {
       // 到着中→非到着への遷移。ただし精度悪化(強制未到着)で静止のまま arrived が
       // false に倒れただけの場合は「発車」ではない。直近に実移動が観測された時だけ
       // DEPARTED として記録し、駅で待機中の偽発車→位置前進を防ぐ(motion gate)。
-      const lastMovingAtMs = store.get(lastMovingAtMsAtom);
-      const recentlyMoving =
-        lastMovingAtMs != null &&
-        Date.now() - lastMovingAtMs < MOVING_RECENCY_MS;
+      const recentlyMoving = isRecentlyMoving(
+        store.get(lastMovingAtMsAtom),
+        Date.now()
+      );
       if (recentlyMoving) {
         setAnchor({
           stationId: prevStation.id,

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -1,9 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
-import { store } from '~/store';
-import { isRecentlyMoving } from '~/utils/etaFallback';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
-import { lastMovingAtMsAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -53,20 +50,14 @@ export const useEtaAnchor = (): void => {
         observedAtMs: Date.now(),
       });
     } else if (prevArrived && !arrived && prevStation?.id != null) {
-      // 到着中→非到着への遷移。ただし精度悪化(強制未到着)で静止のまま arrived が
-      // false に倒れただけの場合は「発車」ではない。直近に実移動が観測された時だけ
-      // DEPARTED として記録し、駅で待機中の偽発車→位置前進を防ぐ(motion gate)。
-      const recentlyMoving = isRecentlyMoving(
-        store.get(lastMovingAtMsAtom),
-        Date.now()
-      );
-      if (recentlyMoving) {
-        setAnchor({
-          stationId: prevStation.id,
-          kind: 'DEPARTED',
-          observedAtMs: Date.now(),
-        });
-      }
+      // 到着中→非到着への遷移(=発車)を検出した瞬間にだけ一発記録する。ETAは位置を
+      // 駆動せず到着しきい値の緩和(R1)にしか使わないため、仮に静止中の強制未到着で
+      // 記録されても、R1は最寄り駅とETA停車駅が一致するときだけ効き、GPS復帰で自己修復する。
+      setAnchor({
+        stationId: prevStation.id,
+        kind: 'DEPARTED',
+        observedAtMs: Date.now(),
+      });
     }
 
     prevArrivedRef.current = arrived;

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -4,11 +4,7 @@ import type { ReactNode } from 'react';
 import type { Station } from '~/@types/graphql';
 import * as remoteConfigModule from '~/lib/remoteConfig';
 import { store } from '~/store';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-  etaPhaseAtom,
-} from '~/store/atoms/etaFallback';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
 import { locationAtom } from '~/store/atoms/location';
 import {
   approachingAtom,
@@ -124,7 +120,6 @@ describe('useEtaFallback', () => {
       observedAtMs: T0,
     });
     store.set(etaPhaseAtom, null);
-    store.set(etaFallbackActiveAtom, false);
     store.set(arrivedAtom, false);
     store.set(approachingAtom, false);
     store.set(stationAtom, STATIONS[0]);
@@ -182,7 +177,7 @@ describe('useEtaFallback', () => {
     expect(store.get(etaPhaseAtom)).toBeNull();
   });
 
-  it('到着・接近・現在駅・位置・活性フラグは一切駆動しない(GPSが唯一の権威)', () => {
+  it('到着・接近・現在駅・位置は一切駆動しない(GPSが唯一の権威)', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
     // ETA上は到着帯(DWELLING)へ進む時刻でも、状態は書き換えないこと。
@@ -194,11 +189,10 @@ describe('useEtaFallback', () => {
       kind: 'DWELLING',
       stationId: 2,
     });
-    // …到着/接近/現在駅/位置/活性フラグはすべて初期値のまま。
+    // …到着/接近/現在駅/位置はすべて初期値のまま。
     expect(store.get(arrivedAtom)).toBe(false);
     expect(store.get(approachingAtom)).toBe(false);
     expect(store.get(stationAtom)?.id).toBe(1);
     expect(store.get(locationAtom)).toBe(BASE_LOCATION);
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
   });
 });

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   lastAcceptedFixAccuracyAtom,
   lastAcceptedFixAtMsAtom,
+  lastMovingAtMsAtom,
   locationAccuracyOutlierAtom,
   locationAtom,
 } from '~/store/atoms/location';
@@ -23,6 +24,7 @@ import {
   stationAtom,
   stationsAtom,
 } from '~/store/atoms/station';
+import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useEtaFallback } from './useEtaFallback';
 
@@ -75,6 +77,8 @@ const STATIONS = [
 ];
 
 const T0 = 1_000_000;
+// GPS喪失(外れ値/精度劣化)が発動するまでの持続閾値。フック内 GPS_LOST_SUSTAIN_MS と同じ。
+const SUSTAIN_MS = 20_000;
 let now = T0;
 
 const setNow = (value: number) => {
@@ -87,6 +91,16 @@ const runTick = () => {
   act(() => {
     jest.advanceTimersByTime(1000);
   });
+};
+
+// GPS喪失(外れ値)が持続閾値を超え、かつ直近に実移動がある状態でフォールバックを発動させる。
+// 1tick目で劣化の起点を記録し、2tick目(持続20秒超)で発動する。発動時の仮想時計は
+// m = 発車累積0.5 + 22秒 ≒ 0.87 分でまだ走行中(RUNNING)。
+const activate = () => {
+  setNow(T0 + 1000);
+  runTick();
+  setNow(T0 + SUSTAIN_MS + 2000);
+  runTick();
 };
 
 const mockRoute = (route: unknown) => {
@@ -113,7 +127,9 @@ describe('useEtaFallback', () => {
 
     mockRoute({ id: 1, stops: STOPS });
 
-    // 既定: ナビ中・autoMode無効・A発車アンカー・GPS外れ値(=喪失)
+    // 既定: ナビ中・autoMode無効・A発車アンカー・GPS外れ値(=喪失)・直近に実移動あり。
+    // lastMovingAtMs は最後の受理測位時刻(T0)と一致させ(実移動は受理測位時にのみ記録される
+    // ため lastMovingAtMs <= lastAcceptedFixAtMs が不変条件)、発動ゲート recentlyMoving を満たす。
     store.set(stationsAtom, STATIONS);
     store.set(selectedBoundAtom, station(3, 35.2, 139.2));
     store.set(autoModeEnabledAtom, false);
@@ -130,6 +146,7 @@ describe('useEtaFallback', () => {
     store.set(locationAccuracyOutlierAtom, true);
     store.set(lastAcceptedFixAtMsAtom, T0);
     store.set(lastAcceptedFixAccuracyAtom, 30);
+    store.set(lastMovingAtMsAtom, T0);
     store.set(locationAtom, {
       timestamp: T0,
       coords: {
@@ -149,11 +166,10 @@ describe('useEtaFallback', () => {
     jest.useRealTimers();
   });
 
-  it('GPS外れ値・アンカーあり・有効時に発動し、発車直後は走行中(未到着・未接近)を駆動する', () => {
+  it('GPS喪失が持続・直近に実移動あり・アンカーありで発動し、発車直後は走行中(未到着・未接近)を駆動する', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000); // A発車から1秒: まだB到着(2分)には遠い
-    runTick();
+    activate();
 
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
     expect(store.get(arrivedAtom)).toBe(false);
@@ -164,6 +180,9 @@ describe('useEtaFallback', () => {
 
   it('B到着時刻+マージン経過で到着を駆動し、駅座標をlocationAtomへスナップする', () => {
     renderHook(() => useEtaFallback(), { wrapper });
+
+    activate();
+    expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
     // 仮想時計 m = 発車累積0.5 + 経過分。B停車帯は m∈[2.5, 3.0)。
     // 経過2.2分 → m=2.7 → DWELLING(B)。
@@ -182,6 +201,8 @@ describe('useEtaFallback', () => {
   it('B到着直前(マージン内)は接近(まもなく)に留める', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
+    activate();
+
     // 仮想時計 m = 発車累積0.5 + 経過分。B接近帯は m∈[到着2.0-lead0.6, 確定2.5)=[1.4,2.5)。
     // 経過1.2分 → m=1.7 → APPROACHING(B)。
     setNow(T0 + 1.2 * 60_000);
@@ -198,12 +219,11 @@ describe('useEtaFallback', () => {
   it('中途半端な測位(200〜1500m)では解除せず、良好測位(≤200m)で解除する', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000);
-    runTick();
+    activate();
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
     // 800mの測位が受理された(外れ値解除・lastFix更新)が、ヒステリシスで解除しない
-    setNow(T0 + 2000);
+    setNow(T0 + SUSTAIN_MS + 3000);
     store.set(locationAccuracyOutlierAtom, false);
     store.set(lastAcceptedFixAtMsAtom, now);
     store.set(lastAcceptedFixAccuracyAtom, 800);
@@ -223,7 +243,7 @@ describe('useEtaFallback', () => {
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
     // 良好測位(50m)を受理 → 解除
-    setNow(T0 + 3000);
+    setNow(T0 + SUSTAIN_MS + 4000);
     store.set(lastAcceptedFixAtMsAtom, now);
     store.set(lastAcceptedFixAccuracyAtom, 50);
     store.set(locationAtom, {
@@ -250,12 +270,11 @@ describe('useEtaFallback', () => {
       .mockReturnValue(0.01);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000);
-    runTick();
+    activate();
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
-    // 発動(T0+1秒)から0.01分(0.6秒)を超過。ETAフェーズはまだRUNNINGのまま。
-    setNow(T0 + 2000);
+    // 発動(T0+22秒)から0.01分(0.6秒)を超過。ETAフェーズはまだRUNNINGのまま。
+    setNow(T0 + SUSTAIN_MS + 3000);
     runTick();
     expect(store.get(etaFallbackActiveAtom)).toBe(false);
   });
@@ -264,21 +283,130 @@ describe('useEtaFallback', () => {
     jest.spyOn(remoteConfigModule, 'isEtaAssistEnabled').mockReturnValue(false);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000);
-    runTick();
+    activate();
 
     expect(store.get(etaFallbackActiveAtom)).toBe(false);
     expect(store.get(etaPhaseAtom)).toBeNull();
   });
 
-  it('GPSが健全(外れ値なし・良好精度)なら発動しない', () => {
+  it('GPSが健全(外れ値なし・良好精度・受理測位が新しい)なら発動しない', () => {
     store.set(locationAccuracyOutlierAtom, false);
     renderHook(() => useEtaFallback(), { wrapper });
 
+    // 良好測位が流れ続ける限り劣化とみなされず、持続喪失ゲートも成立しない。
     setNow(T0 + 1000);
+    store.set(lastAcceptedFixAtMsAtom, now);
     runTick();
 
     expect(store.get(etaFallbackActiveAtom)).toBe(false);
+  });
+
+  it('GPS喪失が一瞬(持続20秒未満)では発動しない', () => {
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    // 外れ値だが劣化継続はまだ数秒。持続喪失ゲート(20秒)を満たさないため発動しない。
+    setNow(T0 + 1000);
+    runTick();
+    expect(store.get(etaFallbackActiveAtom)).toBe(false);
+
+    setNow(T0 + 5000);
+    runTick();
+    expect(store.get(etaFallbackActiveAtom)).toBe(false);
+  });
+
+  it('直近に実移動がなければ(駅で静止・待機)GPS喪失が持続しても発動しない', () => {
+    // lastMovingAtMs を発動有効期間より前に置く=直近に電車が動いた証拠がない。
+    store.set(lastMovingAtMsAtom, T0 - MOVING_RECENCY_MS - 10_000);
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    activate();
+
+    // 持続喪失は満たすが recentlyMoving が偽なので発動しない(待機中の誤前進を防ぐ)。
+    expect(store.get(etaFallbackActiveAtom)).toBe(false);
+  });
+
+  it('AT_STATIONアンカーでは出発を確認するまで前進せず、現在駅でホールドする', () => {
+    // B(id2)に到着済み・現在位置もB座標のまま(まだ発車していない)。
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'AT_STATION',
+      observedAtMs: T0,
+    });
+    store.set(arrivedAtom, true);
+    store.set(stationAtom, STATIONS[1]);
+    store.set(locationAtom, {
+      timestamp: T0,
+      coords: {
+        latitude: 35.1,
+        longitude: 139.1,
+        accuracy: 0,
+        altitude: null,
+        altitudeAccuracy: null,
+        speed: null,
+        heading: null,
+      },
+    });
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    activate();
+    expect(store.get(etaFallbackActiveAtom)).toBe(true);
+
+    // 十分に時間が経過し仮想時計上は次駅へ進むはずでも、位置がB駅から離れない限り
+    // 前進させずBでホールドし続ける(待機中に位置が勝手に進む誤動作を防ぐ)。
+    setNow(T0 + 5 * 60_000);
+    runTick();
+
+    expect(store.get(arrivedAtom)).toBe(true);
+    expect(store.get(approachingAtom)).toBe(false);
+    expect(store.get(stationAtom)?.id).toBe(2);
+  });
+
+  it('AT_STATIONアンカーでも位置が駅から離れれば出発を確認して前進駆動する', () => {
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'AT_STATION',
+      observedAtMs: T0,
+    });
+    store.set(arrivedAtom, true);
+    store.set(stationAtom, STATIONS[1]);
+    store.set(locationAtom, {
+      timestamp: T0,
+      coords: {
+        latitude: 35.1,
+        longitude: 139.1,
+        accuracy: 0,
+        altitude: null,
+        altitudeAccuracy: null,
+        speed: null,
+        heading: null,
+      },
+    });
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    activate();
+    // 発動直後はまだBでホールド(位置がBのまま)。
+    expect(store.get(stationAtom)?.id).toBe(2);
+    expect(store.get(arrivedAtom)).toBe(true);
+
+    // 現在位置がB駅から明確に離れた(=実際に発車した)。以降は通常どおり前進駆動。
+    store.set(locationAtom, {
+      timestamp: now,
+      coords: {
+        latitude: 35.2,
+        longitude: 139.2,
+        accuracy: 30,
+        altitude: null,
+        altitudeAccuracy: null,
+        speed: null,
+        heading: null,
+      },
+    });
+    // 経過3分 → 仮想時計は終端C(id3)方面。出発確認済みなので前進する。
+    setNow(T0 + 3 * 60_000);
+    runTick();
+
+    expect(store.get(stationAtom)?.id).toBe(3);
+    expect(store.get(arrivedAtom)).toBe(true);
   });
 
   it('DWELLING駅がstationsAtom上に見つからない場合は解除して凍結を防ぐ', () => {
@@ -286,9 +414,7 @@ describe('useEtaFallback', () => {
     store.set(stationsAtom, [STATIONS[0], STATIONS[2]]);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    // 発動(走行中)
-    setNow(T0 + 1000);
-    runTick();
+    activate();
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
     // B停車帯(m∈[2.5,3.0))へ進める → Bが見つからず解除

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { Provider } from 'jotai';
 import type { ReactNode } from 'react';
-import type { Station } from '~/@types/graphql';
 import * as remoteConfigModule from '~/lib/remoteConfig';
 import { store } from '~/store';
 import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
@@ -13,6 +12,7 @@ import {
   stationAtom,
   stationsAtom,
 } from '~/store/atoms/station';
+import { createStation } from '~/utils/test/factories';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useEtaFallback } from './useEtaFallback';
 
@@ -43,25 +43,13 @@ const routeStop = (
   stopsHere,
 });
 
-const station = (id: number, lat: number, lng: number): Station =>
-  ({
-    id,
-    groupId: id,
-    latitude: lat,
-    longitude: lng,
-  }) as unknown as Station;
-
 // A(id1) 発 → B(id2, 到着2分/発車2.5分) → C(id3, 到着4分/発車4.5分)
 const STOPS = [
   routeStop(1, 0, 0.5),
   routeStop(2, 2, 2.5),
   routeStop(3, 4, 4.5),
 ];
-const STATIONS = [
-  station(1, 35.0, 139.0),
-  station(2, 35.1, 139.1),
-  station(3, 35.2, 139.2),
-];
+const STATIONS = [createStation(1), createStation(2), createStation(3)];
 
 const T0 = 1_000_000;
 let now = T0;
@@ -113,7 +101,7 @@ describe('useEtaFallback', () => {
     mockRoute({ id: 1, stops: STOPS });
 
     store.set(stationsAtom, STATIONS);
-    store.set(selectedBoundAtom, station(3, 35.2, 139.2));
+    store.set(selectedBoundAtom, createStation(3));
     store.set(etaAnchorAtom, {
       stationId: 1,
       kind: 'DEPARTED',

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -9,14 +9,7 @@ import {
   etaFallbackActiveAtom,
   etaPhaseAtom,
 } from '~/store/atoms/etaFallback';
-import {
-  lastAcceptedFixAccuracyAtom,
-  lastAcceptedFixAtMsAtom,
-  lastMovingAtMsAtom,
-  locationAccuracyOutlierAtom,
-  locationAtom,
-} from '~/store/atoms/location';
-import { autoModeEnabledAtom } from '~/store/atoms/navigation';
+import { locationAtom } from '~/store/atoms/location';
 import {
   approachingAtom,
   arrivedAtom,
@@ -24,7 +17,6 @@ import {
   stationAtom,
   stationsAtom,
 } from '~/store/atoms/station';
-import { MOVING_RECENCY_MS } from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useEtaFallback } from './useEtaFallback';
 
@@ -42,7 +34,6 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <Provider store={store}>{children}</Provider>
 );
 
-// stopsHere / 累積分を持つルート stop を最小構成で作る
 const routeStop = (
   stationId: number,
   cumulativeMinutes: number,
@@ -77,30 +68,16 @@ const STATIONS = [
 ];
 
 const T0 = 1_000_000;
-// GPS喪失(外れ値/精度劣化)が発動するまでの持続閾値。フック内 GPS_LOST_SUSTAIN_MS と同じ。
-const SUSTAIN_MS = 20_000;
 let now = T0;
 
 const setNow = (value: number) => {
   now = value;
 };
 
-// 1tick分だけインターバルを進める。tickはDate.now()を読むので、
-// 事前に setNow で仮想時刻を目標へ合わせておけばその時刻で評価される。
 const runTick = () => {
   act(() => {
     jest.advanceTimersByTime(1000);
   });
-};
-
-// GPS喪失(外れ値)が持続閾値を超え、かつ直近に実移動がある状態でフォールバックを発動させる。
-// 1tick目で劣化の起点を記録し、2tick目(持続20秒超)で発動する。発動時の仮想時計は
-// m = 発車累積0.5 + 22秒 ≒ 0.87 分でまだ走行中(RUNNING)。
-const activate = () => {
-  setNow(T0 + 1000);
-  runTick();
-  setNow(T0 + SUSTAIN_MS + 2000);
-  runTick();
 };
 
 const mockRoute = (route: unknown) => {
@@ -109,6 +86,21 @@ const mockRoute = (route: unknown) => {
     loading: false,
     error: null,
   } as never);
+};
+
+// 現在駅・到着・接近・位置の初期値。R2撤去後は useEtaFallback がこれらを一切書き換えない
+// ことを検証するための基準値として使う。
+const BASE_LOCATION = {
+  timestamp: T0,
+  coords: {
+    latitude: 35.0,
+    longitude: 139.0,
+    accuracy: 30,
+    altitude: null,
+    altitudeAccuracy: null,
+    speed: null,
+    heading: null,
+  },
 };
 
 describe('useEtaFallback', () => {
@@ -121,44 +113,22 @@ describe('useEtaFallback', () => {
     jest
       .spyOn(remoteConfigModule, 'getEtaFallbackArrivalConfirmMarginSec')
       .mockReturnValue(30);
-    jest
-      .spyOn(remoteConfigModule, 'getEtaFallbackMaxDurationMin')
-      .mockReturnValue(30);
 
     mockRoute({ id: 1, stops: STOPS });
 
-    // 既定: ナビ中・autoMode無効・A発車アンカー・GPS外れ値(=喪失)・直近に実移動あり。
-    // lastMovingAtMs は最後の受理測位時刻(T0)と一致させ(実移動は受理測位時にのみ記録される
-    // ため lastMovingAtMs <= lastAcceptedFixAtMs が不変条件)、発動ゲート recentlyMoving を満たす。
     store.set(stationsAtom, STATIONS);
     store.set(selectedBoundAtom, station(3, 35.2, 139.2));
-    store.set(autoModeEnabledAtom, false);
     store.set(etaAnchorAtom, {
       stationId: 1,
       kind: 'DEPARTED',
       observedAtMs: T0,
     });
-    store.set(etaFallbackActiveAtom, false);
     store.set(etaPhaseAtom, null);
+    store.set(etaFallbackActiveAtom, false);
     store.set(arrivedAtom, false);
     store.set(approachingAtom, false);
     store.set(stationAtom, STATIONS[0]);
-    store.set(locationAccuracyOutlierAtom, true);
-    store.set(lastAcceptedFixAtMsAtom, T0);
-    store.set(lastAcceptedFixAccuracyAtom, 30);
-    store.set(lastMovingAtMsAtom, T0);
-    store.set(locationAtom, {
-      timestamp: T0,
-      coords: {
-        latitude: 35.0,
-        longitude: 139.0,
-        accuracy: 30,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
+    store.set(locationAtom, BASE_LOCATION);
   });
 
   afterEach(() => {
@@ -166,248 +136,69 @@ describe('useEtaFallback', () => {
     jest.useRealTimers();
   });
 
-  it('GPS喪失が持続・直近に実移動あり・アンカーありで発動し、発車直後は走行中(未到着・未接近)を駆動する', () => {
+  it('有効・アンカーあり時に推定フェーズを etaPhaseAtom へ公開する', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
-    activate();
-
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-    expect(store.get(arrivedAtom)).toBe(false);
-    expect(store.get(approachingAtom)).toBe(false);
-    const phase = store.get(etaPhaseAtom);
-    expect(phase).toEqual({ kind: 'RUNNING', targetStationId: 2 });
-  });
-
-  it('B到着時刻+マージン経過で到着を駆動し、駅座標をlocationAtomへスナップする', () => {
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // 仮想時計 m = 発車累積0.5 + 経過分。B停車帯は m∈[2.5, 3.0)。
-    // 経過2.2分 → m=2.7 → DWELLING(B)。
-    setNow(T0 + 2.2 * 60_000);
+    // A発車から1秒: まだB到着(2分)には遠い → RUNNING(B)
+    setNow(T0 + 1000);
     runTick();
 
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-    expect(store.get(arrivedAtom)).toBe(true);
-    expect(store.get(approachingAtom)).toBe(false);
-    expect(store.get(stationAtom)?.id).toBe(2);
-    const loc = store.get(locationAtom);
-    expect(loc?.coords.latitude).toBe(35.1);
-    expect(loc?.coords.longitude).toBe(139.1);
-  });
-
-  it('B到着直前(マージン内)は接近(まもなく)に留める', () => {
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-
-    // 仮想時計 m = 発車累積0.5 + 経過分。B接近帯は m∈[到着2.0-lead0.6, 確定2.5)=[1.4,2.5)。
-    // 経過1.2分 → m=1.7 → APPROACHING(B)。
-    setNow(T0 + 1.2 * 60_000);
-    runTick();
-
-    expect(store.get(approachingAtom)).toBe(true);
-    expect(store.get(arrivedAtom)).toBe(false);
     expect(store.get(etaPhaseAtom)).toEqual({
-      kind: 'APPROACHING',
+      kind: 'RUNNING',
       targetStationId: 2,
     });
   });
 
-  it('中途半端な測位(200〜1500m)では解除せず、良好測位(≤200m)で解除する', () => {
+  it('経過に応じて DWELLING など後続フェーズも公開する', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
-    activate();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // 800mの測位が受理された(外れ値解除・lastFix更新)が、ヒステリシスで解除しない
-    setNow(T0 + SUSTAIN_MS + 3000);
-    store.set(locationAccuracyOutlierAtom, false);
-    store.set(lastAcceptedFixAtMsAtom, now);
-    store.set(lastAcceptedFixAccuracyAtom, 800);
-    store.set(locationAtom, {
-      timestamp: now,
-      coords: {
-        latitude: 35.05,
-        longitude: 139.05,
-        accuracy: 800,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
+    // 仮想時計 m = 発車累積0.5 + 経過分。経過2.2分 → m=2.7 → DWELLING(B)。
+    setNow(T0 + 2.2 * 60_000);
     runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
 
-    // 良好測位(50m)を受理 → 解除
-    setNow(T0 + SUSTAIN_MS + 4000);
-    store.set(lastAcceptedFixAtMsAtom, now);
-    store.set(lastAcceptedFixAccuracyAtom, 50);
-    store.set(locationAtom, {
-      timestamp: now,
-      coords: {
-        latitude: 35.05,
-        longitude: 139.05,
-        accuracy: 50,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
+    expect(store.get(etaPhaseAtom)).toEqual({
+      kind: 'DWELLING',
+      stationId: 2,
     });
-    runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
   });
 
-  it('タイムキャップ(最大継続時間)超過で解除する', () => {
-    // 短い上限を設定し、ETAフェーズがまだ返る時刻でcapを踏ませることで、
-    // !phase 解除ではなく capExceeded 経路が働くことを確実に検証する。
-    jest
-      .spyOn(remoteConfigModule, 'getEtaFallbackMaxDurationMin')
-      .mockReturnValue(0.01);
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // 発動(T0+22秒)から0.01分(0.6秒)を超過。ETAフェーズはまだRUNNINGのまま。
-    setNow(T0 + SUSTAIN_MS + 3000);
-    runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
-  });
-
-  it('リモート設定が無効なら発動しない', () => {
+  it('リモート設定が無効ならフェーズは公開しない(null)', () => {
     jest.spyOn(remoteConfigModule, 'isEtaAssistEnabled').mockReturnValue(false);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    activate();
+    setNow(T0 + 1000);
+    runTick();
 
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
     expect(store.get(etaPhaseAtom)).toBeNull();
   });
 
-  it('GPSが健全(外れ値なし・良好精度・受理測位が新しい)なら発動しない', () => {
-    store.set(locationAccuracyOutlierAtom, false);
+  it('アンカーが無ければフェーズは公開しない(null)', () => {
+    store.set(etaAnchorAtom, null);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    // 良好測位が流れ続ける限り劣化とみなされず、持続喪失ゲートも成立しない。
-    setNow(T0 + 1000);
-    store.set(lastAcceptedFixAtMsAtom, now);
-    runTick();
-
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
-  });
-
-  it('GPS喪失が一瞬(持続20秒未満)では発動しない', () => {
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    // 外れ値だが劣化継続はまだ数秒。持続喪失ゲート(20秒)を満たさないため発動しない。
     setNow(T0 + 1000);
     runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
 
-    setNow(T0 + 5000);
-    runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
+    expect(store.get(etaPhaseAtom)).toBeNull();
   });
 
-  it('直近に実移動がなければ(駅で静止・待機)GPS喪失が持続しても発動しない', () => {
-    // lastMovingAtMs を発動有効期間より前に置く=直近に電車が動いた証拠がない。
-    store.set(lastMovingAtMsAtom, T0 - MOVING_RECENCY_MS - 10_000);
+  it('到着・接近・現在駅・位置・活性フラグは一切駆動しない(GPSが唯一の権威)', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
-    activate();
+    // ETA上は到着帯(DWELLING)へ進む時刻でも、状態は書き換えないこと。
+    setNow(T0 + 2.2 * 60_000);
+    runTick();
 
-    // 持続喪失は満たすが recentlyMoving が偽なので発動しない(待機中の誤前進を防ぐ)。
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
-  });
-
-  it('AT_STATIONアンカーは estimateEtaPhase の停車判定で予定発車まで駅に留まり、その後前進する', () => {
-    // B(id2)に到着した状態でGPSを喪失。ホールドゲートは撤去したが、AT_STATION
-    // アンカーは estimateEtaPhase が予定発車まで DWELLING(B) を返すため自然に駅へ留まる。
-    store.set(etaAnchorAtom, {
+    // フェーズは公開されるが…
+    expect(store.get(etaPhaseAtom)).toEqual({
+      kind: 'DWELLING',
       stationId: 2,
-      kind: 'AT_STATION',
-      observedAtMs: T0,
     });
-    store.set(arrivedAtom, true);
-    store.set(stationAtom, STATIONS[1]);
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-    // 発動直後(m≈2.4分)はBの停車帯(effDep=2.5分)なのでBに留まる。
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-    expect(store.get(arrivedAtom)).toBe(true);
-    expect(store.get(stationAtom)?.id).toBe(2);
-
-    // 予定発車を過ぎたら(m=4.7分)ETA時計どおり前進し、C(id3)へ到着駆動する。
-    // GPSが凍結して位置が動かなくても、待機ではなく走行として表示を進める。
-    setNow(T0 + 2.7 * 60_000);
-    runTick();
-
-    expect(store.get(stationAtom)?.id).toBe(3);
-    expect(store.get(arrivedAtom)).toBe(true);
-  });
-
-  it('DWELLING駅がstationsAtom上に見つからない場合は解除して凍結を防ぐ', () => {
-    // stationsAtomからBを除くと、B停車帯の駆動時に駅解決できず解除される。
-    store.set(stationsAtom, [STATIONS[0], STATIONS[2]]);
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // B停車帯(m∈[2.5,3.0))へ進める → Bが見つからず解除
-    setNow(T0 + 2.2 * 60_000);
-    runTick();
+    // …到着/接近/現在駅/位置/活性フラグはすべて初期値のまま。
+    expect(store.get(arrivedAtom)).toBe(false);
+    expect(store.get(approachingAtom)).toBe(false);
+    expect(store.get(stationAtom)?.id).toBe(1);
+    expect(store.get(locationAtom)).toBe(BASE_LOCATION);
     expect(store.get(etaFallbackActiveAtom)).toBe(false);
-  });
-
-  it('到着スナップでlocationAtomがaccuracy:0になっても、実測位が劣化中なら解除しない', () => {
-    // 精度劣化継続(800m)で発動するケース。外れ値ではなく実測位が流れ続ける。
-    const badFix = (ts: number) => {
-      store.set(lastAcceptedFixAtMsAtom, ts);
-      store.set(lastAcceptedFixAccuracyAtom, 800);
-      store.set(locationAtom, {
-        timestamp: ts,
-        coords: {
-          latitude: 35.0,
-          longitude: 139.0,
-          accuracy: 800,
-          altitude: null,
-          altitudeAccuracy: null,
-          speed: null,
-          heading: null,
-        },
-      });
-    };
-
-    store.set(locationAccuracyOutlierAtom, false);
-    badFix(T0);
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    // 1回目のtickで精度劣化の起点を記録(まだ継続時間0なので発動しない)
-    setNow(T0 + 1000);
-    badFix(now);
-    runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(false);
-
-    // 精度劣化が20秒継続 → 発動
-    setNow(T0 + 22_000);
-    badFix(now);
-    runTick();
-    expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // B到着でスナップが走りlocationAtomはaccuracy:0になる。直後も実測位(800m)は
-    // まだ新しいが劣化したまま。locationAtomの精度で見ると誤って解除しうるが、
-    // lastAcceptedFixAccuracy(800m)で判定するため解除しない。
-    setNow(T0 + 2.2 * 60_000);
-    store.set(lastAcceptedFixAtMsAtom, now); // 実測位は届いているが精度は800mのまま
-    runTick();
-    expect(store.get(locationAtom)?.coords.accuracy).toBe(0); // スナップ済み
-    expect(store.get(etaFallbackActiveAtom)).toBe(true); // 早期解除しない
   });
 });

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -325,8 +325,9 @@ describe('useEtaFallback', () => {
     expect(store.get(etaFallbackActiveAtom)).toBe(false);
   });
 
-  it('AT_STATIONアンカーでは出発を確認するまで前進せず、現在駅でホールドする', () => {
-    // B(id2)に到着済み・現在位置もB座標のまま(まだ発車していない)。
+  it('AT_STATIONアンカーは estimateEtaPhase の停車判定で予定発車まで駅に留まり、その後前進する', () => {
+    // B(id2)に到着した状態でGPSを喪失。ホールドゲートは撤去したが、AT_STATION
+    // アンカーは estimateEtaPhase が予定発車まで DWELLING(B) を返すため自然に駅へ留まる。
     store.set(etaAnchorAtom, {
       stationId: 2,
       kind: 'AT_STATION',
@@ -334,75 +335,17 @@ describe('useEtaFallback', () => {
     });
     store.set(arrivedAtom, true);
     store.set(stationAtom, STATIONS[1]);
-    store.set(locationAtom, {
-      timestamp: T0,
-      coords: {
-        latitude: 35.1,
-        longitude: 139.1,
-        accuracy: 0,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
     renderHook(() => useEtaFallback(), { wrapper });
 
     activate();
+    // 発動直後(m≈2.4分)はBの停車帯(effDep=2.5分)なのでBに留まる。
     expect(store.get(etaFallbackActiveAtom)).toBe(true);
-
-    // 十分に時間が経過し仮想時計上は次駅へ進むはずでも、位置がB駅から離れない限り
-    // 前進させずBでホールドし続ける(待機中に位置が勝手に進む誤動作を防ぐ)。
-    setNow(T0 + 5 * 60_000);
-    runTick();
-
     expect(store.get(arrivedAtom)).toBe(true);
-    expect(store.get(approachingAtom)).toBe(false);
     expect(store.get(stationAtom)?.id).toBe(2);
-  });
 
-  it('AT_STATIONアンカーでも位置が駅から離れれば出発を確認して前進駆動する', () => {
-    store.set(etaAnchorAtom, {
-      stationId: 2,
-      kind: 'AT_STATION',
-      observedAtMs: T0,
-    });
-    store.set(arrivedAtom, true);
-    store.set(stationAtom, STATIONS[1]);
-    store.set(locationAtom, {
-      timestamp: T0,
-      coords: {
-        latitude: 35.1,
-        longitude: 139.1,
-        accuracy: 0,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
-    renderHook(() => useEtaFallback(), { wrapper });
-
-    activate();
-    // 発動直後はまだBでホールド(位置がBのまま)。
-    expect(store.get(stationAtom)?.id).toBe(2);
-    expect(store.get(arrivedAtom)).toBe(true);
-
-    // 現在位置がB駅から明確に離れた(=実際に発車した)。以降は通常どおり前進駆動。
-    store.set(locationAtom, {
-      timestamp: now,
-      coords: {
-        latitude: 35.2,
-        longitude: 139.2,
-        accuracy: 30,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
-    // 経過3分 → 仮想時計は終端C(id3)方面。出発確認済みなので前進する。
-    setNow(T0 + 3 * 60_000);
+    // 予定発車を過ぎたら(m=4.7分)ETA時計どおり前進し、C(id3)へ到着駆動する。
+    // GPSが凍結して位置が動かなくても、待機ではなく走行として表示を進める。
+    setNow(T0 + 2.7 * 60_000);
     runTick();
 
     expect(store.get(stationAtom)?.id).toBe(3);

--- a/src/hooks/useEtaFallback.ts
+++ b/src/hooks/useEtaFallback.ts
@@ -1,43 +1,16 @@
 import { useRef } from 'react';
-import { BAD_ACCURACY_THRESHOLD } from '~/constants';
 import {
   getEtaFallbackArrivalConfirmMarginSec,
-  getEtaFallbackMaxDurationMin,
   isEtaAssistEnabled,
 } from '~/lib/remoteConfig';
 import { store } from '~/store';
-import {
-  etaAnchorAtom,
-  etaFallbackActiveAtom,
-  etaPhaseAtom,
-} from '~/store/atoms/etaFallback';
-import {
-  lastAcceptedFixAccuracyAtom,
-  lastAcceptedFixAtMsAtom,
-  lastMovingAtMsAtom,
-  locationAccuracyOutlierAtom,
-  locationAtom,
-} from '~/store/atoms/location';
-import navigationState, { autoModeEnabledAtom } from '~/store/atoms/navigation';
-import stationState, {
-  selectedBoundAtom,
-  stationsAtom,
-} from '~/store/atoms/station';
-import {
-  type EtaFallbackStop,
-  estimateEtaPhase,
-  isRecentlyMoving,
-} from '~/utils/etaFallback';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { type EtaFallbackStop, estimateEtaPhase } from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useInterval } from './useInterval';
 
-// 発動・解除判定の周期(ms)。ETA仮想時計は1秒粒度で進める。
+// フェーズ再評価の周期(ms)。ETA仮想時計は1秒粒度で進める。
 const TICK_INTERVAL_MS = 1_000;
-// 受理測位がこの時間以上途絶したら「無信号」とみなす(ms)。
-const FIX_STALENESS_MS = 30_000;
-// GPS劣化(外れ値/精度>200m)がこの時間「持続」して初めてGPS不良とみなす(ms)。
-// 一瞬の劣化(地上の高架下・ビル街等)では発動させないための持続喪失ゲート。
-const GPS_LOST_SUSTAIN_MS = 20_000;
 // ETAデータの分解能で発車分−到着分が0になる駅の停車時間の底上げ(分)。
 const MIN_DWELL_MIN = 0.5;
 
@@ -72,18 +45,15 @@ const extractStops = (
 };
 
 /**
- * GPS精度が劣化・喪失した区間(地下鉄など)で、サーバー計算のETAとGPSで最後に
- * 確定した駅イベント(アンカー)からの経過時間で走行状態を推定し、接近/到着状態を
- * 前進駆動するフォールバック(R2)。
+ * ETA(サーバー計算の到着予測)とGPSで最後に確定した駅イベント(アンカー)からの経過時間で、
+ * 現在の走行フェーズ(走行中/接近中/停車中)を推定して etaPhaseAtom へ公開するフック。
  *
- * - 発動: リモート設定有効・ナビ中・autoMode無効・GPS不良(外れ値/受理測位の途絶/
- *   精度劣化の継続)・アンカーが有効ルート上にある、をすべて満たすとき。
- * - 解除: 良好測位の受理(≤200m)/ナビ終了/タイムキャップ超過/推定不能。解除後は
- *   GPS優先へ戻り、useRefreshStation が権威を回復する。
- * - 活性中は毎tick estimateEtaPhase を評価し、RUNNING/APPROACHING/DWELLING に応じて
- *   arrived/approaching/現在駅を駆動。到着(DWELLING)へ移った駅では駅座標を
- *   locationAtom へ1回スナップして下流(最寄り駅・距離表示)と整合させる。
- * - 推定フェーズは etaPhaseAtom に常時公開し、精度劣化時の到着しきい値緩和(R1)に使う。
+ * 位置・到着・接近の状態は**駆動しない**(GPS = useRefreshStation を唯一の権威に保つ)。
+ * かつて ETA が状態を独占駆動する R2 フォールバックを備えていたが、GPSが凍結する地下では
+ * ETA時刻がそのまま位置を進め、駅に到着後も現在地が勝手に動く重大なデグレを招いたため撤去した。
+ * 現在の ETA の役割は「GPSの補助」に限定する:
+ * - etaPhaseAtom を公開し、useRefreshStation が精度劣化時に「ETAが同じ駅で停車を示すときだけ
+ *   その駅の到着しきい値を緩和する(R1)」ために使う。到着判定自体は常にGPSが行う。
  */
 export const useEtaFallback = (): void => {
   // 機能が無効な間はETAルートのGraphQL取得自体を止める(LineBoard表示側が
@@ -93,89 +63,6 @@ export const useEtaFallback = (): void => {
   });
   const routeRef = useRef(route);
   routeRef.current = route;
-
-  // GPS劣化(外れ値/精度>200m)が始まった時刻(持続判定用)。良好時は null に戻す。
-  const degradedSinceRef = useRef<number | null>(null);
-  // フォールバックを発動した時刻(タイムキャップ用)。
-  const activatedAtRef = useRef<number | null>(null);
-  // 直近で座標スナップ済みの駅ID(到着ごとに1回だけスナップする)。
-  const snappedStationIdRef = useRef<number | null>(null);
-
-  const deactivate = (): void => {
-    if (store.get(etaFallbackActiveAtom)) {
-      store.set(etaFallbackActiveAtom, false);
-    }
-    activatedAtRef.current = null;
-    snappedStationIdRef.current = null;
-  };
-
-  const snapshotLocation = (
-    latitude: number,
-    longitude: number,
-    nowMs: number
-  ): void => {
-    // setLocation() を通さず直接スナップする。lastFilteredLocation・外れ値フラグ・
-    // 受理測位時刻(staleness判定)を汚染しないため(useSimulationMode と同じ流儀)。
-    store.set(locationAtom, {
-      timestamp: nowMs,
-      coords: {
-        latitude,
-        longitude,
-        accuracy: 0,
-        altitude: null,
-        altitudeAccuracy: null,
-        speed: null,
-        heading: null,
-      },
-    });
-  };
-
-  // 駆動できたら true、DWELLING駅がstationsAtom上に見つからず駆動不能なら false。
-  // false のとき呼び出し側はフォールバックを解除し、状態更新の凍結を防ぐ。
-  const drive = (
-    phase: NonNullable<ReturnType<typeof estimateEtaPhase>>,
-    nowMs: number
-  ): boolean => {
-    if (phase.kind === 'DWELLING') {
-      const station = store
-        .get(stationsAtom)
-        .find((s) => s.id === phase.stationId);
-      if (!station) {
-        return false;
-      }
-      // 到着した駅が変わった瞬間にのみ座標スナップとヘッダー駅更新を行う。
-      if (snappedStationIdRef.current !== station.id) {
-        if (station.latitude != null && station.longitude != null) {
-          snapshotLocation(station.latitude, station.longitude, nowMs);
-        }
-        store.set(navigationState, (prev) =>
-          prev.stationForHeader?.id !== station.id
-            ? { ...prev, stationForHeader: station }
-            : prev
-        );
-        snappedStationIdRef.current = phase.stationId;
-      }
-      store.set(stationState, (prev) =>
-        prev.arrived === true &&
-        prev.approaching === false &&
-        prev.station?.id === station.id
-          ? prev
-          : { ...prev, arrived: true, approaching: false, station }
-      );
-      return true;
-    }
-
-    // RUNNING / APPROACHING: 現在駅(=直前の停車駅)は据え置き、フラグのみ駆動する。
-    const approaching = phase.kind === 'APPROACHING';
-    // 次の停車駅へ走り出したら、次に到着する駅で再びスナップできるよう解除する。
-    snappedStationIdRef.current = null;
-    store.set(stationState, (prev) =>
-      prev.arrived === false && prev.approaching === approaching
-        ? prev
-        : { ...prev, arrived: false, approaching }
-    );
-    return true;
-  };
 
   const tick = (): void => {
     const now = Date.now();
@@ -191,99 +78,8 @@ export const useEtaFallback = (): void => {
             minDwellMin: MIN_DWELL_MIN,
           })
         : null;
-    // R1(到着しきい値緩和)のために推定フェーズを常時公開する。
+    // R1(到着しきい値緩和)のために推定フェーズを公開する。状態の駆動は行わない。
     store.set(etaPhaseAtom, phase);
-
-    const active = store.get(etaFallbackActiveAtom);
-
-    if (!enabled) {
-      if (active) {
-        deactivate();
-      }
-      return;
-    }
-
-    const bound = store.get(selectedBoundAtom);
-    const autoMode = store.get(autoModeEnabledAtom);
-    const outlier = store.get(locationAccuracyOutlierAtom);
-    const lastFixMs = store.get(lastAcceptedFixAtMsAtom);
-    // 精度判定は locationAtom ではなく「最後に受理された実測位」の精度で見る。
-    // 到着スナップが locationAtom を accuracy:0 で直書きするため、locationAtom を見ると
-    // (1) goodFix が偽陽性になり早期解除する、(2) accuracyBad が毎tickリセットされ
-    // 精度劣化の継続を追えなくなる。両者を snapshot 非依存の実測位精度で判定する。
-    const lastFixAccuracy = store.get(lastAcceptedFixAccuracyAtom);
-
-    // 瞬間的な劣化シグナル(外れ値棄却 or 実測位精度>200m)。一瞬の劣化では発動させない。
-    const degraded =
-      outlier ||
-      (lastFixAccuracy != null && lastFixAccuracy > BAD_ACCURACY_THRESHOLD);
-    if (degraded) {
-      if (degradedSinceRef.current == null) {
-        degradedSinceRef.current = now;
-      }
-    } else {
-      degradedSinceRef.current = null;
-    }
-    // 劣化が約20秒「持続」して初めてGPS不良とみなす。これにより地上鉄道の一瞬のGPS飛び
-    // (高架下・ビル街等)では発動せず、地下鉄トンネルや地上の長いトンネルのように
-    // 持続的に喪失した区間だけを対象にする(路線種別で絞らずに本来の意図へ収束させる)。
-    const sustainedDegraded =
-      degradedSinceRef.current != null &&
-      now - degradedSinceRef.current >= GPS_LOST_SUSTAIN_MS;
-    // 受理測位が途絶している(スナップの直書きでは lastFixMs は更新されない)。
-    const stale = lastFixMs != null && now - lastFixMs > FIX_STALENESS_MS;
-    const gpsLost = stale || sustainedDegraded;
-
-    // 良好測位の受理。中途半端な測位(200〜1500m)では解除しない(ヒステリシス)。
-    const goodFix =
-      !outlier &&
-      lastFixAccuracy != null &&
-      lastFixAccuracy <= BAD_ACCURACY_THRESHOLD &&
-      lastFixMs != null &&
-      now - lastFixMs <= FIX_STALENESS_MS;
-
-    // 直近に実移動(電車が動いていた)を観測したか。駅で静止したまま(待機・遅延停車)は
-    // 発動させないための発動ゲート。乗車待ち(実移動なし)ではここで発動を止める。
-    const recentlyMoving = isRecentlyMoving(store.get(lastMovingAtMsAtom), now);
-
-    if (active) {
-      const maxDurationMs = getEtaFallbackMaxDurationMin() * 60_000;
-      const capExceeded =
-        activatedAtRef.current != null &&
-        now - activatedAtRef.current > maxDurationMs;
-      if (
-        bound == null ||
-        autoMode ||
-        goodFix ||
-        capExceeded ||
-        !phase ||
-        !anchor
-      ) {
-        deactivate();
-        return;
-      }
-      // 駆動不能(DWELLING駅がstationsAtom上に無い)なら解除して凍結を防ぐ。
-      if (!drive(phase, now)) {
-        deactivate();
-      }
-      return;
-    }
-
-    if (
-      bound != null &&
-      !autoMode &&
-      gpsLost &&
-      recentlyMoving &&
-      phase &&
-      anchor
-    ) {
-      store.set(etaFallbackActiveAtom, true);
-      activatedAtRef.current = now;
-      snappedStationIdRef.current = null;
-      if (!drive(phase, now)) {
-        deactivate();
-      }
-    }
   };
 
   useInterval(tick, TICK_INTERVAL_MS);

--- a/src/hooks/useEtaFallback.ts
+++ b/src/hooks/useEtaFallback.ts
@@ -1,3 +1,4 @@
+import getDistance from 'geolib/es/getDistance';
 import { useRef } from 'react';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants';
 import {
@@ -14,6 +15,7 @@ import {
 import {
   lastAcceptedFixAccuracyAtom,
   lastAcceptedFixAtMsAtom,
+  lastMovingAtMsAtom,
   locationAccuracyOutlierAtom,
   locationAtom,
 } from '~/store/atoms/location';
@@ -22,7 +24,12 @@ import stationState, {
   selectedBoundAtom,
   stationsAtom,
 } from '~/store/atoms/station';
-import { type EtaFallbackStop, estimateEtaPhase } from '~/utils/etaFallback';
+import {
+  type EtaAnchor,
+  type EtaFallbackStop,
+  estimateEtaPhase,
+  MOVING_RECENCY_MS,
+} from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useInterval } from './useInterval';
 
@@ -30,10 +37,15 @@ import { useInterval } from './useInterval';
 const TICK_INTERVAL_MS = 1_000;
 // 受理測位がこの時間以上途絶したら「無信号」とみなす(ms)。
 const FIX_STALENESS_MS = 30_000;
-// 精度劣化(>200m)がこの時間継続したらGPS不良とみなす(ms)。
-const ACCURACY_SUSTAIN_MS = 20_000;
+// GPS劣化(外れ値/精度>200m)がこの時間「持続」して初めてGPS不良とみなす(ms)。
+// 一瞬の劣化(地上の高架下・ビル街等)では発動させないための持続喪失ゲート。
+const GPS_LOST_SUSTAIN_MS = 20_000;
 // ETAデータの分解能で発車分−到着分が0になる駅の停車時間の底上げ(分)。
 const MIN_DWELL_MIN = 0.5;
+// 出発確認の変位下限(m)。AT_STATIONアンカーから発動した場合、現在位置がアンカー駅から
+// この距離(精度が粗いときはmax(これ, 精度))を超えて離れるまで前進させず現在駅ホールド。
+// 駅で待機中に位置が勝手に進む誤動作を防ぐ(motion gate の中核)。
+const DEPARTURE_MIN_M = 300;
 
 /**
  * route.stops(絶対累積分・全stops)から、停車駅かつ累積分が揃っているものだけを
@@ -88,12 +100,15 @@ export const useEtaFallback = (): void => {
   const routeRef = useRef(route);
   routeRef.current = route;
 
-  // 精度劣化が始まった時刻(継続判定用)。良好時は null に戻す。
-  const badSinceRef = useRef<number | null>(null);
+  // GPS劣化(外れ値/精度>200m)が始まった時刻(持続判定用)。良好時は null に戻す。
+  const degradedSinceRef = useRef<number | null>(null);
   // フォールバックを発動した時刻(タイムキャップ用)。
   const activatedAtRef = useRef<number | null>(null);
   // 直近で座標スナップ済みの駅ID(到着ごとに1回だけスナップする)。
   const snappedStationIdRef = useRef<number | null>(null);
+  // アンカー駅からの出発が確認済みか(前進ゲート)。発動毎にリセットし、確認されるまでは
+  // 現在駅でホールドして前進させない。
+  const departureConfirmedRef = useRef(false);
 
   const deactivate = (): void => {
     if (store.get(etaFallbackActiveAtom)) {
@@ -101,6 +116,30 @@ export const useEtaFallback = (): void => {
     }
     activatedAtRef.current = null;
     snappedStationIdRef.current = null;
+    departureConfirmedRef.current = false;
+  };
+
+  // 出発未確認の間、現在駅(アンカー駅)でホールドする。drive の DWELLING と違い、
+  // 座標スナップはしない(実GPS位置を残し、出発の変位検知を継続できるようにする)。
+  // 駅が見つからなければ false(呼び出し側で解除)。
+  const holdAtStation = (stationId: number): boolean => {
+    const station = store.get(stationsAtom).find((s) => s.id === stationId);
+    if (!station) {
+      return false;
+    }
+    store.set(navigationState, (prev) =>
+      prev.stationForHeader?.id !== station.id
+        ? { ...prev, stationForHeader: station }
+        : prev
+    );
+    store.set(stationState, (prev) =>
+      prev.arrived === true &&
+      prev.approaching === false &&
+      prev.station?.id === station.id
+        ? prev
+        : { ...prev, arrived: true, approaching: false, station }
+    );
+    return true;
   };
 
   const snapshotLocation = (
@@ -171,6 +210,49 @@ export const useEtaFallback = (): void => {
     return true;
   };
 
+  // 前進ゲート: アンカー駅からの出発が確認できるまで現在駅ホールドし、確認後に drive する。
+  // DEPARTED アンカーは motion gate 済み=実発車の確証なので即確認。AT_STATION は現在位置が
+  // アンカー駅から max(DEPARTURE_MIN_M, 実測位精度) を超えて離れたら確認。GPS凍結時は変位
+  // 0のままホールドされ続け、駅で待機中に位置が勝手に進むのを防ぐ。
+  const driveGated = (
+    phase: NonNullable<ReturnType<typeof estimateEtaPhase>>,
+    anchor: EtaAnchor,
+    nowMs: number,
+    lastFixAccuracy: number | null
+  ): boolean => {
+    if (!departureConfirmedRef.current) {
+      if (anchor.kind === 'DEPARTED') {
+        departureConfirmedRef.current = true;
+      } else {
+        const anchorStation = store
+          .get(stationsAtom)
+          .find((s) => s.id === anchor.stationId);
+        const loc = store.get(locationAtom);
+        if (
+          anchorStation?.latitude != null &&
+          anchorStation?.longitude != null &&
+          loc?.coords != null
+        ) {
+          const dist = getDistance(
+            { latitude: loc.coords.latitude, longitude: loc.coords.longitude },
+            {
+              latitude: anchorStation.latitude,
+              longitude: anchorStation.longitude,
+            }
+          );
+          if (dist > Math.max(DEPARTURE_MIN_M, lastFixAccuracy ?? 0)) {
+            departureConfirmedRef.current = true;
+          }
+        }
+      }
+    }
+    if (!departureConfirmedRef.current) {
+      // 未出発: 現在駅ホールド(前進しない・座標スナップしない)。
+      return holdAtStation(anchor.stationId);
+    }
+    return drive(phase, nowMs);
+  };
+
   const tick = (): void => {
     const now = Date.now();
     const enabled = isEtaAssistEnabled();
@@ -207,22 +289,26 @@ export const useEtaFallback = (): void => {
     // 精度劣化の継続を追えなくなる。両者を snapshot 非依存の実測位精度で判定する。
     const lastFixAccuracy = store.get(lastAcceptedFixAccuracyAtom);
 
-    // 精度劣化の継続時間を追跡する。
-    const accuracyBad =
-      lastFixAccuracy != null && lastFixAccuracy > BAD_ACCURACY_THRESHOLD;
-    if (accuracyBad) {
-      if (badSinceRef.current == null) {
-        badSinceRef.current = now;
+    // 瞬間的な劣化シグナル(外れ値棄却 or 実測位精度>200m)。一瞬の劣化では発動させない。
+    const degraded =
+      outlier ||
+      (lastFixAccuracy != null && lastFixAccuracy > BAD_ACCURACY_THRESHOLD);
+    if (degraded) {
+      if (degradedSinceRef.current == null) {
+        degradedSinceRef.current = now;
       }
     } else {
-      badSinceRef.current = null;
+      degradedSinceRef.current = null;
     }
-    const accuracySustainedBad =
-      badSinceRef.current != null &&
-      now - badSinceRef.current >= ACCURACY_SUSTAIN_MS;
+    // 劣化が約20秒「持続」して初めてGPS不良とみなす。これにより地上鉄道の一瞬のGPS飛び
+    // (高架下・ビル街等)では発動せず、地下鉄トンネルや地上の長いトンネルのように
+    // 持続的に喪失した区間だけを対象にする(路線種別で絞らずに本来の意図へ収束させる)。
+    const sustainedDegraded =
+      degradedSinceRef.current != null &&
+      now - degradedSinceRef.current >= GPS_LOST_SUSTAIN_MS;
     // 受理測位が途絶している(スナップの直書きでは lastFixMs は更新されない)。
     const stale = lastFixMs != null && now - lastFixMs > FIX_STALENESS_MS;
-    const gpsLost = outlier || stale || accuracySustainedBad;
+    const gpsLost = stale || sustainedDegraded;
 
     // 良好測位の受理。中途半端な測位(200〜1500m)では解除しない(ヒステリシス)。
     const goodFix =
@@ -232,27 +318,48 @@ export const useEtaFallback = (): void => {
       lastFixMs != null &&
       now - lastFixMs <= FIX_STALENESS_MS;
 
+    // 直近に実移動(電車が動いていた)を観測したか。駅で静止したまま(待機・遅延停車)は
+    // 発動させないための発動ゲート。前進ゲート(driveGated)と併せて誤前進を防ぐ。
+    const lastMovingAtMs = store.get(lastMovingAtMsAtom);
+    const recentlyMoving =
+      lastMovingAtMs != null && now - lastMovingAtMs < MOVING_RECENCY_MS;
+
     if (active) {
       const maxDurationMs = getEtaFallbackMaxDurationMin() * 60_000;
       const capExceeded =
         activatedAtRef.current != null &&
         now - activatedAtRef.current > maxDurationMs;
-      if (bound == null || autoMode || goodFix || capExceeded || !phase) {
+      if (
+        bound == null ||
+        autoMode ||
+        goodFix ||
+        capExceeded ||
+        !phase ||
+        !anchor
+      ) {
         deactivate();
         return;
       }
       // 駆動不能(DWELLING駅がstationsAtom上に無い)なら解除して凍結を防ぐ。
-      if (!drive(phase, now)) {
+      if (!driveGated(phase, anchor, now, lastFixAccuracy)) {
         deactivate();
       }
       return;
     }
 
-    if (bound != null && !autoMode && gpsLost && phase) {
+    if (
+      bound != null &&
+      !autoMode &&
+      gpsLost &&
+      recentlyMoving &&
+      phase &&
+      anchor
+    ) {
       store.set(etaFallbackActiveAtom, true);
       activatedAtRef.current = now;
       snappedStationIdRef.current = null;
-      if (!drive(phase, now)) {
+      departureConfirmedRef.current = false;
+      if (!driveGated(phase, anchor, now, lastFixAccuracy)) {
         deactivate();
       }
     }

--- a/src/hooks/useEtaFallback.ts
+++ b/src/hooks/useEtaFallback.ts
@@ -1,4 +1,3 @@
-import getDistance from 'geolib/es/getDistance';
 import { useRef } from 'react';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants';
 import {
@@ -25,7 +24,6 @@ import stationState, {
   stationsAtom,
 } from '~/store/atoms/station';
 import {
-  type EtaAnchor,
   type EtaFallbackStop,
   estimateEtaPhase,
   isRecentlyMoving,
@@ -42,10 +40,6 @@ const FIX_STALENESS_MS = 30_000;
 const GPS_LOST_SUSTAIN_MS = 20_000;
 // ETAデータの分解能で発車分−到着分が0になる駅の停車時間の底上げ(分)。
 const MIN_DWELL_MIN = 0.5;
-// 出発確認の変位下限(m)。AT_STATIONアンカーから発動した場合、現在位置がアンカー駅から
-// この距離(精度が粗いときはmax(これ, 精度))を超えて離れるまで前進させず現在駅ホールド。
-// 駅で待機中に位置が勝手に進む誤動作を防ぐ(motion gate の中核)。
-const DEPARTURE_MIN_M = 300;
 
 /**
  * route.stops(絶対累積分・全stops)から、停車駅かつ累積分が揃っているものだけを
@@ -106,9 +100,6 @@ export const useEtaFallback = (): void => {
   const activatedAtRef = useRef<number | null>(null);
   // 直近で座標スナップ済みの駅ID(到着ごとに1回だけスナップする)。
   const snappedStationIdRef = useRef<number | null>(null);
-  // アンカー駅からの出発が確認済みか(前進ゲート)。発動毎にリセットし、確認されるまでは
-  // 現在駅でホールドして前進させない。
-  const departureConfirmedRef = useRef(false);
 
   const deactivate = (): void => {
     if (store.get(etaFallbackActiveAtom)) {
@@ -116,30 +107,6 @@ export const useEtaFallback = (): void => {
     }
     activatedAtRef.current = null;
     snappedStationIdRef.current = null;
-    departureConfirmedRef.current = false;
-  };
-
-  // 出発未確認の間、現在駅(アンカー駅)でホールドする。drive の DWELLING と違い、
-  // 座標スナップはしない(実GPS位置を残し、出発の変位検知を継続できるようにする)。
-  // 駅が見つからなければ false(呼び出し側で解除)。
-  const holdAtStation = (stationId: number): boolean => {
-    const station = store.get(stationsAtom).find((s) => s.id === stationId);
-    if (!station) {
-      return false;
-    }
-    store.set(navigationState, (prev) =>
-      prev.stationForHeader?.id !== station.id
-        ? { ...prev, stationForHeader: station }
-        : prev
-    );
-    store.set(stationState, (prev) =>
-      prev.arrived === true &&
-      prev.approaching === false &&
-      prev.station?.id === station.id
-        ? prev
-        : { ...prev, arrived: true, approaching: false, station }
-    );
-    return true;
   };
 
   const snapshotLocation = (
@@ -210,49 +177,6 @@ export const useEtaFallback = (): void => {
     return true;
   };
 
-  // 前進ゲート: アンカー駅からの出発が確認できるまで現在駅ホールドし、確認後に drive する。
-  // DEPARTED アンカーは motion gate 済み=実発車の確証なので即確認。AT_STATION は現在位置が
-  // アンカー駅から max(DEPARTURE_MIN_M, 実測位精度) を超えて離れたら確認。GPS凍結時は変位
-  // 0のままホールドされ続け、駅で待機中に位置が勝手に進むのを防ぐ。
-  const driveGated = (
-    phase: NonNullable<ReturnType<typeof estimateEtaPhase>>,
-    anchor: EtaAnchor,
-    nowMs: number,
-    lastFixAccuracy: number | null
-  ): boolean => {
-    if (!departureConfirmedRef.current) {
-      if (anchor.kind === 'DEPARTED') {
-        departureConfirmedRef.current = true;
-      } else {
-        const anchorStation = store
-          .get(stationsAtom)
-          .find((s) => s.id === anchor.stationId);
-        const loc = store.get(locationAtom);
-        if (
-          anchorStation?.latitude != null &&
-          anchorStation?.longitude != null &&
-          loc?.coords != null
-        ) {
-          const dist = getDistance(
-            { latitude: loc.coords.latitude, longitude: loc.coords.longitude },
-            {
-              latitude: anchorStation.latitude,
-              longitude: anchorStation.longitude,
-            }
-          );
-          if (dist > Math.max(DEPARTURE_MIN_M, lastFixAccuracy ?? 0)) {
-            departureConfirmedRef.current = true;
-          }
-        }
-      }
-    }
-    if (!departureConfirmedRef.current) {
-      // 未出発: 現在駅ホールド(前進しない・座標スナップしない)。
-      return holdAtStation(anchor.stationId);
-    }
-    return drive(phase, nowMs);
-  };
-
   const tick = (): void => {
     const now = Date.now();
     const enabled = isEtaAssistEnabled();
@@ -319,7 +243,7 @@ export const useEtaFallback = (): void => {
       now - lastFixMs <= FIX_STALENESS_MS;
 
     // 直近に実移動(電車が動いていた)を観測したか。駅で静止したまま(待機・遅延停車)は
-    // 発動させないための発動ゲート。前進ゲート(driveGated)と併せて誤前進を防ぐ。
+    // 発動させないための発動ゲート。乗車待ち(実移動なし)ではここで発動を止める。
     const recentlyMoving = isRecentlyMoving(store.get(lastMovingAtMsAtom), now);
 
     if (active) {
@@ -339,7 +263,7 @@ export const useEtaFallback = (): void => {
         return;
       }
       // 駆動不能(DWELLING駅がstationsAtom上に無い)なら解除して凍結を防ぐ。
-      if (!driveGated(phase, anchor, now, lastFixAccuracy)) {
+      if (!drive(phase, now)) {
         deactivate();
       }
       return;
@@ -356,8 +280,7 @@ export const useEtaFallback = (): void => {
       store.set(etaFallbackActiveAtom, true);
       activatedAtRef.current = now;
       snappedStationIdRef.current = null;
-      departureConfirmedRef.current = false;
-      if (!driveGated(phase, anchor, now, lastFixAccuracy)) {
+      if (!drive(phase, now)) {
         deactivate();
       }
     }

--- a/src/hooks/useEtaFallback.ts
+++ b/src/hooks/useEtaFallback.ts
@@ -28,7 +28,7 @@ import {
   type EtaAnchor,
   type EtaFallbackStop,
   estimateEtaPhase,
-  MOVING_RECENCY_MS,
+  isRecentlyMoving,
 } from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useInterval } from './useInterval';
@@ -320,9 +320,7 @@ export const useEtaFallback = (): void => {
 
     // 直近に実移動(電車が動いていた)を観測したか。駅で静止したまま(待機・遅延停車)は
     // 発動させないための発動ゲート。前進ゲート(driveGated)と併せて誤前進を防ぐ。
-    const lastMovingAtMs = store.get(lastMovingAtMsAtom);
-    const recentlyMoving =
-      lastMovingAtMs != null && now - lastMovingAtMs < MOVING_RECENCY_MS;
+    const recentlyMoving = isRecentlyMoving(store.get(lastMovingAtMsAtom), now);
 
     if (active) {
       const maxDurationMs = getEtaFallbackMaxDurationMin() * 60_000;

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -90,7 +90,7 @@ describe('useRefreshStation', () => {
   });
 
   it('runs without crashing with basic mocks', () => {
-    // locationAtom, locationAccuracyOutlierAtom, etaFallbackActiveAtom, notifyStateの順で呼ばれる
+    // locationAtom, locationAccuracyOutlierAtom, notifyStateの順で呼ばれる
     mockUseAtomValue
       .mockReturnValueOnce({
         coords: {
@@ -99,7 +99,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     jest
@@ -139,7 +138,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     // useRefreshStation内のuseSetAtom呼び出し順:
@@ -187,7 +185,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(true) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     const setStation = jest.fn();
@@ -237,7 +234,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(true) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     const setStation = jest.fn();
@@ -300,7 +296,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     const setStation = jest.fn();
@@ -369,7 +364,6 @@ describe('useRefreshStation', () => {
         },
       }) // locationAtom
       .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [] }); // notifyState
 
     const setStation = jest.fn();
@@ -434,7 +428,6 @@ describe('useRefreshStation', () => {
         coords: { latitude: 35.0, longitude: 135.0 },
       }) // locationAtom
       .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(false) // etaFallbackActiveAtom
       .mockReturnValue({ targetStationIds: [2] }); // notifyState(接近駅id=2が通知対象)
 
     mockUseSetAtom.mockReturnValue(jest.fn());
@@ -468,48 +461,5 @@ describe('useRefreshStation', () => {
     const body = mockSendNotification.mock.calls[0][0].body;
     expect(body).toContain('Approaching Station');
     expect(body).not.toContain('Nearest Station');
-  });
-
-  it('ETAフォールバック活性中は状態書き込み・通知を行わない(2ライター競合の抑止)', () => {
-    // locationAtom, locationAccuracyOutlierAtom, etaFallbackActiveAtom, notifyStateの順で呼ばれる
-    mockUseAtomValue
-      .mockReturnValueOnce({
-        coords: { latitude: 35.0, longitude: 135.0, accuracy: 10 },
-      }) // locationAtom(最寄り駅と同一座標=通常なら到着)
-      .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
-      .mockReturnValueOnce(true) // etaFallbackActiveAtom(活性)
-      .mockReturnValue({ targetStationIds: [1] }); // notifyState
-
-    const setStation = jest.fn();
-    mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
-
-    jest
-      .spyOn(useNearestStationModule, 'useNearestStation')
-      .mockReturnValue(mockStation);
-    jest
-      .spyOn(useApproachingStationModule, 'useApproachingStation')
-      .mockReturnValue(mockStation);
-    jest
-      .spyOn(useNextStationModule, 'useNextStation')
-      .mockReturnValue(mockStation);
-    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
-    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
-      arrivedThreshold: 100,
-      approachingThreshold: 300,
-    });
-    jest
-      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
-      .mockReturnValue({
-        isWrongDirection: false,
-        isLoopLineWrongDirection: false,
-      });
-
-    renderHook(() => useRefreshStation(), {
-      wrapper: ({ children }) => <Provider>{children}</Provider>,
-    });
-
-    // 活性中は駅状態の書き込みも到着/接近通知も抑止される
-    expect(setStation).not.toHaveBeenCalled();
-    expect(mockSendNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -10,7 +10,7 @@ import {
   isForceNotArrivedOnLowAccuracyEnabled,
 } from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaFallbackActiveAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaPhaseAtom } from '~/store/atoms/etaFallback';
 import {
   locationAccuracyOutlierAtom,
   locationAtom,
@@ -52,9 +52,6 @@ export const useRefreshStation = (): void => {
   const setNavigation = useSetAtom(navigationState);
   const location = useAtomValue(locationAtom);
   const isAccuracyOutlier = useAtomValue(locationAccuracyOutlierAtom);
-  // ETAフォールバック(R2)活性中は本フックの状態書き込みを停止し、ETA駆動と
-  // 凍結座標基準の判定が同一atomを奪い合う2ライター競合を防ぐ。
-  const etaFallbackActive = useAtomValue(etaFallbackActiveAtom);
   const latitude = location?.coords.latitude;
   const longitude = location?.coords.longitude;
   const accuracy = location?.coords.accuracy;
@@ -217,7 +214,7 @@ export const useRefreshStation = (): void => {
   );
 
   useEffect(() => {
-    if (!canGoForward || etaFallbackActive) {
+    if (!canGoForward) {
       return;
     }
 
@@ -250,7 +247,6 @@ export const useRefreshStation = (): void => {
     }
   }, [
     canGoForward,
-    etaFallbackActive,
     isApproaching,
     isArrived,
     approachingStation,
@@ -269,7 +265,6 @@ export const useRefreshStation = (): void => {
     }
 
     if (
-      etaFallbackActive ||
       !wrongDirectionNotifyEnabled ||
       (!isWrongDirection && !isLoopLineWrongDirection) ||
       nextStationId == null ||
@@ -287,7 +282,6 @@ export const useRefreshStation = (): void => {
     }).catch(() => {});
     lastNotifiedWrongDirectionStationIdRef.current = nextStationId;
   }, [
-    etaFallbackActive,
     isWrongDirection,
     isLoopLineWrongDirection,
     nextStationId,
@@ -295,7 +289,7 @@ export const useRefreshStation = (): void => {
   ]);
 
   useEffect(() => {
-    if (!nearestStation || etaFallbackActive) {
+    if (!nearestStation) {
       return;
     }
 
@@ -325,12 +319,5 @@ export const useRefreshStation = (): void => {
           : prev
       );
     }
-  }, [
-    etaFallbackActive,
-    isApproaching,
-    isArrived,
-    nearestStation,
-    setNavigation,
-    setStation,
-  ]);
+  }, [isApproaching, isArrived, nearestStation, setNavigation, setStation]);
 };

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -1,4 +1,6 @@
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { store } from '~/store';
+import { etaAssistManualEnabledAtom } from '~/store/atoms/experimental';
 import {
   getEtaFallbackArrivalConfirmMarginSec,
   getEtaFallbackMaxDurationMin,
@@ -28,6 +30,8 @@ const mockRemoteConfig = (body: unknown, ok = true) => {
 afterEach(() => {
   jest.clearAllMocks();
   resetRemoteConfigCache();
+  // 手動トグルは共有ストアに残るため、テスト間の汚染を防ぐべく毎回戻す。
+  store.set(etaAssistManualEnabledAtom, false);
 });
 
 afterAll(() => {
@@ -98,6 +102,16 @@ describe('isEtaAssistEnabled', () => {
     mockRemoteConfig({ max_permit_accuracy: 1500 });
     await setupRemoteConfig();
     expect(isEtaAssistEnabled()).toBe(false);
+  });
+
+  it('手動トグル(試験的機能)がONならリモート設定に依らず有効を返す', async () => {
+    // リモートは無効(未配信=フォールバックfalse)でも、手動トグルONで有効化される。
+    store.set(etaAssistManualEnabledAtom, true);
+    expect(isEtaAssistEnabled()).toBe(true);
+
+    mockRemoteConfig({ eta_assist_enabled: false });
+    await setupRemoteConfig();
+    expect(isEtaAssistEnabled()).toBe(true);
   });
 });
 

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -6,6 +6,7 @@ import {
   getEtaFallbackMaxDurationMin,
   getMaxPermitAccuracy,
   isEtaAssistEnabled,
+  isEtaAssistRemoteEnabled,
   isForceNotArrivedOnLowAccuracyEnabled,
   resetRemoteConfigCache,
   setupRemoteConfig,
@@ -83,9 +84,9 @@ describe('isForceNotArrivedOnLowAccuracyEnabled', () => {
   });
 });
 
-describe('isEtaAssistEnabled', () => {
+describe('isEtaAssistRemoteEnabled（マスタースイッチ）', () => {
   it('falls back to false before setup', () => {
-    expect(isEtaAssistEnabled()).toBe(false);
+    expect(isEtaAssistRemoteEnabled()).toBe(false);
   });
 
   it('returns the remote boolean after setup', async () => {
@@ -95,23 +96,37 @@ describe('isEtaAssistEnabled', () => {
       eta_assist_enabled: true,
     });
     await setupRemoteConfig();
-    expect(isEtaAssistEnabled()).toBe(true);
+    expect(isEtaAssistRemoteEnabled()).toBe(true);
   });
 
   it('falls back to false when the boolean is missing', async () => {
     mockRemoteConfig({ max_permit_accuracy: 1500 });
     await setupRemoteConfig();
+    expect(isEtaAssistRemoteEnabled()).toBe(false);
+  });
+});
+
+describe('isEtaAssistEnabled（Remote AND 手動トグル）', () => {
+  it('Remoteと手動トグルの両方がONのときだけ有効', async () => {
+    mockRemoteConfig({ eta_assist_enabled: true });
+    await setupRemoteConfig();
+    // Remoteがtrueでも手動トグルOFFなら無効
+    expect(isEtaAssistEnabled()).toBe(false);
+    // 手動トグルONで有効
+    store.set(etaAssistManualEnabledAtom, true);
+    expect(isEtaAssistEnabled()).toBe(true);
+  });
+
+  it('Remoteがfalseなら手動トグルONでも無効(マスターOFF)', async () => {
+    store.set(etaAssistManualEnabledAtom, true);
+    mockRemoteConfig({ eta_assist_enabled: false });
+    await setupRemoteConfig();
     expect(isEtaAssistEnabled()).toBe(false);
   });
 
-  it('手動トグル(試験的機能)がONならリモート設定に依らず有効を返す', async () => {
-    // リモートは無効(未配信=フォールバックfalse)でも、手動トグルONで有効化される。
+  it('セットアップ前(Remote未取得=false)は手動トグルONでも無効', () => {
     store.set(etaAssistManualEnabledAtom, true);
-    expect(isEtaAssistEnabled()).toBe(true);
-
-    mockRemoteConfig({ eta_assist_enabled: false });
-    await setupRemoteConfig();
-    expect(isEtaAssistEnabled()).toBe(true);
+    expect(isEtaAssistEnabled()).toBe(false);
   });
 });
 

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -121,19 +121,22 @@ export const isForceNotArrivedOnLowAccuracyEnabled = (): boolean => {
   return FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK;
 };
 
-// ETAフォールバック機能の有効/無効を同期的に取得する。
-// 設定画面の試験的機能トグル(手動A/Bテスト用)が有効なら、リモート設定に依らず有効化する。
-// それ以外は setupRemoteConfig 完了後の取得済みリモート値を、未設定・取得失敗時は
-// フォールバック(false=既定無効)を返す。
-export const isEtaAssistEnabled = (): boolean => {
-  if (store.get(etaAssistManualEnabledAtom)) {
-    return true;
-  }
+// Remote Config が配信する ETA補助の許可(マスタースイッチ)を同期的に取得する。
+// setupRemoteConfig 完了後は取得済みのリモート値を、未設定・取得失敗時はフォールバック
+// (false=既定無効)を返す。これが false のときは機能を提供せず、設定画面の手動トグルも
+// 操作不可にする(ExperimentalSettings 側で disabled)。
+export const isEtaAssistRemoteEnabled = (): boolean => {
   if (cachedEtaAssistEnabled != null) {
     return cachedEtaAssistEnabled;
   }
   return ETA_ASSIST_ENABLED_FALLBACK;
 };
+
+// ETA補助機能の実効的な有効/無効を同期的に取得する。Remote Config が許可(マスターON)し、
+// かつ設定画面の手動トグルもONのときだけ有効。Remote が false のときは手動トグルの値に
+// 関わらず無効。
+export const isEtaAssistEnabled = (): boolean =>
+  isEtaAssistRemoteEnabled() && store.get(etaAssistManualEnabledAtom);
 
 // ETAフォールバックの到着確定マージン(秒)を同期的に取得する。setupRemoteConfig 完了後は
 // 取得済みのリモート値を、未完了・未設定・取得失敗時はフォールバックを返す。

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -1,4 +1,6 @@
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
+import { store } from '~/store';
+import { etaAssistManualEnabledAtom } from '~/store/atoms/experimental';
 import { workerUrl } from './workerApi';
 
 // Cloudflare Worker(/config/remote) 配信の設定キー。Worker 側のレスポンスキーと一致させる。
@@ -119,9 +121,14 @@ export const isForceNotArrivedOnLowAccuracyEnabled = (): boolean => {
   return FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK;
 };
 
-// ETAフォールバック機能の有効/無効を同期的に取得する。setupRemoteConfig 完了後は
-// 取得済みのリモート値を、未設定・取得失敗時はフォールバック(false=既定無効)を返す。
+// ETAフォールバック機能の有効/無効を同期的に取得する。
+// 設定画面の試験的機能トグル(手動A/Bテスト用)が有効なら、リモート設定に依らず有効化する。
+// それ以外は setupRemoteConfig 完了後の取得済みリモート値を、未設定・取得失敗時は
+// フォールバック(false=既定無効)を返す。
 export const isEtaAssistEnabled = (): boolean => {
+  if (store.get(etaAssistManualEnabledAtom)) {
+    return true;
+  }
   if (cachedEtaAssistEnabled != null) {
     return cachedEtaAssistEnabled;
   }

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { Alert } from 'react-native';
 import { STORAGE_KEYS } from '~/constants';
+import * as remoteConfigModule from '~/lib/remoteConfig';
 import { storage } from '~/lib/storage';
 import {
   etaAssistManualEnabledAtom,
@@ -98,7 +99,10 @@ describe('ExperimentalSettingsScreen', () => {
     alertSpy.mockRestore();
   });
 
-  it('ETA補助をONにするとatomとストレージへ保存される', () => {
+  it('Remote Config が許可していればETA補助をONにできる(atomとストレージへ保存)', () => {
+    jest
+      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
+      .mockReturnValue(true);
     const { getByLabelText, store } = renderWithStore(false);
 
     fireEvent.press(getByLabelText('etaAssistTitle'));
@@ -109,7 +113,10 @@ describe('ExperimentalSettingsScreen', () => {
     );
   });
 
-  it('ETA補助をOFFにするとatomとストレージへ保存される', () => {
+  it('Remote Config が許可していればETA補助をOFFにできる(atomとストレージへ保存)', () => {
+    jest
+      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
+      .mockReturnValue(true);
     const { getByLabelText, store } = renderWithStore(false, false, true);
 
     fireEvent.press(getByLabelText('etaAssistTitle'));
@@ -117,6 +124,21 @@ describe('ExperimentalSettingsScreen', () => {
     expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
     expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).toBe(
       'false'
+    );
+  });
+
+  it('Remote Config が false のときはETA補助トグルを操作できない', () => {
+    jest
+      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
+      .mockReturnValue(false);
+    const { getByLabelText, store } = renderWithStore(false);
+
+    // 操作不可(disabled)。押してもatomはONにならず、ONの永続化も走らない。
+    fireEvent.press(getByLabelText('etaAssistTitle'));
+
+    expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).not.toBe(
+      'true'
     );
   });
 

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -3,7 +3,10 @@ import { createStore, Provider } from 'jotai';
 import { Alert } from 'react-native';
 import { STORAGE_KEYS } from '~/constants';
 import { storage } from '~/lib/storage';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import {
+  etaAssistManualEnabledAtom,
+  portraitModeEnabledAtom,
+} from '~/store/atoms/experimental';
 import tuningState from '~/store/atoms/tuning';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
 
@@ -24,10 +27,12 @@ jest.mock('~/translation', () => ({
 
 const renderWithStore = (
   portraitModeEnabled: boolean,
-  telemetryEnabled = false
+  telemetryEnabled = false,
+  etaAssistManualEnabled = false
 ) => {
   const store = createStore();
   store.set(portraitModeEnabledAtom, portraitModeEnabled);
+  store.set(etaAssistManualEnabledAtom, etaAssistManualEnabled);
   store.set(tuningState, (prev) => ({ ...prev, telemetryEnabled }));
 
   const screen = render(
@@ -91,6 +96,28 @@ describe('ExperimentalSettingsScreen', () => {
     setSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     alertSpy.mockRestore();
+  });
+
+  it('ETA補助をONにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('etaAssistTitle'));
+
+    expect(store.get(etaAssistManualEnabledAtom)).toBe(true);
+    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).toBe(
+      'true'
+    );
+  });
+
+  it('ETA補助をOFFにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false, false, true);
+
+    fireEvent.press(getByLabelText('etaAssistTitle'));
+
+    expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).toBe(
+      'false'
+    );
   });
 
   it('テレメトリをONにするとatomとストレージへ保存される', () => {

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -16,7 +16,10 @@ import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import {
+  etaAssistManualEnabledAtom,
+  portraitModeEnabledAtom,
+} from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
@@ -95,6 +98,9 @@ const ExperimentalSettingsScreen: React.FC = () => {
   const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
     portraitModeEnabledAtom
   );
+  const [etaAssistManualEnabled, setEtaAssistManualEnabled] = useAtom(
+    etaAssistManualEnabledAtom
+  );
   const [tuning, setTuning] = useAtom(tuningState);
 
   const navigation = useNavigation();
@@ -112,6 +118,23 @@ const ExperimentalSettingsScreen: React.FC = () => {
       Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }
   }, [portraitModeEnabled, setPortraitModeEnabled]);
+
+  const handleToggleEtaAssist = useCallback(() => {
+    const flag = !etaAssistManualEnabled;
+    setEtaAssistManualEnabled(flag);
+    try {
+      storage.set(
+        STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED,
+        flag ? 'true' : 'false'
+      );
+    } catch (error) {
+      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
+      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
+      setEtaAssistManualEnabled(!flag);
+      console.error('Failed to save ETA assist setting', error);
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [etaAssistManualEnabled, setEtaAssistManualEnabled]);
 
   const handleToggleTelemetry = useCallback(() => {
     const flag = !tuning.telemetryEnabled;
@@ -161,6 +184,16 @@ const ExperimentalSettingsScreen: React.FC = () => {
           </View>
           <Typography style={styles.description}>
             {translate('telemetryDescription')}
+          </Typography>
+          <View style={styles.toggleSpacer}>
+            <ToggleItem
+              title={translate('etaAssistTitle')}
+              state={etaAssistManualEnabled}
+              onToggle={handleToggleEtaAssist}
+            />
+          </View>
+          <Typography style={styles.description}>
+            {translate('etaAssistDescription')}
           </Typography>
           <Typography style={styles.notice}>
             {translate('experimentalSettingsNotice')}

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -16,6 +16,7 @@ import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
+import { isEtaAssistRemoteEnabled } from '~/lib/remoteConfig';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
@@ -58,10 +59,12 @@ const ToggleItem = ({
   title,
   state,
   onToggle,
+  disabled = false,
 }: {
   title: string;
   state: boolean;
   onToggle: () => void;
+  disabled?: boolean;
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
@@ -69,7 +72,8 @@ const ToggleItem = ({
     <Pressable
       accessibilityRole="switch"
       accessibilityLabel={title}
-      accessibilityState={{ checked: state }}
+      accessibilityState={{ checked: state, disabled }}
+      disabled={disabled}
       onPress={onToggle}
       style={{
         flexDirection: 'row',
@@ -78,6 +82,8 @@ const ToggleItem = ({
         paddingVertical: 16,
         backgroundColor: isLEDTheme ? '#333' : 'white',
         borderRadius: isLEDTheme ? 0 : 12,
+        // Remote Config で許可されていない等、操作不可のときは淡色にして無効を示す。
+        opacity: disabled ? 0.4 : 1,
       }}
     >
       <Typography style={{ flex: 1, fontSize: 21, fontWeight: 'bold' }}>
@@ -103,6 +109,10 @@ const ExperimentalSettingsScreen: React.FC = () => {
   );
   const [tuning, setTuning] = useAtom(tuningState);
 
+  // Remote Config(マスタースイッチ)が許可していない間は、手動トグルを操作不可にする。
+  // 配信状態は起動時に確定する非リアクティブ値のため、レンダー時に一度参照すれば足りる。
+  const etaAssistRemoteEnabled = isEtaAssistRemoteEnabled();
+
   const navigation = useNavigation();
 
   const handleTogglePortraitMode = useCallback(() => {
@@ -120,6 +130,10 @@ const ExperimentalSettingsScreen: React.FC = () => {
   }, [portraitModeEnabled, setPortraitModeEnabled]);
 
   const handleToggleEtaAssist = useCallback(() => {
+    // Remote Config が許可していないときは操作させない(UI側でも disabled)。
+    if (!etaAssistRemoteEnabled) {
+      return;
+    }
     const flag = !etaAssistManualEnabled;
     setEtaAssistManualEnabled(flag);
     try {
@@ -134,7 +148,11 @@ const ExperimentalSettingsScreen: React.FC = () => {
       console.error('Failed to save ETA assist setting', error);
       Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }
-  }, [etaAssistManualEnabled, setEtaAssistManualEnabled]);
+  }, [
+    etaAssistManualEnabled,
+    setEtaAssistManualEnabled,
+    etaAssistRemoteEnabled,
+  ]);
 
   const handleToggleTelemetry = useCallback(() => {
     const flag = !tuning.telemetryEnabled;
@@ -188,8 +206,9 @@ const ExperimentalSettingsScreen: React.FC = () => {
           <View style={styles.toggleSpacer}>
             <ToggleItem
               title={translate('etaAssistTitle')}
-              state={etaAssistManualEnabled}
+              state={etaAssistRemoteEnabled && etaAssistManualEnabled}
               onToggle={handleToggleEtaAssist}
+              disabled={!etaAssistRemoteEnabled}
             />
           </View>
           <Typography style={styles.description}>

--- a/src/store/atoms/etaFallback.ts
+++ b/src/store/atoms/etaFallback.ts
@@ -1,10 +1,8 @@
 import { atom } from 'jotai';
 import type { EtaAnchor, EtaPhase } from '~/utils/etaFallback';
 
-// GPSで最後に確定した駅イベント(ETAフォールバックの仮想時計の起点)
+// GPSで最後に確定した駅イベント(ETA推定フェーズの仮想時計の起点)
 export const etaAnchorAtom = atom<EtaAnchor | null>(null);
-// ETAフォールバック(R2: ETA単独駆動)が活性中か
-export const etaFallbackActiveAtom = atom(false);
-// ETA仮想時計から推定した最新の走行フェーズ。R2駆動と、精度劣化時の
-// 到着しきい値緩和(R1: useRefreshStation が非リアクティブに参照)の双方で使う。
+// ETA仮想時計から推定した最新の走行フェーズ。精度劣化時の到着しきい値緩和
+// (R1: useRefreshStation が非リアクティブに参照)に使う。
 export const etaPhaseAtom = atom<EtaPhase | null>(null);

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -3,3 +3,9 @@ import { atom } from 'jotai';
 // 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
 // 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
 export const portraitModeEnabledAtom = atom(false);
+
+// 地下GPS喪失時のETA位置補完(R2フォールバック)を手動で有効化するトグル。
+// リモート設定(eta_assist_enabled)だけだと手動A/Bテストがしづらいため、設定画面の
+// 試験的機能から個別に切り替えられるようにする。ONのときはリモート設定より優先して
+// 有効化する(isEtaAssistEnabled 参照)。
+export const etaAssistManualEnabledAtom = atom(false);

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -4,6 +4,7 @@ import { store } from '..';
 import {
   accuracyHistoryAtom,
   lastAcceptedFixAtMsAtom,
+  lastMovingAtMsAtom,
   locationAccuracyOutlierAtom,
   locationAtom,
   rawLocationAtom,
@@ -245,6 +246,79 @@ describe('setLocation', () => {
       resetLocationState();
 
       expect(store.get(lastAcceptedFixAtMsAtom)).toBeNull();
+    });
+  });
+
+  describe('lastMovingAtMsAtom（実移動の検知）', () => {
+    // recordMotion は dt を Date.now() 差で測るため、決定的にするため now を固定する。
+    let currentNow = 1_000_000;
+
+    beforeEach(() => {
+      currentNow = 1_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => currentNow);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('初回の受理測位では基準サンプルを初期化するだけで lastMovingAtMs は立たない', () => {
+      setLocation(makeLocation(35.0, 139.0, 30, 1000));
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
+    it('閾値(150m)を超える正味変位で lastMovingAtMs が更新される', () => {
+      setLocation(makeLocation(35.0, 139.0, 30, 1000)); // 基準サンプル
+      currentNow = 1_030_000; // 30秒後
+      // 緯度 +0.003 度 ≒ 333m の北進。速度 333/30 ≒ 11 m/s で現実的。
+      setLocation(makeLocation(35.003, 139.0, 30, 31000));
+
+      expect(store.get(lastMovingAtMsAtom)).toBe(1_030_000);
+    });
+
+    it('閾値以下の微小変位(静止ジッタ)では lastMovingAtMs は更新されない', () => {
+      setLocation(makeLocation(35.0, 139.0, 30, 1000));
+      currentNow = 1_030_000;
+      // 緯度 +0.0005 度 ≒ 55m。閾値 max(150, 精度30)=150 未満なので実移動とみなさない。
+      setLocation(makeLocation(35.0005, 139.0, 30, 31000));
+
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
+    it('測位精度が粗い場合は閾値が精度まで引き上げられ、精度内の変位は無視する', () => {
+      setLocation(makeLocation(35.0, 139.0, 400, 1000));
+      currentNow = 1_030_000;
+      // 約333mの変位だが精度400mなので閾値 max(150,400)=400 を超えず未更新。
+      setLocation(makeLocation(35.003, 139.0, 400, 31000));
+
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
+    it('スムージングスキップ経路(地下鉄・不安定)でも閾値超の正味変位を検知する', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]); // 不安定=スキップ
+      setLocation(makeLocation(35.0, 139.0, 100, 1000));
+      currentNow = 1_030_000;
+      setLocation(makeLocation(35.003, 139.0, 100, 31000)); // 約333m / 30秒
+
+      expect(store.get(lastMovingAtMsAtom)).toBe(1_030_000);
+    });
+
+    it('スムージングスキップ経路でも非現実的速度のワープは実移動とみなさない', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+      setLocation(makeLocation(35.0, 139.0, 500, 1000));
+      currentNow = 1_000_100; // わずか0.1秒後
+      // 緯度 +0.01 度 ≒ 1113m を0.1秒 = 11130 m/s。MAX_PLAUSIBLE_SPEED超で除外。
+      setLocation(makeLocation(35.01, 139.0, 500, 1100));
+
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
+    it('resetLocationStateで lastMovingAtMs が null に戻る', () => {
+      store.set(lastMovingAtMsAtom, 12_345);
+      resetLocationState();
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
     });
   });
 });

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -294,6 +294,18 @@ describe('setLocation', () => {
       expect(store.get(lastMovingAtMsAtom)).toBeNull();
     });
 
+    it('低精度で基準点を確立後、良好測位が閾値超で離れても基準の不確実性内なら実移動としない', () => {
+      // 精度400mの粗い基準点。真の位置は±400mの不確実性を持つ。
+      setLocation(makeLocation(35.0, 139.0, 400, 1000));
+      currentNow = 1_030_000;
+      // その後、精度20mの良好測位。基準点から約333m離れているが、これは基準点(400m)の
+      // 不確実性で説明でき、実際の移動とは限らない。閾値 max(150, 20, 前回400)=400 を
+      // 超えないため打刻しない(劣化→復帰直後の誤検知を防ぐ)。
+      setLocation(makeLocation(35.003, 139.0, 20, 31000));
+
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
     it('スムージングスキップ経路(地下鉄・不安定)でも閾値超の正味変位を検知する', () => {
       setStationLineType(LineType.Subway);
       store.set(accuracyHistoryAtom, [10, 300, 20, 400]); // 不安定=スキップ

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -327,6 +327,18 @@ describe('setLocation', () => {
       expect(store.get(lastMovingAtMsAtom)).toBeNull();
     });
 
+    it('長時間停車後に単発の粗いドリフトが来ても(低速なら)実移動とみなさない', () => {
+      // 基準サンプルを確立。
+      setLocation(makeLocation(35.0, 139.0, 60, 1000));
+      // 10分静止(この間は棄却などで打刻されず基準サンプルは古いまま)。
+      currentNow = 1_000_000 + 600_000;
+      // 10分後に約222mジャンプ。dist>閾値だが 222m/600s≒0.37m/s と低速なので、
+      // 走行ではなくドリフトとみなして打刻しない。
+      setLocation(makeLocation(35.002, 139.0, 60, 1_601_000));
+
+      expect(store.get(lastMovingAtMsAtom)).toBeNull();
+    });
+
     it('resetLocationStateで lastMovingAtMs が null に戻る', () => {
       store.set(lastMovingAtMsAtom, 12_345);
       resetLocationState();

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -3,7 +3,6 @@ import { LineType, type Station } from '~/@types/graphql';
 import { store } from '..';
 import {
   accuracyHistoryAtom,
-  lastAcceptedFixAtMsAtom,
   lastMovingAtMsAtom,
   locationAccuracyOutlierAtom,
   locationAtom,
@@ -189,63 +188,6 @@ describe('setLocation', () => {
       const result = store.get(locationAtom);
       expect(result?.coords.latitude).toBe(35.0);
       expect(result?.coords.longitude).toBe(139.0);
-    });
-  });
-
-  describe('lastAcceptedFixAtMsAtom（ETAフォールバックのstaleness判定用）', () => {
-    it('通常のsetLocation受理でlastAcceptedFixAtMsが更新される', () => {
-      const before = Date.now();
-      setLocation(makeLocation(35.0, 139.0, 30, 1000));
-      const after = Date.now();
-
-      const recordedAt = store.get(lastAcceptedFixAtMsAtom);
-      expect(recordedAt).not.toBeNull();
-      expect(recordedAt as number).toBeGreaterThanOrEqual(before);
-      expect(recordedAt as number).toBeLessThanOrEqual(after);
-    });
-
-    it('地下鉄でスムージングスキップされた受理パスでもlastAcceptedFixAtMsが更新される', () => {
-      setStationLineType(LineType.Subway);
-      // 高い変動の精度履歴をセット（スムージングスキップ条件を満たす）
-      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
-
-      const before = Date.now();
-      setLocation(makeLocation(35.0, 139.0, 500, 1000));
-      const after = Date.now();
-
-      const recordedAt = store.get(lastAcceptedFixAtMsAtom);
-      expect(recordedAt).not.toBeNull();
-      expect(recordedAt as number).toBeGreaterThanOrEqual(before);
-      expect(recordedAt as number).toBeLessThanOrEqual(after);
-    });
-
-    it('speedフィルタでワープ棄却される場合はlastAcceptedFixAtMsが更新されない', () => {
-      // フィルタ基準となる前回値を用意する
-      setLocation(makeLocation(35.0, 139.0, 30, 1000));
-      const recordedAfterFirst = store.get(lastAcceptedFixAtMsAtom);
-
-      // 1秒で遠方へジャンプ → MAX_PLAUSIBLE_SPEED超過で座標は棄却される
-      setLocation(makeLocation(36.0, 140.0, 30, 2000));
-
-      expect(store.get(lastAcceptedFixAtMsAtom)).toBe(recordedAfterFirst);
-    });
-
-    it('store.set(locationAtom, …)の直書きではlastAcceptedFixAtMsは更新されない', () => {
-      expect(store.get(lastAcceptedFixAtMsAtom)).toBeNull();
-
-      store.set(locationAtom, makeLocation(35.0, 139.0, 30, 1000));
-
-      expect(store.get(locationAtom)).not.toBeNull();
-      expect(store.get(lastAcceptedFixAtMsAtom)).toBeNull();
-    });
-
-    it('resetLocationStateでnullに戻る', () => {
-      setLocation(makeLocation(35.0, 139.0, 30, 1000));
-      expect(store.get(lastAcceptedFixAtMsAtom)).not.toBeNull();
-
-      resetLocationState();
-
-      expect(store.get(lastAcceptedFixAtMsAtom)).toBeNull();
     });
   });
 

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -3,7 +3,6 @@ import { LineType, type Station } from '~/@types/graphql';
 import { store } from '..';
 import {
   accuracyHistoryAtom,
-  lastMovingAtMsAtom,
   locationAccuracyOutlierAtom,
   locationAtom,
   rawLocationAtom,
@@ -188,103 +187,6 @@ describe('setLocation', () => {
       const result = store.get(locationAtom);
       expect(result?.coords.latitude).toBe(35.0);
       expect(result?.coords.longitude).toBe(139.0);
-    });
-  });
-
-  describe('lastMovingAtMsAtom（実移動の検知）', () => {
-    // recordMotion は dt を Date.now() 差で測るため、決定的にするため now を固定する。
-    let currentNow = 1_000_000;
-
-    beforeEach(() => {
-      currentNow = 1_000_000;
-      jest.spyOn(Date, 'now').mockImplementation(() => currentNow);
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('初回の受理測位では基準サンプルを初期化するだけで lastMovingAtMs は立たない', () => {
-      setLocation(makeLocation(35.0, 139.0, 30, 1000));
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('閾値(150m)を超える正味変位で lastMovingAtMs が更新される', () => {
-      setLocation(makeLocation(35.0, 139.0, 30, 1000)); // 基準サンプル
-      currentNow = 1_030_000; // 30秒後
-      // 緯度 +0.003 度 ≒ 333m の北進。速度 333/30 ≒ 11 m/s で現実的。
-      setLocation(makeLocation(35.003, 139.0, 30, 31000));
-
-      expect(store.get(lastMovingAtMsAtom)).toBe(1_030_000);
-    });
-
-    it('閾値以下の微小変位(静止ジッタ)では lastMovingAtMs は更新されない', () => {
-      setLocation(makeLocation(35.0, 139.0, 30, 1000));
-      currentNow = 1_030_000;
-      // 緯度 +0.0005 度 ≒ 55m。閾値 max(150, 精度30)=150 未満なので実移動とみなさない。
-      setLocation(makeLocation(35.0005, 139.0, 30, 31000));
-
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('測位精度が粗い場合は閾値が精度まで引き上げられ、精度内の変位は無視する', () => {
-      setLocation(makeLocation(35.0, 139.0, 400, 1000));
-      currentNow = 1_030_000;
-      // 約333mの変位だが精度400mなので閾値 max(150,400)=400 を超えず未更新。
-      setLocation(makeLocation(35.003, 139.0, 400, 31000));
-
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('低精度で基準点を確立後、良好測位が閾値超で離れても基準の不確実性内なら実移動としない', () => {
-      // 精度400mの粗い基準点。真の位置は±400mの不確実性を持つ。
-      setLocation(makeLocation(35.0, 139.0, 400, 1000));
-      currentNow = 1_030_000;
-      // その後、精度20mの良好測位。基準点から約333m離れているが、これは基準点(400m)の
-      // 不確実性で説明でき、実際の移動とは限らない。閾値 max(150, 20, 前回400)=400 を
-      // 超えないため打刻しない(劣化→復帰直後の誤検知を防ぐ)。
-      setLocation(makeLocation(35.003, 139.0, 20, 31000));
-
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('スムージングスキップ経路(地下鉄・不安定)でも閾値超の正味変位を検知する', () => {
-      setStationLineType(LineType.Subway);
-      store.set(accuracyHistoryAtom, [10, 300, 20, 400]); // 不安定=スキップ
-      setLocation(makeLocation(35.0, 139.0, 100, 1000));
-      currentNow = 1_030_000;
-      setLocation(makeLocation(35.003, 139.0, 100, 31000)); // 約333m / 30秒
-
-      expect(store.get(lastMovingAtMsAtom)).toBe(1_030_000);
-    });
-
-    it('スムージングスキップ経路でも非現実的速度のワープは実移動とみなさない', () => {
-      setStationLineType(LineType.Subway);
-      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
-      setLocation(makeLocation(35.0, 139.0, 500, 1000));
-      currentNow = 1_000_100; // わずか0.1秒後
-      // 緯度 +0.01 度 ≒ 1113m を0.1秒 = 11130 m/s。MAX_PLAUSIBLE_SPEED超で除外。
-      setLocation(makeLocation(35.01, 139.0, 500, 1100));
-
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('長時間停車後に単発の粗いドリフトが来ても(低速なら)実移動とみなさない', () => {
-      // 基準サンプルを確立。
-      setLocation(makeLocation(35.0, 139.0, 60, 1000));
-      // 10分静止(この間は棄却などで打刻されず基準サンプルは古いまま)。
-      currentNow = 1_000_000 + 600_000;
-      // 10分後に約222mジャンプ。dist>閾値だが 222m/600s≒0.37m/s と低速なので、
-      // 走行ではなくドリフトとみなして打刻しない。
-      setLocation(makeLocation(35.002, 139.0, 60, 1_601_000));
-
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
-    });
-
-    it('resetLocationStateで lastMovingAtMs が null に戻る', () => {
-      store.set(lastMovingAtMsAtom, 12_345);
-      resetLocationState();
-      expect(store.get(lastMovingAtMsAtom)).toBeNull();
     });
   });
 });

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -92,9 +92,16 @@ const lastMotionSampleAtom = atom<{
 // 変位を蓄積する(徒歩・静止ジッタの誤検知を抑える)。
 const MOTION_MIN_DISTANCE_M = 150;
 
+// 実移動とみなす実効速度の下限(m/s ≒ 5.4km/h)。長時間停車後は基準サンプルが古くなり
+// dtSec が肥大化するため、単発の粗い測位ドリフト(例:10分停車→200mジャンプ=0.33m/s)でも
+// dist 閾値を超えると誤打刻しうる。列車走行は徐行でもこれを上回るため、下限速度で
+// 「ゆっくりドリフト」と「走行」を切り分ける。
+const MOTION_MIN_SPEED_MPS = 1.5;
+
 // 受理測位ごとに、直前サンプルからの正味変位で実移動(=電車が動いている)を検知して
-// 打刻する。ジッタ(≤max(150m, 前後の精度))は無視、ワープ(>MAX_PLAUSIBLE_SPEED)も除外。
-// GPS凍結(棄却)中は受理測位が来ないため呼ばれず、駅で待機中に誤って移動と判定しない。
+// 打刻する。ジッタ(≤max(150m, 前後の精度))は無視、速度が下限〜ワープの範囲外(=停車中の
+// 緩慢なドリフトや非現実的なジャンプ)も除外。GPS凍結(棄却)中は受理測位が来ないため
+// 呼ばれず、駅で待機中に誤って移動と判定しない。
 const recordMotion = (
   location: Location.LocationObject,
   nowMs: number
@@ -111,7 +118,7 @@ const recordMotion = (
     return;
   }
   const dtSec = (nowMs - prev.timestampMs) / 1000;
-  // 同一時刻・時刻逆行では速度を評価できず、ワープガードが機能しない。実移動とみなさず
+  // 同一時刻・時刻逆行では速度を評価できず、速度ガードが機能しない。実移動とみなさず
   // 打ち切る(サンプルも据え置き、次の正の経過時間の測位で正しく判定する)。
   if (dtSec <= 0) {
     return;
@@ -129,7 +136,11 @@ const recordMotion = (
     accuracy ?? 0,
     prev.accuracy ?? 0
   );
-  if (dist > threshold && speed < MAX_PLAUSIBLE_SPEED) {
+  if (
+    dist > threshold &&
+    speed > MOTION_MIN_SPEED_MPS &&
+    speed < MAX_PLAUSIBLE_SPEED
+  ) {
     store.set(lastMovingAtMsAtom, nowMs);
     store.set(lastMotionSampleAtom, {
       latitude,

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -61,85 +61,6 @@ export const locationAccuracyOutlierAtom = atom(false);
 // 地下鉄モード中は更新しないため、モード復帰後にノイジーなprevで誤棄却されるのを防ぐ
 const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
 
-// 実移動(=電車が実際に動いている)を最後に観測した時刻(ms)。ETAフォールバックが
-// 「駅で静止して待っているだけ」を「走行中」と誤認して位置を進めてしまう問題を防ぐため、
-// GPS喪失直前に電車が動いていたかの判定に使う。人の静止・GPS凍結中は更新されない。
-export const lastMovingAtMsAtom = atom<number | null>(null);
-
-// 移動検知用の直近サンプル(受理測位の座標+時刻+精度)。lastFilteredLocationは地下鉄
-// スキップ経路で更新されないため、全受理経路で更新する専用サンプルを使う。精度も持たせ、
-// 劣化区間の粗い基準点が残ったまま良好測位が復帰した際の誤検知抑止に使う。
-const lastMotionSampleAtom = atom<{
-  latitude: number;
-  longitude: number;
-  timestampMs: number;
-  accuracy: number | null;
-} | null>(null);
-
-// 実移動とみなす正味変位の下限(m)。粗い測位のジッタ(±精度)を超える移動のみ拾うため、
-// 精度と併せて max を取る。閾値以下ではサンプルを更新せず、真の移動でのみ超えるよう
-// 変位を蓄積する(徒歩・静止ジッタの誤検知を抑える)。
-const MOTION_MIN_DISTANCE_M = 150;
-
-// 実移動とみなす実効速度の下限(m/s ≒ 5.4km/h)。長時間停車後は基準サンプルが古くなり
-// dtSec が肥大化するため、単発の粗い測位ドリフト(例:10分停車→200mジャンプ=0.33m/s)でも
-// dist 閾値を超えると誤打刻しうる。列車走行は徐行でもこれを上回るため、下限速度で
-// 「ゆっくりドリフト」と「走行」を切り分ける。
-const MOTION_MIN_SPEED_MPS = 1.5;
-
-// 受理測位ごとに、直前サンプルからの正味変位で実移動(=電車が動いている)を検知して
-// 打刻する。ジッタ(≤max(150m, 前後の精度))は無視、速度が下限〜ワープの範囲外(=停車中の
-// 緩慢なドリフトや非現実的なジャンプ)も除外。GPS凍結(棄却)中は受理測位が来ないため
-// 呼ばれず、駅で待機中に誤って移動と判定しない。
-const recordMotion = (
-  location: Location.LocationObject,
-  nowMs: number
-): void => {
-  const prev = store.get(lastMotionSampleAtom);
-  const { latitude, longitude, accuracy } = location.coords;
-  if (prev == null) {
-    store.set(lastMotionSampleAtom, {
-      latitude,
-      longitude,
-      timestampMs: nowMs,
-      accuracy: accuracy ?? null,
-    });
-    return;
-  }
-  const dtSec = (nowMs - prev.timestampMs) / 1000;
-  // 同一時刻・時刻逆行では速度を評価できず、速度ガードが機能しない。実移動とみなさず
-  // 打ち切る(サンプルも据え置き、次の正の経過時間の測位で正しく判定する)。
-  if (dtSec <= 0) {
-    return;
-  }
-  const dist = getDistance(
-    { latitude: prev.latitude, longitude: prev.longitude },
-    { latitude, longitude }
-  );
-  const speed = dist / dtSec;
-  // 前後どちらの測位の精度も不確実性として効く。劣化区間の粗い基準点(例:400m)が
-  // 残ったままGPSが良好復帰した直後、その不確実性の範囲内の見かけの変位を実移動と
-  // 誤認しないよう、前サンプルと現在の精度の大きい方まで閾値を引き上げる。
-  const threshold = Math.max(
-    MOTION_MIN_DISTANCE_M,
-    accuracy ?? 0,
-    prev.accuracy ?? 0
-  );
-  if (
-    dist > threshold &&
-    speed > MOTION_MIN_SPEED_MPS &&
-    speed < MAX_PLAUSIBLE_SPEED
-  ) {
-    store.set(lastMovingAtMsAtom, nowMs);
-    store.set(lastMotionSampleAtom, {
-      latitude,
-      longitude,
-      timestampMs: nowMs,
-      accuracy: accuracy ?? null,
-    });
-  }
-};
-
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
   store.set(locationAtom, null);
@@ -147,8 +68,6 @@ export const resetLocationState = () => {
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
-  store.set(lastMovingAtMsAtom, null);
-  store.set(lastMotionSampleAtom, null);
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -175,7 +94,6 @@ export const setLocation = (location: Location.LocationObject) => {
   // フィルタ判定より前で解除する。
   store.set(locationAccuracyOutlierAtom, false);
 
-  const nowMs = Date.now();
   const filteredPrev = store.get(lastFilteredLocationAtom);
   const currentHistory = store.get(accuracyHistoryAtom);
   const newAccuracy = location.coords.accuracy;
@@ -196,7 +114,6 @@ export const setLocation = (location: Location.LocationObject) => {
   if (skipSmoothing) {
     store.set(locationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    recordMotion(location, nowMs);
     return;
   }
 
@@ -205,7 +122,6 @@ export const setLocation = (location: Location.LocationObject) => {
     store.set(locationAtom, location);
     store.set(lastFilteredLocationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    recordMotion(location, nowMs);
     return;
   }
 
@@ -253,6 +169,4 @@ export const setLocation = (location: Location.LocationObject) => {
   store.set(locationAtom, smoothedLocation);
   store.set(lastFilteredLocationAtom, smoothedLocation);
   store.set(accuracyHistoryAtom, updatedHistory);
-  // 移動検知は生の測位座標(smoothedではなく実測変位)で行う。
-  recordMotion(location, nowMs);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -72,6 +72,58 @@ export const lastAcceptedFixAtMsAtom = atom<number | null>(null);
 // 「良好測位が来た」と誤判定しうる。スナップの影響を受けないこの値で解除判定を行う。
 export const lastAcceptedFixAccuracyAtom = atom<number | null>(null);
 
+// 実移動(=電車が実際に動いている)を最後に観測した時刻(ms)。ETAフォールバックが
+// 「駅で静止して待っているだけ」を「走行中」と誤認して位置を進めてしまう問題を防ぐため、
+// GPS喪失直前に電車が動いていたかの判定に使う。人の静止・GPS凍結中は更新されない。
+export const lastMovingAtMsAtom = atom<number | null>(null);
+
+// 移動検知用の直近サンプル(受理測位の座標+時刻)。lastFilteredLocationは地下鉄スキップ
+// 経路で更新されないため、全受理経路で更新する専用サンプルを使う。
+const lastMotionSampleAtom = atom<{
+  latitude: number;
+  longitude: number;
+  timestampMs: number;
+} | null>(null);
+
+// 実移動とみなす正味変位の下限(m)。粗い測位のジッタ(±精度)を超える移動のみ拾うため、
+// 精度と併せて max を取る。閾値以下ではサンプルを更新せず、真の移動でのみ超えるよう
+// 変位を蓄積する(徒歩・静止ジッタの誤検知を抑える)。
+const MOTION_MIN_DISTANCE_M = 150;
+
+// 受理測位ごとに、直前サンプルからの正味変位で実移動(=電車が動いている)を検知して
+// 打刻する。ジッタ(≤max(150m, 精度))は無視、ワープ(>MAX_PLAUSIBLE_SPEED)も除外。
+// GPS凍結(棄却)中は受理測位が来ないため呼ばれず、駅で待機中に誤って移動と判定しない。
+const recordMotion = (
+  location: Location.LocationObject,
+  nowMs: number
+): void => {
+  const prev = store.get(lastMotionSampleAtom);
+  const { latitude, longitude, accuracy } = location.coords;
+  if (prev == null) {
+    store.set(lastMotionSampleAtom, {
+      latitude,
+      longitude,
+      timestampMs: nowMs,
+    });
+    return;
+  }
+  const dist = getDistance(
+    { latitude: prev.latitude, longitude: prev.longitude },
+    { latitude, longitude }
+  );
+  const dtSec = (nowMs - prev.timestampMs) / 1000;
+  const speed = dtSec > 0 ? dist / dtSec : 0;
+  const threshold = Math.max(MOTION_MIN_DISTANCE_M, accuracy ?? 0);
+  if (dist > threshold && speed < MAX_PLAUSIBLE_SPEED) {
+    store.set(lastMovingAtMsAtom, nowMs);
+    store.set(lastMotionSampleAtom, {
+      latitude,
+      longitude,
+      timestampMs: nowMs,
+    });
+  }
+};
+
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
   store.set(locationAtom, null);
@@ -81,6 +133,8 @@ export const resetLocationState = () => {
   store.set(locationAccuracyOutlierAtom, false);
   store.set(lastAcceptedFixAtMsAtom, null);
   store.set(lastAcceptedFixAccuracyAtom, null);
+  store.set(lastMovingAtMsAtom, null);
+  store.set(lastMotionSampleAtom, null);
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -107,6 +161,7 @@ export const setLocation = (location: Location.LocationObject) => {
   // フィルタ判定より前で解除する。
   store.set(locationAccuracyOutlierAtom, false);
 
+  const nowMs = Date.now();
   const filteredPrev = store.get(lastFilteredLocationAtom);
   const currentHistory = store.get(accuracyHistoryAtom);
   const newAccuracy = location.coords.accuracy;
@@ -127,8 +182,9 @@ export const setLocation = (location: Location.LocationObject) => {
   if (skipSmoothing) {
     store.set(locationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    store.set(lastAcceptedFixAtMsAtom, Date.now());
+    store.set(lastAcceptedFixAtMsAtom, nowMs);
     store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
+    recordMotion(location, nowMs);
     return;
   }
 
@@ -137,8 +193,9 @@ export const setLocation = (location: Location.LocationObject) => {
     store.set(locationAtom, location);
     store.set(lastFilteredLocationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    store.set(lastAcceptedFixAtMsAtom, Date.now());
+    store.set(lastAcceptedFixAtMsAtom, nowMs);
     store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
+    recordMotion(location, nowMs);
     return;
   }
 
@@ -186,6 +243,8 @@ export const setLocation = (location: Location.LocationObject) => {
   store.set(locationAtom, smoothedLocation);
   store.set(lastFilteredLocationAtom, smoothedLocation);
   store.set(accuracyHistoryAtom, updatedHistory);
-  store.set(lastAcceptedFixAtMsAtom, Date.now());
+  store.set(lastAcceptedFixAtMsAtom, nowMs);
   store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
+  // 移動検知は生の測位座標(smoothedではなく実測変位)で行う。
+  recordMotion(location, nowMs);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -61,17 +61,6 @@ export const locationAccuracyOutlierAtom = atom(false);
 // 地下鉄モード中は更新しないため、モード復帰後にノイジーなprevで誤棄却されるのを防ぐ
 const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
 
-// setLocation()を通過して受理された最後の実測位の時刻(ms)。ETAフォールバックの
-// 無信号(staleness)判定に使う。store.set(locationAtom, …)の直書き(シミュレーション/
-// フォールバックの座標スナップ)では更新されないことが重要で、GPSが実際に生きているか
-// どうかをこの値の新しさだけで判定できるようにする。
-export const lastAcceptedFixAtMsAtom = atom<number | null>(null);
-
-// 上記と対になる「最後に受理された実測位の精度(m)」。フォールバックの座標スナップは
-// locationAtom を accuracy:0 で直書きするため、locationAtom の精度だけを見ると
-// 「良好測位が来た」と誤判定しうる。スナップの影響を受けないこの値で解除判定を行う。
-export const lastAcceptedFixAccuracyAtom = atom<number | null>(null);
-
 // 実移動(=電車が実際に動いている)を最後に観測した時刻(ms)。ETAフォールバックが
 // 「駅で静止して待っているだけ」を「走行中」と誤認して位置を進めてしまう問題を防ぐため、
 // GPS喪失直前に電車が動いていたかの判定に使う。人の静止・GPS凍結中は更新されない。
@@ -158,8 +147,6 @@ export const resetLocationState = () => {
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
-  store.set(lastAcceptedFixAtMsAtom, null);
-  store.set(lastAcceptedFixAccuracyAtom, null);
   store.set(lastMovingAtMsAtom, null);
   store.set(lastMotionSampleAtom, null);
 };
@@ -209,8 +196,6 @@ export const setLocation = (location: Location.LocationObject) => {
   if (skipSmoothing) {
     store.set(locationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    store.set(lastAcceptedFixAtMsAtom, nowMs);
-    store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
     recordMotion(location, nowMs);
     return;
   }
@@ -220,8 +205,6 @@ export const setLocation = (location: Location.LocationObject) => {
     store.set(locationAtom, location);
     store.set(lastFilteredLocationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
-    store.set(lastAcceptedFixAtMsAtom, nowMs);
-    store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
     recordMotion(location, nowMs);
     return;
   }
@@ -270,8 +253,6 @@ export const setLocation = (location: Location.LocationObject) => {
   store.set(locationAtom, smoothedLocation);
   store.set(lastFilteredLocationAtom, smoothedLocation);
   store.set(accuracyHistoryAtom, updatedHistory);
-  store.set(lastAcceptedFixAtMsAtom, nowMs);
-  store.set(lastAcceptedFixAccuracyAtom, newAccuracy ?? null);
   // 移動検知は生の測位座標(smoothedではなく実測変位)で行う。
   recordMotion(location, nowMs);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -77,12 +77,14 @@ export const lastAcceptedFixAccuracyAtom = atom<number | null>(null);
 // GPS喪失直前に電車が動いていたかの判定に使う。人の静止・GPS凍結中は更新されない。
 export const lastMovingAtMsAtom = atom<number | null>(null);
 
-// 移動検知用の直近サンプル(受理測位の座標+時刻)。lastFilteredLocationは地下鉄スキップ
-// 経路で更新されないため、全受理経路で更新する専用サンプルを使う。
+// 移動検知用の直近サンプル(受理測位の座標+時刻+精度)。lastFilteredLocationは地下鉄
+// スキップ経路で更新されないため、全受理経路で更新する専用サンプルを使う。精度も持たせ、
+// 劣化区間の粗い基準点が残ったまま良好測位が復帰した際の誤検知抑止に使う。
 const lastMotionSampleAtom = atom<{
   latitude: number;
   longitude: number;
   timestampMs: number;
+  accuracy: number | null;
 } | null>(null);
 
 // 実移動とみなす正味変位の下限(m)。粗い測位のジッタ(±精度)を超える移動のみ拾うため、
@@ -91,7 +93,7 @@ const lastMotionSampleAtom = atom<{
 const MOTION_MIN_DISTANCE_M = 150;
 
 // 受理測位ごとに、直前サンプルからの正味変位で実移動(=電車が動いている)を検知して
-// 打刻する。ジッタ(≤max(150m, 精度))は無視、ワープ(>MAX_PLAUSIBLE_SPEED)も除外。
+// 打刻する。ジッタ(≤max(150m, 前後の精度))は無視、ワープ(>MAX_PLAUSIBLE_SPEED)も除外。
 // GPS凍結(棄却)中は受理測位が来ないため呼ばれず、駅で待機中に誤って移動と判定しない。
 const recordMotion = (
   location: Location.LocationObject,
@@ -104,22 +106,36 @@ const recordMotion = (
       latitude,
       longitude,
       timestampMs: nowMs,
+      accuracy: accuracy ?? null,
     });
+    return;
+  }
+  const dtSec = (nowMs - prev.timestampMs) / 1000;
+  // 同一時刻・時刻逆行では速度を評価できず、ワープガードが機能しない。実移動とみなさず
+  // 打ち切る(サンプルも据え置き、次の正の経過時間の測位で正しく判定する)。
+  if (dtSec <= 0) {
     return;
   }
   const dist = getDistance(
     { latitude: prev.latitude, longitude: prev.longitude },
     { latitude, longitude }
   );
-  const dtSec = (nowMs - prev.timestampMs) / 1000;
-  const speed = dtSec > 0 ? dist / dtSec : 0;
-  const threshold = Math.max(MOTION_MIN_DISTANCE_M, accuracy ?? 0);
+  const speed = dist / dtSec;
+  // 前後どちらの測位の精度も不確実性として効く。劣化区間の粗い基準点(例:400m)が
+  // 残ったままGPSが良好復帰した直後、その不確実性の範囲内の見かけの変位を実移動と
+  // 誤認しないよう、前サンプルと現在の精度の大きい方まで閾値を引き上げる。
+  const threshold = Math.max(
+    MOTION_MIN_DISTANCE_M,
+    accuracy ?? 0,
+    prev.accuracy ?? 0
+  );
   if (dist > threshold && speed < MAX_PLAUSIBLE_SPEED) {
     store.set(lastMovingAtMsAtom, nowMs);
     store.set(lastMotionSampleAtom, {
       latitude,
       longitude,
       timestampMs: nowMs,
+      accuracy: accuracy ?? null,
     });
   }
 };

--- a/src/utils/etaFallback.ts
+++ b/src/utils/etaFallback.ts
@@ -58,24 +58,6 @@ export const APPROACH_LEAD_MIN_MIN = 0.5;
 /** 接近リードの上限(分)。長い駅間でも接近開始が早すぎないよう頭打ちにする。 */
 export const APPROACH_LEAD_MAX_MIN = 1.5;
 
-/**
- * 「電車が実際に動いていた」とみなす有効期間(ms)。GPS喪失の直前この時間内に実移動が
- * 観測されていれば R2 の発動・発車(DEPARTED)記録を許可する。静止が続くと期限切れになり、
- * 駅で待機中に位置が勝手に進む誤動作を防ぐ(motion gate)。実機チューニング前提。
- */
-export const MOVING_RECENCY_MS = 90_000;
-
-/**
- * GPS喪失の直前この時間内に実移動が観測されていたか(=電車が実際に動いていた証拠)。
- * useEtaAnchor(発車記録)と useEtaFallback(R2発動)が同じ基準を使うよう共通化し、
- * しきい値や判定条件を変えても両者がずれないようにする。
- */
-export const isRecentlyMoving = (
-  lastMovingAtMs: number | null,
-  nowMs: number
-): boolean =>
-  lastMovingAtMs != null && nowMs - lastMovingAtMs < MOVING_RECENCY_MS;
-
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 

--- a/src/utils/etaFallback.ts
+++ b/src/utils/etaFallback.ts
@@ -58,6 +58,13 @@ export const APPROACH_LEAD_MIN_MIN = 0.5;
 /** 接近リードの上限(分)。長い駅間でも接近開始が早すぎないよう頭打ちにする。 */
 export const APPROACH_LEAD_MAX_MIN = 1.5;
 
+/**
+ * 「電車が実際に動いていた」とみなす有効期間(ms)。GPS喪失の直前この時間内に実移動が
+ * 観測されていれば R2 の発動・発車(DEPARTED)記録を許可する。静止が続くと期限切れになり、
+ * 駅で待機中に位置が勝手に進む誤動作を防ぐ(motion gate)。実機チューニング前提。
+ */
+export const MOVING_RECENCY_MS = 90_000;
+
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 

--- a/src/utils/etaFallback.ts
+++ b/src/utils/etaFallback.ts
@@ -65,6 +65,17 @@ export const APPROACH_LEAD_MAX_MIN = 1.5;
  */
 export const MOVING_RECENCY_MS = 90_000;
 
+/**
+ * GPS喪失の直前この時間内に実移動が観測されていたか(=電車が実際に動いていた証拠)。
+ * useEtaAnchor(発車記録)と useEtaFallback(R2発動)が同じ基準を使うよう共通化し、
+ * しきい値や判定条件を変えても両者がずれないようにする。
+ */
+export const isRecentlyMoving = (
+  lastMovingAtMs: number | null,
+  nowMs: number
+): boolean =>
+  lastMovingAtMs != null && nowMs - lastMovingAtMs < MOVING_RECENCY_MS;
+
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 


### PR DESCRIPTION
## 概要

先行PR #6366 で入れた ETA フォールバックのうち、**GPSが喪失した区間で ETA が現在地・到着を単独駆動する部分（R2）** が、地下鉄で重大なデグレを起こすことが実機で判明したため撤去する。具体的には、駅に到着後も ETA の時刻進行にしたがって現在地が勝手に動き、GPSの実測と喧嘩していた（クレームになりうるレベル）。

GPSが完全凍結した区間では「待機／走行／遅延」を位置から区別できず、ETA単独で位置を進めるのは原理的に安全に行えない。そこで **ETA は「GPSの補助」に役割を限定**する:

- **到着・現在地・接近は常にGPS（`useRefreshStation`）が権威**。ETA はこれらを一切駆動しない。
- ETA は推定フェーズ（`etaPhaseAtom`）の公開に徹し、精度劣化時に **「ETAが同じ駅で停車を示すときだけ、その駅の到着しきい値を緩和する」補助（R1、既存）** にのみ使う。到着判定自体はGPSが行う。

あわせて、この ETA 補助を切り替えられるよう、設定画面の試験的機能にトグルを追加する。**Remote Config `eta_assist_enabled` をマスタースイッチ**とし、それが false のときは手動トグルも操作不可にする。

> 注: 本PRは「精度向上」ではなく主に「デグレの除去」。R1 が体感精度を上げるかは未検証で、追加したトグルで今後検証する前提。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- **R2（ETA単独の位置・到着駆動）を撤去**（`src/hooks/useEtaFallback.ts`）: 発動／解除／`drive`／座標スナップ／`etaFallbackActiveAtom` の駆動をすべて削除し、`useEtaFallback` は毎tick `estimateEtaPhase` を評価して `etaPhaseAtom` を公開するだけにした。位置・到着・接近・現在駅は書き換えない（GPSを唯一の権威に保つ）。
- **ETA補助（R1）は維持**（`src/hooks/useRefreshStation.ts`）: 精度劣化時に `etaPhaseAtom` が最寄り駅で DWELLING を示すときだけ到着しきい値を緩和する既存ロジックはそのまま。到着はGPSが確定する。
- **アンカー記録**（`src/hooks/useEtaAnchor.ts`）: 到着中／発車（`arrived` true→false）を `etaAnchorAtom` へ記録し、`etaPhaseAtom` の仮想時計の起点にする。ETAは位置を駆動しないため、仮に静止中の強制未到着で `DEPARTED` が記録されても、R1は最寄り駅とETA停車駅が一致する時だけ効き、GPS復帰で自己修復する。
- **設定の試験的機能に「到着判定の改善」トグルを追加**（`src/screens/ExperimentalSettings.tsx` ほか）: `etaAssistManualEnabledAtom`＋`ETA_ASSIST_MANUAL_ENABLED` で永続化し、起動時に `Permitted.tsx` で復元。**実効有効 = Remote Config（マスター）AND 手動トグル**。Remote が false のときはトグルを disabled にして手動でも有効化できない（`isEtaAssistRemoteEnabled` を切り出し）。翻訳キー `etaAssistTitle` / `etaAssistDescription` を ja/en に追加。
- **不要コードの撤去**: R2撤去で参照ゼロになった `etaFallbackActiveAtom`（＋`useRefreshStation` の2ライターゲート）、staleness用の `lastAcceptedFix*` atom を削除。ETAが位置を駆動しなくなったことで役割を失った実移動検知（`recordMotion` / `lastMovingAtMsAtom` / `isRecentlyMoving`）も撤去。
- **DevOverlay**: ETA補助が無効なときはETA診断カード（FALLBACK / ANCHOR）を表示せず、フェーズ表示の警告色は精度劣化時のみ点灯するよう調整。
- 対応するユニットテストを追加・更新（`useEtaFallback` はフェーズ公開のみ＆状態非駆動、`remoteConfig`／`ExperimentalSettings` のマスタースイッチ挙動、`DevOverlay` の無効時非表示ほか）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（2005件パス）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ETA補助の手動切り替え設定を追加し、設定画面から有効/無効を変更できるようになりました。
  * ETA推定フェーズに応じた表示を導入し、到着判定や補助情報の見え方を改善しました。

* **変更**
  * 地下などでGPS精度が落ちる場面でも、ETA補助の表示がより安定して反映されるようになりました。
  * アンカー表示や各種通知の挙動を整理し、状態更新の一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->