### PR TITLE
CanaryのiOSビルドを一時停止

### DIFF
--- a/.eas/workflows/create-development-builds.yml
+++ b/.eas/workflows/create-development-builds.yml
@@ -59,40 +59,41 @@ jobs:
       build_id: ${{ needs.build_android.outputs.build_id }}
       profile: development
 
-  build_ios:
-    type: build
-    environment: development
-    params:
-      platform: ios
-      profile: development
-    steps:
-      - uses: eas/checkout
-      - name: Checkout submodules
-        run: |
-          set -euo pipefail
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git submodule update --init --recursive
-      - name: Decode .env.local
-        run: |
-          if [ -z "${DOTENV_LOCAL_BASE64:-}" ]; then
-            echo "Environment variable DOTENV_LOCAL_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$DOTENV_LOCAL_BASE64" | base64 --decode > .env.local
-      - name: Decode Sentry properties
-        run: |
-          if [ -z "${SENTRY_PROPERTIES_BASE64:-}" ]; then
-            echo "Environment variable SENTRY_PROPERTIES_BASE64 is not set."
-            exit 1
-          fi
-          printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > ios/sentry.properties
-      - uses: eas/build
+  # 最近プロビジョニングプロファイルの問題でiOSビルドが失敗することがあるため、iOSビルドは一時的に無効化している
+  # build_ios:
+  #   type: build
+  #   environment: development
+  #   params:
+  #     platform: ios
+  #     profile: development
+  #   steps:
+  #     - uses: eas/checkout
+  #     - name: Checkout submodules
+  #       run: |
+  #         set -euo pipefail
+  #         git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+  #         git submodule update --init --recursive
+  #     - name: Decode .env.local
+  #       run: |
+  #         if [ -z "${DOTENV_LOCAL_BASE64:-}" ]; then
+  #           echo "Environment variable DOTENV_LOCAL_BASE64 is not set."
+  #           exit 1
+  #         fi
+  #         printf '%s' "$DOTENV_LOCAL_BASE64" | base64 --decode > .env.local
+  #     - name: Decode Sentry properties
+  #       run: |
+  #         if [ -z "${SENTRY_PROPERTIES_BASE64:-}" ]; then
+  #           echo "Environment variable SENTRY_PROPERTIES_BASE64 is not set."
+  #           exit 1
+  #         fi
+  #         printf '%s' "$SENTRY_PROPERTIES_BASE64" | base64 --decode > ios/sentry.properties
+  #     - uses: eas/build
 
-  submit_ios:
-    name: Submit to TestFlight
-    needs: [build_ios]
-    type: testflight
-    environment: development
-    params:
-      build_id: ${{ needs.build_ios.outputs.build_id }}
-      profile: development
+  # submit_ios:
+  #   name: Submit to TestFlight
+  #   needs: [build_ios]
+  #   type: testflight
+  #   environment: development
+  #   params:
+  #     build_id: ${{ needs.build_ios.outputs.build_id }}
+  #     profile: development


### PR DESCRIPTION
## 概要

Canary ビルドで発生している iOS プロビジョニングプロファイル問題の影響を避けるため、iOS ビルドと TestFlight 提出を一時的に無効化します。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.eas/workflows/create-development-builds.yml` の `build_ios` ジョブをコメントアウト
- `build_ios` に依存する `submit_ios` ジョブをコメントアウト
- 一時停止理由をコメントとして追記
- Android のビルドおよび Google Play Store 提出は従来どおり維持

iOS の開発ビルドと TestFlight 提出は、このワークフローから実行されなくなります。問題解消後はコメントアウトを解除することで再開できます。

## リスクと対策

Canary の iOS 成果物が生成・提出されない点が意図した影響です。Android ジョブには変更を加えておらず、YAML を解析して有効なジョブが `build_android` と `submit_android` のみであることを確認しました。

## テスト

- [x] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [x] `npm run typecheck` が通ること
- [x] YAML 構文と有効なジョブ構成を確認
- [x] `git diff --check` が通ること

`npm test` は Windows 用に `TZ=UTC` を設定して再実行しましたが、120 秒以内に完了せずタイムアウトしました。

## 関連Issue

なし

## スクリーンショット（任意）

UI 変更なし