### PR TITLE
テレメトリにインタラクションイベント送信を実装しアプリ起動時にapp_launchを送信

### DIFF
--- a/src/hooks/useTelemetrySender.appLaunch.test.tsx
+++ b/src/hooks/useTelemetrySender.appLaunch.test.tsx
@@ -1,0 +1,175 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { Provider, useAtomValue } from 'jotai';
+import { useCurrentLine } from '~/hooks/useCurrentLine';
+import { useCurrentStation } from '~/hooks/useCurrentStation';
+import { useIsPassing } from '~/hooks/useIsPassing';
+import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
+import { useTelemetrySender } from '~/hooks/useTelemetrySender';
+import stationState from '~/store/atoms/station';
+
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.0.0',
+  nativeBuildVersion: '42',
+}));
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'test-session-id'),
+}));
+jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
+jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
+jest.mock('expo-battery', () => ({
+  BatteryState: {
+    UNKNOWN: 0,
+    UNPLUGGED: 1,
+    CHARGING: 2,
+    FULL: 3,
+  },
+  getBatteryLevelAsync: jest.fn(),
+  getBatteryStateAsync: jest.fn(),
+}));
+jest.mock('expo-network', () => ({
+  useNetworkState: jest.fn().mockReturnValue({ type: 'WIFI' }),
+  NetworkStateType: { WIFI: 'WIFI' },
+}));
+jest.mock('~/utils/telemetryConfig', () => ({
+  isTelemetryEnabledByBuild: true,
+}));
+jest.mock('jotai', () => {
+  const actual = jest.requireActual('jotai');
+  return {
+    ...actual,
+    useAtomValue: jest.fn(),
+  };
+});
+jest.mock('~/hooks/useCurrentLine', () => ({
+  useCurrentLine: jest.fn(),
+}));
+jest.mock('~/hooks/useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+jest.mock('~/hooks/useIsPassing', () => ({
+  useIsPassing: jest.fn(),
+}));
+jest.mock('~/hooks/useTelemetryEnabled', () => ({
+  useTelemetryEnabled: jest.fn(),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider
+    // @ts-expect-error - initialValues is valid for jotai Provider but types are not up to date
+    initialValues={[
+      [
+        stationState,
+        {
+          arrived: false,
+          approaching: false,
+          station: null,
+          stations: [],
+          stationsCache: [],
+          pendingStation: null,
+          pendingStations: [],
+          selectedDirection: null,
+          selectedBound: null,
+          wantedDestination: null,
+        },
+      ],
+    ]}
+  >
+    {children}
+  </Provider>
+);
+
+let mockFetch: jest.Mock;
+
+const findAppLaunchCalls = () =>
+  mockFetch.mock.calls.filter((call: any[]) => {
+    if (call[0] !== 'https://example.com/graphql') {
+      return false;
+    }
+    const body = JSON.parse(call[1].body);
+    return (
+      body.query.includes('sendInteractionEvent') &&
+      body.variables.input.eventName === 'app_launch'
+    );
+  });
+
+// NOTE: app_launchの一度きり送信はモジュールレベルのフラグで管理されるため、
+// このdescribe内のテストは記述順に依存する(disabled → 初回送信 → 再送なし)
+describe('useTelemetrySender (app_launch event)', () => {
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          data: { sendInteractionEvent: { sessionId: 'test-session-id' } },
+        }),
+    });
+    global.fetch = mockFetch;
+
+    (useAtomValue as jest.Mock).mockReturnValue({
+      coords: null,
+      timestamp: Date.now(),
+    });
+
+    (useCurrentLine as jest.Mock).mockReturnValue(null);
+    (useCurrentStation as jest.Mock).mockReturnValue(null);
+    (useIsPassing as jest.Mock).mockReturnValue(false);
+    (useTelemetryEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should not send app_launch while telemetry is disabled', async () => {
+    (useTelemetryEnabled as jest.Mock).mockReturnValue(false);
+
+    renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('should send app_launch once when telemetry becomes enabled', async () => {
+    renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await waitFor(
+      () => {
+        const calls = findAppLaunchCalls();
+        expect(calls.length).toBe(1);
+        const input = JSON.parse(calls[0][1].body).variables.input;
+        expect(input.sessionId).toBe('test-session-id');
+        expect(input.device).toBe('MockDevice');
+        expect(input.appVersion).toBe('1.0.0(42)');
+        expect(input.platform).toBe('ios');
+        expect(input.channel).toBe('production');
+        expect(input.properties).toBeNull();
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  test('should not send app_launch again from other hook instances', async () => {
+    renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+    renderHook(
+      () => useTelemetrySender(true, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(findAppLaunchCalls().length).toBe(0);
+  });
+});

--- a/src/hooks/useTelemetrySender.appLaunch.test.tsx
+++ b/src/hooks/useTelemetrySender.appLaunch.test.tsx
@@ -1,122 +1,23 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
-import { renderHook, waitFor } from '@testing-library/react-native';
-import { Provider, useAtomValue } from 'jotai';
-import { useCurrentLine } from '~/hooks/useCurrentLine';
-import { useCurrentStation } from '~/hooks/useCurrentStation';
-import { useIsPassing } from '~/hooks/useIsPassing';
-import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
-import { useTelemetrySender } from '~/hooks/useTelemetrySender';
-import stationState from '~/store/atoms/station';
-
-jest.mock('expo-application', () => ({
-  nativeApplicationVersion: '1.0.0',
-  nativeBuildVersion: '42',
-}));
-jest.mock('expo-crypto', () => ({
-  randomUUID: jest.fn(() => 'test-session-id'),
-}));
-jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
-jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
-jest.mock('expo-battery', () => ({
-  BatteryState: {
-    UNKNOWN: 0,
-    UNPLUGGED: 1,
-    CHARGING: 2,
-    FULL: 3,
-  },
-  getBatteryLevelAsync: jest.fn(),
-  getBatteryStateAsync: jest.fn(),
-}));
-jest.mock('expo-network', () => ({
-  useNetworkState: jest.fn().mockReturnValue({ type: 'WIFI' }),
-  NetworkStateType: { WIFI: 'WIFI' },
-}));
-jest.mock('~/utils/telemetryConfig', () => ({
-  isTelemetryEnabledByBuild: true,
-}));
-jest.mock('jotai', () => {
-  const actual = jest.requireActual('jotai');
-  return {
-    ...actual,
-    useAtomValue: jest.fn(),
-  };
-});
-jest.mock('~/hooks/useCurrentLine', () => ({
-  useCurrentLine: jest.fn(),
-}));
-jest.mock('~/hooks/useCurrentStation', () => ({
-  useCurrentStation: jest.fn(),
-}));
-jest.mock('~/hooks/useIsPassing', () => ({
-  useIsPassing: jest.fn(),
-}));
-jest.mock('~/hooks/useTelemetryEnabled', () => ({
-  useTelemetryEnabled: jest.fn(),
-}));
-
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <Provider
-    // @ts-expect-error - initialValues is valid for jotai Provider but types are not up to date
-    initialValues={[
-      [
-        stationState,
-        {
-          arrived: false,
-          approaching: false,
-          station: null,
-          stations: [],
-          stationsCache: [],
-          pendingStation: null,
-          pendingStations: [],
-          selectedDirection: null,
-          selectedBound: null,
-          wantedDestination: null,
-        },
-      ],
-    ]}
-  >
-    {children}
-  </Provider>
-);
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  findInteractionEventCalls,
+  setupTelemetrySenderMocks,
+  TELEMETRY_TEST_BASE_URL,
+  TelemetryTestWrapper,
+  useTelemetryEnabled,
+  useTelemetrySender,
+} from '~/utils/test/telemetrySenderTestSetup';
 
 let mockFetch: jest.Mock;
 
 const findAppLaunchCalls = () =>
-  mockFetch.mock.calls.filter((call: any[]) => {
-    if (call[0] !== 'https://example.com/graphql') {
-      return false;
-    }
-    const body = JSON.parse(call[1].body);
-    return (
-      body.query.includes('sendInteractionEvent') &&
-      body.variables.input.eventName === 'app_launch'
-    );
-  });
+  findInteractionEventCalls(mockFetch, 'app_launch');
 
 // NOTE: app_launchの一度きり送信はモジュールレベルのフラグで管理されるため、
-// このdescribe内のテストは記述順に依存する(disabled → 初回送信 → 再送なし)
+// このdescribe内のテストは記述順に依存する(disabled → 失敗時再送 → 初回送信 → 再送なし)
 describe('useTelemetrySender (app_launch event)', () => {
   beforeEach(() => {
-    mockFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: () =>
-        Promise.resolve({
-          data: { sendInteractionEvent: { sessionId: 'test-session-id' } },
-        }),
-    });
-    global.fetch = mockFetch;
-
-    (useAtomValue as jest.Mock).mockReturnValue({
-      coords: null,
-      timestamp: Date.now(),
-    });
-
-    (useCurrentLine as jest.Mock).mockReturnValue(null);
-    (useCurrentStation as jest.Mock).mockReturnValue(null);
-    (useIsPassing as jest.Mock).mockReturnValue(false);
-    (useTelemetryEnabled as jest.Mock).mockReturnValue(true);
+    mockFetch = setupTelemetrySenderMocks();
   });
 
   afterEach(() => {
@@ -127,8 +28,8 @@ describe('useTelemetrySender (app_launch event)', () => {
     (useTelemetryEnabled as jest.Mock).mockReturnValue(false);
 
     renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await new Promise((r) => setTimeout(r, 30));
@@ -136,10 +37,63 @@ describe('useTelemetrySender (app_launch event)', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  test('should reset the sent flag and retry app_launch after a failure', async () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const first = renderHook(
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
+    );
+
+    await waitFor(
+      () => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Failed to send interaction event:',
+          expect.any(Error)
+        );
+      },
+      { timeout: 2000 }
+    );
+    // 失敗後のフラグ戻し(.then)まで確実に流してからアンマウントする
+    await act(async () => {
+      await Promise.resolve();
+    });
+    first.unmount();
+
+    // フラグが戻っているため、新しいインスタンスが再送を試みる
+    consoleSpy.mockClear();
+    const second = renderHook(
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
+    );
+
+    await waitFor(
+      () => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Failed to send interaction event:',
+          expect.any(Error)
+        );
+      },
+      { timeout: 2000 }
+    );
+    // 2回目の失敗のフラグ戻しも流しきってからテストを終える
+    // (後続テストへ非同期のフラグ操作が漏れるのを防ぐ)
+    await act(async () => {
+      await Promise.resolve();
+    });
+    second.unmount();
+
+    consoleSpy.mockRestore();
+  });
+
   test('should send app_launch once when telemetry becomes enabled', async () => {
     renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await waitFor(
@@ -156,16 +110,20 @@ describe('useTelemetrySender (app_launch event)', () => {
       },
       { timeout: 2000 }
     );
+    // 送信成功の確定(.then)まで流し、フラグを確実にtrueで固定する
+    await act(async () => {
+      await Promise.resolve();
+    });
   });
 
   test('should not send app_launch again from other hook instances', async () => {
     renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
     renderHook(
-      () => useTelemetrySender(true, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(true, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await new Promise((r) => setTimeout(r, 30));

--- a/src/hooks/useTelemetrySender.enabled.test.tsx
+++ b/src/hooks/useTelemetrySender.enabled.test.tsx
@@ -101,11 +101,21 @@ const findGraphQLCall = (mutationName: string) =>
 
 describe('useTelemetrySender', () => {
   beforeEach(() => {
+    // どのmutationに対しても有効なレスポンスを返す。app_launchの自動送信が
+    // 失敗扱いになると送信済みフラグが戻り、後続テストのmockResolvedValueOnce等が
+    // app_launch側に消費されてしまうため、成功レスポンスでフラグを確定させる
     mockFetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
       statusText: 'OK',
-      json: () => Promise.resolve({ ok: true }),
+      json: () =>
+        Promise.resolve({
+          data: {
+            sendLogEvent: { sessionId: 'test-session-id' },
+            sendLocation: { sessionId: 'test-session-id', warning: null },
+            sendInteractionEvent: { sessionId: 'test-session-id' },
+          },
+        }),
     });
     global.fetch = mockFetch;
 

--- a/src/hooks/useTelemetrySender.interaction.test.tsx
+++ b/src/hooks/useTelemetrySender.interaction.test.tsx
@@ -1,129 +1,21 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
 import { act, renderHook, waitFor } from '@testing-library/react-native';
-import { Provider, useAtomValue } from 'jotai';
-import { useCurrentLine } from '~/hooks/useCurrentLine';
-import { useCurrentStation } from '~/hooks/useCurrentStation';
-import { useIsPassing } from '~/hooks/useIsPassing';
-import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
-import { useTelemetrySender } from '~/hooks/useTelemetrySender';
-import stationState from '~/store/atoms/station';
-
-jest.mock('expo-application', () => ({
-  nativeApplicationVersion: '1.0.0',
-  nativeBuildVersion: '42',
-}));
-jest.mock('expo-crypto', () => ({
-  randomUUID: jest.fn(() => 'test-session-id'),
-}));
-jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
-jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
-jest.mock('expo-battery', () => ({
-  BatteryState: {
-    UNKNOWN: 0,
-    UNPLUGGED: 1,
-    CHARGING: 2,
-    FULL: 3,
-  },
-  getBatteryLevelAsync: jest.fn(),
-  getBatteryStateAsync: jest.fn(),
-}));
-jest.mock('expo-network', () => ({
-  useNetworkState: jest.fn().mockReturnValue({ type: 'WIFI' }),
-  NetworkStateType: { WIFI: 'WIFI' },
-}));
-jest.mock('~/utils/telemetryConfig', () => ({
-  isTelemetryEnabledByBuild: true,
-}));
-jest.mock('jotai', () => {
-  const actual = jest.requireActual('jotai');
-  return {
-    ...actual,
-    useAtomValue: jest.fn(),
-  };
-});
-jest.mock('~/hooks/useCurrentLine', () => ({
-  useCurrentLine: jest.fn(),
-}));
-jest.mock('~/hooks/useCurrentStation', () => ({
-  useCurrentStation: jest.fn(),
-}));
-jest.mock('~/hooks/useIsPassing', () => ({
-  useIsPassing: jest.fn(),
-}));
-jest.mock('~/hooks/useTelemetryEnabled', () => ({
-  useTelemetryEnabled: jest.fn(),
-}));
-
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <Provider
-    // @ts-expect-error - initialValues is valid for jotai Provider but types are not up to date
-    initialValues={[
-      [
-        stationState,
-        {
-          arrived: false,
-          approaching: false,
-          station: null,
-          stations: [],
-          stationsCache: [],
-          pendingStation: null,
-          pendingStations: [],
-          selectedDirection: null,
-          selectedBound: null,
-          wantedDestination: null,
-        },
-      ],
-    ]}
-  >
-    {children}
-  </Provider>
-);
+import {
+  findInteractionEventCalls,
+  setupTelemetrySenderMocks,
+  TELEMETRY_TEST_BASE_URL,
+  TelemetryTestWrapper,
+  useTelemetryEnabled,
+  useTelemetrySender,
+} from '~/utils/test/telemetrySenderTestSetup';
 
 let mockFetch: jest.Mock;
 
-// app_launch の自動送信と手動送信イベントが混ざるため、eventName で見分ける
 const findInteractionCall = (eventName: string) =>
-  mockFetch.mock.calls.find((call: any[]) => {
-    if (call[0] !== 'https://example.com/graphql') {
-      return false;
-    }
-    const body = JSON.parse(call[1].body);
-    return (
-      body.query.includes('sendInteractionEvent') &&
-      body.variables.input.eventName === eventName
-    );
-  });
+  findInteractionEventCalls(mockFetch, eventName)[0];
 
 describe('useTelemetrySender (interaction events)', () => {
   beforeEach(() => {
-    mockFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: () =>
-        Promise.resolve({
-          data: { sendInteractionEvent: { sessionId: 'test-session-id' } },
-        }),
-    });
-    global.fetch = mockFetch;
-
-    (useAtomValue as jest.Mock).mockReturnValue({
-      coords: {
-        latitude: 35.0,
-        longitude: 139.0,
-        accuracy: 5,
-        speed: 10,
-        altitude: null,
-        altitudeAccuracy: null,
-        heading: null,
-      },
-      timestamp: Date.now(),
-    });
-
-    (useCurrentLine as jest.Mock).mockReturnValue({ id: 11302 });
-    (useCurrentStation as jest.Mock).mockReturnValue({ id: 1130224 });
-    (useIsPassing as jest.Mock).mockReturnValue(false);
-    (useTelemetryEnabled as jest.Mock).mockReturnValue(true);
+    mockFetch = setupTelemetrySenderMocks();
   });
 
   afterEach(() => {
@@ -132,8 +24,8 @@ describe('useTelemetrySender (interaction events)', () => {
 
   test('should send interaction event via GraphQL sendInteractionEvent mutation', async () => {
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {
@@ -168,8 +60,8 @@ describe('useTelemetrySender (interaction events)', () => {
 
   test('should send null properties when omitted', async () => {
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {
@@ -189,8 +81,8 @@ describe('useTelemetrySender (interaction events)', () => {
 
   test('should include Authorization header with token', async () => {
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {
@@ -213,8 +105,8 @@ describe('useTelemetrySender (interaction events)', () => {
     (useTelemetryEnabled as jest.Mock).mockReturnValue(false);
 
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {
@@ -227,7 +119,7 @@ describe('useTelemetrySender (interaction events)', () => {
 
   test('should not send interaction event if baseUrl is not provided', async () => {
     const { result } = renderHook(() => useTelemetrySender(false, ''), {
-      wrapper,
+      wrapper: TelemetryTestWrapper,
     });
 
     await act(async () => {
@@ -249,8 +141,8 @@ describe('useTelemetrySender (interaction events)', () => {
     });
 
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {
@@ -278,8 +170,8 @@ describe('useTelemetrySender (interaction events)', () => {
     mockFetch.mockRejectedValue(new Error('Network error'));
 
     const { result } = renderHook(
-      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
-      { wrapper }
+      () => useTelemetrySender(false, TELEMETRY_TEST_BASE_URL, 'test-token'),
+      { wrapper: TelemetryTestWrapper }
     );
 
     await act(async () => {

--- a/src/hooks/useTelemetrySender.interaction.test.tsx
+++ b/src/hooks/useTelemetrySender.interaction.test.tsx
@@ -1,0 +1,302 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: テストコードまで型安全にするのはつらい */
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { Provider, useAtomValue } from 'jotai';
+import { useCurrentLine } from '~/hooks/useCurrentLine';
+import { useCurrentStation } from '~/hooks/useCurrentStation';
+import { useIsPassing } from '~/hooks/useIsPassing';
+import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
+import { useTelemetrySender } from '~/hooks/useTelemetrySender';
+import stationState from '~/store/atoms/station';
+
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.0.0',
+  nativeBuildVersion: '42',
+}));
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'test-session-id'),
+}));
+jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
+jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
+jest.mock('expo-battery', () => ({
+  BatteryState: {
+    UNKNOWN: 0,
+    UNPLUGGED: 1,
+    CHARGING: 2,
+    FULL: 3,
+  },
+  getBatteryLevelAsync: jest.fn(),
+  getBatteryStateAsync: jest.fn(),
+}));
+jest.mock('expo-network', () => ({
+  useNetworkState: jest.fn().mockReturnValue({ type: 'WIFI' }),
+  NetworkStateType: { WIFI: 'WIFI' },
+}));
+jest.mock('~/utils/telemetryConfig', () => ({
+  isTelemetryEnabledByBuild: true,
+}));
+jest.mock('jotai', () => {
+  const actual = jest.requireActual('jotai');
+  return {
+    ...actual,
+    useAtomValue: jest.fn(),
+  };
+});
+jest.mock('~/hooks/useCurrentLine', () => ({
+  useCurrentLine: jest.fn(),
+}));
+jest.mock('~/hooks/useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+jest.mock('~/hooks/useIsPassing', () => ({
+  useIsPassing: jest.fn(),
+}));
+jest.mock('~/hooks/useTelemetryEnabled', () => ({
+  useTelemetryEnabled: jest.fn(),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider
+    // @ts-expect-error - initialValues is valid for jotai Provider but types are not up to date
+    initialValues={[
+      [
+        stationState,
+        {
+          arrived: false,
+          approaching: false,
+          station: null,
+          stations: [],
+          stationsCache: [],
+          pendingStation: null,
+          pendingStations: [],
+          selectedDirection: null,
+          selectedBound: null,
+          wantedDestination: null,
+        },
+      ],
+    ]}
+  >
+    {children}
+  </Provider>
+);
+
+let mockFetch: jest.Mock;
+
+// app_launch の自動送信と手動送信イベントが混ざるため、eventName で見分ける
+const findInteractionCall = (eventName: string) =>
+  mockFetch.mock.calls.find((call: any[]) => {
+    if (call[0] !== 'https://example.com/graphql') {
+      return false;
+    }
+    const body = JSON.parse(call[1].body);
+    return (
+      body.query.includes('sendInteractionEvent') &&
+      body.variables.input.eventName === eventName
+    );
+  });
+
+describe('useTelemetrySender (interaction events)', () => {
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          data: { sendInteractionEvent: { sessionId: 'test-session-id' } },
+        }),
+    });
+    global.fetch = mockFetch;
+
+    (useAtomValue as jest.Mock).mockReturnValue({
+      coords: {
+        latitude: 35.0,
+        longitude: 139.0,
+        accuracy: 5,
+        speed: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+      },
+      timestamp: Date.now(),
+    });
+
+    (useCurrentLine as jest.Mock).mockReturnValue({ id: 11302 });
+    (useCurrentStation as jest.Mock).mockReturnValue({ id: 1130224 });
+    (useIsPassing as jest.Mock).mockReturnValue(false);
+    (useTelemetryEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should send interaction event via GraphQL sendInteractionEvent mutation', async () => {
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change', {
+        tabName: 'settings',
+        index: 2,
+        fromUser: true,
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        const call = findInteractionCall('tab_change');
+        expect(call).toBeDefined();
+        const input = JSON.parse(call[1].body).variables.input;
+        expect(input.sessionId).toBe('test-session-id');
+        expect(input.device).toBe('MockDevice');
+        expect(input.appVersion).toBe('1.0.0(42)');
+        expect(input.platform).toBe('ios');
+        expect(input.channel).toBe('production');
+        expect(typeof input.timestamp).toBe('number');
+        expect(input.properties).toEqual({
+          tabName: 'settings',
+          index: 2,
+          fromUser: true,
+        });
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  test('should send null properties when omitted', async () => {
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('screen_view');
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        const call = findInteractionCall('screen_view');
+        expect(call).toBeDefined();
+        expect(JSON.parse(call[1].body).variables.input.properties).toBeNull();
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  test('should include Authorization header with token', async () => {
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change');
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        const call = findInteractionCall('tab_change');
+        expect(call).toBeDefined();
+        expect(call[1].headers.Authorization).toBe('Bearer test-token');
+        expect(call[1].headers['Content-Type']).toBe('application/json');
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  test('should not send interaction event if telemetry is disabled', async () => {
+    (useTelemetryEnabled as jest.Mock).mockReturnValue(false);
+
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change');
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('should not send interaction event if baseUrl is not provided', async () => {
+    const { result } = renderHook(() => useTelemetrySender(false, ''), {
+      wrapper,
+    });
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change');
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('should warn when API returns error', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({ data: null, errors: [{ message: 'Server error' }] }),
+    });
+
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change');
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Interaction event API error:',
+          'Server error'
+        );
+      },
+      { timeout: 2000 }
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  test('should handle fetch error gracefully', async () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(
+      () => useTelemetrySender(false, 'https://example.com', 'test-token'),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.sendInteractionEvent('tab_change');
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Failed to send interaction event:',
+          expect.any(Error)
+        );
+      },
+      { timeout: 2000 }
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -233,10 +233,14 @@ export const useTelemetrySender = (
     return 'moving';
   }, [arrivedFromState, approachingFromState, passing]);
 
+  // 戻り値は送信の成否。呼び出し元が失敗時の再送制御をできるようにする
   const sendInteractionEvent = useCallback(
-    async (eventName: string, properties?: InteractionEventProperties) => {
+    async (
+      eventName: string,
+      properties?: InteractionEventProperties
+    ): Promise<boolean> => {
       if (!isTelemetryEnabled || !baseUrl) {
-        return;
+        return false;
       }
 
       const payload = InteractionEventInput.safeParse({
@@ -252,7 +256,7 @@ export const useTelemetrySender = (
 
       if (payload.error) {
         console.error('Invalid interaction event payload:', payload.error);
-        return;
+        return false;
       }
 
       try {
@@ -272,7 +276,7 @@ export const useTelemetrySender = (
           console.error(
             `HTTP error: ${response.status} ${response.statusText}`
           );
-          return;
+          return false;
         }
 
         let json: unknown;
@@ -280,7 +284,7 @@ export const useTelemetrySender = (
           json = await response.json();
         } catch {
           console.error('Failed to parse response JSON');
-          return;
+          return false;
         }
 
         const result = SendInteractionEventResponse.safeParse(json);
@@ -290,7 +294,7 @@ export const useTelemetrySender = (
             result.error,
             json
           );
-          return;
+          return false;
         }
         if (result.data.errors?.length) {
           console.warn(
@@ -298,8 +302,11 @@ export const useTelemetrySender = (
             result.data.errors.map((e) => e.message).join(', ')
           );
         }
+        // サーバ側でデータとして受理されたことをもって送信成功とみなす
+        return result.data.data?.sendInteractionEvent != null;
       } catch (error) {
         console.error('Failed to send interaction event:', error);
+        return false;
       }
     },
     [isTelemetryEnabled, baseUrl, token]
@@ -506,7 +513,13 @@ export const useTelemetrySender = (
     }
 
     hasAppLaunchEventBeenSent = true;
-    sendInteractionEvent('app_launch');
+    sendInteractionEvent('app_launch').then((sent) => {
+      if (!sent) {
+        // 起動直後の通信不調などで失敗した場合はフラグを戻し、
+        // 後続のマウントや設定変更のタイミングで再送できるようにする
+        hasAppLaunchEventBeenSent = false;
+      }
+    });
   }, [isTelemetryEnabled, baseUrl, sendInteractionEvent]);
 
   return { sendLog, sendInteractionEvent };

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -90,6 +90,22 @@ const SendLocationResponse = z
 const TelemetryPlatform = z.enum(['ios', 'android', 'macos', 'unknown']);
 type TelemetryPlatform = z.infer<typeof TelemetryPlatform>;
 
+// テレメトリ基盤がセッション単位でイベントを紐付けるためのID。
+// フックは複数コンポーネントから使われるため、インスタンス毎ではなく
+// アプリプロセス全体で共有し、位置情報・ログ・インタラクションを突合可能にする
+let telemetrySessionId: string | null = null;
+const getOrCreateSessionId = (): string => {
+  if (telemetrySessionId == null) {
+    telemetrySessionId = Crypto.randomUUID();
+  }
+  return telemetrySessionId;
+};
+
+// アプリプロセスごとに1回だけapp_launchイベントを送るためのフラグ。
+// telemetryEnabledはPermittedがMMKVからatomへ復元するまでfalseのため、
+// マウント時ではなく有効化を検知した時点で送信する
+let hasAppLaunchEventBeenSent = false;
+
 const getTelemetryPlatform = (): TelemetryPlatform => {
   switch (Platform.OS) {
     case 'ios':
@@ -139,14 +155,59 @@ const SendLogEventResponse = z
     message: 'Either data.sendLogEvent or non-empty errors is required',
   });
 
+// テレメトリ基盤のGraphQL Propertiesスカラーに対応。
+// フラットなmapのみ許容され、ネストしたオブジェクトや配列は基盤側で拒否される
+const InteractionEventProperties = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean(), z.null()])
+);
+export type InteractionEventProperties = z.infer<
+  typeof InteractionEventProperties
+>;
+
+// テレメトリ基盤のGraphQL InteractionEventInputに対応
+const InteractionEventInput = z.object({
+  sessionId: z.string().min(1),
+  device: z.string().nullable().optional(),
+  appVersion: z.string().min(1),
+  platform: TelemetryPlatform,
+  channel: z.enum(['production', 'canary']),
+  timestamp: z.number(),
+  eventName: z.string().min(1),
+  properties: InteractionEventProperties.nullable().optional(),
+});
+
+const SEND_INTERACTION_EVENT_MUTATION = `
+  mutation SendInteractionEvent($input: InteractionEventInput!) {
+    sendInteractionEvent(input: $input) {
+      sessionId
+    }
+  }
+`;
+
+const SendInteractionEventResponse = z
+  .object({
+    data: z
+      .object({
+        sendInteractionEvent: z.object({
+          sessionId: z.string(),
+        }),
+      })
+      .nullable()
+      .optional(),
+    errors: z.array(z.object({ message: z.string() })).optional(),
+  })
+  // {}のような空レスポンスを不正として弾く
+  .refine((res) => res.data != null || (res.errors?.length ?? 0) > 0, {
+    message: 'Either data.sendInteractionEvent or non-empty errors is required',
+  });
+
 export const useTelemetrySender = (
   sendTelemetryAutomatically = false,
   baseUrl = EXPERIMENTAL_TELEMETRY_ENDPOINT_URL,
   token = EXPERIMENTAL_TELEMETRY_TOKEN
 ) => {
   const lastSentTelemetryRef = useRef<number>(0);
-  // テレメトリ基盤がセッション単位で位置情報を紐付けるためのID。初回送信時に生成する
-  const sessionIdRef = useRef<string | null>(null);
 
   const station = useCurrentStation();
   const line = useCurrentLine();
@@ -172,12 +233,77 @@ export const useTelemetrySender = (
     return 'moving';
   }, [arrivedFromState, approachingFromState, passing]);
 
-  const getSessionId = useCallback(() => {
-    if (sessionIdRef.current == null) {
-      sessionIdRef.current = Crypto.randomUUID();
-    }
-    return sessionIdRef.current;
-  }, []);
+  const sendInteractionEvent = useCallback(
+    async (eventName: string, properties?: InteractionEventProperties) => {
+      if (!isTelemetryEnabled || !baseUrl) {
+        return;
+      }
+
+      const payload = InteractionEventInput.safeParse({
+        sessionId: getOrCreateSessionId(),
+        device: Device.modelName ?? 'unknown',
+        appVersion: `${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`,
+        platform: getTelemetryPlatform(),
+        channel: isDevApp ? 'canary' : 'production',
+        timestamp: Date.now(),
+        eventName,
+        properties: properties ?? null,
+      });
+
+      if (payload.error) {
+        console.error('Invalid interaction event payload:', payload.error);
+        return;
+      }
+
+      try {
+        const response = await fetch(`${baseUrl}/graphql`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            query: SEND_INTERACTION_EVENT_MUTATION,
+            variables: { input: payload.data },
+          }),
+        });
+
+        if (!response.ok) {
+          console.error(
+            `HTTP error: ${response.status} ${response.statusText}`
+          );
+          return;
+        }
+
+        let json: unknown;
+        try {
+          json = await response.json();
+        } catch {
+          console.error('Failed to parse response JSON');
+          return;
+        }
+
+        const result = SendInteractionEventResponse.safeParse(json);
+        if (!result.success) {
+          console.error(
+            'Invalid interaction event response:',
+            result.error,
+            json
+          );
+          return;
+        }
+        if (result.data.errors?.length) {
+          console.warn(
+            'Interaction event API error:',
+            result.data.errors.map((e) => e.message).join(', ')
+          );
+        }
+      } catch (error) {
+        console.error('Failed to send interaction event:', error);
+      }
+    },
+    [isTelemetryEnabled, baseUrl, token]
+  );
 
   const sendLog = useCallback(
     async (
@@ -191,7 +317,7 @@ export const useTelemetrySender = (
       const now = Date.now();
 
       const payload = LogEventInput.safeParse({
-        sessionId: getSessionId(),
+        sessionId: getOrCreateSessionId(),
         device: Device.modelName ?? 'unknown',
         appVersion: `${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`,
         platform: getTelemetryPlatform(),
@@ -250,7 +376,7 @@ export const useTelemetrySender = (
         console.error('Failed to send log:', error);
       }
     },
-    [isTelemetryEnabled, baseUrl, token, getSessionId]
+    [isTelemetryEnabled, baseUrl, token]
   );
 
   const sendTelemetry = useCallback(async () => {
@@ -283,7 +409,7 @@ export const useTelemetrySender = (
     }
 
     const payload = LocationEventInput.safeParse({
-      sessionId: getSessionId(),
+      sessionId: getOrCreateSessionId(),
       device: Device.modelName ?? 'unknown',
       state,
       lineId: line.id,
@@ -362,7 +488,6 @@ export const useTelemetrySender = (
     station?.id,
     baseUrl,
     token,
-    getSessionId,
   ]);
 
   useEffect(() => {
@@ -373,5 +498,16 @@ export const useTelemetrySender = (
     sendTelemetry();
   }, [sendTelemetry, sendTelemetryAutomatically, isTelemetryEnabled]);
 
-  return { sendLog };
+  // アプリ起動のインタラクションイベント。設定復元によりtelemetryEnabledが
+  // trueへ変わった時点で、プロセス内のどのインスタンスからでも1回だけ送る
+  useEffect(() => {
+    if (!isTelemetryEnabled || !baseUrl || hasAppLaunchEventBeenSent) {
+      return;
+    }
+
+    hasAppLaunchEventBeenSent = true;
+    sendInteractionEvent('app_launch');
+  }, [isTelemetryEnabled, baseUrl, sendInteractionEvent]);
+
+  return { sendLog, sendInteractionEvent };
 };

--- a/src/utils/test/telemetrySenderTestSetup.tsx
+++ b/src/utils/test/telemetrySenderTestSetup.tsx
@@ -1,0 +1,140 @@
+import { Provider, useAtomValue } from 'jotai';
+import { useCurrentLine } from '~/hooks/useCurrentLine';
+import { useCurrentStation } from '~/hooks/useCurrentStation';
+import { useIsPassing } from '~/hooks/useIsPassing';
+import { useTelemetryEnabled } from '~/hooks/useTelemetryEnabled';
+import stationState from '~/store/atoms/station';
+
+// useTelemetrySenderのテスト用共通セットアップ。
+// jest.mockはbabel-preset-jestによりこのモジュールの先頭へホイストされるため、
+// テストファイルが本モジュールをimportした時点で依存モジュールのモックが登録される。
+// テスト対象(useTelemetrySender)やモック済みフックは順序事故を防ぐため
+// 必ず本モジュールのre-export経由でimportすること。
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.0.0',
+  nativeBuildVersion: '42',
+}));
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'test-session-id'),
+}));
+jest.mock('expo-device', () => ({ modelName: 'MockDevice' }));
+jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
+jest.mock('expo-battery', () => ({
+  BatteryState: {
+    UNKNOWN: 0,
+    UNPLUGGED: 1,
+    CHARGING: 2,
+    FULL: 3,
+  },
+  getBatteryLevelAsync: jest.fn(),
+  getBatteryStateAsync: jest.fn(),
+}));
+jest.mock('expo-network', () => ({
+  useNetworkState: jest.fn().mockReturnValue({ type: 'WIFI' }),
+  NetworkStateType: { WIFI: 'WIFI' },
+}));
+jest.mock('~/utils/telemetryConfig', () => ({
+  isTelemetryEnabledByBuild: true,
+}));
+jest.mock('jotai', () => {
+  const actual = jest.requireActual('jotai');
+  return {
+    ...actual,
+    useAtomValue: jest.fn(),
+  };
+});
+jest.mock('~/hooks/useCurrentLine', () => ({
+  useCurrentLine: jest.fn(),
+}));
+jest.mock('~/hooks/useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+jest.mock('~/hooks/useIsPassing', () => ({
+  useIsPassing: jest.fn(),
+}));
+jest.mock('~/hooks/useTelemetryEnabled', () => ({
+  useTelemetryEnabled: jest.fn(),
+}));
+
+export { useTelemetrySender } from '~/hooks/useTelemetrySender';
+export { useTelemetryEnabled };
+
+export const TELEMETRY_TEST_BASE_URL = 'https://example.com';
+
+export const TelemetryTestWrapper = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => (
+  <Provider
+    // @ts-expect-error - initialValues is valid for jotai Provider but types are not up to date
+    initialValues={[
+      [
+        stationState,
+        {
+          arrived: false,
+          approaching: false,
+          station: null,
+          stations: [],
+          stationsCache: [],
+          pendingStation: null,
+          pendingStations: [],
+          selectedDirection: null,
+          selectedBound: null,
+          wantedDestination: null,
+        },
+      ],
+    ]}
+  >
+    {children}
+  </Provider>
+);
+
+// beforeEachから呼び、モックの既定値とfetchモックをまとめて設定する
+export const setupTelemetrySenderMocks = (): jest.Mock => {
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        data: { sendInteractionEvent: { sessionId: 'test-session-id' } },
+      }),
+  });
+  global.fetch = mockFetch;
+
+  (useAtomValue as jest.Mock).mockReturnValue({
+    coords: {
+      latitude: 35.0,
+      longitude: 139.0,
+      accuracy: 5,
+      speed: 10,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+    },
+    timestamp: Date.now(),
+  });
+  (useCurrentLine as jest.Mock).mockReturnValue({ id: 11302 });
+  (useCurrentStation as jest.Mock).mockReturnValue({ id: 1130224 });
+  (useIsPassing as jest.Mock).mockReturnValue(false);
+  (useTelemetryEnabled as jest.Mock).mockReturnValue(true);
+
+  return mockFetch;
+};
+
+// app_launchの自動送信と手動送信イベントが混ざるため、eventNameで見分ける
+export const findInteractionEventCalls = (
+  mockFetch: jest.Mock,
+  eventName: string
+) =>
+  mockFetch.mock.calls.filter((call) => {
+    if (call[0] !== `${TELEMETRY_TEST_BASE_URL}/graphql`) {
+      return false;
+    }
+    const body = JSON.parse(call[1].body);
+    return (
+      body.query.includes('sendInteractionEvent') &&
+      body.variables.input.eventName === eventName
+    );
+  });


### PR DESCRIPTION
## 概要

実験的テレメトリ基盤の GraphQL `sendInteractionEvent` mutation に対応し、インタラクションイベントを送信できる仕組みを `useTelemetrySender` に追加しました。現時点でアプリが実際に送信するのはアプリ起動時の `app_launch` イベントのみです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useTelemetrySender` に `sendInteractionEvent(eventName, properties?)` を追加（テレメトリ基盤の GraphQL `InteractionEventInput` に対応。properties はフラットな map のみ許容）
- 設定復元により telemetry が有効化された時点で、アプリプロセスごとに 1 回だけ `app_launch` インタラクションイベントを自動送信
- セッション ID をフックインスタンス毎の生成からモジュールレベル共有に変更し、位置情報・ログ・インタラクションイベントを同一セッション ID で突合できるように変更
- `sendInteractionEvent` のペイロード構造・エラーハンドリングと `app_launch` の一度きり送信を検証する単体テストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 操作や画面などのインタラクションイベントをテレメトリとして送信できるようになりました。
  - テレメトリ有効化後、アプリ起動イベント（app_launch）を自動で1回だけ送信します。
- **改善**
  - ログ/テレメトリで同一のセッションIDを継続利用します。
  - 送信失敗やAPIエラー時のログ出力を強化し、テレメトリ無効または送信先未設定時は送信しません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->