### PR TITLE
試験的機能からETAアシストを廃止しリモート設定のみで自動有効化するよう変更

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -329,8 +329,6 @@
   "portraitModeTitle": "Portrait Mode",
   "portraitModeDescription": "When enabled, the running screen switches to a layout optimized for portrait orientation while you hold your device upright.",
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
-  "etaAssistTitle": "Improve arrival detection",
-  "etaAssistDescription": "When enabled, in sections where GPS accuracy drops such as subways, the app uses the server's estimated arrival times (ETA) to assist arrival detection. GPS remains the source of truth for arrival and current location; ETA is only an aid.",
   "batterySettings": "Battery",
   "powerSavingLocationTitle": "Power-saving location mode",
   "powerSavingLocationDescription": "When enabled, location accuracy is lowered to a battery-friendly level and iOS pauses tracking automatically while you are stopped, further reducing battery drain and heat on long rides. The lower accuracy may delay or shift station detection and arrival announcements. The relaxed update frequency is already part of the default settings. It also turns on automatically while your device is in low-power mode.",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -330,8 +330,6 @@
   "portraitModeTitle": "ポートレートモード",
   "portraitModeDescription": "有効にすると、走行画面で端末を縦向きにした際に、縦画面に最適化されたデザインで表示します。",
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
-  "etaAssistTitle": "到着判定の改善",
-  "etaAssistDescription": "有効にすると、地下鉄などGPSの精度が落ちる区間で、サーバーの到着予測(ETA)を使って到着判定を補助します。到着や現在地はGPSが基準で、ETAはあくまで補助です。",
   "batterySettings": "バッテリー",
   "powerSavingLocationTitle": "省電力測位モード",
   "powerSavingLocationDescription": "有効にすると、測位精度を電池優先まで下げ、停車中はiOSが測位を自動休止して、長時間の乗車での電池消費と発熱をさらに減らします。精度の低下により駅の判定や到着案内が遅れたりずれたりする場合があります。位置情報の更新頻度の緩和は標準設定に組み込まれています。端末の省電力モード中は自動的に有効になります。",

