### PR TITLE
省電力モードを試験的機能から外し設定に「バッテリー」画面を新設して移動

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -331,6 +331,7 @@
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
   "etaAssistTitle": "Improve arrival detection",
   "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid.",
+  "batterySettings": "Battery",
   "powerSavingLocationTitle": "Power-saving location mode",
   "powerSavingLocationDescription": "When enabled, location accuracy is lowered to a battery-friendly level and iOS pauses tracking automatically while you are stopped, further reducing battery drain and heat on long rides. The lower accuracy may delay or shift station detection and arrival announcements. The relaxed update frequency is already part of the default settings. It also turns on automatically while your device is in low-power mode.",
   "passStationLabel": "Pass"

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -332,6 +332,7 @@
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
   "etaAssistTitle": "到着判定の改善",
   "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。",
+  "batterySettings": "バッテリー",
   "powerSavingLocationTitle": "省電力測位モード",
   "powerSavingLocationDescription": "有効にすると、測位精度を電池優先まで下げ、停車中はiOSが測位を自動休止して、長時間の乗車での電池消費と発熱をさらに減らします。精度の低下により駅の判定や到着案内が遅れたりずれたりする場合があります。位置情報の更新頻度の緩和は標準設定に組み込まれています。端末の省電力モード中は自動的に有効になります。",
   "passStationLabel": "通過"

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -445,7 +445,7 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       );
       // NOTE: powerSavingLocationEnabledAtom はここでは復元しない。effect復元だと
       // 継続測位がデフォルト精度で一度起動してから再起動されるため、
