### PR TITLE
ライセンス画面に京王バスと東急バスのODPTライセンスを追記

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -247,6 +247,8 @@
   "kyotoCity": "Kyoto Municipal Transportation Bureau",
   "yokohamaCity": "Transportation Bureau, City of Yokohama",
   "seibuBus": "Seibu Bus Co., Ltd.",
+  "keioBus": "Keio Bus Co., Ltd.",
+  "tokyuBus": "Tokyu Bus Corporation",
   "hakodateCity": "Transportation Department, Hakodate City Enterprise Bureau",
   "odptBasicLicense": "Public Transportation Open Data Basic License",
   "odptGtfs": "GTFS (Public Transportation Open Data Center)",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -248,6 +248,8 @@
   "kyotoCity": "京都市交通局",
   "yokohamaCity": "横浜市交通局",
   "seibuBus": "西武バス",
+  "keioBus": "京王バス",
+  "tokyuBus": "東急バス",
   "hakodateCity": "函館市企業局交通部",
   "odptBasicLicense": "公共交通オープンデータ基本ライセンス",
   "odptGtfs": "GTFS (公共交通オープンデータセンター)",

--- a/src/screens/Licenses.tsx
+++ b/src/screens/Licenses.tsx
@@ -31,6 +31,8 @@ type LicenseId =
   | 'kyoto_city'
   | 'yokohama_city'
   | 'seibu_bus'
+  | 'keio_bus'
+  | 'tokyu_bus'
   | 'hakodate_city'
   | 'roboto'
   | 'other_oss';
@@ -207,6 +209,24 @@ const Licenses: React.FC = () => {
             title: translate('seibuBus'),
             icon: '🚌',
             href: 'https://www.seibubus.co.jp/',
+            license: translate('odptBasicLicense'),
+            licenseUrl: ODPT_BASIC_LICENSE_URL,
+            devOnly: false,
+          },
+          {
+            id: 'keio_bus',
+            title: translate('keioBus'),
+            icon: '🚌',
+            href: 'https://www.keio-bus.com/',
+            license: translate('odptBasicLicense'),
+            licenseUrl: ODPT_BASIC_LICENSE_URL,
+            devOnly: false,
+          },
+          {
+            id: 'tokyu_bus',
+            title: translate('tokyuBus'),
+            icon: '🚌',
+            href: 'https://www.tokyubus.co.jp/',
             license: translate('odptBasicLicense'),
             licenseUrl: ODPT_BASIC_LICENSE_URL,
             devOnly: false,


### PR DESCRIPTION
## 概要

京王バスと東急バスのODPT GTFSデータを新たに利用するため、ライセンス画面に2社のODPTライセンス表記を追加しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- ライセンス画面（`src/screens/Licenses.tsx`）に「京王バス」「東急バス」のライセンス項目を追加。西武バスと同じ公共交通オープンデータ基本ライセンス（`odptBasicLicense` / `ODPT_BASIC_LICENSE_URL`）を適用。
- `LicenseId` 型に `keio_bus` / `tokyu_bus` を追加し、既存のバス事業者（西武バス）の直後に配置。
- 翻訳ファイルに表示名の翻訳キーを追加（`ja.json`: `keioBus`=京王バス / `tokyuBus`=東急バス、`en.json`: Keio Bus Co., Ltd. / Tokyu Bus Corporation）。

補足: 両社の GTFS データセットは ODPT データカタログ（ckan.odpt.org）で `license_id=odpt-ptodbl`（公共交通オープンデータ基本ライセンス）を指定しているため、函館市電の GTFS-RUL ではなく、既存の西武バスと同一のライセンスを適用しています。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sqf7mKCpBJfJKpKczHrxN8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ライセンス一覧に「京王バス」と「東急バス」を追加しました。
  * 各事業者の公式サイトへのリンクと、ライセンス情報を確認できるようになりました。
  * 日本語・英語の事業者名に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->