### PR TITLE
初期画面のPull to Refreshの対象をプリセットカードより下の路線リストのみに限定

### DIFF
--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -282,16 +282,18 @@ describe('SelectLineScreen', () => {
   });
 
   describe('ローディング状態', () => {
-    it('nearbyStationLoading=true のときスケルトンが表示される', () => {
+    it('nearbyStationLoading=true のとき路線リストのスケルトンが表示される', () => {
       setupDefaults({ nearbyStationLoading: true });
 
-      const { getByTestId, queryByTestId } = render(<SelectLineScreen />);
+      const { getByTestId } = render(<SelectLineScreen />);
 
       expect(getByTestId('skeleton-placeholder')).toBeTruthy();
-      expect(queryByTestId('presets')).toBeNull();
+      // プリセットカードは上部固定表示になり最寄り駅のローディングとは独立したため、
+      // ローディング中でも常に表示される
+      expect(getByTestId('presets')).toBeTruthy();
     });
 
-    it('nearbyStationLoading=false のときプリセットが表示される', () => {
+    it('nearbyStationLoading=false のとき路線リストのスケルトンは表示されない', () => {
       setupDefaults({ nearbyStationLoading: false });
 
       const { getByTestId, queryByTestId } = render(<SelectLineScreen />);

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -16,7 +16,6 @@ import {
   View,
 } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Line, LineNested } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
@@ -45,10 +44,7 @@ import { SelectLineScreenPresets } from './SelectLineScreenPresets';
 
 const styles = StyleSheet.create({
   root: { paddingHorizontal: 24, flex: 1 },
-  listContainerStyle: {
-    paddingBottom: 24,
-    paddingHorizontal: 24,
-  },
+  listScroll: { flex: 1 },
   heading: {
     fontSize: 24,
     fontWeight: 'bold',
@@ -68,6 +64,10 @@ const styles = StyleSheet.create({
 // RN 0.81 + New Architecture で tintColor がマウント時に無視されるバグの回避用遅延(ms)
 // https://github.com/facebook/react-native/issues/53987
 const REFRESH_TINT_DELAY_MS = 500;
+
+// 路線リストのスクロール領域下端の基本パディング。実際の下端余白はこれに
+// フッタータブバーの高さ(useFooterHeight)を加算して算出する
+const LIST_CONTENT_PADDING_BOTTOM = 24;
 
 const NearbyStationLoader = () => (
   <SkeletonPlaceholder borderRadius={4} speed={1500}>
@@ -152,12 +152,10 @@ const SelectLineScreen = () => {
 
   // --- 派生値 ---
   const footerHeight = useFooterHeight();
-  const listPaddingBottom = useMemo(() => {
-    const flattened = StyleSheet.flatten(styles.listContainerStyle) as {
-      paddingBottom?: number;
-    };
-    return (flattened?.paddingBottom ?? 24) + footerHeight;
-  }, [footerHeight]);
+  const listPaddingBottom = useMemo(
+    () => LIST_CONTENT_PADDING_BOTTOM + footerHeight,
+    [footerHeight]
+  );
 
   const orientation = useDeviceOrientation();
   const isPortraitOrientation = useMemo(
@@ -303,36 +301,44 @@ const SelectLineScreen = () => {
   // --- JSX ---
   return (
     <>
-      <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
+      {/*
+        NowHeader / FooterTabBar は絶対配置のオーバーレイで上下のセーフエリアを
+        それぞれ処理する。中央のコンテンツはその間に収まればよいため、コンテナ
+        自体はセーフエリアを持たない View で構成する。
+      */}
+      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
+        {/*
+          プリセットカードは上部に固定表示し、Pull to Refresh の対象外にする。
+          paddingTop で固定ヘッダー(NowHeader)の直下に配置する。
+        */}
+        <View style={nowHeaderHeight ? { paddingTop: nowHeaderHeight } : null}>
+          <View ref={presetsRef} onLayout={handlePresetsLayout}>
+            <SelectLineScreenPresets
+              carouselData={carouselData}
+              isPresetsLoading={isPresetsLoading}
+              onPress={handlePresetPress}
+            />
+          </View>
+        </View>
+
+        {/* プリセットカードより下の路線リストのみ Pull to Refresh の対象にする */}
         <Animated.ScrollView
-          style={StyleSheet.absoluteFill}
+          style={styles.listScroll}
           onScroll={handleScroll}
           scrollEventThrottle={16}
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
               onRefresh={handleRefresh}
-              progressViewOffset={nowHeaderHeight}
               tintColor={refreshTintColor}
             />
           }
-          contentContainerStyle={[
-            styles.listContainerStyle,
-            nowHeaderHeight ? { paddingTop: nowHeaderHeight } : null,
-            { paddingBottom: listPaddingBottom },
-          ]}
+          contentContainerStyle={{ paddingBottom: listPaddingBottom }}
         >
           {nearbyStationLoading && !refreshing ? (
             <NearbyStationLoader />
           ) : (
             <>
-              <View ref={presetsRef} onLayout={handlePresetsLayout}>
-                <SelectLineScreenPresets
-                  carouselData={carouselData}
-                  isPresetsLoading={isPresetsLoading}
-                  onPress={handlePresetPress}
-                />
-              </View>
               <View ref={lineListRef} onLayout={handleLineListLayout}>
                 {stationLines.length > 0 && (
                   <Heading style={styles.heading} singleLine>
@@ -383,7 +389,7 @@ const SelectLineScreen = () => {
           )}
           <EmptyLineSeparator />
         </Animated.ScrollView>
-      </SafeAreaView>
+      </View>
 
       {/* 固定ヘッダー */}
       <NowHeader

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -16,6 +16,7 @@ import {
   View,
 } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Line, LineNested } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
@@ -302,11 +303,14 @@ const SelectLineScreen = () => {
   return (
     <>
       {/*
-        NowHeader / FooterTabBar は絶対配置のオーバーレイで上下のセーフエリアを
-        それぞれ処理する。中央のコンテンツはその間に収まればよいため、コンテナ
-        自体はセーフエリアを持たない View で構成する。
+        上下のセーフエリアは絶対配置オーバーレイの NowHeader / FooterTabBar が
+        それぞれ処理するため上下インセットは無効化する。一方、横向き/タブレットの
+        ノッチでコンテンツが欠けないよう、左右インセットだけは SafeAreaView で確保する。
       */}
-      <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
+      <SafeAreaView
+        edges={['left', 'right']}
+        style={[styles.root, !isLEDTheme && styles.screenBg]}
+      >
         {/*
           プリセットカードは上部に固定表示し、Pull to Refresh の対象外にする。
           paddingTop で固定ヘッダー(NowHeader)の直下に配置する。
@@ -389,7 +393,7 @@ const SelectLineScreen = () => {
           )}
           <EmptyLineSeparator />
         </Animated.ScrollView>
-      </View>
+      </SafeAreaView>
 
       {/* 固定ヘッダー */}
       <NowHeader


### PR DESCRIPTION
## 概要

初期画面（路線選択画面）の Pull to Refresh の対象を、プリセットカードより下の路線リストだけに限定しました。従来は画面全体が単一のスクロールビューで `RefreshControl` を保持していたため、プリセットカード上を含め画面のどこを下に引っ張っても最寄り駅の再取得が発火していました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- プリセットカルーセルを `NowHeader` 直下に固定表示する独立領域へ切り出し、スクロール／Pull to Refresh の対象外にした
- プリセットより下の路線リスト・バス路線のみを `RefreshControl` 付きの `Animated.ScrollView` に配置し、Pull to Refresh の対象をそこだけに限定した
- 固定ヘッダー分のオフセットが不要になったため `RefreshControl` の `progressViewOffset` を削除
- ルートコンテナは上下のセーフエリアを担う `NowHeader` / `FooterTabBar`（いずれも絶対配置オーバーレイ）に委ねられるため `SafeAreaView` を通常の `View` に変更（フルブリードのカルーセル・カードの 24px ガター・フッター分の下端余白は維持）
- プリセットは最寄り駅データと独立しているため最寄り駅ローディング中も常時表示に変更し、レンダーテストのアサーションを更新

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu76E8vDn9ZheWEpmQj6Db)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 近くの駅情報を読み込み中でも、プリセット路線を常に表示できるようになりました。
  * 路線リストの読み込み状態が、より分かりやすく表示されるようになりました。
  * プリセットと路線リストの配置を見直し、画面上部の表示とスクロール時のレイアウトを改善しました。
  * 路線リスト下部の余白や更新操作時の表示を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->