### PR TITLE
初期画面のPull to Refresh対象を路線リストに限定した変更をリバートして元のスクロール挙動に戻す

### DIFF
--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -282,18 +282,16 @@ describe('SelectLineScreen', () => {
   });
 
   describe('ローディング状態', () => {
-    it('nearbyStationLoading=true のとき路線リストのスケルトンが表示される', () => {
+    it('nearbyStationLoading=true のときスケルトンが表示される', () => {
       setupDefaults({ nearbyStationLoading: true });
 
-      const { getByTestId } = render(<SelectLineScreen />);
+      const { getByTestId, queryByTestId } = render(<SelectLineScreen />);
 
       expect(getByTestId('skeleton-placeholder')).toBeTruthy();
-      // プリセットカードは上部固定表示になり最寄り駅のローディングとは独立したため、
-      // ローディング中でも常に表示される
-      expect(getByTestId('presets')).toBeTruthy();
+      expect(queryByTestId('presets')).toBeNull();
     });
 
-    it('nearbyStationLoading=false のとき路線リストのスケルトンは表示されない', () => {
+    it('nearbyStationLoading=false のときプリセットが表示される', () => {
       setupDefaults({ nearbyStationLoading: false });
 
       const { getByTestId, queryByTestId } = render(<SelectLineScreen />);

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -45,7 +45,10 @@ import { SelectLineScreenPresets } from './SelectLineScreenPresets';
 
 const styles = StyleSheet.create({
   root: { paddingHorizontal: 24, flex: 1 },
-  listScroll: { flex: 1 },
+  listContainerStyle: {
+    paddingBottom: 24,
+    paddingHorizontal: 24,
+  },
   heading: {
     fontSize: 24,
     fontWeight: 'bold',
@@ -65,10 +68,6 @@ const styles = StyleSheet.create({
 // RN 0.81 + New Architecture で tintColor がマウント時に無視されるバグの回避用遅延(ms)
 // https://github.com/facebook/react-native/issues/53987
 const REFRESH_TINT_DELAY_MS = 500;
-
-// 路線リストのスクロール領域下端の基本パディング。実際の下端余白はこれに
-// フッタータブバーの高さ(useFooterHeight)を加算して算出する
-const LIST_CONTENT_PADDING_BOTTOM = 24;
 
 const NearbyStationLoader = () => (
   <SkeletonPlaceholder borderRadius={4} speed={1500}>
@@ -153,10 +152,12 @@ const SelectLineScreen = () => {
 
   // --- 派生値 ---
   const footerHeight = useFooterHeight();
-  const listPaddingBottom = useMemo(
-    () => LIST_CONTENT_PADDING_BOTTOM + footerHeight,
-    [footerHeight]
-  );
+  const listPaddingBottom = useMemo(() => {
+    const flattened = StyleSheet.flatten(styles.listContainerStyle) as {
+      paddingBottom?: number;
+    };
+    return (flattened?.paddingBottom ?? 24) + footerHeight;
+  }, [footerHeight]);
 
   const orientation = useDeviceOrientation();
   const isPortraitOrientation = useMemo(
@@ -302,47 +303,36 @@ const SelectLineScreen = () => {
   // --- JSX ---
   return (
     <>
-      {/*
-        上下のセーフエリアは絶対配置オーバーレイの NowHeader / FooterTabBar が
-        それぞれ処理するため上下インセットは無効化する。一方、横向き/タブレットの
-        ノッチでコンテンツが欠けないよう、左右インセットだけは SafeAreaView で確保する。
-      */}
-      <SafeAreaView
-        edges={['left', 'right']}
-        style={[styles.root, !isLEDTheme && styles.screenBg]}
-      >
-        {/*
-          プリセットカードは上部に固定表示し、Pull to Refresh の対象外にする。
-          paddingTop で固定ヘッダー(NowHeader)の直下に配置する。
-        */}
-        <View style={nowHeaderHeight ? { paddingTop: nowHeaderHeight } : null}>
-          <View ref={presetsRef} onLayout={handlePresetsLayout}>
-            <SelectLineScreenPresets
-              carouselData={carouselData}
-              isPresetsLoading={isPresetsLoading}
-              onPress={handlePresetPress}
-            />
-          </View>
-        </View>
-
-        {/* プリセットカードより下の路線リストのみ Pull to Refresh の対象にする */}
+      <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
         <Animated.ScrollView
-          style={styles.listScroll}
+          style={StyleSheet.absoluteFill}
           onScroll={handleScroll}
           scrollEventThrottle={16}
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
               onRefresh={handleRefresh}
+              progressViewOffset={nowHeaderHeight}
               tintColor={refreshTintColor}
             />
           }
-          contentContainerStyle={{ paddingBottom: listPaddingBottom }}
+          contentContainerStyle={[
+            styles.listContainerStyle,
+            nowHeaderHeight ? { paddingTop: nowHeaderHeight } : null,
+            { paddingBottom: listPaddingBottom },
+          ]}
         >
           {nearbyStationLoading && !refreshing ? (
             <NearbyStationLoader />
           ) : (
             <>
+              <View ref={presetsRef} onLayout={handlePresetsLayout}>
+                <SelectLineScreenPresets
+                  carouselData={carouselData}
+                  isPresetsLoading={isPresetsLoading}
+                  onPress={handlePresetPress}
+                />
+              </View>
               <View ref={lineListRef} onLayout={handleLineListLayout}>
                 {stationLines.length > 0 && (
                   <Heading style={styles.heading} singleLine>


### PR DESCRIPTION
## 概要

初期画面の Pull to Refresh 対象を路線リストに限定した変更（#6412）を差し戻し、`SelectLineScreen` を変更前の状態へ復元します。

差戻しの理由: 元々の画面設計が Pull to Refresh を前提としておらず、「一部分（路線リスト）だけを PTR 対象にする」にはデザイン（構造）の変更が必要になる可能性が高いと判断したため。一旦挙動を元に戻し、設計方針は別途検討します。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- #6412 を差し戻し、`SelectLineScreen.tsx` / `SelectLineScreen.render.test.tsx` を変更前と同一内容へ復元
- プリセットカルーセル・路線一覧・バス路線は元どおり一緒にスクロールに追従する挙動へ戻す（プリセットの上部固定化を撤回）
- Pull to Refresh は元どおり単一の ScrollView（画面全体）で発火する挙動へ戻す（`progressViewOffset` / `SafeAreaView` 構成も復元）

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu76E8vDn9ZheWEpmQj6Db)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 近隣駅の読み込み中に、専用のローディング表示を追加しました。
  * プリセット表示をリスト内に統合し、更新操作の対象に含めました。

* **改善**
  * リスト下部の余白とスクロール表示を調整しました。
  * 更新中のインジケーター表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->