### PR TITLE
R1(到着圏の緩和)を発車観測後(DEPARTEDアンカー)の前方駅限定にして地下始発駅で現在駅が進まないロックを解消

### DIFF
--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -11,6 +11,8 @@ import { useRefreshStation } from '~/hooks/useRefreshStation';
 import * as useThresholdModule from '~/hooks/useThreshold';
 import * as useWrongDirectionDetectorModule from '~/hooks/useWrongDirectionDetector';
 import * as remoteConfigModule from '~/lib/remoteConfig';
+import { store } from '~/store';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
 import sendNotificationAsync from '~/utils/native/ios/sensitiveNotificationMoudle';
 
 jest.mock('jotai', () => {
@@ -87,6 +89,9 @@ describe('useRefreshStation', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+    // R1テストで設定したETAアンカー/フェーズを既定(null)へ戻し、他テストへ漏れないようにする
+    store.set(etaAnchorAtom, null);
+    store.set(etaPhaseAtom, null);
   });
 
   it('runs without crashing with basic mocks', () => {
@@ -461,5 +466,78 @@ describe('useRefreshStation', () => {
     const body = mockSendNotification.mock.calls[0][0].body;
     expect(body).toContain('Approaching Station');
     expect(body).not.toContain('Nearest Station');
+  });
+
+  // R1(到着圏の緩和)は「発車(DEPARTED)を観測済みで、ETAが前方の次駅で停車中」の
+  // ときだけ効く。精度800mでは通常圏は arrivedThreshold(100)+min(400,150)=250m、
+  // R1圏は 100+min(400,500)=500m。駅から約350m(通常圏外・R1圏内)に現在地を置き、
+  // アンカー種別だけを変えて緩和の有無を検証する。
+  const setupR1 = (anchorKind: 'AT_STATION' | 'DEPARTED') => {
+    // mockStation.id は Maybe<number> だが実体は 1。R1は phase.stationId と
+    // nearestStation.id の一致で効くため、同じ値を数値として使い回す。
+    const stationId = mockStation.id as number;
+
+    jest.spyOn(remoteConfigModule, 'isEtaAssistEnabled').mockReturnValue(true);
+
+    // 駅(35.0,135.0)から約350m北。通常圏(250m)外・R1圏(500m)内。
+    mockUseAtomValue
+      .mockReturnValueOnce({
+        coords: {
+          latitude: 35.00315,
+          longitude: 135.0,
+          accuracy: 800,
+        },
+      }) // locationAtom
+      .mockReturnValueOnce(false) // locationAccuracyOutlierAtom
+      .mockReturnValue({ targetStationIds: [] }); // notifyState
+
+    const setStation = jest.fn();
+    mockUseSetAtom.mockReturnValueOnce(setStation).mockReturnValue(jest.fn());
+
+    jest
+      .spyOn(useNearestStationModule, 'useNearestStation')
+      .mockReturnValue(mockStation);
+    jest
+      .spyOn(useNextStationModule, 'useNextStation')
+      .mockReturnValue(mockStation);
+    jest.spyOn(useCanGoForwardModule, 'useCanGoForward').mockReturnValue(true);
+    jest.spyOn(useThresholdModule, 'useThreshold').mockReturnValue({
+      arrivedThreshold: 100,
+      approachingThreshold: 300,
+    });
+    jest
+      .spyOn(useWrongDirectionDetectorModule, 'useWrongDirectionDetector')
+      .mockReturnValue({
+        isWrongDirection: false,
+        isLoopLineWrongDirection: false,
+      });
+
+    store.set(etaAnchorAtom, {
+      stationId: anchorKind === 'DEPARTED' ? 99 : stationId,
+      kind: anchorKind,
+      observedAtMs: 0,
+    });
+    store.set(etaPhaseAtom, { kind: 'DWELLING', stationId });
+
+    renderHook(() => useRefreshStation(), {
+      wrapper: ({ children }) => <Provider>{children}</Provider>,
+    });
+
+    expect(setStation).toHaveBeenCalled();
+    const updater = setStation.mock.calls[0][0] as (prev: any) => any;
+    return updater({});
+  };
+
+  it('R1: DEPARTED後にETAが前方の次駅で停車中なら到着圏を広げて到着を確定する', () => {
+    const nextState = setupR1('DEPARTED');
+    expect(nextState.arrived).toBe(true);
+  });
+
+  it('R1: AT_STATION(停車中の自駅)には緩和を効かせず始発駅ロックを防ぐ', () => {
+    // AT_STATION アンカーの自駅DWELLINGでは緩和しないため、通常圏(250m)外の
+    // 現在地は到着扱いにならない。これにより arrived が張り付いてDEPARTEDが
+    // 記録されない自己強化ロック(始発駅から進めない)を防ぐ。
+    const nextState = setupR1('AT_STATION');
+    expect(nextState.arrived).toBe(false);
   });
 });

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -10,7 +10,7 @@ import {
   isForceNotArrivedOnLowAccuracyEnabled,
 } from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
 import {
   locationAccuracyOutlierAtom,
   locationAtom,
@@ -132,14 +132,26 @@ export const useRefreshStation = (): void => {
     // ETAが同じ駅を指すときのみ効く確認的な緩和で、精度が良い通常時(≤200m)は
     // この分岐に入らず到着判定は一切変わらない。etaPhaseAtom は毎秒更新されるため
     // 再レンダーを避けて非リアクティブに参照し、測位更新時の再評価で拾う。
+    //
+    // 前方駅限定: アンカーが DEPARTED(=発車を観測済み)のときだけ緩和する。
+    // AT_STATION アンカーから出る DWELLING は必ず自駅であり、これを緩和すると
+    // その駅の到着圏が広がって arrived が張り付く→DEPARTED が記録されず→フェーズが
+    // 自駅DWELLINGに固定される、という自己強化ロック(始発駅から進めない)に陥る。
+    // DEPARTED アンカーから出る DWELLING は前方の次駅なので、発車後の次駅到着検出
+    // という本来の目的だけを助け、停車中の駅を過剰に保持しない。
     let arrivedRadius = effectiveArrivedThreshold;
     if (
       isEtaAssistEnabled() &&
       accuracy != null &&
       accuracy > BAD_ACCURACY_THRESHOLD
     ) {
+      const anchor = store.get(etaAnchorAtom);
       const phase = store.get(etaPhaseAtom);
-      if (phase?.kind === 'DWELLING' && phase.stationId === nearestStation.id) {
+      if (
+        anchor?.kind === 'DEPARTED' &&
+        phase?.kind === 'DWELLING' &&
+        phase.stationId === nearestStation.id
+      ) {
         arrivedRadius =
           arrivedThreshold + Math.min(accuracy * 0.5, ETA_ARRIVED_BONUS_CAP);
       }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

地下鉄などGPS精度が落ちる区間で、ETA補助(R1)を有効にすると「最初の駅から現在駅が進みにくくなる」実機フィードバックへの修正です。R1の到着圏緩和が始発駅で自己強化ロックを作っていたため、緩和の適用範囲を「発車を観測済み(DEPARTEDアンカー)の前方駅」に限定します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useRefreshStation.ts` の R1(到着圏の緩和)に `anchor?.kind === 'DEPARTED'` 条件を追加し、緩和を「発車観測後の前方駅」限定にした。
  - `AT_STATION` アンカーから出る DWELLING は必ず自駅。これを緩和すると自駅の到着圏が広がって `arrived` が張り付き、`DEPARTED` が記録されず自駅 DWELLING に固定される自己強化ロック(始発駅から現在駅が進まない)に陥っていた。
  - `DEPARTED` アンカーから出る DWELLING は前方の次駅なので、発車後に次駅の到着をETAで補助する本来の目的だけを残し、停車中の駅を過剰に保持しない。
- `useRefreshStation.test.tsx` に回帰テストを2件追加(精度800m・駅から約350m=通常圏250m外/R1圏500m内でアンカー種別のみを変えて検証)。
  - `DEPARTED`: 到着圏を広げて `arrived=true`(次駅到着補助の利点は維持)。
  - `AT_STATION`: 緩和せず `arrived=false`(始発駅ロック防止を固定)。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEhSCr8uZ4drhiUxKcRFRU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ETA支援時の到着判定を調整し、特定の条件で到着圏の緩和が正しく適用されるようになりました。
  * 現在停車中の状況では緩和が適用されないようになり、判定の一貫性が向上しました。

* **Tests**
  * ETA支援の有効・無効やアンカー種別ごとの到着判定を確認するテストを追加しました。
  * テスト間で状態が残らないように整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->