### PR TITLE
iOSで日本語TTS完了前に英語TTSへ進む不具合を修正

### DIFF
--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -311,7 +311,7 @@ describe('playAudio', () => {
     // iOS は早期終了前の実位置を通常更新で通知した後、完了イベントだけ
     // currentTime=duration に上書きする。この終端値を信用すると英語へ進んでしまう。
     mock.emitStatus({ currentTime: 10, duration: 30 });
-    mock.player.currentTime = 10;
+    mock.player.currentTime = 0;
     mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
 
     expect(onFinish).not.toHaveBeenCalled();
@@ -335,7 +335,7 @@ describe('playAudio', () => {
     playAudio({ uri: 'ios-complete.mp3', onFinish, onError });
 
     mock.emitStatus({ currentTime: 29.9, duration: 30 });
-    mock.player.currentTime = 30;
+    mock.player.currentTime = 0;
     mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
 
     expect(onFinish).toHaveBeenCalledTimes(1);

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -311,7 +311,7 @@ describe('playAudio', () => {
     // iOS は早期終了前の実位置を通常更新で通知した後、完了イベントだけ
     // currentTime=duration に上書きする。この終端値を信用すると英語へ進んでしまう。
     mock.emitStatus({ currentTime: 10, duration: 30 });
-    mock.player.currentTime = 0;
+    mock.player.currentTime = 10;
     mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
 
     expect(onFinish).not.toHaveBeenCalled();
@@ -326,6 +326,31 @@ describe('playAudio', () => {
     warnSpy.mockRestore();
   });
 
+  it('プレイヤー位置が0にリセットされた場合は直前の状態位置から再開する', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    const handle = playAudio({
+      uri: 'ios-reset-early-finish.mp3',
+      onFinish,
+      onError,
+    });
+
+    mock.emitStatus({ currentTime: 10, duration: 30 });
+    mock.player.currentTime = 0;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    handle.listener.remove();
+    warnSpy.mockRestore();
+  });
+
   it('直前の実位置が終端付近なら上書きされた完了通知を受理する', () => {
     const mock = createMockPlayer({ playing: true, duration: 30 });
     mockCreateAudioPlayer.mockReturnValue(mock.player);
@@ -335,7 +360,7 @@ describe('playAudio', () => {
     playAudio({ uri: 'ios-complete.mp3', onFinish, onError });
 
     mock.emitStatus({ currentTime: 29.9, duration: 30 });
-    mock.player.currentTime = 0;
+    mock.player.currentTime = 30;
     mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
 
     expect(onFinish).toHaveBeenCalledTimes(1);

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -299,6 +299,50 @@ describe('playAudio', () => {
     expect(mock.player.seekTo).not.toHaveBeenCalled();
   });
 
+  it('完了通知が位置を終端で上書きしても直前の実位置から再開する', async () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'ios-early-finish.mp3', onFinish, onError });
+
+    // iOS は早期終了前の実位置を通常更新で通知した後、完了イベントだけ
+    // currentTime=duration に上書きする。この終端値を信用すると英語へ進んでしまう。
+    mock.emitStatus({ currentTime: 10, duration: 30 });
+    mock.player.currentTime = 10;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(mock.player.play).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
+  it('直前の実位置が終端付近なら上書きされた完了通知を受理する', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'ios-complete.mp3', onFinish, onError });
+
+    mock.emitStatus({ currentTime: 29.9, duration: 30 });
+    mock.player.currentTime = 30;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+  });
+
   it('終端手前の didJustFinish は早期完了とみなしその位置から再開する', async () => {
     const mock = createMockPlayer({ playing: true, duration: 30 });
     mockCreateAudioPlayer.mockReturnValue(mock.player);

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -55,6 +55,7 @@ export const playAudio = (options: {
   let settled = false;
   let stalledTicks = 0;
   let lastCurrentTime = -1;
+  let lastStatusPosition = 0;
   let resumeAttempts = 0;
   const maxStalledTicks = Math.ceil(STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS);
 
@@ -68,7 +69,20 @@ export const playAudio = (options: {
     reasonForWaitingToPlay?: string;
   }) => {
     const duration = status.duration || player.duration || 0;
-    const position = status.currentTime ?? player.currentTime ?? 0;
+    const reportedPosition = status.currentTime ?? player.currentTime ?? 0;
+    // expo-audio (iOS) は AVPlayerItemDidPlayToEndTime を受けると、実際の
+    // 停止位置にかかわらず完了イベントの currentTime を duration で上書きする。
+    // player.currentTime 自体は AVPlayer の実位置を返すため、まずそちらを参照し、
+    // 0 にリセット済みなら通常の状態更新で最後に観測した実再生位置を使う。
+    const playerPosition = player.currentTime ?? 0;
+    const position =
+      playerPosition > 0
+        ? playerPosition
+        : lastStatusPosition > 0 &&
+            duration > 0 &&
+            reportedPosition >= duration - FINISH_END_EPSILON_SEC
+          ? lastStatusPosition
+          : reportedPosition;
     const reachedEnd =
       duration <= 0 || position >= duration - FINISH_END_EPSILON_SEC;
 
@@ -117,6 +131,11 @@ export const playAudio = (options: {
       } else if ('error' in status && status.error) {
         console.warn('[ttsAudioPlayer] playback error:', status.error);
         settle(() => onError(status.error));
+      } else if (
+        Number.isFinite(status.currentTime) &&
+        status.currentTime >= 0
+      ) {
+        lastStatusPosition = status.currentTime;
       }
     }
   );


### PR DESCRIPTION
## 概要

iOSで日本語TTSの再生完了前に英語TTSへ進み、日本語アナウンスへ割り込む不具合を修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `expo-audio` のiOS実装が完了イベントの `currentTime` を常に `duration` で上書きする挙動を考慮
- 完了イベントの報告位置だけでなく、プレイヤー本体の実再生位置を優先して終端到達を判定
- プレイヤー位置が0へリセットされた場合に備え、通常の状態更新で最後に観測した再生位置へフォールバック
- 実際の終端より前なら日本語TTSをその位置から再開し、英語TTSへ進ませないよう修正
- 正のプレイヤー位置を使う既存テストを維持しつつ、プレイヤー位置が0へリセットされた場合の保存位置フォールバックを直接検証する回帰テストを追加

根本原因は、早期完了イベントでも `currentTime === duration` となるため、既存の終端判定が途中終了を正常終了と誤認していたことです。

回帰リスクとして、完了イベント受信時の位置取得に失敗すると再生完了が遅れる可能性があります。プレイヤー本体、直前の状態更新、イベント報告値の順にフォールバックし、位置通知がない短い音声は従来どおり完了として扱うことで影響を限定しています。

## テスト

- [x] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm exec -- jest --runInBand src/hooks/useTTS.test.ts src/utils/ttsAudioPlayer.test.ts`: 2スイート、40テスト成功
- `npm run lint`: 成功
- `npm run typecheck`: 成功
- `git diff --check`: 成功

Windowsでは既存の `npm test` に含まれるUnix形式の `TZ=UTC` を直接解釈できないため、PowerShellで同じ環境変数を設定して関連Jestテストを実行しました。全テストスイートは未実行です。

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし
