### PR TITLE
TTS 送信前に英語駅名のマクロンを除去して誤読を防ぐ

### DIFF
--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -188,6 +188,77 @@ describe('fetchSpeechAudio', () => {
     expect(body.data.ssmlEn).toBe('<speak>test</speak>');
   });
 
+  it('英語 SSML の可視テキストからマクロンを除去して送信する', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: 'tts-127',
+          jaAudioContent: 'QQ==',
+          enAudioContent: 'QQ==',
+        },
+      }),
+    });
+
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Kiryū and Ōhirashita',
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.data.ssmlEn).toBe('<speak>Kiryu and Ohirashita</speak>');
+  });
+
+  it('マクロン除去時に SSML タグと IPA 発音記号 (ph 属性) は保持する', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: 'tts-128',
+          jaAudioContent: 'QQ==',
+          enAudioContent: 'QQ==',
+        },
+      }),
+    });
+
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'the <phoneme alphabet="ipa" ph="toːkʲoː">Tōkyō</phoneme> Line',
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    // ph 属性内の IPA (長音 ː) はそのまま、可視テキストの Tōkyō のみ Tokyo になる
+    expect(body.data.ssmlEn).toBe(
+      '<speak>the <phoneme alphabet="ipa" ph="toːkʲoː">Tokyo</phoneme> Line</speak>'
+    );
+  });
+
+  it('マクロン有無で同じキャッシュを共有する', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: 'tts-129',
+          jaAudioContent: 'QQ==',
+          enAudioContent: 'QQ==',
+        },
+      }),
+    });
+
+    const first = await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Tōkyō',
+    });
+    const second = await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Tokyo',
+    });
+
+    expect(first).toEqual(second);
+    // 2 回目はキャッシュヒットで fetch は 1 回だけ
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('PCM MIME の場合は WAV として保存する', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -106,6 +106,22 @@ const normalizeOptional = (val: string | undefined): string => {
   return trimmed.length > 0 ? trimmed : '';
 };
 
+// ヘボン式ローマ字の長音符（マクロン: Ā ā Ē ē Ī ī Ō ō Ū ū）を素の母音へ落とす。
+// NFD で母音と結合マクロン（U+0304）へ分解し、マクロンだけ取り除いて NFC に戻す。
+// 既存の useIsDifferentStationName と同じ手法。
+const COMBINING_MACRON = String.fromCharCode(0x0304);
+const stripMacrons = (text: string): string =>
+  text.normalize('NFD').replaceAll(COMBINING_MACRON, '').normalize('NFC');
+
+// TTS API（Azure Speech）はマクロン付き母音を正しく読めず、英語駅名を誤読・無音化
+// することがあるため、SSML の可視テキストからマクロンを除去する。
+// タグ（<...>）は属性ごと保護し、タグ外のテキストだけを対象にすることで、
+// <phoneme ph="..."> の IPA 発音記号など読みの正確さに関わる値は温存する。
+const stripMacronsFromSsmlText = (ssml: string): string =>
+  ssml.replace(/<[^>]*>|[^<]+/g, (token) =>
+    token.startsWith('<') ? token : stripMacrons(token)
+  );
+
 const buildCacheKey = (opts: FetchSpeechOptions): string =>
   `${opts.textJa}\0${opts.textEn}\0${normalizeOptional(opts.jaVoiceName)}\0${normalizeOptional(opts.enVoiceName)}`;
 
@@ -136,7 +152,11 @@ export const fetchSpeechAudio = async (
     return null;
   }
 
-  const cacheKey = buildCacheKey(options);
+  // TTS API はマクロン付き英語駅名を誤読・無音化することがあるため、送信前に
+  // 英語 SSML の可視テキストからマクロンを除去する（日本語側は元々マクロンを含まない）。
+  const sanitizedTextEn = stripMacronsFromSsmlText(textEn);
+
+  const cacheKey = buildCacheKey({ ...options, textEn: sanitizedTextEn });
   const cached = fetchCache.get(cacheKey);
   if (cached) {
     return cached;
@@ -148,7 +168,7 @@ export const fetchSpeechAudio = async (
   const reqBody = {
     data: {
       ssmlJa: `<speak>${textJa.trim()}</speak>`,
-      ssmlEn: `<speak>${textEn.trim()}</speak>`,
+      ssmlEn: `<speak>${sanitizedTextEn.trim()}</speak>`,
       ...(normalizedJaVoiceName ? { jaVoiceName: normalizedJaVoiceName } : {}),
       ...(normalizedEnVoiceName ? { enVoiceName: normalizedEnVoiceName } : {}),
     },


### PR DESCRIPTION
## 概要

TTS API へ送る英語アナウンス文からヘボン式長音符（マクロン）を除去し、マクロン付きの英語駅名（例: `Tōkyō` / `Kiryū` / `Ōhirashita`）が誤読・無音化される問題を防ぎます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ttsSpeechFetcher` に送信直前のマクロン除去を追加。`normalize('NFD')` で結合マクロン（`U+0304`）へ分解 → 除去 → `normalize('NFC')` で再結合し、`ō → o` などへ正規化する（既存の `useIsDifferentStationName` と同じ手法）。
- SSML のタグ（`<...>`）は属性ごと保護し、タグ外の可視テキストだけを対象にすることで、`<phoneme ph="...">` の IPA 発音記号を壊さず温存する。
- キャッシュキーも除去後のテキストで生成し、マクロンの有無で同一音声のキャッシュを共有する。
- 日本語側の SSML は元々マクロンを含まないため対象外（英語テキストのみ処理）。
- テストを 4 件追加（可視テキストのマクロン除去 / SSML タグ・IPA 属性の保持 / マクロン有無でのキャッシュ共有）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 英語の音声合成で、可視テキスト中のマクロン（長音記号）を自動的に除去するようになりました。
  * SSMLタグや発音記号は維持され、正規化後のテキストが音声合成とキャッシュに反映されます。
  * マクロンの有無にかかわらず同じキャッシュが利用され、不要な再取得を抑制します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->