### PR TITLE
オートモードの折り返し時にTTSの初回放送を再発火するよう変更

### DIFF
--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -660,10 +660,11 @@ describe('useSimulationMode', () => {
         .spyOn(trainSpeedModule, 'generateTrainSpeedProfile')
         .mockReturnValue([2000]);
 
-      // resetFirstSpeechAtom は数値、それ以外(locationAtom)は位置オブジェクトを返す
+      // resetFirstSpeechAtom は非ゼロの数値、それ以外(locationAtom)は位置オブジェクトを返す。
+      // 非ゼロ(3)にすることで「現在値 + 1」を読んでいることを検証できる（固定値1だと通ってしまう）。
       (store.get as jest.Mock).mockImplementation((atom) =>
         atom?.toString?.() === 'resetFirstSpeechAtom'
-          ? 0
+          ? 3
           : mockLocationObject(35.691, 139.777)
       );
 
@@ -701,12 +702,13 @@ describe('useSimulationMode', () => {
       );
       expect(boundSetCalls.length).toBeGreaterThanOrEqual(1);
 
-      // 折り返し時に初回放送(firstSpeech)が再発火する(resetFirstSpeechをインクリメント)
+      // 折り返し時に初回放送(firstSpeech)が再発火する(resetFirstSpeechをインクリメント)。
+      // 現在値3 + 1 = 4 が設定され、二重発火せず1回だけ呼ばれることを検証する。
       const resetFirstSpeechCalls = (store.set as jest.Mock).mock.calls.filter(
         (call) => call[0]?.toString?.() === 'resetFirstSpeechAtom'
       );
-      expect(resetFirstSpeechCalls.length).toBeGreaterThanOrEqual(1);
-      expect(resetFirstSpeechCalls[0][1]).toBe(1);
+      expect(resetFirstSpeechCalls).toHaveLength(1);
+      expect(resetFirstSpeechCalls[0][1]).toBe(4);
     });
 
     it('ループ線では終点でも方面を逆転せず先頭に戻って周回を続ける', () => {

--- a/src/hooks/useSimulationMode.test.tsx
+++ b/src/hooks/useSimulationMode.test.tsx
@@ -38,6 +38,12 @@ jest.mock('~/store/atoms/navigation', () => ({
   autoModeEnabledAtom: { toString: () => 'autoModeEnabledAtom' },
 }));
 
+jest.mock('~/store/atoms/speech', () => ({
+  __esModule: true,
+  default: { toString: () => 'speechState' },
+  resetFirstSpeechAtom: { toString: () => 'resetFirstSpeechAtom' },
+}));
+
 jest.mock('~/store', () => ({
   store: {
     get: jest.fn(() => null),
@@ -654,8 +660,11 @@ describe('useSimulationMode', () => {
         .spyOn(trainSpeedModule, 'generateTrainSpeedProfile')
         .mockReturnValue([2000]);
 
-      (store.get as jest.Mock).mockReturnValue(
-        mockLocationObject(35.691, 139.777)
+      // resetFirstSpeechAtom は数値、それ以外(locationAtom)は位置オブジェクトを返す
+      (store.get as jest.Mock).mockImplementation((atom) =>
+        atom?.toString?.() === 'resetFirstSpeechAtom'
+          ? 0
+          : mockLocationObject(35.691, 139.777)
       );
 
       renderHook(() => useSimulationMode(), {
@@ -669,6 +678,12 @@ describe('useSimulationMode', () => {
         (call) => call[0]?.toString?.() === 'selectedDirectionAtom'
       );
       expect(directionSetCalls).toHaveLength(0);
+      // 折り返す前は初回放送の再発火も起きない
+      expect(
+        (store.set as jest.Mock).mock.calls.filter(
+          (call) => call[0]?.toString?.() === 'resetFirstSpeechAtom'
+        )
+      ).toHaveLength(0);
 
       // さらに進めて待機時間を超過させると方面(selectedDirection/selectedBound)が逆転する
       jest.advanceTimersByTime(40000);
@@ -685,6 +700,13 @@ describe('useSimulationMode', () => {
         (call) => call[0]?.toString?.() === 'selectedBoundAtom'
       );
       expect(boundSetCalls.length).toBeGreaterThanOrEqual(1);
+
+      // 折り返し時に初回放送(firstSpeech)が再発火する(resetFirstSpeechをインクリメント)
+      const resetFirstSpeechCalls = (store.set as jest.Mock).mock.calls.filter(
+        (call) => call[0]?.toString?.() === 'resetFirstSpeechAtom'
+      );
+      expect(resetFirstSpeechCalls.length).toBeGreaterThanOrEqual(1);
+      expect(resetFirstSpeechCalls[0][1]).toBe(1);
     });
 
     it('ループ線では終点でも方面を逆転せず先頭に戻って周回を続ける', () => {

--- a/src/hooks/useSimulationMode.ts
+++ b/src/hooks/useSimulationMode.ts
@@ -11,6 +11,7 @@ import { GET_TRAIN_ROUTE } from '~/lib/graphql/queries';
 import { store } from '~/store';
 import { locationAtom } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
+import { resetFirstSpeechAtom } from '~/store/atoms/speech';
 import { generateTrainSpeedProfile } from '~/utils/trainSpeed';
 import {
   selectedBoundAtom,
@@ -520,6 +521,10 @@ export const useSimulationMode = (): void => {
           // 折り返し後の行き先(selectedBound)は現在の始発駅にあたる先頭要素。
           store.set(selectedBoundAtom, maybeRevsersedStations[0] ?? null);
           store.set(selectedDirectionAtom, reversedDirection);
+          // 折り返し後は新しい行き先として初回放送(この電車は〜行きです)を再発火させる。
+          // resetFirstSpeechAtom を進めると useTTS 側で firstSpeech が true に戻り、
+          // 行き先変更 + 発車後(arrived=false)に初回TTSが改めて再生される。
+          store.set(resetFirstSpeechAtom, store.get(resetFirstSpeechAtom) + 1);
           return;
         }
 


### PR DESCRIPTION
## 概要

オートモードの折り返し（終点で約1分停車後に方面を逆転して折り返す挙動、#6403 で追加）に続く変更です。折り返して新しい行き先へ発車する際、TTS の初回放送（「この電車は〜行きです」）が改めて再生されるようにしました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useSimulationMode.ts`: 終点での待機完了後に方面（`selectedDirection` / `selectedBound`）を逆転させるタイミングで `resetFirstSpeechAtom` をインクリメントするようにした。これにより `useTTS` 側で `firstSpeech` が `true` に戻る。
- 行き先（`selectedBound`）の変更と併せて `firstSpeech` が再セットされるため、`useTTS` の抑止ロジック（`suppressFirstSpeechUntilDepartureRef` / `computeSuppressionDecision`）により終点停車中（`arrived=true`）は再生されず、折り返して発車した後（`arrived=false`）に初回放送が改めて再生される。
- ループ線は折り返さない（従来どおり周回を継続する）ため、この再発火の対象外。
- `src/hooks/useSimulationMode.test.tsx`: 折り返し前は `resetFirstSpeech` が発火しないこと、折り返し時に `resetFirstSpeech` がインクリメントされること（初回放送の再発火）を検証するアサーションを追加。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest src/hooks/useSimulationMode.test.tsx`（25 件パス）、`npm run typecheck`、Biome lint を実行し、いずれも成功を確認。

## 関連Issue

Refs #6403

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dhifdRFT6ZRWghyvrDFzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012dhifdRFT6ZRWghyvrDFzk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 折り返し運転の開始時に音声案内を初期化し、折り返し後の発車時に初回案内が再生されるよう改善しました。
* **テスト**
  * 終点到着後の待機中に不要な音声案内が再生されないことを確認するテストを追加しました。
  * 折り返し時の音声案内リセット動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->