### PR TITLE
縦画面時の種別変更通知の表示位置を修正

### DIFF
--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -33,9 +33,30 @@ const mockAtomValues = ({
   });
 };
 
-jest.mock('react-native-safe-area-context', () => ({
-  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
-}));
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({
+      children,
+      edges,
+      ...props
+    }: {
+      children: React.ReactNode;
+      edges?: readonly string[];
+      [key: string]: unknown;
+    }) =>
+      React.createElement(
+        View,
+        {
+          ...props,
+          testID: 'safe-area-view',
+          accessibilityLabel: edges?.join(',') ?? 'all',
+        },
+        children
+      ),
+  };
+});
 
 jest.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: { children: React.ReactNode }) => children,
@@ -100,6 +121,12 @@ jest.mock('./Typography', () => {
 describe('TypeChangeNotify', () => {
   beforeEach(() => {
     mockAtomValues();
+    const { useLandscapeWindowDimensions } = require('~/hooks');
+    useLandscapeWindowDimensions.mockReturnValue({
+      width: 812,
+      height: 375,
+      isPortrait: false,
+    });
   });
 
   afterEach(() => {
@@ -110,6 +137,31 @@ describe('TypeChangeNotify', () => {
     expect(() => {
       render(<TypeChangeNotify />);
     }).not.toThrow();
+  });
+
+  it('物理画面が縦向きの場合は上下のセーフエリアを適用しない', () => {
+    const { useLandscapeWindowDimensions } = require('~/hooks');
+    useLandscapeWindowDimensions.mockReturnValue({
+      width: 812,
+      height: 375,
+      isPortrait: true,
+    });
+
+    const { getByTestId } = render(<TypeChangeNotify />);
+
+    expect(getByTestId('safe-area-view')).toHaveProp(
+      'accessibilityLabel',
+      'left,right'
+    );
+  });
+
+  it('物理画面が横向きの場合は全方向のセーフエリアを適用する', () => {
+    const { getByTestId } = render(<TypeChangeNotify />);
+
+    expect(getByTestId('safe-area-view')).toHaveProp(
+      'accessibilityLabel',
+      'all'
+    );
   });
 
   it('trainTypeがnullの場合でもクラッシュしない', () => {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1297,6 +1297,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
   const nextTrainType = useNextTrainType();
+  const { isPortrait } = useLandscapeWindowDimensions();
 
   const isJaEnabled = enabledLanguages.includes('JA');
   const isEnEnabled = enabledLanguages.includes('EN');
@@ -1536,7 +1537,10 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
   ]);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={styles.container}
+      edges={isPortrait ? ['left', 'right'] : undefined}
+    >
       <View style={styles.top}>
         {isJaEnabled ? <HeadingJa headingTexts={headingTexts} /> : null}
         {isEnEnabled ? (

--- a/src/hooks/useLandscapeWindowDimensions.test.ts
+++ b/src/hooks/useLandscapeWindowDimensions.test.ts
@@ -1,0 +1,19 @@
+import { getLandscapeWindowDimensions } from './useLandscapeWindowDimensions';
+
+describe('getLandscapeWindowDimensions', () => {
+  it('物理画面が縦向きでも横長の寸法と向き判定を返す', () => {
+    expect(getLandscapeWindowDimensions(375, 812)).toEqual({
+      width: 812,
+      height: 375,
+      isPortrait: true,
+    });
+  });
+
+  it('物理画面が横向きの場合は寸法を維持する', () => {
+    expect(getLandscapeWindowDimensions(812, 375)).toEqual({
+      width: 812,
+      height: 375,
+      isPortrait: false,
+    });
+  });
+});

--- a/src/hooks/useLandscapeWindowDimensions.ts
+++ b/src/hooks/useLandscapeWindowDimensions.ts
@@ -1,13 +1,19 @@
 import { useWindowDimensions } from 'react-native';
 
+export const getLandscapeWindowDimensions = (
+  width: number,
+  height: number
+) => ({
+  width: Math.max(width, height),
+  height: Math.min(width, height),
+  isPortrait: height > width,
+});
+
 // Main 画面は常に横長レイアウト前提だが、端末側の回転ロック ON 等で物理的に
 // portrait のままだと useWindowDimensions が縦寸を返してしまい、Main 配下の
 // レイアウトが画面いっぱいに広がらない。長辺を width / 短辺を height として返す
 // ことで、Main.tsx 側の 90deg 回転ラッパーと矛盾しないサイズを子に渡す。
 export const useLandscapeWindowDimensions = () => {
   const { width, height } = useWindowDimensions();
-  return {
-    width: Math.max(width, height),
-    height: Math.min(width, height),
-  };
+  return getLandscapeWindowDimensions(width, height);
 };


### PR DESCRIPTION
## 概要

端末が縦向きのまま Main 画面を90度回転して表示する場合に、種別変更通知が以前より下へずれて見える問題を修正します。

物理画面の縦向き用セーフエリアが、回転後の横長レイアウトの上下余白として適用されていたことが原因です。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 横長寸法フックから物理画面が縦向きかどうかを取得できるように変更
- 物理画面が縦向きの場合、種別変更通知の上下セーフエリアを除外
- 物理画面が横向きの場合は従来どおり全方向のセーフエリアを維持
- 縦向き・横向き双方の回帰テストを追加

回帰リスクはセーフエリアの適用方向に限定されます。通常の横画面では従来の設定を維持し、向きごとのテストで軽減しています。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

Windows環境では `npm test` の `TZ=UTC` 指定をPowerShell側で設定し、`npx jest --runInBand` を実行しました。

- 189テストスイート、2031テスト成功
- `git diff --check` 成功

## 関連Issue

なし

## スクリーンショット（任意）

未取得

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 端末の向きに応じて、セーフエリアの適用範囲を最適化しました。
  * 縦向きでは左右のみ、横向きでは全方向にセーフエリアを適用します。
  * 画面サイズを横長レイアウト向けに正しく判定できるよう改善しました。

* **テスト**
  * 縦向き・横向きそれぞれの画面サイズ判定と、セーフエリア適用範囲を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->