-      // atom定義側(store/atoms/experimental.ts)でMMKVから同期的に初期値を確定している。
+      // atom定義側(store/atoms/battery.ts)でMMKVから同期的に初期値を確定している。
 
       if (themePreferenceKey) {
         setThemePreference(themePreferenceKey as ThemePreference);

--- a/src/hooks/useStartBackgroundLocationUpdates.test.tsx
+++ b/src/hooks/useStartBackgroundLocationUpdates.test.tsx
@@ -13,7 +13,6 @@ import { useStartBackgroundLocationUpdates } from './useStartBackgroundLocationU
 
 let mockNeedsJobSchedulerBypass = false;
 let mockSystemLowPowerMode = false;
-let mockIsDevApp = false;
 jest.mock('../constants/native', () => ({
   get NEEDS_JOBSCHEDULER_BYPASS() {
     return mockNeedsJobSchedulerBypass;
@@ -22,11 +21,6 @@ jest.mock('../constants/native', () => ({
 
 jest.mock('expo-battery', () => ({
   useLowPowerMode: () => mockSystemLowPowerMode,
-}));
-jest.mock('~/utils/isDevApp', () => ({
-  get isDevApp() {
-    return mockIsDevApp;
-  },
 }));
 jest.mock('expo-location');
 jest.mock('./useLocationPermissionsGranted');
@@ -44,7 +38,7 @@ jest.mock('~/store/atoms/navigation', () => ({
   default: {},
   autoModeEnabledAtom: { toString: () => 'autoModeEnabledAtom' },
 }));
-jest.mock('~/store/atoms/experimental', () => ({
+jest.mock('~/store/atoms/battery', () => ({
   powerSavingLocationEnabledAtom: {
     toString: () => 'powerSavingLocationEnabledAtom',
   },
@@ -92,7 +86,6 @@ describe('useStartBackgroundLocationUpdates', () => {
     mockAutoModeEnabled = false;
     mockPowerSavingLocationEnabled = false;
     mockSystemLowPowerMode = false;
-    mockIsDevApp = false;
     mockNeedsJobSchedulerBypass = false;
     mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
     mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
@@ -391,7 +384,6 @@ describe('useStartBackgroundLocationUpdates', () => {
   describe('power saving location mode', () => {
     test('should lower accuracy and allow automatic pauses for background updates when enabled', async () => {
       mockPowerSavingLocationEnabled = true;
-      mockIsDevApp = true;
       mockUseLocationPermissionsGranted.mockReturnValue(true);
 
       renderHook(() => useStartBackgroundLocationUpdates());
@@ -429,10 +421,9 @@ describe('useStartBackgroundLocationUpdates', () => {
       );
     });
 
-    test('should enable the power-saving profile in the dev app while the system low-power mode is active', async () => {
+    test('should enable the power-saving profile while the system low-power mode is active', async () => {
       mockPowerSavingLocationEnabled = false;
       mockSystemLowPowerMode = true;
-      mockIsDevApp = true;
       mockUseLocationPermissionsGranted.mockReturnValue(true);
 
       renderHook(() => useStartBackgroundLocationUpdates());
@@ -449,50 +440,8 @@ describe('useStartBackgroundLocationUpdates', () => {
       );
     });
 
-    test('should keep the default profile in production while the system low-power mode is active', async () => {
-      mockPowerSavingLocationEnabled = false;
-      mockSystemLowPowerMode = true;
-      mockIsDevApp = false;
-      mockUseLocationPermissionsGranted.mockReturnValue(true);
-
-      renderHook(() => useStartBackgroundLocationUpdates());
-
-      await new Promise(process.nextTick);
-
-      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
-        LOCATION_TASK_NAME,
-        expect.objectContaining({
-          ...LOCATION_TASK_OPTIONS,
-          accuracy: Location.Accuracy.High,
-          pausesUpdatesAutomatically: false,
-          foregroundService: expect.objectContaining({
-            killServiceOnDestroy: true,
-          }),
-        })
-      );
-    });
-
-    test('should ignore the experimental setting outside the dev app', async () => {
-      mockPowerSavingLocationEnabled = true;
-      mockIsDevApp = false;
-      mockUseLocationPermissionsGranted.mockReturnValue(true);
-
-      renderHook(() => useStartBackgroundLocationUpdates());
-
-      await new Promise(process.nextTick);
-
-      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
-        LOCATION_TASK_NAME,
-        expect.objectContaining({
-          accuracy: Location.Accuracy.High,
-          pausesUpdatesAutomatically: false,
-        })
-      );
-    });
-
     test('should apply the power-saving accuracy to foreground watchPositionAsync when enabled', async () => {
       mockPowerSavingLocationEnabled = true;
-      mockIsDevApp = true;
       mockUseLocationPermissionsGranted.mockReturnValue(false);
 
       renderHook(() => useStartBackgroundLocationUpdates());

--- a/src/hooks/useStartBackgroundLocationUpdates.ts
+++ b/src/hooks/useStartBackgroundLocationUpdates.ts
@@ -3,11 +3,10 @@ import * as Location from 'expo-location';
 import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
 import { store } from '~/store';
-import { powerSavingLocationEnabledAtom } from '~/store/atoms/experimental';
+import { powerSavingLocationEnabledAtom } from '~/store/atoms/battery';
 import { backgroundLocationTrackingAtom } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { handleTrackingLocation } from '~/utils/handleTrackingLocation';
-import { isDevApp } from '~/utils/isDevApp';
 import {
   LOCATION_START_MAX_RETRIES,
   LOCATION_START_RETRY_BASE_DELAY_MS,
@@ -30,16 +29,15 @@ export const useStartBackgroundLocationUpdates = () => {
   const bgPermGranted = useLocationPermissionsGranted();
   const autoModeEnabled = useAtomValue(autoModeEnabledAtom);
   const systemLowPowerMode = Battery.useLowPowerMode();
-  // 省電力測位モード(実験的機能)。精度をBalancedへ下げ、停車中の測位自動休止
-  // (iOSのみ)を許可する。旧プロファイルのHigh精度・更新間隔の緩和は実車検証を
-  // 経て既定値へ昇格済み(constants/location.ts)。
+  // 省電力測位モード。精度をBalancedへ下げ、停車中の測位自動休止(iOSのみ)を
+  // 許可する。旧プロファイルのHigh精度・更新間隔の緩和は実車検証を経て既定値へ
+  // 昇格済み(constants/location.ts)。
   const powerSavingSettingEnabled = useAtomValue(
     powerSavingLocationEnabledAtom
   );
-  // 試験用機能のためdevアプリだけで有効化する。手動設定に加えて、
-  // 端末の省電力モード中も自動的に同じプロファイルへ切り替える。
-  const powerSavingEnabled =
-    isDevApp && (powerSavingSettingEnabled || systemLowPowerMode);
+  // 「バッテリー」設定でONにしたときに加え、端末の省電力モード中も自動的に
+  // 同じプロファイルへ切り替える。
+  const powerSavingEnabled = powerSavingSettingEnabled || systemLowPowerMode;
   // 選択するオブジェクトはモジュール定数なので、effect依存でも参照が安定する。
   const watchOptions = powerSavingEnabled
     ? LOCATION_WATCH_OPTIONS_POWER_SAVING

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -318,7 +318,7 @@ const AppSettingsScreen: React.FC = () => {
         {
           id: SETTING_ITEM_ID_MAP.personalize_battery,
           title: translate('batterySettings'),
-          color: '#00C7BE',
+          color: '#30B0C7',
           onPress: () => navigation.navigate('BatterySettings' as never),
         },
         // 試験的機能はカナリアリリース(devアプリ)限定で表示する

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -40,6 +40,7 @@ const SETTING_ITEM_ID_MAP = {
   personalize_tts: 'personalize_tts',
   personalize_languages: 'personalize_languages',
   personalize_notifications: 'personalize_notifications',
+  personalize_battery: 'personalize_battery',
   personalize_experimental: 'personalize_experimental',
   personalize_android: 'personalize_android',
   about_app_licenses: 'about_app_licenses',
@@ -110,6 +111,8 @@ const SettingsItem = ({
         return 'globe';
       case 'personalize_notifications':
         return 'notifications';
+      case 'personalize_battery':
+        return 'battery-half';
       case 'personalize_experimental':
         return 'flask';
       case 'personalize_android':
@@ -311,6 +314,12 @@ const AppSettingsScreen: React.FC = () => {
           title: translate('notificationSettings'),
           color: '#FF3B30',
           onPress: () => navigation.navigate('NotificationSettings' as never),
+        },
+        {
+          id: SETTING_ITEM_ID_MAP.personalize_battery,
+          title: translate('batterySettings'),
+          color: '#00C7BE',
+          onPress: () => navigation.navigate('BatterySettings' as never),
         },
         // 試験的機能はカナリアリリース(devアプリ)限定で表示する
         ...(isDevApp

--- a/src/screens/BatterySettings.test.tsx
+++ b/src/screens/BatterySettings.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import { Alert } from 'react-native';
+import { STORAGE_KEYS } from '~/constants';
+import { storage } from '~/lib/storage';
+import { powerSavingLocationEnabledAtom } from '~/store/atoms/battery';
+import BatterySettingsScreen from './BatterySettings';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    goBack: jest.fn(),
+  }),
+}));
+
+jest.mock('~/components/FooterTabBar', () => () => null);
+jest.mock('~/components/SettingsHeader', () => ({
+  SettingsHeader: () => null,
+}));
+jest.mock('~/components/Button', () => () => null);
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+const renderWithStore = (powerSavingLocationEnabled = false) => {
+  const store = createStore();
+  store.set(powerSavingLocationEnabledAtom, powerSavingLocationEnabled);
+
+  const screen = render(
+    <Provider store={store}>
+      <BatterySettingsScreen />
+    </Provider>
+  );
+
+  return { ...screen, store };
+};
+
+describe('BatterySettingsScreen', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('省電力測位モードをONにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
+
+    expect(store.get(powerSavingLocationEnabledAtom)).toBe(true);
+    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
+      'true'
+    );
+  });
+
+  it('省電力測位モードをOFFにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(true);
+
+    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
+
+    expect(store.get(powerSavingLocationEnabledAtom)).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
+      'false'
+    );
+  });
+
+  it('ストレージへの保存に失敗した場合はatom状態をロールバックしエラーを通知する', () => {
+    const setSpy = jest.spyOn(storage, 'set').mockImplementationOnce(() => {
+      throw new Error('storage failure');
+    });
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const { getByLabelText, store } = renderWithStore(false);
+
+    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
+
+    // 保存失敗後にロールバックされる（MMKVは同期APIのため即時）
+    expect(store.get(powerSavingLocationEnabledAtom)).toBe(false);
+
+    // エラーログとユーザーへのアラート表示を検証
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to save power saving location setting',
+      expect.any(Error)
+    );
+    expect(alertSpy).toHaveBeenCalledWith(
+      'errorTitle',
+      'failedToSavePreference'
+    );
+
+    setSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+});

--- a/src/screens/BatterySettings.tsx
+++ b/src/screens/BatterySettings.tsx
@@ -1,0 +1,155 @@
+import { useNavigation } from '@react-navigation/native';
+import { useAtom, useAtomValue } from 'jotai';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  Animated as RNAnimated,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import Button from '~/components/Button';
+import FooterTabBar from '~/components/FooterTabBar';
+import { SettingsHeader } from '~/components/SettingsHeader';
+import { StatePanel } from '~/components/ToggleButton';
+import Typography from '~/components/Typography';
+import { powerSavingLocationEnabledAtom } from '~/store/atoms/battery';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+import { STORAGE_KEYS } from '../constants';
+import { storage } from '../lib/storage';
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 24,
+    flex: 1,
+  },
+  screenBg: {
+    backgroundColor: '#FAFAFA',
+  },
+  description: {
+    marginTop: 16,
+    color: '#8B8B8B',
+    lineHeight: 21,
+  },
+  okButton: {
+    width: 128,
+    alignSelf: 'center',
+    marginTop: 32,
+  },
+});
+
+const ToggleItem = ({
+  title,
+  state,
+  onToggle,
+}: {
+  title: string;
+  state: boolean;
+  onToggle: () => void;
+}) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityLabel={title}
+      accessibilityState={{ checked: state }}
+      onPress={onToggle}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 24,
+        paddingVertical: 16,
+        backgroundColor: isLEDTheme ? '#333' : 'white',
+        borderRadius: isLEDTheme ? 0 : 12,
+      }}
+    >
+      <Typography style={{ flex: 1, fontSize: 21, fontWeight: 'bold' }}>
+        {title}
+      </Typography>
+
+      <StatePanel state={state} />
+    </Pressable>
+  );
+};
+
+const BatterySettingsScreen: React.FC = () => {
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const [powerSavingLocationEnabled, setPowerSavingLocationEnabled] = useAtom(
+    powerSavingLocationEnabledAtom
+  );
+
+  const navigation = useNavigation();
+
+  const handleTogglePowerSavingLocation = useCallback(() => {
+    const flag = !powerSavingLocationEnabled;
+    setPowerSavingLocationEnabled(flag);
+    try {
+      storage.set(
+        STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED,
+        flag ? 'true' : 'false'
+      );
+    } catch (error) {
+      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
+      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
+      setPowerSavingLocationEnabled(!flag);
+      console.error('Failed to save power saving location setting', error);
+      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [powerSavingLocationEnabled, setPowerSavingLocationEnabled]);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollY.setValue(e.nativeEvent.contentOffset.y);
+    },
+    [scrollY]
+  );
+
+  return (
+    <>
+      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
+        <ScrollView
+          contentContainerStyle={
+            headerHeight
+              ? { marginTop: headerHeight, paddingBottom: headerHeight }
+              : null
+          }
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+        >
+          <ToggleItem
+            title={translate('powerSavingLocationTitle')}
+            state={powerSavingLocationEnabled}
+            onToggle={handleTogglePowerSavingLocation}
+          />
+          <Typography style={styles.description}>
+            {translate('powerSavingLocationDescription')}
+          </Typography>
+          <Button
+            style={styles.okButton}
+            textStyle={{ fontWeight: 'bold' }}
+            onPress={() => navigation.goBack()}
+          >
+            OK
+          </Button>
+        </ScrollView>
+      </View>
+      <SettingsHeader
+        title={translate('batterySettings')}
+        onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height + 32)}
+        scrollY={scrollY}
+      />
+      <FooterTabBar active="settings" />
+    </>
+  );
+};
+
+export default React.memo(BatterySettingsScreen);

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -7,7 +7,6 @@ import { storage } from '~/lib/storage';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
-  powerSavingLocationEnabledAtom,
 } from '~/store/atoms/experimental';
 import tuningState from '~/store/atoms/tuning';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
@@ -30,13 +29,11 @@ jest.mock('~/translation', () => ({
 const renderWithStore = (
   portraitModeEnabled: boolean,
   telemetryEnabled = false,
-  etaAssistManualEnabled = false,
-  powerSavingLocationEnabled = false
+  etaAssistManualEnabled = false
 ) => {
   const store = createStore();
   store.set(portraitModeEnabledAtom, portraitModeEnabled);
   store.set(etaAssistManualEnabledAtom, etaAssistManualEnabled);
-  store.set(powerSavingLocationEnabledAtom, powerSavingLocationEnabled);
   store.set(tuningState, (prev) => ({ ...prev, telemetryEnabled }));
 
   const screen = render(
@@ -142,33 +139,6 @@ describe('ExperimentalSettingsScreen', () => {
     expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
     expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).not.toBe(
       'true'
-    );
-  });
-
-  it('省電力測位モードをONにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false);
-
-    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
-
-    expect(store.get(powerSavingLocationEnabledAtom)).toBe(true);
-    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
-      'true'
-    );
-  });
-
-  it('省電力測位モードをOFFにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(
-      false,
-      false,
-      false,
-      true
-    );
-
-    fireEvent.press(getByLabelText('powerSavingLocationTitle'));
-
-    expect(store.get(powerSavingLocationEnabledAtom)).toBe(false);
-    expect(storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED)).toBe(
-      'false'
     );
   });
 

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -20,7 +20,6 @@ import { isEtaAssistRemoteEnabled } from '~/lib/remoteConfig';
 import {
   etaAssistManualEnabledAtom,
   portraitModeEnabledAtom,
-  powerSavingLocationEnabledAtom,
 } from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
@@ -108,9 +107,6 @@ const ExperimentalSettingsScreen: React.FC = () => {
   const [etaAssistManualEnabled, setEtaAssistManualEnabled] = useAtom(
     etaAssistManualEnabledAtom
   );
-  const [powerSavingLocationEnabled, setPowerSavingLocationEnabled] = useAtom(
-    powerSavingLocationEnabledAtom
-  );
   const [tuning, setTuning] = useAtom(tuningState);
 
   // Remote Config(マスタースイッチ)が許可していない間は、手動トグルを操作不可にする。
@@ -157,23 +153,6 @@ const ExperimentalSettingsScreen: React.FC = () => {
     setEtaAssistManualEnabled,
     etaAssistRemoteEnabled,
   ]);
-
-  const handleTogglePowerSavingLocation = useCallback(() => {
-    const flag = !powerSavingLocationEnabled;
-    setPowerSavingLocationEnabled(flag);
-    try {
-      storage.set(
-        STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED,
-        flag ? 'true' : 'false'
-      );
-    } catch (error) {
-      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
-      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
-      setPowerSavingLocationEnabled(!flag);
-      console.error('Failed to save power saving location setting', error);
-      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
-    }
-  }, [powerSavingLocationEnabled, setPowerSavingLocationEnabled]);
 
   const handleToggleTelemetry = useCallback(() => {
     const flag = !tuning.telemetryEnabled;
@@ -234,16 +213,6 @@ const ExperimentalSettingsScreen: React.FC = () => {
           </View>
           <Typography style={styles.description}>
             {translate('etaAssistDescription')}
-          </Typography>
-          <View style={styles.toggleSpacer}>
-            <ToggleItem
-              title={translate('powerSavingLocationTitle')}
-              state={powerSavingLocationEnabled}
-              onToggle={handleTogglePowerSavingLocation}
-            />
-          </View>
-          <Typography style={styles.description}>
-            {translate('powerSavingLocationDescription')}
           </Typography>
           <Typography style={styles.notice}>
             {translate('experimentalSettingsNotice')}

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -5,6 +5,7 @@ import {
 import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
 import AndroidSettings from '~/screens/AndroidSettings';
+import BatterySettings from '~/screens/BatterySettings';
 import ExperimentalSettings from '~/screens/ExperimentalSettings';
 import Licenses from '~/screens/Licenses';
 import NotificationSettings from '~/screens/NotificationSettings';
@@ -112,6 +113,11 @@ const MainStack: React.FC = () => {
           options={optionsWithCustomStyle}
           name="AndroidSettings"
           component={AndroidSettings}
+        />
+        <Stack.Screen
+          options={optionsWithCustomStyle}
+          name="BatterySettings"
+          component={BatterySettings}
         />
         <Stack.Screen
           options={optionsWithCustomStyle}

--- a/src/store/atoms/battery.ts
+++ b/src/store/atoms/battery.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai';
+import { STORAGE_KEYS } from '~/constants/storage';
+import { storage } from '~/lib/storage';
+
+// 省電力測位モード。測位精度をBalancedへ下げ、停車中の測位自動休止(iOSのみ)を
+// 許可して、長時間乗車時の電池消費・発熱をさらに抑える。旧プロファイルのHigh精度・
+// 更新間隔の緩和は実車検証を経て既定値へ昇格済み(constants/location.ts)。
+// 「バッテリー」設定から切り替えられる正式機能。手動でONのときに加え、端末の
+// 省電力モード中も自動的に同じプロファイルへ切り替わる(useStartBackgroundLocationUpdates)。
+// 他の設定と異なり Permitted の loadSettings(effect) では復元せず、MMKVの同期APIで
+// 初期値をここで確定する。effect復元だと Main 側の継続測位が一度デフォルト精度で
+// 起動→復元後に停止・再起動され、起動のたびに無駄な測位再起動が発生するため。
+export const powerSavingLocationEnabledAtom = atom(
+  storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED) === 'true'
+);

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -1,6 +1,4 @@
 import { atom } from 'jotai';
-import { STORAGE_KEYS } from '~/constants/storage';
-import { storage } from '~/lib/storage';
 
 // 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
 // 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
@@ -11,15 +9,3 @@ export const portraitModeEnabledAtom = atom(false);
 // 試験的機能から個別に切り替えられるようにする。ONのときはリモート設定より優先して
 // 有効化する(isEtaAssistEnabled 参照)。
 export const etaAssistManualEnabledAtom = atom(false);
-
-// 省電力測位モード。測位精度をBalancedへ下げ、停車中の測位自動休止(iOSのみ)を
-// 許可して、長時間乗車時の電池消費・発熱をさらに抑える。旧プロファイルのHigh精度・
-// 更新間隔の緩和は実車検証を経て既定値へ昇格済み(constants/location.ts)。
-// 精度低下と自動休止からの復帰遅れが到着判定へ与える影響を実車で検証するため
-// 実験的機能としてトグル化する。
-// 他の設定と異なり Permitted の loadSettings(effect) では復元せず、MMKVの同期APIで
-// 初期値をここで確定する。effect復元だと Main 側の継続測位が一度デフォルト精度で
-// 起動→復元後に停止・再起動され、起動のたびに無駄な測位再起動が発生するため。
-export const powerSavingLocationEnabledAtom = atom(
-  storage.getString(STORAGE_KEYS.POWER_SAVING_LOCATION_ENABLED) === 'true'
-);


### PR DESCRIPTION
## 概要

省電力測位モード（省電力モード）を試験的機能から外し、設定画面に新設した「バッテリー」項目へ移動しました。あわせて実験的機能扱いだった `isDevApp` ゲートを撤去し、全ユーザーが利用できる正式機能へ昇格しています。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 設定画面（`AppSettings`）の「通知」の下に「バッテリー」項目を追加し、全ユーザーへ表示（アイコン `battery-half` / 遷移先 `BatterySettings`）
- 省電力測位モードのトグルを持つ新画面 `BatterySettings` を追加し、`MainStack` に登録
- 試験的機能画面（`ExperimentalSettings`）から省電力トグル・ハンドラ・atom 参照を削除
- `powerSavingLocationEnabledAtom` を `store/atoms/experimental` から `store/atoms/battery` へ移設（MMKV 同期での初期値確定ロジックはそのまま維持）
- `useStartBackgroundLocationUpdates` の `isDevApp` ゲートを撤去し、手動 ON 時・端末の省電力モード中の測位プロファイル切り替えを本番でも有効化
- 翻訳（ja/en）に `batterySettings`（バッテリー / Battery）を追加
- 関連テストを更新（`BatterySettings.test` を追加、`ExperimentalSettings.test` から省電力ケースを削除、フックのテストを昇格後の挙動（低電力モードは全ビルドで有効）に合わせて再構成）

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 設定画面に「バッテリー」項目を追加し、省電力測位モードを切り替えられるようになりました。
  - バッテリー設定は端末に保存され、次回起動時にも維持されます。
  - 省電力測位は、設定の有効化または端末の低電力モードに応じて適用されます。

- **変更**
  - 省電力測位の設定を「実験的設定」から「バッテリー設定」へ移動しました。
  - 設定の保存に失敗した場合、変更を元に戻しエラーを通知します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->