### PR TITLE
テレメトリ送信をGraphQLのsendLocation/sendLogEvent mutationへ移行

### DIFF
--- a/src/hooks/useTelemetrySender.enabled.test.tsx
+++ b/src/hooks/useTelemetrySender.enabled.test.tsx
@@ -11,7 +11,15 @@ import stationState from '~/store/atoms/station';
 
 const TELEMETRY_THROTTLE_MS = 1; // NOTE: flakyになるので実運用より短め
 
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.0.0',
+  nativeBuildVersion: '42',
+}));
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'test-session-id'),
+}));
 jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
+jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
 jest.mock('expo-battery', () => ({
   BatteryState: {
     UNKNOWN: 0,
@@ -82,6 +90,15 @@ let mockFetch: jest.Mock;
 const mockGetBatteryLevelAsync = Battery.getBatteryLevelAsync as jest.Mock;
 const mockGetBatteryStateAsync = Battery.getBatteryStateAsync as jest.Mock;
 
+// ログも位置情報も同じ/graphqlに飛ぶため、mutation名でリクエストを見分ける
+const findGraphQLCall = (mutationName: string) =>
+  mockFetch.mock.calls.find((call: any[]) => {
+    return (
+      call[0] === 'https://example.com/graphql' &&
+      JSON.parse(call[1].body).query.includes(mutationName)
+    );
+  });
+
 describe('useTelemetrySender', () => {
   beforeEach(() => {
     mockFetch = jest.fn().mockResolvedValue({
@@ -121,7 +138,7 @@ describe('useTelemetrySender', () => {
     jest.useRealTimers();
   });
 
-  test('should send log via fetch API', async () => {
+  test('should send log via GraphQL sendLogEvent mutation', async () => {
     const { result } = renderHook(
       () => useTelemetrySender(false, 'https://example.com', 'test-token'),
       { wrapper }
@@ -135,16 +152,17 @@ describe('useTelemetrySender', () => {
     await waitFor(
       () => {
         expect(mockFetch).toHaveBeenCalled();
-        const calls = mockFetch.mock.calls;
-        const logCall = calls.find((call: any[]) => {
-          return call[0] === 'https://example.com/api/log';
-        });
+        const logCall = findGraphQLCall('sendLogEvent');
         expect(logCall).toBeDefined();
-        const body = JSON.parse(logCall[1].body);
-        expect(body.log.message).toBe('Test log from the app');
-        expect(body.log.level).toBe('info');
-        expect(body.log.type).toBe('app');
-        expect(body.device).toBe('MockDevice');
+        const input = JSON.parse(logCall[1].body).variables.input;
+        expect(input.message).toBe('Test log from the app');
+        expect(input.level).toBe('info');
+        expect(input.type).toBe('app');
+        expect(input.device).toBe('MockDevice');
+        expect(input.sessionId).toBe('test-session-id');
+        expect(input.appVersion).toBe('1.0.0(42)');
+        expect(input.platform).toBe('ios');
+        expect(input.channel).toBe('production');
       },
       { timeout: 2000 }
     );
@@ -164,13 +182,10 @@ describe('useTelemetrySender', () => {
     await waitFor(
       () => {
         expect(mockFetch).toHaveBeenCalled();
-        const calls = mockFetch.mock.calls;
-        const logCall = calls.find((call: any[]) => {
-          return call[0] === 'https://example.com/api/log';
-        });
+        const logCall = findGraphQLCall('sendLogEvent');
         expect(logCall).toBeDefined();
         const body = JSON.parse(logCall[1].body);
-        expect(body.log.level).toBe('debug');
+        expect(body.variables.input.level).toBe('debug');
       },
       { timeout: 2000 }
     );
@@ -190,14 +205,11 @@ describe('useTelemetrySender', () => {
     await waitFor(
       () => {
         expect(mockFetch).toHaveBeenCalled();
-        const calls = mockFetch.mock.calls;
-        const logCall = calls.find((call: any[]) => {
-          return call[0] === 'https://example.com/api/log';
-        });
+        const logCall = findGraphQLCall('sendLogEvent');
         expect(logCall).toBeDefined();
-        const body = JSON.parse(logCall[1].body);
-        expect(body.log.message).toContain('token=[REDACTED]');
-        expect(body.log.message).not.toContain('abc123-secret-value');
+        const message = JSON.parse(logCall[1].body).variables.input.message;
+        expect(message).toContain('token=[REDACTED]');
+        expect(message).not.toContain('abc123-secret-value');
       },
       { timeout: 2000 }
     );
@@ -246,10 +258,7 @@ describe('useTelemetrySender', () => {
     await waitFor(
       () => {
         expect(mockFetch).toHaveBeenCalled();
-        const calls = mockFetch.mock.calls;
-        const logCall = calls.find((call: any[]) => {
-          return call[0] === 'https://example.com/api/log';
-        });
+        const logCall = findGraphQLCall('sendLogEvent');
         expect(logCall).toBeDefined();
         expect(logCall[1].headers.Authorization).toMatch(/^Bearer .+$/);
         expect(logCall[1].headers['Content-Type']).toBe('application/json');
@@ -293,7 +302,8 @@ describe('useTelemetrySender', () => {
       ok: true,
       status: 200,
       statusText: 'OK',
-      json: () => Promise.resolve({ ok: false, error: 'Server error' }),
+      json: () =>
+        Promise.resolve({ data: null, errors: [{ message: 'Server error' }] }),
     });
 
     const { result } = renderHook(
@@ -334,9 +344,37 @@ describe('useTelemetrySender', () => {
     await waitFor(
       () => {
         const logCalls = mockFetch.mock.calls.filter(
-          (call: any[]) => call[0] === 'https://example.com/api/log'
+          (call: any[]) =>
+            call[0] === 'https://example.com/graphql' &&
+            JSON.parse(call[1].body).query.includes('sendLogEvent')
         );
         expect(logCalls.length).toBe(2);
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  test('should send location via GraphQL sendLocation mutation', async () => {
+    renderHook(
+      () => useTelemetrySender(true, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await waitFor(
+      () => {
+        const locationCall = findGraphQLCall('sendLocation');
+        expect(locationCall).toBeDefined();
+        const body = JSON.parse(locationCall[1].body);
+        const input = body.variables.input;
+        expect(input.sessionId).toBe('test-session-id');
+        expect(input.device).toBe('MockDevice');
+        // useAtomValueのモックが全atomに同じtruthyな値を返すためarrivedになる
+        expect(input.state).toBe('arrived');
+        expect(input.lineId).toBe(11302);
+        expect(input.stationId).toBe(1130224);
+        // expo-locationのm/sからkm/hに変換される
+        expect(input.coords.speed).toBeCloseTo(36);
+        expect(input.batteryState).toBe('charging');
       },
       { timeout: 2000 }
     );
@@ -352,14 +390,43 @@ describe('useTelemetrySender', () => {
 
     await waitFor(
       () => {
-        const locationCall = mockFetch.mock.calls.find((call: any[]) => {
-          return call[0] === 'https://example.com/api/location';
-        });
+        const locationCall = findGraphQLCall('sendLocation');
         expect(locationCall).toBeDefined();
         const body = JSON.parse(locationCall[1].body);
-        expect(body.batteryLevel).toBeNull();
+        expect(body.variables.input.batteryLevel).toBeNull();
       },
       { timeout: 2000 }
     );
+  });
+
+  test('should warn when GraphQL API returns errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          data: null,
+          errors: [{ message: 'unauthorized' }],
+        }),
+    });
+
+    renderHook(
+      () => useTelemetrySender(true, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await waitFor(
+      () => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Location API error:',
+          'unauthorized'
+        );
+      },
+      { timeout: 2000 }
+    );
+
+    consoleSpy.mockRestore();
   });
 });

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -68,18 +68,23 @@ const SEND_LOCATION_MUTATION = `
 `;
 
 // 認可エラー等もHTTP 200 + errors配列で返る
-const SendLocationResponse = z.object({
-  data: z
-    .object({
-      sendLocation: z.object({
-        sessionId: z.string(),
-        warning: z.string().nullable().optional(),
-      }),
-    })
-    .nullable()
-    .optional(),
-  errors: z.array(z.object({ message: z.string() })).optional(),
-});
+const SendLocationResponse = z
+  .object({
+    data: z
+      .object({
+        sendLocation: z.object({
+          sessionId: z.string(),
+          warning: z.string().nullable().optional(),
+        }),
+      })
+      .nullable()
+      .optional(),
+    errors: z.array(z.object({ message: z.string() })).optional(),
+  })
+  // {}のような空レスポンスを不正として弾く
+  .refine((res) => res.data != null || (res.errors?.length ?? 0) > 0, {
+    message: 'Either data.sendLocation or non-empty errors is required',
+  });
 
 // テレメトリ基盤のGraphQL enum Platform
 const TelemetryPlatform = z.enum(['ios', 'android', 'macos', 'unknown']);
@@ -117,17 +122,22 @@ const SEND_LOG_EVENT_MUTATION = `
   }
 `;
 
-const SendLogEventResponse = z.object({
-  data: z
-    .object({
-      sendLogEvent: z.object({
-        sessionId: z.string(),
-      }),
-    })
-    .nullable()
-    .optional(),
-  errors: z.array(z.object({ message: z.string() })).optional(),
-});
+const SendLogEventResponse = z
+  .object({
+    data: z
+      .object({
+        sendLogEvent: z.object({
+          sessionId: z.string(),
+        }),
+      })
+      .nullable()
+      .optional(),
+    errors: z.array(z.object({ message: z.string() })).optional(),
+  })
+  // {}のような空レスポンスを不正として弾く
+  .refine((res) => res.data != null || (res.errors?.length ?? 0) > 0, {
+    message: 'Either data.sendLogEvent or non-empty errors is required',
+  });
 
 export const useTelemetrySender = (
   sendTelemetryAutomatically = false,
@@ -226,7 +236,11 @@ export const useTelemetrySender = (
         }
 
         const result = SendLogEventResponse.safeParse(json);
-        if (result.success && result.data.errors?.length) {
+        if (!result.success) {
+          console.error('Invalid log response:', result.error, json);
+          return;
+        }
+        if (result.data.errors?.length) {
           console.warn(
             'Log API error:',
             result.data.errors.map((e) => e.message).join(', ')
@@ -322,18 +336,20 @@ export const useTelemetrySender = (
       }
 
       const result = SendLocationResponse.safeParse(json);
-      if (result.success) {
-        if (result.data.errors?.length) {
-          console.warn(
-            'Location API error:',
-            result.data.errors.map((e) => e.message).join(', ')
-          );
-        } else if (result.data.data?.sendLocation.warning) {
-          console.warn(
-            'Location API warning:',
-            result.data.data.sendLocation.warning
-          );
-        }
+      if (!result.success) {
+        console.error('Invalid location response:', result.error, json);
+        return;
+      }
+      if (result.data.errors?.length) {
+        console.warn(
+          'Location API error:',
+          result.data.errors.map((e) => e.message).join(', ')
+        );
+      } else if (result.data.data?.sendLocation.warning) {
+        console.warn(
+          'Location API warning:',
+          result.data.data.sendLocation.warning
+        );
       }
     } catch (error) {
       console.error('Failed to send location:', error);

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -1,7 +1,10 @@
+import * as Application from 'expo-application';
 import * as Battery from 'expo-battery';
+import * as Crypto from 'expo-crypto';
 import * as Device from 'expo-device';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
 import {
   EXPERIMENTAL_TELEMETRY_ENDPOINT_URL,
   EXPERIMENTAL_TELEMETRY_TOKEN,
@@ -9,6 +12,7 @@ import {
 import { z } from 'zod';
 import { TELEMETRY_THROTTLE_MS } from '~/constants/telemetry';
 import { locationAtom } from '~/store/atoms/location';
+import { isDevApp } from '~/utils/isDevApp';
 import { sanitizeTelemetryMessage } from '~/utils/sanitizeTelemetryMessage';
 import { approachingAtom, arrivedAtom } from '../store/atoms/station';
 import { useCurrentLine } from './useCurrentLine';
@@ -19,7 +23,25 @@ import { useTelemetryEnabled } from './useTelemetryEnabled';
 const MovingState = z.enum(['arrived', 'approaching', 'passing', 'moving']);
 type MovingState = z.infer<typeof MovingState>;
 
-const LocationUpdateRequest = z.object({
+// テレメトリ基盤のGraphQL enum BatteryState(駅情報APIとは別基盤)
+const TelemetryBatteryState = z.enum([
+  'unknown',
+  'unplugged',
+  'charging',
+  'full',
+]);
+type TelemetryBatteryState = z.infer<typeof TelemetryBatteryState>;
+
+const BATTERY_STATE_MAP: Record<Battery.BatteryState, TelemetryBatteryState> = {
+  [Battery.BatteryState.UNKNOWN]: 'unknown',
+  [Battery.BatteryState.UNPLUGGED]: 'unplugged',
+  [Battery.BatteryState.CHARGING]: 'charging',
+  [Battery.BatteryState.FULL]: 'full',
+};
+
+// テレメトリ基盤のGraphQL LocationEventInputに対応
+const LocationEventInput = z.object({
+  sessionId: z.string().min(1),
   device: z.string(),
   state: MovingState,
   stationId: z.number().nullable().optional(),
@@ -28,28 +50,83 @@ const LocationUpdateRequest = z.object({
     latitude: z.number(),
     longitude: z.number(),
     accuracy: z.number().nullable().optional(),
+    // km/h(expo-locationのm/sではない)
     speed: z.number().nullable().optional(),
   }),
   batteryLevel: z.number().nullable().optional(),
-  batteryState: z.nativeEnum(Battery.BatteryState).nullable().optional(),
+  batteryState: TelemetryBatteryState.nullable().optional(),
   timestamp: z.number(),
 });
 
-const LogRequest = z.object({
-  device: z.string(),
-  timestamp: z.number(),
-  log: z.object({
-    type: z.enum(['system', 'app', 'client']),
-    level: z.enum(['debug', 'info', 'warn', 'error']),
-    message: z.string().min(1),
-  }),
+const SEND_LOCATION_MUTATION = `
+  mutation SendLocation($input: LocationEventInput!) {
+    sendLocation(input: $input) {
+      sessionId
+      warning
+    }
+  }
+`;
+
+// 認可エラー等もHTTP 200 + errors配列で返る
+const SendLocationResponse = z.object({
+  data: z
+    .object({
+      sendLocation: z.object({
+        sessionId: z.string(),
+        warning: z.string().nullable().optional(),
+      }),
+    })
+    .nullable()
+    .optional(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
 });
 
-const ApiResponse = z.object({
-  ok: z.boolean(),
-  id: z.string().optional(),
-  warning: z.string().optional(),
-  error: z.string().optional(),
+// テレメトリ基盤のGraphQL enum Platform
+const TelemetryPlatform = z.enum(['ios', 'android', 'macos', 'unknown']);
+type TelemetryPlatform = z.infer<typeof TelemetryPlatform>;
+
+const getTelemetryPlatform = (): TelemetryPlatform => {
+  switch (Platform.OS) {
+    case 'ios':
+    case 'android':
+    case 'macos':
+      return Platform.OS;
+    default:
+      return 'unknown';
+  }
+};
+
+// テレメトリ基盤のGraphQL LogEventInputに対応
+const LogEventInput = z.object({
+  sessionId: z.string().min(1),
+  device: z.string().nullable().optional(),
+  appVersion: z.string().min(1),
+  platform: TelemetryPlatform,
+  channel: z.enum(['production', 'canary']),
+  timestamp: z.number(),
+  type: z.enum(['system', 'app', 'client']),
+  level: z.enum(['debug', 'info', 'warn', 'error']),
+  message: z.string().min(1),
+});
+
+const SEND_LOG_EVENT_MUTATION = `
+  mutation SendLogEvent($input: LogEventInput!) {
+    sendLogEvent(input: $input) {
+      sessionId
+    }
+  }
+`;
+
+const SendLogEventResponse = z.object({
+  data: z
+    .object({
+      sendLogEvent: z.object({
+        sessionId: z.string(),
+      }),
+    })
+    .nullable()
+    .optional(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
 });
 
 export const useTelemetrySender = (
@@ -58,6 +135,8 @@ export const useTelemetrySender = (
   token = EXPERIMENTAL_TELEMETRY_TOKEN
 ) => {
   const lastSentTelemetryRef = useRef<number>(0);
+  // テレメトリ基盤がセッション単位で位置情報を紐付けるためのID。初回送信時に生成する
+  const sessionIdRef = useRef<string | null>(null);
 
   const station = useCurrentStation();
   const line = useCurrentLine();
@@ -83,6 +162,13 @@ export const useTelemetrySender = (
     return 'moving';
   }, [arrivedFromState, approachingFromState, passing]);
 
+  const getSessionId = useCallback(() => {
+    if (sessionIdRef.current == null) {
+      sessionIdRef.current = Crypto.randomUUID();
+    }
+    return sessionIdRef.current;
+  }, []);
+
   const sendLog = useCallback(
     async (
       message: string,
@@ -94,14 +180,16 @@ export const useTelemetrySender = (
 
       const now = Date.now();
 
-      const payload = LogRequest.safeParse({
+      const payload = LogEventInput.safeParse({
+        sessionId: getSessionId(),
         device: Device.modelName ?? 'unknown',
+        appVersion: `${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`,
+        platform: getTelemetryPlatform(),
+        channel: isDevApp ? 'canary' : 'production',
         timestamp: now,
-        log: {
-          type: 'app',
-          level,
-          message: sanitizeTelemetryMessage(message),
-        },
+        type: 'app',
+        level,
+        message: sanitizeTelemetryMessage(message),
       });
 
       if (payload.error) {
@@ -110,13 +198,16 @@ export const useTelemetrySender = (
       }
 
       try {
-        const response = await fetch(`${baseUrl}/api/log`, {
+        const response = await fetch(`${baseUrl}/graphql`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify(payload.data),
+          body: JSON.stringify({
+            query: SEND_LOG_EVENT_MUTATION,
+            variables: { input: payload.data },
+          }),
         });
 
         if (!response.ok) {
@@ -134,15 +225,18 @@ export const useTelemetrySender = (
           return;
         }
 
-        const result = ApiResponse.safeParse(json);
-        if (result.success && !result.data.ok) {
-          console.warn('Log API error:', result.data.error);
+        const result = SendLogEventResponse.safeParse(json);
+        if (result.success && result.data.errors?.length) {
+          console.warn(
+            'Log API error:',
+            result.data.errors.map((e) => e.message).join(', ')
+          );
         }
       } catch (error) {
         console.error('Failed to send log:', error);
       }
     },
-    [isTelemetryEnabled, baseUrl, token]
+    [isTelemetryEnabled, baseUrl, token, getSessionId]
   );
 
   const sendTelemetry = useCallback(async () => {
@@ -174,7 +268,8 @@ export const useTelemetrySender = (
       batteryState = null;
     }
 
-    const payload = LocationUpdateRequest.safeParse({
+    const payload = LocationEventInput.safeParse({
+      sessionId: getSessionId(),
       device: Device.modelName ?? 'unknown',
       state,
       lineId: line.id,
@@ -183,10 +278,13 @@ export const useTelemetrySender = (
         latitude: coords.latitude,
         longitude: coords.longitude,
         accuracy: coords.accuracy,
-        speed: coords.speed,
+        // expo-locationはm/s。負値は測位不能を表すためnullに落とす
+        speed:
+          coords.speed != null && coords.speed >= 0 ? coords.speed * 3.6 : null,
       },
       batteryLevel,
-      batteryState,
+      batteryState:
+        batteryState != null ? BATTERY_STATE_MAP[batteryState] : null,
       timestamp: now,
     });
 
@@ -198,13 +296,16 @@ export const useTelemetrySender = (
     lastSentTelemetryRef.current = now;
 
     try {
-      const response = await fetch(`${baseUrl}/api/location`, {
+      const response = await fetch(`${baseUrl}/graphql`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(payload.data),
+        body: JSON.stringify({
+          query: SEND_LOCATION_MUTATION,
+          variables: { input: payload.data },
+        }),
       });
 
       if (!response.ok) {
@@ -220,14 +321,18 @@ export const useTelemetrySender = (
         return;
       }
 
-      const result = ApiResponse.safeParse(json);
+      const result = SendLocationResponse.safeParse(json);
       if (result.success) {
-        if (result.data.ok) {
-          if (result.data.warning) {
-            console.warn('Location API warning:', result.data.warning);
-          }
-        } else {
-          console.warn('Location API error:', result.data.error);
+        if (result.data.errors?.length) {
+          console.warn(
+            'Location API error:',
+            result.data.errors.map((e) => e.message).join(', ')
+          );
+        } else if (result.data.data?.sendLocation.warning) {
+          console.warn(
+            'Location API warning:',
+            result.data.data.sendLocation.warning
+          );
         }
       }
     } catch (error) {
@@ -241,6 +346,7 @@ export const useTelemetrySender = (
     station?.id,
     baseUrl,
     token,
+    getSessionId,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## 概要

実験的テレメトリの送信を、REST API (`/api/location`・`/api/log`) から新テレメトリ基盤の GraphQL mutation (`sendLocation`・`sendLogEvent`) へ移行する。既存の駅情報 GraphQL とは別基盤のため、既存の GraphQL クライアントには乗せず従来どおり素の fetch で送信する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 位置情報送信を `POST {baseUrl}/api/location` から `sendLocation` mutation (`POST {baseUrl}/graphql`) に置き換え
- ログ送信を `POST {baseUrl}/api/log` から `sendLogEvent` mutation に置き換え
- 実稼働エンドポイントの introspection で確認したスキーマ差分に対応
  - `sessionId`(必須): expo-crypto の `randomUUID()` で初回送信時に生成し、位置情報・ログの両送信で共有
  - `coords.speed`: サーバ仕様が km/h のため expo-location の m/s から換算(負値=測位不能は null)
  - `batteryState`: expo-battery の数値 enum を文字列 enum (`unknown`/`unplugged`/`charging`/`full`) にマッピング
  - `appVersion`・`platform`・`channel`(`sendLogEvent` の必須項目): expo-application / `Platform.OS` / `isDevApp` から取得(`useFeedback` と同じ慣習)
- GraphQL のエラーが HTTP 200 + `errors` 配列で返る形式に合わせてレスポンス処理を変更(実エンドポイントで確認済み)
- テストを GraphQL 前提に更新(mutation 名でリクエストを判別するヘルパー追加、payload 検証の拡充)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ログと位置情報の送信処理を刷新し、テレメトリデータの連携精度と安定性を向上しました。
  * 開発版・本番版に応じて適切な送信先を利用するようになりました。
  * 位置情報の速度やバッテリー情報を正しく変換して送信します。
  * ログに含まれるトークン風文字列を引き続き秘匿します。
  * 通信エラーやサーバーからの警告を検知しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->