### PR TITLE
TZ=UTC のテストスクリプトを cross-env 経由にしてWindowsで動くようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "web": "expo start --web",
     "lint": "biome check ./src",
     "format": "biome format ./src --write",
-    "test": "TZ=UTC jest",
+    "test": "cross-env TZ=UTC jest",
     "typecheck": "tsc --noEmit",
-    "watch:test": "TZ=UTC jest --watch",
+    "watch:test": "cross-env TZ=UTC jest --watch",
     "gql:codegen": "graphql-codegen --config utils/codegen.ts",
     "version:bump": "node scripts/bump-version.js",
     "postinstall": "patch-package"


### PR DESCRIPTION
## 概要

`npm test` / `npm run watch:test` の `TZ=UTC` 環境変数指定が Windows の PowerShell / cmd では解釈されずコマンドが失敗していたため、`cross-env` 経由に変更してクロスプラットフォームで動くようにしました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `package.json` の `test` を `TZ=UTC jest` → `cross-env TZ=UTC jest` に変更
- `package.json` の `watch:test` を `TZ=UTC jest --watch` → `cross-env TZ=UTC jest --watch` に変更
- `cross-env`（`^10.1.0`）は既に devDependencies に存在し、`android` / `ios` スクリプトでも利用済みのため依存追加は不要

## テスト

<!-- npm スクリプト（ビルド設定）のみの変更でアプリ本体コード（src/** 等）に変更が無いため、下記チェックは実行対象外として省略 -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * テスト実行時のタイムゾーン設定を改善し、環境に依存せず安定してテストを実行できるようにしました。
  * 通常のテスト実行とウォッチモードの両方に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->