### PR TITLE
オートモードで終点到着後は1分停車してから方面を逆転して折り返すよう変更

### DIFF
--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -11,6 +11,7 @@ import {
 import { YAMANOTE_LINE_ID } from '~/constants';
 import * as useCurrentTrainTypeModule from '~/hooks/useCurrentTrainType';
 import { useGraphQLQuery } from '~/hooks/useGraphQLQuery';
+import { useLoopLine } from '~/hooks/useLoopLine';
 import { useSimulationMode } from '~/hooks/useSimulationMode';
 import { GET_TRAIN_ROUTE } from '~/lib/graphql/queries';
 import { store } from '~/store';
@@ -28,6 +29,7 @@ jest.mock('~/store/atoms/station', () => ({
   stationAtom: { toString: () => 'stationAtom' },
   stationsAtom: { toString: () => 'stationsAtom' },
   selectedDirectionAtom: { toString: () => 'selectedDirectionAtom' },
+  selectedBoundAtom: { toString: () => 'selectedBoundAtom' },
 }));
 
 jest.mock('~/store/atoms/navigation', () => ({
@@ -198,6 +200,10 @@ describe('useSimulationMode', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(100000));
+
+    // 各テストは非ループ線を前提とする。ループ線テストで上書きした実装が
+    // 後続テストへ漏れないよう毎回明示的にリセットする。
+    (useLoopLine as jest.Mock).mockReturnValue({ isLoopLine: false });
 
     jest
       .spyOn(useCurrentTrainTypeModule, 'useCurrentTrainType')
@@ -575,8 +581,8 @@ describe('useSimulationMode', () => {
       );
     });
 
-    it('終端駅到達後、先頭に戻ったときに速度プロファイルを最初から再生する', () => {
-      // 駅が1つだけ → nextStopStationがない → 即座に先頭リセット
+    it('終点到達後は即座に折り返さず終点で停車し続ける', () => {
+      // 駅が1つだけ → nextStopStationがない → 即座に終点扱い
       const stations = [mockStation(1, 1, 35.681, 139.767)];
 
       setupAtomMocks(
@@ -588,37 +594,150 @@ describe('useSimulationMode', () => {
         { autoModeEnabled: true }
       );
 
-      // step内でstore.getが呼ばれる
+      // dwell処理内でstore.getが呼ばれる
       (store.get as jest.Mock).mockReturnValue(
         mockLocationObject(35.681, 139.767)
       );
 
       // 速度プロファイルは空（駅が1つで次の駅がない）なので
       // interval tick 1: speeds=[], i(0)>=0 → dwellPending=true
-      // interval tick 2: dwell handler → nextSegment=-1 → 先頭に戻る
-      // interval tick 3: speeds=[] again → dwellPending=true
-      // 先頭に戻る際にchildIndexがリセットされていれば、
-      // 毎回i=0から開始される（リセットされていないとiが進み続ける）
+      // interval tick 2以降: dwell handler → nextSegment=-1 → 終点で停車し
+      //   TERMINAL_DWELL_TICKS に達するまで方面逆転せず待機し続ける。
+      // 待機中は始発駅へワープせず、終点座標で speed=0 のまま留まる。
       renderHook(() => useSimulationMode(), {
         wrapper: ({ children }) => <Provider>{children}</Provider>,
       });
 
-      // 6秒分進める（複数回のリセットサイクルを経る）
+      // 6秒分進める（待機継続中）
       jest.advanceTimersByTime(6000);
 
-      // 先頭駅の位置が繰り返しセットされることを確認（リセットが正しく機能している）
+      // 終点座標で speed=0 の位置更新が繰り返しセットされることを確認
       const locationSetCalls = (store.set as jest.Mock).mock.calls
         .filter((call) => call[0] === locationAtom)
         .map((call) => call[1]);
 
-      const resetCalls = locationSetCalls.filter(
+      const dwellCalls = locationSetCalls.filter(
         (loc) =>
           loc?.coords?.latitude === stations[0].latitude &&
           loc?.coords?.longitude === stations[0].longitude &&
           loc?.coords?.speed === 0
       );
-      // 初期化 + dwellハンドラでの複数回リセット
-      expect(resetCalls.length).toBeGreaterThanOrEqual(2);
+      // 終点停車中の複数回の位置更新
+      expect(dwellCalls.length).toBeGreaterThanOrEqual(2);
+
+      // 待機時間(60ティック)未満では方面逆転(selectedDirection書き込み)は起きない
+      const directionSetCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'selectedDirectionAtom'
+      );
+      expect(directionSetCalls).toHaveLength(0);
+    });
+
+    it('終点で約1分停車したのち方面を逆転して折り返す', () => {
+      const stations = [
+        mockStation(1, 1, 35.681, 139.767),
+        mockStation(2, 2, 35.691, 139.777),
+      ];
+
+      setupAtomMocks(
+        {
+          station: stations[0],
+          stations,
+          selectedDirection: 'INBOUND',
+        },
+        { autoModeEnabled: true }
+      );
+
+      mockTrainRoute(stations);
+
+      // 1駅1ティックで終点まで到達させる
+      jest
+        .spyOn(trainSpeedModule, 'generateTrainSpeedProfile')
+        .mockReturnValue([2000]);
+
+      (store.get as jest.Mock).mockReturnValue(
+        mockLocationObject(35.691, 139.777)
+      );
+
+      renderHook(() => useSimulationMode(), {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      });
+
+      // 終点到達 + 30秒程度の停車。まだ待機時間(約60秒)に満たないので折り返さない
+      jest.advanceTimersByTime(30000);
+
+      let directionSetCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'selectedDirectionAtom'
+      );
+      expect(directionSetCalls).toHaveLength(0);
+
+      // さらに進めて待機時間を超過させると方面(selectedDirection/selectedBound)が逆転する
+      jest.advanceTimersByTime(40000);
+
+      directionSetCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'selectedDirectionAtom'
+      );
+      expect(directionSetCalls.length).toBeGreaterThanOrEqual(1);
+      // INBOUND → OUTBOUND へ逆転
+      expect(directionSetCalls[0][1]).toBe('OUTBOUND');
+
+      // 折り返し後の行き先(selectedBound)も更新される
+      const boundSetCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'selectedBoundAtom'
+      );
+      expect(boundSetCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ループ線では終点でも方面を逆転せず先頭に戻って周回を続ける', () => {
+      (useLoopLine as jest.Mock).mockReturnValue({ isLoopLine: true });
+
+      const stations = [
+        mockStation(1, 1, 35.681, 139.767),
+        mockStation(2, 2, 35.691, 139.777),
+      ];
+
+      setupAtomMocks(
+        {
+          station: stations[1],
+          stations,
+          selectedDirection: 'INBOUND',
+        },
+        { autoModeEnabled: true }
+      );
+
+      // ループ線 + INBOUND では進行順が reverse される（[s2, s1]）
+      mockTrainRoute([stations[1], stations[0]]);
+
+      jest
+        .spyOn(trainSpeedModule, 'generateTrainSpeedProfile')
+        .mockReturnValue([2000]);
+
+      (store.get as jest.Mock).mockReturnValue(
+        mockLocationObject(35.691, 139.777)
+      );
+
+      renderHook(() => useSimulationMode(), {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      });
+
+      // 非ループ線なら折り返す待機時間を超過しても、ループ線では方面を逆転しない
+      jest.advanceTimersByTime(70000);
+
+      const directionSetCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'selectedDirectionAtom'
+      );
+      expect(directionSetCalls).toHaveLength(0);
+
+      // 先頭駅（周回の始点）へ戻る位置更新が行われている
+      const locationSetCalls = (store.set as jest.Mock).mock.calls
+        .filter((call) => call[0] === locationAtom)
+        .map((call) => call[1]);
+      const backToStartCalls = locationSetCalls.filter(
+        (loc) =>
+          loc?.coords?.latitude === stations[1].latitude &&
+          loc?.coords?.longitude === stations[1].longitude &&
+          loc?.coords?.speed === 0
+      );
+      expect(backToStartCalls.length).toBeGreaterThanOrEqual(1);
     });
 
     it('速度プロファイルの終端に達したら次のセグメントに移動する', () => {

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -13,6 +13,7 @@ import { locationAtom } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { generateTrainSpeedProfile } from '~/utils/trainSpeed';
 import {
+  selectedBoundAtom,
   selectedDirectionAtom,
   stationAtom,
   stationsAtom,
@@ -22,6 +23,10 @@ import getIsPass from '../utils/isPass';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useGraphQLQuery } from './useGraphQLQuery';
 import { useLoopLine } from './useLoopLine';
+
+// 終点到着後、方面を逆転して折り返すまでの待機時間。
+// step のインターバルが1秒間隔のため、ティック数（≒秒数）としてそのまま扱う。
+const TERMINAL_DWELL_TICKS = 60;
 
 export const useSimulationMode = (): void => {
   const currentStation = useAtomValue(stationAtom);
@@ -40,6 +45,11 @@ export const useSimulationMode = (): void => {
   const speedProfilesRef = useRef<number[][]>([]);
   const segmentProgressDistanceRef = useRef(0);
   const dwellPendingRef = useRef(false);
+  // 終点到着後、方面を逆転して折り返すまで終点で停車し続けたティック数
+  const terminalDwellCountRef = useRef(0);
+  // 方面逆転中フラグ。新しい進行方向の速度プロファイルが再生成されるまで
+  // 終点で停車したまま待機し、旧方向のプロファイル/ジオメトリでの誤stepを防ぐ。
+  const reversingRef = useRef(false);
   // 区間ごとの (waypoints, cumulativeDistances) キャッシュ。
   // step() は毎秒呼ばれる。区間が変わらない限り cumulativeDistances は同じなので、
   // waypoints 毎の getDistance / reduce を毎ティック走らせる必要は無い。
@@ -282,6 +292,9 @@ export const useSimulationMode = (): void => {
     childIndexRef.current = 0;
     segmentProgressDistanceRef.current = 0;
     dwellPendingRef.current = false;
+    terminalDwellCountRef.current = 0;
+    // 新しい方向の速度プロファイルが揃ったので折り返し待機を解除する
+    reversingRef.current = false;
   }, [maybeRevsersedStations, trainRouteData, resolveStartIndex]);
 
   const step = useCallback(
@@ -427,6 +440,23 @@ export const useSimulationMode = (): void => {
 
       const speeds = speedProfilesRef.current[segmentIndexRef.current] ?? [];
 
+      // 方面逆転中は新方向の速度プロファイルが再生成されるまで終点で停車して待つ。
+      // 旧方向のプロファイル/ジオメトリで step すると位置が飛ぶため、ここで待機する。
+      if (reversingRef.current) {
+        const prev = store.get(locationAtom);
+        if (prev) {
+          store.set(locationAtom, {
+            timestamp: Date.now(),
+            coords: {
+              ...prev.coords,
+              speed: 0,
+              heading: null,
+            },
+          });
+        }
+        return;
+      }
+
       if (dwellPendingRef.current) {
         const prev = store.get(locationAtom);
         if (prev) {
@@ -442,27 +472,58 @@ export const useSimulationMode = (): void => {
         const nextSegmentIndex = speedProfilesRef.current.findIndex(
           (seg, idx) => seg.length > 0 && idx > segmentIndexRef.current
         );
+
         if (nextSegmentIndex === -1) {
-          const firstStation = maybeRevsersedStations[0];
-          if (
-            prev &&
-            firstStation?.latitude != null &&
-            firstStation?.longitude != null
-          ) {
-            store.set(locationAtom, {
-              timestamp: Date.now(),
-              coords: {
-                ...prev.coords,
-                latitude: firstStation.latitude,
-                longitude: firstStation.longitude,
-                speed: 0,
-                heading: null,
-              },
-            });
+          if (isLoopLine) {
+            // ループ線には折り返す終点が無いため、従来どおり先頭に戻って
+            // 同一方向のまま周回を続ける。
+            const firstStation = maybeRevsersedStations[0];
+            if (
+              prev &&
+              firstStation?.latitude != null &&
+              firstStation?.longitude != null
+            ) {
+              store.set(locationAtom, {
+                timestamp: Date.now(),
+                coords: {
+                  ...prev.coords,
+                  latitude: firstStation.latitude,
+                  longitude: firstStation.longitude,
+                  speed: 0,
+                  heading: null,
+                },
+              });
+            }
+            segmentIndexRef.current = 0;
+            childIndexRef.current = 0;
+            segmentProgressDistanceRef.current = 0;
+            dwellPendingRef.current = false;
+            return;
           }
+
+          // 終点に到達。すぐには折り返さず、約1分間そのまま停車してから
+          // 方面(selectedDirection / selectedBound)を逆転させて折り返す。
+          if (terminalDwellCountRef.current < TERMINAL_DWELL_TICKS) {
+            terminalDwellCountRef.current += 1;
+            return;
+          }
+
+          // 待機完了 → 方面を逆転する。maybeRevsersedStations と trainRoute は
+          // どちらも selectedDirection に依存して再計算されるため、方向を反転すれば
+          // 終点始発の折り返し運転として自然にシミュレーションが継続する。
+          terminalDwellCountRef.current = 0;
+          dwellPendingRef.current = false;
+          reversingRef.current = true;
+          const reversedDirection =
+            selectedDirection === 'INBOUND' ? 'OUTBOUND' : 'INBOUND';
+          // 反転後の進行方向は現在の maybeRevsersedStations の逆順になるため、
+          // 折り返し後の行き先(selectedBound)は現在の始発駅にあたる先頭要素。
+          store.set(selectedBoundAtom, maybeRevsersedStations[0] ?? null);
+          store.set(selectedDirectionAtom, reversedDirection);
+          return;
         }
-        segmentIndexRef.current =
-          nextSegmentIndex === -1 ? 0 : nextSegmentIndex;
+
+        segmentIndexRef.current = nextSegmentIndex;
         childIndexRef.current = 0;
         segmentProgressDistanceRef.current = 0;
         dwellPendingRef.current = false;
@@ -483,5 +544,5 @@ export const useSimulationMode = (): void => {
     return () => {
       clearInterval(intervalId);
     };
-  }, [enabled, maybeRevsersedStations, selectedDirection, step]);
+  }, [enabled, isLoopLine, maybeRevsersedStations, selectedDirection, step]);
 };


### PR DESCRIPTION
## 概要

オートモードで終点に到着した際の挙動を変更しました。従来は終点到着直後に始発駅へ戻っていましたが、約1分間終点で停車したのち、方面（進行方向）を逆転させて折り返すようにしました。実際の折り返し運転に近い挙動になります。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useSimulationMode.ts`: 終点（次の停車セグメントが無い状態）到達時に即座に折り返さず、`TERMINAL_DWELL_TICKS`（1秒間隔 × 60 ≒ 約1分）ぶん終点で `speed: 0` のまま停車させるようにした。
- 待機完了後、`selectedDirection`（INBOUND ⇄ OUTBOUND）と `selectedBound` を逆転させ、終点始発の折り返し運転として継続させる。`maybeRevsersedStations` と `trainRoute` クエリはどちらも `selectedDirection` 由来のため、方向反転だけで駅順・行き先・残り駅表示などが折り返し方向へ切り替わる。
- 方面逆転中は新方向の速度プロファイルが再生成されるまで終点で停車して待機する `reversingRef` ガードを追加し、旧方向のプロファイル/ジオメトリで `step()` して位置が飛ぶ問題を防止。
- ループ線には折り返す終点が無いため、`isLoopLine` の場合は従来どおり先頭に戻って同一方向で周回を継続（リグレッション回避）。
- `src/hooks/useSimulationMode.test.tsx`: 終点で即折り返さず停車を続けること、約1分後に方面（`selectedDirection` / `selectedBound`）が逆転すること、ループ線では逆転せず周回すること、を検証するテストを追加・更新。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest src/hooks/useSimulationMode.test.tsx`（25 件パス）、`npm run typecheck`、Biome lint を実行し、いずれも成功を確認。関連スイート（`useWrongDirectionDetector` / `useBounds` / `DevOverlay` / `trainSpeed`）も回帰なし。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dhifdRFT6ZRWghyvrDFzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012dhifdRFT6ZRWghyvrDFzk)_