--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -43,10 +43,7 @@ import {
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import { storage } from '../lib/storage';
 import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
-import {
-  etaAssistManualEnabledAtom,
-  portraitModeEnabledAtom,
-} from '../store/atoms/experimental';
+import { portraitModeEnabledAtom } from '../store/atoms/experimental';
 import navigationState, {
   autoModeEnabledAtom,
   isAppLatestAtom,
@@ -78,7 +75,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
   const setNotify = useSetAtom(notifyState);
   const setPictureInPicture = useSetAtom(pictureInPictureAtom);
   const setPortraitModeEnabled = useSetAtom(portraitModeEnabledAtom);
-  const setEtaAssistManualEnabled = useSetAtom(etaAssistManualEnabledAtom);
   const { enabled: pictureInPictureEnabled, active: pictureInPictureActive } =
     useAtomValue(pictureInPictureAtom);
   const isAppActive = useIsAppActive();
@@ -440,9 +436,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       const portraitModeEnabledStr = storage.getString(
         STORAGE_KEYS.PORTRAIT_MODE_ENABLED
       );
-      const etaAssistManualEnabledStr = storage.getString(
-        STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED
-      );
       // NOTE: powerSavingLocationEnabledAtom はここでは復元しない。effect復元だと
       // 継続測位がデフォルト精度で一度起動してから再起動されるため、
       // atom定義側(store/atoms/battery.ts)でMMKVから同期的に初期値を確定している。
@@ -555,9 +548,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
       if (portraitModeEnabledStr) {
         setPortraitModeEnabled(portraitModeEnabledStr === 'true');
       }
-      if (etaAssistManualEnabledStr) {
-        setEtaAssistManualEnabled(etaAssistManualEnabledStr === 'true');
-      }
     };
 
     loadSettings();
@@ -569,7 +559,6 @@ const PermittedLayout: React.FC<Props> = ({ children }: Props) => {
     setNotify,
     setPictureInPicture,
     setPortraitModeEnabled,
-    setEtaAssistManualEnabled,
   ]);
 
   useEffect(() => {

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -36,7 +36,6 @@ export const STORAGE_KEYS = {
   WRONG_DIRECTION_NOTIFY_ENABLED: '@TrainLCD:wrongDirectionNotifyEnabled',
   PICTURE_IN_PICTURE_ENABLED: '@TrainLCD:pictureInPictureEnabled',
   PORTRAIT_MODE_ENABLED: '@TrainLCD:portraitModeEnabled',
-  ETA_ASSIST_MANUAL_ENABLED: '@TrainLCD:etaAssistManualEnabled',
   POWER_SAVING_LOCATION_ENABLED: '@TrainLCD:powerSavingLocationEnabled',
 } as const;
 

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -1,12 +1,9 @@
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { store } from '~/store';
-import { etaAssistManualEnabledAtom } from '~/store/atoms/experimental';
 import {
   getEtaFallbackArrivalConfirmMarginSec,
   getEtaFallbackMaxDurationMin,
   getMaxPermitAccuracy,
   isEtaAssistEnabled,
-  isEtaAssistRemoteEnabled,
   isForceNotArrivedOnLowAccuracyEnabled,
   resetRemoteConfigCache,
   setupRemoteConfig,
@@ -31,8 +28,6 @@ const mockRemoteConfig = (body: unknown, ok = true) => {
 afterEach(() => {
   jest.clearAllMocks();
   resetRemoteConfigCache();
-  // 手動トグルは共有ストアに残るため、テスト間の汚染を防ぐべく毎回戻す。
-  store.set(etaAssistManualEnabledAtom, false);
 });
 
 afterAll(() => {
@@ -84,48 +79,30 @@ describe('isForceNotArrivedOnLowAccuracyEnabled', () => {
   });
 });
 
-describe('isEtaAssistRemoteEnabled（マスタースイッチ）', () => {
+describe('isEtaAssistEnabled（Remoteマスタースイッチのみで判定）', () => {
   it('falls back to false before setup', () => {
-    expect(isEtaAssistRemoteEnabled()).toBe(false);
+    expect(isEtaAssistEnabled()).toBe(false);
   });
 
-  it('returns the remote boolean after setup', async () => {
+  it('RemoteがONなら自動的に有効(手動トグルなし)', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
       force_not_arrived_on_low_accuracy: true,
       eta_assist_enabled: true,
     });
     await setupRemoteConfig();
-    expect(isEtaAssistRemoteEnabled()).toBe(true);
+    expect(isEtaAssistEnabled()).toBe(true);
+  });
+
+  it('RemoteがOFFなら無効(サーバー側キルスイッチ)', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500, eta_assist_enabled: false });
+    await setupRemoteConfig();
+    expect(isEtaAssistEnabled()).toBe(false);
   });
 
   it('falls back to false when the boolean is missing', async () => {
     mockRemoteConfig({ max_permit_accuracy: 1500 });
     await setupRemoteConfig();
-    expect(isEtaAssistRemoteEnabled()).toBe(false);
-  });
-});
-
-describe('isEtaAssistEnabled（Remote AND 手動トグル）', () => {
-  it('Remoteと手動トグルの両方がONのときだけ有効', async () => {
-    mockRemoteConfig({ eta_assist_enabled: true });
-    await setupRemoteConfig();
-    // Remoteがtrueでも手動トグルOFFなら無効
-    expect(isEtaAssistEnabled()).toBe(false);
-    // 手動トグルONで有効
-    store.set(etaAssistManualEnabledAtom, true);
-    expect(isEtaAssistEnabled()).toBe(true);
-  });
-
-  it('Remoteがfalseなら手動トグルONでも無効(マスターOFF)', async () => {
-    store.set(etaAssistManualEnabledAtom, true);
-    mockRemoteConfig({ eta_assist_enabled: false });
-    await setupRemoteConfig();
-    expect(isEtaAssistEnabled()).toBe(false);
-  });
-
-  it('セットアップ前(Remote未取得=false)は手動トグルONでも無効', () => {
-    store.set(etaAssistManualEnabledAtom, true);
     expect(isEtaAssistEnabled()).toBe(false);
   });
 });

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -1,6 +1,4 @@
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { store } from '~/store';
-import { etaAssistManualEnabledAtom } from '~/store/atoms/experimental';
 import { workerUrl } from './workerApi';
 
 // Cloudflare Worker(/config/remote) 配信の設定キー。Worker 側のレスポンスキーと一致させる。
@@ -121,22 +119,17 @@ export const isForceNotArrivedOnLowAccuracyEnabled = (): boolean => {
   return FORCE_NOT_ARRIVED_ON_LOW_ACCURACY_FALLBACK;
 };
 
-// Remote Config が配信する ETA補助の許可(マスタースイッチ)を同期的に取得する。
-// setupRemoteConfig 完了後は取得済みのリモート値を、未設定・取得失敗時はフォールバック
-// (false=既定無効)を返す。これが false のときは機能を提供せず、設定画面の手動トグルも
-// 操作不可にする(ExperimentalSettings 側で disabled)。
-export const isEtaAssistRemoteEnabled = (): boolean => {
+// ETA補助機能の実効的な有効/無効を同期的に取得する。以前は設定画面の手動トグルとの AND で
+// 判定していたが、手動トグルを廃止し自動有効化に変更したため、Remote Config が配信する
+// マスタースイッチ(eta_assist_enabled)のみで判定する。setupRemoteConfig 完了後は取得済みの
+// リモート値を、未設定・取得失敗時はフォールバック(false=既定無効)を返す。これが false の
+// ときは機能を提供しない(サーバー側キルスイッチ)。
+export const isEtaAssistEnabled = (): boolean => {
   if (cachedEtaAssistEnabled != null) {
     return cachedEtaAssistEnabled;
   }
   return ETA_ASSIST_ENABLED_FALLBACK;
 };
-
-// ETA補助機能の実効的な有効/無効を同期的に取得する。Remote Config が許可(マスターON)し、
-// かつ設定画面の手動トグルもONのときだけ有効。Remote が false のときは手動トグルの値に
-// 関わらず無効。
-export const isEtaAssistEnabled = (): boolean =>
-  isEtaAssistRemoteEnabled() && store.get(etaAssistManualEnabledAtom);
 
 // ETAフォールバックの到着確定マージン(秒)を同期的に取得する。setupRemoteConfig 完了後は
 // 取得済みのリモート値を、未完了・未設定・取得失敗時はフォールバックを返す。

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -2,12 +2,8 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { Alert } from 'react-native';
 import { STORAGE_KEYS } from '~/constants';
-import * as remoteConfigModule from '~/lib/remoteConfig';
 import { storage } from '~/lib/storage';
-import {
-  etaAssistManualEnabledAtom,
-  portraitModeEnabledAtom,
-} from '~/store/atoms/experimental';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import tuningState from '~/store/atoms/tuning';
 import ExperimentalSettingsScreen from './ExperimentalSettings';
 
@@ -28,12 +24,10 @@ jest.mock('~/translation', () => ({
 
 const renderWithStore = (
   portraitModeEnabled: boolean,
-  telemetryEnabled = false,
-  etaAssistManualEnabled = false
+  telemetryEnabled = false
 ) => {
   const store = createStore();
   store.set(portraitModeEnabledAtom, portraitModeEnabled);
-  store.set(etaAssistManualEnabledAtom, etaAssistManualEnabled);
   store.set(tuningState, (prev) => ({ ...prev, telemetryEnabled }));
 
   const screen = render(
@@ -99,47 +93,10 @@ describe('ExperimentalSettingsScreen', () => {
     alertSpy.mockRestore();
   });
 
-  it('Remote Config が許可していればETA補助をONにできる(atomとストレージへ保存)', () => {
-    jest
-      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
-      .mockReturnValue(true);
-    const { getByLabelText, store } = renderWithStore(false);
+  it('ETA補助トグルは廃止され表示されない(自動有効化)', () => {
+    const { queryByLabelText } = renderWithStore(false);
 
-    fireEvent.press(getByLabelText('etaAssistTitle'));
-
-    expect(store.get(etaAssistManualEnabledAtom)).toBe(true);
-    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).toBe(
-      'true'
-    );
-  });
-
-  it('Remote Config が許可していればETA補助をOFFにできる(atomとストレージへ保存)', () => {
-    jest
-      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
-      .mockReturnValue(true);
-    const { getByLabelText, store } = renderWithStore(false, false, true);
-
-    fireEvent.press(getByLabelText('etaAssistTitle'));
-
-    expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
-    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).toBe(
-      'false'
-    );
-  });
-
-  it('Remote Config が false のときはETA補助トグルを操作できない', () => {
-    jest
-      .spyOn(remoteConfigModule, 'isEtaAssistRemoteEnabled')
-      .mockReturnValue(false);
-    const { getByLabelText, store } = renderWithStore(false);
-
-    // 操作不可(disabled)。押してもatomはONにならず、ONの永続化も走らない。
-    fireEvent.press(getByLabelText('etaAssistTitle'));
-
-    expect(store.get(etaAssistManualEnabledAtom)).toBe(false);
-    expect(storage.getString(STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED)).not.toBe(
-      'true'
-    );
+    expect(queryByLabelText('etaAssistTitle')).toBeNull();
   });
 
   it('テレメトリをONにするとatomとストレージへ保存される', () => {

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -16,11 +16,7 @@ import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
-import { isEtaAssistRemoteEnabled } from '~/lib/remoteConfig';
-import {
-  etaAssistManualEnabledAtom,
-  portraitModeEnabledAtom,
-} from '~/store/atoms/experimental';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
@@ -104,14 +100,7 @@ const ExperimentalSettingsScreen: React.FC = () => {
   const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
     portraitModeEnabledAtom
   );
-  const [etaAssistManualEnabled, setEtaAssistManualEnabled] = useAtom(
-    etaAssistManualEnabledAtom
-  );
   const [tuning, setTuning] = useAtom(tuningState);
-
-  // Remote Config(マスタースイッチ)が許可していない間は、手動トグルを操作不可にする。
-  // 配信状態は起動時に確定する非リアクティブ値のため、レンダー時に一度参照すれば足りる。
-  const etaAssistRemoteEnabled = isEtaAssistRemoteEnabled();
 
   const navigation = useNavigation();
 
@@ -128,31 +117,6 @@ const ExperimentalSettingsScreen: React.FC = () => {
       Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
     }
   }, [portraitModeEnabled, setPortraitModeEnabled]);
-
-  const handleToggleEtaAssist = useCallback(() => {
-    // Remote Config が許可していないときは操作させない(UI側でも disabled)。
-    if (!etaAssistRemoteEnabled) {
-      return;
-    }
-    const flag = !etaAssistManualEnabled;
-    setEtaAssistManualEnabled(flag);
-    try {
-      storage.set(
-        STORAGE_KEYS.ETA_ASSIST_MANUAL_ENABLED,
-        flag ? 'true' : 'false'
-      );
-    } catch (error) {
-      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
-      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
-      setEtaAssistManualEnabled(!flag);
-      console.error('Failed to save ETA assist setting', error);
-      Alert.alert(translate('errorTitle'), translate('failedToSavePreference'));
-    }
-  }, [
-    etaAssistManualEnabled,
-    setEtaAssistManualEnabled,
-    etaAssistRemoteEnabled,
-  ]);
 
   const handleToggleTelemetry = useCallback(() => {
     const flag = !tuning.telemetryEnabled;
@@ -202,17 +166,6 @@ const ExperimentalSettingsScreen: React.FC = () => {
           </View>
           <Typography style={styles.description}>
             {translate('telemetryDescription')}
-          </Typography>
-          <View style={styles.toggleSpacer}>
-            <ToggleItem
-              title={translate('etaAssistTitle')}
-              state={etaAssistRemoteEnabled && etaAssistManualEnabled}
-              onToggle={handleToggleEtaAssist}
-              disabled={!etaAssistRemoteEnabled}
-            />
-          </View>
-          <Typography style={styles.description}>
-            {translate('etaAssistDescription')}
           </Typography>
           <Typography style={styles.notice}>
             {translate('experimentalSettingsNotice')}

--- a/src/store/atoms/experimental.ts
+++ b/src/store/atoms/experimental.ts
@@ -3,9 +3,3 @@ import { atom } from 'jotai';
 // 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
 // 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
 export const portraitModeEnabledAtom = atom(false);
-
-// 地下GPS喪失時のETA位置補完(R2フォールバック)を手動で有効化するトグル。
-// リモート設定(eta_assist_enabled)だけだと手動A/Bテストがしづらいため、設定画面の
-// 試験的機能から個別に切り替えられるようにする。ONのときはリモート設定より優先して
-// 有効化する(isEtaAssistEnabled 参照)。
-export const etaAssistManualEnabledAtom = atom(false);


### PR DESCRIPTION
## 概要

リモート設定(`eta_assist_enabled`)が許可している場合に ETA アシスト（到着判定の改善）を自動的に有効化するよう変更し、試験的機能設定から手動トグル項目を削除しました。従来はリモート設定のマスタースイッチに加えてユーザーの手動トグルが必要でしたが、手動トグルを廃止し、リモート設定のみで判定します。リモート設定はサーバー側キルスイッチとして継続して残します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 試験的機能設定画面(`ExperimentalSettings`)から ETA アシストのトグル項目・説明文・トグル処理を削除
- `isEtaAssistEnabled()` を「リモート設定 AND 手動トグル」から「リモート設定(`eta_assist_enabled`)のみ」に変更し、統合により不要となった `isEtaAssistRemoteEnabled()` を削除
- 手動トグル用の atom(`etaAssistManualEnabledAtom`)を削除
- 起動時の手動トグル復元処理(`Permitted`)と永続化ストレージキー(`ETA_ASSIST_MANUAL_ENABLED`)を削除
- 未使用となった翻訳文言(`etaAssistTitle` / `etaAssistDescription`、ja/en)を削除
- 関連テスト(`remoteConfig.test.ts` / `ExperimentalSettings.test.tsx`)を新仕様へ更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4aCJFU5HuP4vcYPpnZLpz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 設定画面からETA補助の手動切り替え項目を削除しました。
  - ポートレートモードの設定項目を追加し、縦持ち時のレイアウトを切り替えられるようにしました。
  - テレメトリに関する説明文を更新し、端末の地理座標が分析サーバーへ送信されることを明示しました。
  - 設定値の保存・復元対象を更新しました。

- **テスト**
  - ETA補助がリモート設定に基づいてのみ有効になる動作を確認するテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->