### PR TITLE
継続測位の二重処理・ETA毎秒常駐タイマー・未使用GNSS購読を排除し、iOS向け省電力測位モードを実験的機能として追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -329,5 +329,7 @@
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
   "etaAssistTitle": "Improve arrival detection",
   "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid.",
+  "powerSavingLocationTitle": "Power-saving location mode",
+  "powerSavingLocationDescription": "When enabled, the app slightly lowers the requested location accuracy (best → roughly 10-meter granularity) to reduce battery drain and heat on long rides. Arrival detection uses radii of 100 meters or more, so it should not be affected; turn this off if you notice any issues. This only takes effect on iOS — behavior on Android is unchanged.",
   "passStationLabel": "Pass"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -330,5 +330,7 @@
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
   "etaAssistTitle": "到着判定の改善",
   "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。",
+  "powerSavingLocationTitle": "省電力測位モード",
+  "powerSavingLocationDescription": "有効にすると、位置情報の要求精度をわずかに下げて(最高精度→約10m単位)、長時間の乗車での電池消費と発熱を抑えます。到着判定は100m以上の圏内判定のため影響はない想定ですが、気になる場合はオフに戻してください。効果があるのはiOSのみで、Androidでは動作は変わりません。",
   "passStationLabel": "通過"
 }

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -6,7 +6,7 @@ import type { Station } from '~/@types/graphql';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import * as remoteConfigModule from '~/lib/remoteConfig';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom } from '~/store/atoms/etaFallback';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
@@ -14,6 +14,7 @@ import {
 } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
 import DevOverlay, { getDevOverlayDragTranslation } from './DevOverlay';
 
 jest.mock('jotai', () => {
@@ -45,6 +46,11 @@ jest.mock('~/hooks/useTelemetryEnabled', () => ({
   useTelemetryEnabled: jest.fn(() => true),
 }));
 
+// ETA推定フェーズは常駐atomではなくオンデマンド計算になったため、関数ごとモックする
+jest.mock('~/utils/etaPhaseNow', () => ({
+  getEtaPhaseNow: jest.fn(() => null),
+}));
+
 // Import mocked hooks for type safety
 import { useDistanceToNextStation, useNextStation } from '~/hooks';
 
@@ -58,6 +64,9 @@ const mockUseDistanceToNextStation =
   >;
 const mockUseNextStation = useNextStation as jest.MockedFunction<
   typeof useNextStation
+>;
+const mockGetEtaPhaseNow = getEtaPhaseNow as jest.MockedFunction<
+  typeof getEtaPhaseNow
 >;
 
 describe('DevOverlay', () => {
@@ -92,6 +101,7 @@ describe('DevOverlay', () => {
     etaPhase?: unknown;
     etaAnchor?: unknown;
   } = {}) => {
+    mockGetEtaPhaseNow.mockReturnValue(etaPhase as never);
     mockUseAtomValue.mockImplementation((atom) => {
       if (atom === locationAtom) {
         return location as never;
@@ -104,9 +114,6 @@ describe('DevOverlay', () => {
       }
       if (atom === autoModeEnabledAtom) {
         return autoModeEnabled as never;
-      }
-      if (atom === etaPhaseAtom) {
-        return etaPhase as never;
       }
       if (atom === etaAnchorAtom) {
         return etaAnchor as never;

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -21,13 +21,14 @@ import {
 } from '~/hooks';
 import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
 import { getMaxPermitAccuracy, isEtaAssistEnabled } from '~/lib/remoteConfig';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom } from '~/store/atoms/etaFallback';
 import {
   backgroundLocationTrackingAtom,
   locationAtom,
   rawLocationAtom,
 } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
+import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
 import AccuracyHistoryChart from './AccuracyHistoryChart';
 import Typography from './Typography';
 
@@ -355,9 +356,10 @@ const DevOverlay: React.FC = () => {
     backgroundLocationTrackingAtom
   );
   // ETA補助の診断表示。有効フラグ(リモート設定/手動トグル)は非リアクティブなgetter、
-  // 推定フェーズ・アンカーはatomから購読する。
+  // アンカーはatomから購読する。推定フェーズは常駐タイマーで公開されなくなったため、
+  // DevOverlay自身の1秒ティック(nowTick)を評価時刻としてオンデマンド計算する。
   const etaAssistEnabled = isEtaAssistEnabled();
-  const etaPhase = useAtomValue(etaPhaseAtom);
+  const etaPhase = useMemo(() => getEtaPhaseNow(nowTick), [nowTick]);
   const etaAnchor = useAtomValue(etaAnchorAtom);
 
   const coordsSpeed = ((speed ?? 0) < 0 ? 0 : speed) ?? 0;

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -46,7 +46,6 @@ import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
-  powerSavingLocationEnabledAtom,
 } from '../store/atoms/experimental';
 import navigationState, {
   autoModeEnabledAtom,
@@ -80,9 +79,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
   const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
   const setEtaAssistManualEnabled = useSetAtom(etaAssistManualEnabledAtom);
-  const setPowerSavingLocationEnabled = useSetAtom(
-    powerSavingLocationEnabledAtom
-  );
   const { enabled: pictureInPictureEnabled, active: pictureInPictureActive } =
     useAtomValue(pictureInPictureAtom);
   const isAppActive = useIsAppActive();
@@ -447,9 +443,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       const etaAssistManualEnabledStr = storage.getString(
         STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED
       );
-      const powerSavingLocationEnabledStr = storage.getString(
-        STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED
-      );
+      // NOTE: powerSavingLocationEnabledAtom はここでは復元しない。effect復元だと
+      // 継続測位がデフォルト精度で一度起動してから再起動されるため、
+      // atom定義側(store/atoms/experimental.ts)でMMKVから同期的に初期値を確定している。
 
       if (themePreferenceKey) {
         setThemePreference(themePreferenceKey as ThemePreference);
@@ -562,9 +558,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       if (etaAssistManualEnabledStr) {
         setEtaAssistManualEnabled(etaAssistManualEnabledStr === 'true');
       }
-      if (powerSavingLocationEnabledStr) {
-        setPowerSavingLocationEnabled(powerSavingLocationEnabledStr === 'true');
-      }
     };
 
     loadSettings();
@@ -577,7 +570,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     setPictureInPicture,
     setPortraitModeEnabled,
     setEtaAssistManualEnabled,
-    setPowerSavingLocationEnabled,
   ]);
 
   useEffect(() => {

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -46,6 +46,7 @@ import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
+  powerSavingLocationEnabledAtom,
 } from '../store/atoms/experimental';
 import navigationState, {
   autoModeEnabledAtom,
@@ -79,6 +80,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
   const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
   const setEtaAssistManualEnabled = useSetAtom(etaAssistManualEnabledAtom);
+  const setPowerSavingLocationEnabled = useSetAtom(
+    powerSavingLocationEnabledAtom
+  );
   const { enabled: pictureInPictureEnabled, active: pictureInPictureActive } =
     useAtomValue(pictureInPictureAtom);
   const isAppActive = useIsAppActive();
@@ -443,6 +447,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       const etaAssistManualEnabledStr = storage.getString(
         STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED
       );
+      const powerSavingLocationEnabledStr = storage.getString(
+        STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED
+      );
 
       if (themePreferenceKey) {
         setThemePreference(themePreferenceKey as ThemePreference);
@@ -555,6 +562,9 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       if (etaAssistManualEnabledStr) {
         setEtaAssistManualEnabled(etaAssistManualEnabledStr === 'true');
       }
+      if (powerSavingLocationEnabledStr) {
+        setPowerSavingLocationEnabled(powerSavingLocationEnabledStr === 'true');
+      }
     };
 
     loadSettings();
@@ -567,6 +577,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     setPictureInPicture,
     setPortraitModeEnabled,
     setEtaAssistManualEnabled,
+    setPowerSavingLocationEnabled,
   ]);
 
   useEffect(() => {

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -2,6 +2,11 @@ import * as Location from 'expo-location';
 
 export const LOCATION_TASK_NAME = 'trainlcd-background-location-task';
 export const LOCATION_ACCURACY = Location.Accuracy.Highest;
+// 省電力測位モード(実験的機能)時の要求精度。iOSでは kCLLocationAccuracyBest →
+// kCLLocationAccuracyNearestTenMeters(約10m粒度)へ一段下がり電池消費を抑えられる。
+// Androidでは Highest / High とも PRIORITY_HIGH_ACCURACY にマップされるため挙動は変わらない。
+// 到着判定の閾値は最小でも100m+精度ボーナスのため、10m粒度でも判定精度への実害はない想定。
+export const LOCATION_ACCURACY_POWER_SAVING = Location.Accuracy.High;
 export const LOCATION_DISTANCE_INTERVAL = 10;
 export const LOCATION_TIME_INTERVAL = 5000;
 

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -37,6 +37,7 @@ export const STORAGE_KEYS = {
   PICTURE_IN_PICTURE_ENABLED: '@TrainLCD:pictureInPictureEnabled',
   PORTRAIT_MODE_ENABLED: '@TrainLCD:portraitModeEnabled',
   ETA_ASSIST_MANUAL_ENABLED: '@TrainLCD:etaAssistManualEnabled',
+  POWER_SAVING_LOCATION_ENABLED: '@TrainLCD:powerSavingLocationEnabled',
 } as const;
 
 export type StorageKeys = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -14,7 +14,7 @@ const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
 
 /**
  * GPSで最後に確定した駅イベント(到着中/発車)を etaAnchorAtom へ記録するフック。
- * このアンカーは ETA 推定フェーズ(etaPhaseAtom)の仮想時計の起点として使われ、
+ * このアンカーは ETA 推定フェーズ(getEtaPhaseNow)の仮想時計の起点として使われ、
  * 精度劣化時の到着しきい値緩和(R1)の対象駅判定に用いられる。
  */
 export const useEtaAnchor = (): void => {

--- a/src/hooks/useEtaFallback.test.tsx
+++ b/src/hooks/useEtaFallback.test.tsx
@@ -1,9 +1,9 @@
-import { act, renderHook } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react-native';
 import { Provider } from 'jotai';
 import type { ReactNode } from 'react';
 import * as remoteConfigModule from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom, etaStopsAtom } from '~/store/atoms/etaFallback';
 import { locationAtom } from '~/store/atoms/location';
 import {
   approachingAtom,
@@ -12,6 +12,7 @@ import {
   stationAtom,
   stationsAtom,
 } from '~/store/atoms/station';
+import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
 import { createStation } from '~/utils/test/factories';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 import { useEtaFallback } from './useEtaFallback';
@@ -52,17 +53,6 @@ const STOPS = [
 const STATIONS = [createStation(1), createStation(2), createStation(3)];
 
 const T0 = 1_000_000;
-let now = T0;
-
-const setNow = (value: number) => {
-  now = value;
-};
-
-const runTick = () => {
-  act(() => {
-    jest.advanceTimersByTime(1000);
-  });
-};
 
 const mockRoute = (route: unknown) => {
   mockUseEstimateArrivalTimesRoute.mockReturnValue({
@@ -72,7 +62,7 @@ const mockRoute = (route: unknown) => {
   } as never);
 };
 
-// 現在駅・到着・接近・位置の初期値。R2撤去後は useEtaFallback がこれらを一切書き換えない
+// 現在駅・到着・接近・位置の初期値。R2撤去後は ETA まわりがこれらを一切書き換えない
 // ことを検証するための基準値として使う。
 const BASE_LOCATION = {
   timestamp: T0,
@@ -87,12 +77,8 @@ const BASE_LOCATION = {
   },
 };
 
-describe('useEtaFallback', () => {
+describe('useEtaFallback / getEtaPhaseNow', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
-    now = T0;
-    jest.spyOn(Date, 'now').mockImplementation(() => now);
-
     jest.spyOn(remoteConfigModule, 'isEtaAssistEnabled').mockReturnValue(true);
     jest
       .spyOn(remoteConfigModule, 'getEtaFallbackArrivalConfirmMarginSec')
@@ -107,7 +93,7 @@ describe('useEtaFallback', () => {
       kind: 'DEPARTED',
       observedAtMs: T0,
     });
-    store.set(etaPhaseAtom, null);
+    store.set(etaStopsAtom, []);
     store.set(arrivedAtom, false);
     store.set(approachingAtom, false);
     store.set(stationAtom, STATIONS[0]);
@@ -116,64 +102,82 @@ describe('useEtaFallback', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    jest.useRealTimers();
   });
 
-  it('有効・アンカーあり時に推定フェーズを etaPhaseAtom へ公開する', () => {
+  it('停車駅リスト(推定フェーズの入力)を etaStopsAtom へ公開し、アンマウントで空へ戻す', () => {
+    const { unmount } = renderHook(() => useEtaFallback(), { wrapper });
+
+    expect(store.get(etaStopsAtom)).toEqual([
+      { stationId: 1, cumulativeMinutes: 0, departureCumulativeMinutes: 0.5 },
+      { stationId: 2, cumulativeMinutes: 2, departureCumulativeMinutes: 2.5 },
+      { stationId: 3, cumulativeMinutes: 4, departureCumulativeMinutes: 4.5 },
+    ]);
+
+    unmount();
+    expect(store.get(etaStopsAtom)).toEqual([]);
+  });
+
+  it('通過駅・累積分欠損の駅は etaStopsAtom へ含めない', () => {
+    mockRoute({
+      id: 1,
+      stops: [
+        routeStop(1, 0, 0.5),
+        routeStop(9, 1, 1.2, false), // 通過駅
+        { stationId: 2, stationGroupId: 2, stopsHere: true }, // 累積分欠損
+        routeStop(3, 4, 4.5),
+      ],
+    });
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    expect(store.get(etaStopsAtom).map((s) => s.stationId)).toEqual([1, 3]);
+  });
+
+  it('有効・アンカーあり時に評価時点の推定フェーズを返す', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
     // A発車から1秒: まだB到着(2分)には遠い → RUNNING(B)
-    setNow(T0 + 1000);
-    runTick();
-
-    expect(store.get(etaPhaseAtom)).toEqual({
+    expect(getEtaPhaseNow(T0 + 1000)).toEqual({
       kind: 'RUNNING',
       targetStationId: 2,
     });
   });
 
-  it('経過に応じて DWELLING など後続フェーズも公開する', () => {
+  it('経過に応じて DWELLING など後続フェーズも返す', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
     // 仮想時計 m = 発車累積0.5 + 経過分。経過2.2分 → m=2.7 → DWELLING(B)。
-    setNow(T0 + 2.2 * 60_000);
-    runTick();
-
-    expect(store.get(etaPhaseAtom)).toEqual({
+    expect(getEtaPhaseNow(T0 + 2.2 * 60_000)).toEqual({
       kind: 'DWELLING',
       stationId: 2,
     });
   });
 
-  it('リモート設定が無効ならフェーズは公開しない(null)', () => {
+  it('リモート設定が無効ならフェーズを返さない(null)', () => {
     jest.spyOn(remoteConfigModule, 'isEtaAssistEnabled').mockReturnValue(false);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000);
-    runTick();
-
-    expect(store.get(etaPhaseAtom)).toBeNull();
+    expect(getEtaPhaseNow(T0 + 1000)).toBeNull();
   });
 
-  it('アンカーが無ければフェーズは公開しない(null)', () => {
+  it('アンカーが無ければフェーズを返さない(null)', () => {
     store.set(etaAnchorAtom, null);
     renderHook(() => useEtaFallback(), { wrapper });
 
-    setNow(T0 + 1000);
-    runTick();
+    expect(getEtaPhaseNow(T0 + 1000)).toBeNull();
+  });
 
-    expect(store.get(etaPhaseAtom)).toBeNull();
+  it('停車駅リストが空ならフェーズを返さない(null)', () => {
+    mockRoute(null);
+    renderHook(() => useEtaFallback(), { wrapper });
+
+    expect(getEtaPhaseNow(T0 + 1000)).toBeNull();
   });
 
   it('到着・接近・現在駅・位置は一切駆動しない(GPSが唯一の権威)', () => {
     renderHook(() => useEtaFallback(), { wrapper });
 
     // ETA上は到着帯(DWELLING)へ進む時刻でも、状態は書き換えないこと。
-    setNow(T0 + 2.2 * 60_000);
-    runTick();
-
-    // フェーズは公開されるが…
-    expect(store.get(etaPhaseAtom)).toEqual({
+    expect(getEtaPhaseNow(T0 + 2.2 * 60_000)).toEqual({
       kind: 'DWELLING',
       stationId: 2,
     });

--- a/src/hooks/useEtaFallback.ts
+++ b/src/hooks/useEtaFallback.ts
@@ -1,18 +1,9 @@
-import { useRef } from 'react';
-import {
-  getEtaFallbackArrivalConfirmMarginSec,
-  isEtaAssistEnabled,
-} from '~/lib/remoteConfig';
+import { useEffect } from 'react';
+import { isEtaAssistEnabled } from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
-import { type EtaFallbackStop, estimateEtaPhase } from '~/utils/etaFallback';
+import { etaStopsAtom } from '~/store/atoms/etaFallback';
+import type { EtaFallbackStop } from '~/utils/etaFallback';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
-import { useInterval } from './useInterval';
-
-// フェーズ再評価の周期(ms)。ETA仮想時計は1秒粒度で進める。
-const TICK_INTERVAL_MS = 1_000;
-// ETAデータの分解能で発車分−到着分が0になる駅の停車時間の底上げ(分)。
-const MIN_DWELL_MIN = 0.5;
 
 /**
  * route.stops(絶対累積分・全stops)から、停車駅かつ累積分が揃っているものだけを
@@ -45,15 +36,19 @@ const extractStops = (
 };
 
 /**
- * ETA(サーバー計算の到着予測)とGPSで最後に確定した駅イベント(アンカー)からの経過時間で、
- * 現在の走行フェーズ(走行中/接近中/停車中)を推定して etaPhaseAtom へ公開するフック。
+ * ETA(サーバー計算の到着予測)ルートを取得し、推定フェーズの入力となる停車駅リストを
+ * etaStopsAtom へ公開するフック。
  *
  * 位置・到着・接近の状態は**駆動しない**(GPS = useRefreshStation を唯一の権威に保つ)。
  * かつて ETA が状態を独占駆動する R2 フォールバックを備えていたが、GPSが凍結する地下では
  * ETA時刻がそのまま位置を進め、駅に到着後も現在地が勝手に動く重大なデグレを招いたため撤去した。
  * 現在の ETA の役割は「GPSの補助」に限定する:
- * - etaPhaseAtom を公開し、useRefreshStation が精度劣化時に「ETAが同じ駅で停車を示すときだけ
- *   その駅の到着しきい値を緩和する(R1)」ために使う。到着判定自体は常にGPSが行う。
+ * - useRefreshStation が精度劣化時に getEtaPhaseNow で仮想時計フェーズをオンデマンド計算し、
+ *   「ETAが同じ駅で停車を示すときだけその駅の到着しきい値を緩和する(R1)」ために使う。
+ *   到着判定自体は常にGPSが行う。
+ * - 以前は本フックが1秒間隔の常駐タイマーでフェーズを計算しatomへ公開していたが、
+ *   参照頻度の低い値のために毎秒JSスレッドを起こすのは電池・発熱面で無駄なため、
+ *   タイマーを廃してオンデマンド計算(utils/etaPhaseNow.ts)へ移行した。
  */
 export const useEtaFallback = (): void => {
   // 機能が無効な間はETAルートのGraphQL取得自体を止める(LineBoard表示側が
@@ -61,26 +56,11 @@ export const useEtaFallback = (): void => {
   const { route } = useEstimateArrivalTimesRoute({
     skip: !isEtaAssistEnabled(),
   });
-  const routeRef = useRef(route);
-  routeRef.current = route;
 
-  const tick = (): void => {
-    const now = Date.now();
-    const enabled = isEtaAssistEnabled();
-
-    const stops = extractStops(routeRef.current);
-    const anchor = store.get(etaAnchorAtom);
-    const marginMin = getEtaFallbackArrivalConfirmMarginSec() / 60;
-    const phase =
-      enabled && stops.length > 0 && anchor
-        ? estimateEtaPhase(stops, anchor, now, {
-            arrivalConfirmMarginMin: marginMin,
-            minDwellMin: MIN_DWELL_MIN,
-          })
-        : null;
-    // R1(到着しきい値緩和)のために推定フェーズを公開する。状態の駆動は行わない。
-    store.set(etaPhaseAtom, phase);
-  };
-
-  useInterval(tick, TICK_INTERVAL_MS);
+  useEffect(() => {
+    store.set(etaStopsAtom, extractStops(route));
+    return () => {
+      store.set(etaStopsAtom, []);
+    };
+  }, [route]);
 };

--- a/src/hooks/useRefreshStation.test.tsx
+++ b/src/hooks/useRefreshStation.test.tsx
@@ -12,7 +12,8 @@ import * as useThresholdModule from '~/hooks/useThreshold';
 import * as useWrongDirectionDetectorModule from '~/hooks/useWrongDirectionDetector';
 import * as remoteConfigModule from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom } from '~/store/atoms/etaFallback';
+import * as etaPhaseNowModule from '~/utils/etaPhaseNow';
 import sendNotificationAsync from '~/utils/native/ios/sensitiveNotificationMoudle';
 
 jest.mock('jotai', () => {
@@ -89,9 +90,8 @@ describe('useRefreshStation', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-    // R1テストで設定したETAアンカー/フェーズを既定(null)へ戻し、他テストへ漏れないようにする
+    // R1テストで設定したETAアンカーを既定(null)へ戻し、他テストへ漏れないようにする
     store.set(etaAnchorAtom, null);
-    store.set(etaPhaseAtom, null);
   });
 
   it('runs without crashing with basic mocks', () => {
@@ -517,7 +517,10 @@ describe('useRefreshStation', () => {
       kind: anchorKind,
       observedAtMs: 0,
     });
-    store.set(etaPhaseAtom, { kind: 'DWELLING', stationId });
+    // フェーズは常駐atomではなくオンデマンド計算になったため、計算結果をスタブする
+    jest
+      .spyOn(etaPhaseNowModule, 'getEtaPhaseNow')
+      .mockReturnValue({ kind: 'DWELLING', stationId });
 
     renderHook(() => useRefreshStation(), {
       wrapper: ({ children }) => <Provider>{children}</Provider>,

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -10,7 +10,7 @@ import {
   isForceNotArrivedOnLowAccuracyEnabled,
 } from '~/lib/remoteConfig';
 import { store } from '~/store';
-import { etaAnchorAtom, etaPhaseAtom } from '~/store/atoms/etaFallback';
+import { etaAnchorAtom } from '~/store/atoms/etaFallback';
 import {
   locationAccuracyOutlierAtom,
   locationAtom,
@@ -19,6 +19,7 @@ import navigationState from '../store/atoms/navigation';
 import notifyState from '../store/atoms/notify';
 import stationState from '../store/atoms/station';
 import { isJapanese, translate } from '../translation';
+import { getEtaPhaseNow } from '../utils/etaPhaseNow';
 import getIsPass from '../utils/isPass';
 import sendNotificationAsync from '../utils/native/ios/sensitiveNotificationMoudle';
 import { useApproachingStation } from './useApproachingStation';
@@ -130,8 +131,9 @@ export const useRefreshStation = (): void => {
     // R1(到着圏の緩和): 精度劣化(>200m)時に、ETA仮想時計が最寄り停車駅での
     // 停車(DWELLING)を示す場合に限り、その駅の到着圏を広げる。GPSの最寄り駅と
     // ETAが同じ駅を指すときのみ効く確認的な緩和で、精度が良い通常時(≤200m)は
-    // この分岐に入らず到着判定は一切変わらない。etaPhaseAtom は毎秒更新されるため
-    // 再レンダーを避けて非リアクティブに参照し、測位更新時の再評価で拾う。
+    // この分岐に入らず到着判定は一切変わらない。フェーズは常駐タイマーで公開せず、
+    // この分岐に入った瞬間に getEtaPhaseNow でオンデマンド計算する(毎秒タイマーより
+    // 評価時点が新しく、精度劣化時以外は計算コスト自体が発生しない)。
     //
     // 前方駅限定: アンカーが DEPARTED(=発車を観測済み)のときだけ緩和する。
     // AT_STATION アンカーから出る DWELLING は必ず自駅であり、これを緩和すると
@@ -146,14 +148,15 @@ export const useRefreshStation = (): void => {
       accuracy > BAD_ACCURACY_THRESHOLD
     ) {
       const anchor = store.get(etaAnchorAtom);
-      const phase = store.get(etaPhaseAtom);
-      if (
-        anchor?.kind === 'DEPARTED' &&
-        phase?.kind === 'DWELLING' &&
-        phase.stationId === nearestStation.id
-      ) {
-        arrivedRadius =
-          arrivedThreshold + Math.min(accuracy * 0.5, ETA_ARRIVED_BONUS_CAP);
+      if (anchor?.kind === 'DEPARTED') {
+        const phase = getEtaPhaseNow();
+        if (
+          phase?.kind === 'DWELLING' &&
+          phase.stationId === nearestStation.id
+        ) {
+          arrivedRadius =
+            arrivedThreshold + Math.min(accuracy * 0.5, ETA_ARRIVED_BONUS_CAP);
+        }
       }
     }
 

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -32,6 +32,11 @@ jest.mock('~/store/atoms/navigation', () => ({
   default: {},
   autoModeEnabledAtom: { toString: () => 'autoModeEnabledAtom' },
 }));
+jest.mock('~/store/atoms/experimental', () => ({
+  powerSavingLocationEnabledAtom: {
+    toString: () => 'powerSavingLocationEnabledAtom',
+  },
+}));
 
 const mockUseLocationPermissionsGranted =
   useLocationPermissionsGranted as jest.Mock;
@@ -45,11 +50,18 @@ const mockWatchPositionAsync = Location.watchPositionAsync as jest.Mock;
 
 // jotai useAtomValueのモック
 let mockAutoModeEnabled = false;
+let mockPowerSavingLocationEnabled = false;
 jest.mock('jotai', () => ({
   ...jest.requireActual('jotai'),
-  useAtomValue: jest.fn((atom: unknown) =>
-    String(atom) === 'autoModeEnabledAtom' ? mockAutoModeEnabled : undefined
-  ),
+  useAtomValue: jest.fn((atom: unknown) => {
+    if (String(atom) === 'autoModeEnabledAtom') {
+      return mockAutoModeEnabled;
+    }
+    if (String(atom) === 'powerSavingLocationEnabledAtom') {
+      return mockPowerSavingLocationEnabled;
+    }
+    return undefined;
+  }),
 }));
 
 describe('useStartBackgroundLocationUpdates', () => {
@@ -66,6 +78,7 @@ describe('useStartBackgroundLocationUpdates', () => {
     // beforeEachでもclearAllMocksを行い、前テストの残留呼び出しを確実にリセットする。
     jest.clearAllMocks();
     mockAutoModeEnabled = false;
+    mockPowerSavingLocationEnabled = false;
     mockNeedsJobSchedulerBypass = false;
     mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
     mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
@@ -358,6 +371,50 @@ describe('useStartBackgroundLocationUpdates', () => {
 
       consoleWarnSpy.mockRestore();
       jest.useRealTimers();
+    });
+  });
+
+  describe('power saving location mode', () => {
+    test('should request power-saving accuracy for background updates when enabled', async () => {
+      mockPowerSavingLocationEnabled = true;
+      mockUseLocationPermissionsGranted.mockReturnValue(true);
+
+      renderHook(() => useStartBackgroundLocationUpdates());
+
+      await new Promise(process.nextTick);
+
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        LOCATION_TASK_NAME,
+        expect.objectContaining({ accuracy: Location.Accuracy.High })
+      );
+    });
+
+    test('should request default accuracy for background updates when disabled', async () => {
+      mockPowerSavingLocationEnabled = false;
+      mockUseLocationPermissionsGranted.mockReturnValue(true);
+
+      renderHook(() => useStartBackgroundLocationUpdates());
+
+      await new Promise(process.nextTick);
+
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        LOCATION_TASK_NAME,
+        expect.objectContaining({ accuracy: Location.Accuracy.Highest })
+      );
+    });
+
+    test('should apply power-saving accuracy to foreground watchPositionAsync when enabled', async () => {
+      mockPowerSavingLocationEnabled = true;
+      mockUseLocationPermissionsGranted.mockReturnValue(false);
+
+      renderHook(() => useStartBackgroundLocationUpdates());
+
+      await new Promise(process.nextTick);
+
+      expect(mockWatchPositionAsync).toHaveBeenCalledWith(
+        { ...LOCATION_WATCH_OPTIONS, accuracy: Location.Accuracy.High },
+        expect.any(Function)
+      );
     });
   });
 

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -416,6 +416,20 @@ describe('useStartBackgroundLocationUpdates', () => {
         expect.any(Function)
       );
     });
+
+    test('should apply default accuracy to foreground watchPositionAsync when disabled', async () => {
+      mockPowerSavingLocationEnabled = false;
+      mockUseLocationPermissionsGranted.mockReturnValue(false);
+
+      renderHook(() => useStartBackgroundLocationUpdates());
+
+      await new Promise(process.nextTick);
+
+      expect(mockWatchPositionAsync).toHaveBeenCalledWith(
+        { ...LOCATION_WATCH_OPTIONS, accuracy: Location.Accuracy.Highest },
+        expect.any(Function)
+      );
+    });
   });
 
   describe('foreground location watch (fallback)', () => {

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -2,10 +2,13 @@ import * as Location from 'expo-location';
 import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
 import { store } from '~/store';
+import { powerSavingLocationEnabledAtom } from '~/store/atoms/experimental';
 import { backgroundLocationTrackingAtom } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { handleTrackingLocation } from '~/utils/handleTrackingLocation';
 import {
+  LOCATION_ACCURACY,
+  LOCATION_ACCURACY_POWER_SAVING,
   LOCATION_START_MAX_RETRIES,
   LOCATION_START_RETRY_BASE_DELAY_MS,
   LOCATION_TASK_NAME,
@@ -24,6 +27,12 @@ const wait = (ms: number) =>
 export const useStartBackgroundLocationUpdates = () => {
   const bgPermGranted = useLocationPermissionsGranted();
   const autoModeEnabled = useAtomValue(autoModeEnabledAtom);
+  // 省電力測位モード(実験的機能)。要求精度を一段下げる(実効差はiOSのみ)。
+  // effectの依存に含めることで、トグル切替時は継続測位を新しい精度で開始し直す。
+  const powerSavingEnabled = useAtomValue(powerSavingLocationEnabledAtom);
+  const locationAccuracy = powerSavingEnabled
+    ? LOCATION_ACCURACY_POWER_SAVING
+    : LOCATION_ACCURACY;
 
   useEffect(() => {
     if (autoModeEnabled || !bgPermGranted) {
@@ -63,6 +72,7 @@ export const useStartBackgroundLocationUpdates = () => {
           // スロットリングを回避し、アプリプロセスの生存を維持する（Android 8以降の制約）
           await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
             ...LOCATION_TASK_OPTIONS,
+            accuracy: locationAccuracy,
             // NOTE: マップマッチが勝手に行われると電車での経路と大きく異なることがあるはずなので
             // OtherNavigationは必須
             activityType: Location.ActivityType.OtherNavigation,
@@ -96,7 +106,7 @@ export const useStartBackgroundLocationUpdates = () => {
             if (NEEDS_JOBSCHEDULER_BYPASS) {
               try {
                 const sub = await Location.watchPositionAsync(
-                  LOCATION_WATCH_OPTIONS,
+                  { ...LOCATION_WATCH_OPTIONS, accuracy: locationAccuracy },
                   handleTrackingLocation
                 );
                 if (cancelled) {
@@ -142,7 +152,7 @@ export const useStartBackgroundLocationUpdates = () => {
         );
       });
     };
-  }, [autoModeEnabled, bgPermGranted]);
+  }, [autoModeEnabled, bgPermGranted, locationAccuracy]);
 
   useEffect(() => {
     let watchPositionSub: Location.LocationSubscription | null = null;
@@ -155,7 +165,7 @@ export const useStartBackgroundLocationUpdates = () => {
     (async () => {
       try {
         const sub = await Location.watchPositionAsync(
-          LOCATION_WATCH_OPTIONS,
+          { ...LOCATION_WATCH_OPTIONS, accuracy: locationAccuracy },
           handleTrackingLocation
         );
         if (cancelled) {
@@ -172,5 +182,5 @@ export const useStartBackgroundLocationUpdates = () => {
       cancelled = true;
       watchPositionSub?.remove();
     };
-  }, [autoModeEnabled, bgPermGranted]);
+  }, [autoModeEnabled, bgPermGranted, locationAccuracy]);
 };

--- a/src/hooks/useTelemetrySender.enabled.test.tsx
+++ b/src/hooks/useTelemetrySender.enabled.test.tsx
@@ -52,12 +52,6 @@ jest.mock('~/hooks/useIsPassing', () => ({
 jest.mock('~/hooks/useTelemetryEnabled', () => ({
   useTelemetryEnabled: jest.fn(),
 }));
-jest.mock('~/utils/native/android/gnssModule', () => ({
-  subscribeGnss: jest.fn((_callback) => {
-    // No-op for tests
-    return () => {};
-  }),
-}));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <Provider

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -9,10 +9,6 @@ import {
 import { z } from 'zod';
 import { TELEMETRY_THROTTLE_MS } from '~/constants/telemetry';
 import { locationAtom } from '~/store/atoms/location';
-import {
-  type GnssState,
-  subscribeGnss,
-} from '~/utils/native/android/gnssModule';
 import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import { approachingAtom, arrivedAtom } from '../store/atoms/station';
 import { useCurrentLine } from './useCurrentLine';
@@ -62,18 +58,9 @@ export const useTelemetrySender = (
   token = EXPERIMENTAL_TELEMETRY_TOKEN
 ) => {
   const lastSentTelemetryRef = useRef<number>(0);
-  const gnssRef = useRef<GnssState | null>(null);
 
   const station = useCurrentStation();
   const line = useCurrentLine();
-
-  useEffect(
-    () =>
-      subscribeGnss((gnss) => {
-        gnssRef.current = gnss;
-      }),
-    []
-  );
 
   const coords = useAtomValue(locationAtom)?.coords;
 

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -7,6 +7,7 @@ import { storage } from '~/lib/storage';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
+  powerSavingLocationEnabledAtom,
 } from '~/store/atoms/experimental';
 import tuningState from '~/store/atoms/tuning';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
@@ -29,11 +30,13 @@ jest.mock('~/translation', () => ({
 const renderWithStore = (
   portraitModeEnabled: boolean,
   telemetryEnabled = false,
-  etaAssistManualEnabled = false
+  etaAssistManualEnabled = false,
+  powerSavingLocationEnabled = false
 ) => {
   const store = createStore();
   store.set(portraitModeEnabledAtom, portraitModeEnabled);
   store.set(etaAssistManualEnabledAtom, etaAssistManualEnabled);
+  store.set(powerSavingLocationEnabledAtom, powerSavingLocationEnabled);
   store.set(tuningState, (prev) => ({ ...prev, telemetryEnabled }));
 
   const screen = render(
@@ -139,6 +142,33 @@ describe('ExperimentalSettingsScreen', () => {
     expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
     expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).not.toBe(
       'true'
+    );
+  });
+
+  it('省電力測位モードをONにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
+
+    expect(store.get(powerSavingLocationEnabledAtom)).toBe(true);
+    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
+      'true'
+    );
+  });
+
+  it('省電力測位モードをOFFにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(
+      false,
+      false,
+      false,
+      true
+    );
+
+    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
+
+    expect(store.get(powerSavingLocationEnabledAtom)).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
+      'false'
     );
   });
 

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -20,6 +20,7 @@ import { isEtaAssistRemoteEnabled } from '~/lib/remoteConfig';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
+  powerSavingLocationEnabledAtom,
 } from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
@@ -107,6 +108,9 @@ const ExperimentalSettingsScreen: React.FC = () => {
   const [etaAssistManualEnabled, setEtaAssistManualEnabled] = useAtom(
     etaAssistManualEnabledAtom
   );
+  const [powerSavingLocationEnabled, setPowerSavingLocationEnabled] = useAtom(
+    powerSavingLocationEnabledAtom
+  );
   const [tuning, setTuning] = useAtom(tuningState);
 
   // Remote Config(マスタースイッチ)が許可していない間は、手動トグルを操作不可にする。
@@ -153,6 +157,23 @@ const ExperimentalSettingsScreen: React.FC = () => {
     setEtaAssistManualEnabled,
     etaAssistRemoteEnabled,
   ]);
+
+  const handleTogglePowerSavingLocation = useCallback(() => {
+    const flag = !powerSavingLocationEnabled;
+    setPowerSavingLocationEnabled(flag);
+    try {
+      storage.set(
+        STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED,
+        flag ? 'true' : 'false'
+      );
+    } catch (error) {
+      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
+      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
+      setPowerSavingLocationEnabled(!flag);
+      console.error('Failed to save power saving location setting', error);
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [powerSavingLocationEnabled, setPowerSavingLocationEnabled]);
 
   const handleToggleTelemetry = useCallback(() => {
     const flag = !tuning.telemetryEnabled;
@@ -213,6 +234,16 @@ const ExperimentalSettingsScreen: React.FC = () => {
           </View>
           <Typography style={styles.description}>
             {translate('etaAssistDescription')}
+          </Typography>
+          <View style={styles.toggleSpacer}>
+            <ToggleItem
+              title={translate('powerSavingLocationTitle')}
+              state={powerSavingLocationEnabled}
+              onToggle={handleTogglePowerSavingLocation}
+            />
+          </View>
+          <Typography style={styles.description}>
+            {translate('powerSavingLocationDescription')}
           </Typography>
           <Typography style={styles.notice}>
             {translate('experimentalSettingsNotice')}

--- a/src/store/atoms/etaFallback.ts
+++ b/src/store/atoms/etaFallback.ts
@@ -1,8 +1,8 @@
 import { atom } from 'jotai';
-import type { EtaAnchor, EtaPhase } from '~/utils/etaFallback';
+import type { EtaAnchor, EtaFallbackStop } from '~/utils/etaFallback';
 
 // GPSで最後に確定した駅イベント(ETA推定フェーズの仮想時計の起点)
 export const etaAnchorAtom = atom<EtaAnchor | null>(null);
-// ETA仮想時計から推定した最新の走行フェーズ。精度劣化時の到着しきい値緩和
-// (R1: useRefreshStation が非リアクティブに参照)に使う。
-export const etaPhaseAtom = atom<EtaPhase | null>(null);
+// ETA推定フェーズの入力となる停車駅リスト(useEtaFallbackがルート変更時に更新)。
+// フェーズ自体はatomで常駐更新せず、必要な瞬間にgetEtaPhaseNowで計算する。
+export const etaStopsAtom = atom<EtaFallbackStop[]>([]);

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -9,3 +9,9 @@ export const portraitModeEnabledAtom = atom(false);
 // 試験的機能から個別に切り替えられるようにする。ONのときはリモート設定より優先して
 // 有効化する(isEtaAssistEnabled 参照)。
 export const etaAssistManualEnabledAtom = atom(false);
+
+// 省電力測位モード。継続測位の要求精度を LOCATION_ACCURACY_POWER_SAVING へ下げ、
+// 長時間乗車時の電池消費・発熱を抑える。実効差があるのはiOSのみ
+// (constants/location.ts のコメント参照)。到着判定への影響を実車で検証するため
+// 実験的機能としてトグル化する。
+export const powerSavingLocationEnabledAtom = atom(false);

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -1,4 +1,6 @@
 import { atom } from 'jotai';
+import { STORAGE_KEYS } from '~/constants/storage';
+import { storage } from '~/lib/storage';
 
 // 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
 // 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
@@ -14,4 +16,9 @@ export const etaAssistManualEnabledAtom = atom(false);
 // 長時間乗車時の電池消費・発熱を抑える。実効差があるのはiOSのみ
 // (constants/location.ts のコメント参照)。到着判定への影響を実車で検証するため
 // 実験的機能としてトグル化する。
-export const powerSavingLocationEnabledAtom = atom(false);
+// 他の設定と異なり Permitted の loadSettings(effect) では復元せず、MMKVの同期APIで
+// 初期値をここで確定する。effect復元だと Main 側の継続測位が一度デフォルト精度で
+// 起動→復元後に停止・再起動され、起動のたびに無駄な測位再起動が発生するため。
+export const powerSavingLocationEnabledAtom = atom(
+  storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED) === 'true'
+);

--- a/src/utils/etaPhaseNow.ts
+++ b/src/utils/etaPhaseNow.ts
@@ -1,0 +1,34 @@
+import {
+  getEtaFallbackArrivalConfirmMarginSec,
+  isEtaAssistEnabled,
+} from '~/lib/remoteConfig';
+import { store } from '~/store';
+import { etaAnchorAtom, etaStopsAtom } from '~/store/atoms/etaFallback';
+import { type EtaPhase, estimateEtaPhase } from './etaFallback';
+
+// ETAデータの分解能で発車分−到着分が0になる駅の停車時間の底上げ(分)。
+const MIN_DWELL_MIN = 0.5;
+
+/**
+ * ETA仮想時計の現在フェーズをオンデマンドで計算する。
+ *
+ * かつては1秒間隔の常駐タイマー(useEtaFallback)が毎秒計算してatomへ公開していたが、
+ * 結果を使うのは「精度劣化時のGPS到着判定補助(R1)」とDevOverlayの診断表示だけで、
+ * どちらも参照頻度が低い。毎秒JSスレッドを起こす電池コストを避けるため、
+ * 必要になった瞬間に純関数で求める方式に変更した。評価時点のnowMsで計算するので、
+ * タイマー方式(最大1秒古い値)より鮮度はむしろ高く、推定結果は同一である。
+ */
+export const getEtaPhaseNow = (nowMs: number = Date.now()): EtaPhase | null => {
+  if (!isEtaAssistEnabled()) {
+    return null;
+  }
+  const anchor = store.get(etaAnchorAtom);
+  const stops = store.get(etaStopsAtom);
+  if (!anchor || stops.length === 0) {
+    return null;
+  }
+  return estimateEtaPhase(stops, anchor, nowMs, {
+    arrivalConfirmMarginMin: getEtaFallbackArrivalConfirmMarginSec() / 60,
+    minDwellMin: MIN_DWELL_MIN,
+  });
+};

--- a/src/utils/handleTrackingLocation.test.ts
+++ b/src/utils/handleTrackingLocation.test.ts
@@ -5,7 +5,10 @@ import {
   setLocationAccuracyOutlier,
   setRawLocation,
 } from '~/store/atoms/location';
-import { handleTrackingLocation } from './handleTrackingLocation';
+import {
+  handleTrackingLocation,
+  resetTrackingLocationDedup,
+} from './handleTrackingLocation';
 
 jest.mock('~/store/atoms/location', () => ({
   setLocation: jest.fn(),
@@ -24,7 +27,10 @@ const mockSetLocation = setLocation as jest.Mock;
 const mockSetRawLocation = setRawLocation as jest.Mock;
 const mockSetLocationAccuracyOutlier = setLocationAccuracyOutlier as jest.Mock;
 
-const makeLocation = (accuracy: number | null): Location.LocationObject => ({
+const makeLocation = (
+  accuracy: number | null,
+  timestamp = 1000
+): Location.LocationObject => ({
   coords: {
     latitude: 35.0,
     longitude: 139.0,
@@ -34,13 +40,14 @@ const makeLocation = (accuracy: number | null): Location.LocationObject => ({
     heading: 0,
     speed: 0,
   },
-  timestamp: 1000,
+  timestamp,
 });
 
 describe('handleTrackingLocation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsDevApp = false;
+    resetTrackingLocationDedup();
   });
 
   it('精度がMAX_PERMIT_ACCURACY以下ならsetLocationに渡す（外れ値フラグの解除はsetLocationに委譲）', () => {
@@ -84,5 +91,51 @@ describe('handleTrackingLocation', () => {
 
     expect(mockSetRawLocation).not.toHaveBeenCalled();
     expect(mockSetLocation).toHaveBeenCalledWith(loc);
+  });
+
+  describe('重複・順序逆転した測位の破棄（Android 16の2系統配信対策）', () => {
+    it('同一タイムスタンプの測位は2回目以降を破棄する', () => {
+      const loc = makeLocation(30, 1000);
+      handleTrackingLocation(loc);
+      handleTrackingLocation({ ...loc });
+
+      expect(mockSetLocation).toHaveBeenCalledTimes(1);
+    });
+
+    it('処理済みより古いタイムスタンプの測位（遅延バッチ再配信）は破棄する', () => {
+      handleTrackingLocation(makeLocation(30, 5000));
+      handleTrackingLocation(makeLocation(30, 3000));
+
+      expect(mockSetLocation).toHaveBeenCalledTimes(1);
+      expect(mockSetLocation).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: 5000 })
+      );
+    });
+
+    it('新しいタイムスタンプの測位は通常どおり処理する', () => {
+      handleTrackingLocation(makeLocation(30, 1000));
+      handleTrackingLocation(makeLocation(30, 2000));
+
+      expect(mockSetLocation).toHaveBeenCalledTimes(2);
+    });
+
+    it('破棄した測位は生の値としても記録しない（DevOverlayにも重複を流さない）', () => {
+      mockIsDevApp = true;
+      const loc = makeLocation(30, 1000);
+      handleTrackingLocation(loc);
+      handleTrackingLocation({ ...loc });
+
+      expect(mockSetRawLocation).toHaveBeenCalledTimes(1);
+    });
+
+    it('システム時計が巻き戻された場合はガードをリセットして測位を受理する', () => {
+      // 処理済みタイムスタンプが現在時刻より大きく未来 = 時計巻き戻り発生とみなす
+      const futureTs = Date.now() + 60_000;
+      handleTrackingLocation(makeLocation(30, futureTs));
+      // 巻き戻り後の測位（現在時刻ベース）は futureTs より古いが、凍結せず受理される
+      handleTrackingLocation(makeLocation(30, Date.now()));
+
+      expect(mockSetLocation).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/utils/handleTrackingLocation.ts
+++ b/src/utils/handleTrackingLocation.ts
@@ -7,10 +7,39 @@ import {
 } from '~/store/atoms/location';
 import { isDevApp } from './isDevApp';
 
+// システム時計の巻き戻りとみなす閾値(ms)。処理済みタイムスタンプが現在時刻より
+// これ以上未来にある場合は時計が巻き戻されたと判断し、重複排除ガードをリセットする
+// (リセットしないと時計が追いつくまで全測位が「古い」と誤判定され凍結する)。
+const CLOCK_ROLLBACK_TOLERANCE_MS = 5_000;
+
+// 最後に本関数で処理した測位のタイムスタンプ。Android 16ではTaskManagerと
+// watchPositionAsyncの2系統が同じ測位を配信するため(useStartBackgroundLocationUpdates)、
+// これ以下のタイムスタンプの測位を重複・遅延再配信として破棄する基準に使う。
+let lastProcessedTimestampMs = 0;
+
+// テスト用: モジュール内部の重複排除状態をリセットする
+export const resetTrackingLocationDedup = () => {
+  lastProcessedTimestampMs = 0;
+};
+
 // watchPositionAsync / startLocationUpdatesAsync 双方の継続測位の共通入口。
 // 経路ごとにMAX_PERMIT_ACCURACYの適用漏れが起きないよう、精度フィルタをここへ集約する。
 // （getCurrentPositionAsyncによるワンショット取得や手動選択はsetLocationを直接呼ぶため対象外）
 export const handleTrackingLocation = (location: Location.LocationObject) => {
+  // 重複・順序逆転した測位の破棄。Android 16(API 36)ではJobSchedulerクォータ対策で
+  // TaskManagerとwatchPositionAsyncの直接コールバックを併用しており、同一の測位が
+  // 2系統から届く。破棄しないと同じ測位にEMAスムージングが二重適用されて座標が歪み、
+  // 下流の最寄り駅探索・到着判定・再レンダーも全て二重に走って電池を無駄に消費する。
+  // また、クォータでスロットルされたTaskManagerのバッチが遅れて届いた場合、直接
+  // コールバック済みの新しい測位より古い座標へ位置が引き戻されるのもここで防ぐ。
+  if (lastProcessedTimestampMs > Date.now() + CLOCK_ROLLBACK_TOLERANCE_MS) {
+    lastProcessedTimestampMs = 0;
+  }
+  if (location.timestamp <= lastProcessedTimestampMs) {
+    return;
+  }
+  lastProcessedTimestampMs = location.timestamp;
+
   // DevOverlayの診断表示用に、フィルタで棄却される測位も生の値として記録する。
   // DevOverlayはisDevApp時しか描画されないため、本番ビルドでは記録しない。
   if (isDevApp) {


### PR DESCRIPTION
## 概要

実車利用時の電池消費・端末発熱の対策として、位置情報精度・到着判定精度に影響しない範囲で冗長な常駐処理を3点排除する。加えて、iOSの位置情報要求精度を一段下げて消費を抑える「省電力測位モード」を実験的機能として追加する(既定OFF・実車検証用)。既定の測位設定(`Accuracy.Highest` / 10m / 5秒 / フォアグラウンドサービス常駐)と到着判定ロジックには手を加えていない。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- **Android 16 の二重測位配信の重複排除** (`handleTrackingLocation`): #5427 で導入した TaskManager + `watchPositionAsync` の2系統併用はそのまま維持しつつ、処理済みタイムスタンプ以下の測位(重複コピー・順序逆転した遅延バッチ)を共通入口で破棄。同一測位へのEMAスムージング二重適用と、下流(最寄り駅探索〜再レンダー)の二重実行を排除する。クォータでスロットルされた古いバッチが後着して位置が過去に引き戻される経路もこれで塞がる。システム時計巻き戻り時にガードが測位を凍結し続けないようリセット処理つき
- **ETA推定フェーズの毎秒常駐タイマー廃止** (`useEtaFallback` / 新規 `utils/etaPhaseNow.ts`): フェーズは「精度劣化(&gt;200m)時のGPS到着判定補助(R1)」とDevOverlay表示でしか使われないため、1秒間隔の `useInterval` + `etaPhaseAtom` 公開をやめ、必要になった瞬間に純関数 `getEtaPhaseNow` で計算する方式へ変更。`useEtaFallback` はルート変更時に入力(停車駅リスト)を `etaStopsAtom` へ公開するだけになる。評価時点の時刻で計算するため、判定に使う値の鮮度は従来(最大1秒古い)より向上
- **未使用GNSSネイティブ購読の削除** (`useTelemetrySender`): 購読結果が ref に保存されるだけでどこからも読まれていなかったため削除。テレメトリ無効の本番ビルドを含む全Android端末で毎秒発生していたネイティブ→JSブリッジイベントを停止する(`gnssModule.ts` ラッパー自体は温存)
- **省電力測位モードを実験的機能として追加** (`ExperimentalSettings` / `useStartBackgroundLocationUpdates`): ONにすると継続測位の要求精度を `Accuracy.Highest` → `Accuracy.High` へ一段下げる。iOSでは `kCLLocationAccuracyBest` → `kCLLocationAccuracyNearestTenMeters`(約10m粒度)となり電池消費を抑えられる。Androidでは両者とも `PRIORITY_HIGH_ACCURACY` にマップされるため挙動は変わらない。到着判定の閾値は最小でも100m+精度ボーナスのため判定への実害はない想定だが、実車検証のため既定OFFのトグルとして追加(MMKVで永続化、切替時は継続測位を新しい精度で再起動)
- 上記に伴うテスト更新と、重複破棄・時計巻き戻り・停車駅リスト公開・フェーズ計算・省電力モードの精度切替/永続化の新規テスト追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

188スイート・2020テスト全通過(`npm run lint && npm test && npm run typecheck` をローカル実行)。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01557yDZepaRWkvy4vwBK7pc)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 省電力測位モードを追加（iOSのみ）。長時間乗車時の電池消費・発熱を抑えるため、位置精度を段階的に見直します。
  * ETAフェーズをオンデマンドで算出して表示・判定し、ETA補助ルートの停車駅情報をGPS補助に活用します。
* **バグ修正**
  * 測位の重複配信や順序逆転による位置の引き戻しを抑制します。
* **改善**
  * テレメトリー送信時の測位情報の扱いを整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->