### PR TITLE
JSスレッド駆動アニメーションのネイティブ化と検索結果の仮想化などパフォーマンス改善のフォローアップ

### DIFF
--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -458,12 +458,12 @@ const PadArch: React.FC<Props> = ({
             toValue: 1,
             duration: YAMANOTE_CHEVRON_MOVE_DURATION * 2,
             easing: Easing.linear,
-            useNativeDriver: false,
+            useNativeDriver: true,
           }),
           Animated.timing(chevronTimeline, {
             toValue: 0,
             duration: 0,
-            useNativeDriver: false,
+            useNativeDriver: true,
           }),
         ])
       ).start();

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -119,10 +119,20 @@ export const useLineSelection = (): UseLineSelectionResult => {
         pendingTrainType: null,
       }));
 
-      const result = await fetchStationsByLineId({
-        variables: { lineId, stationId: lineStationId },
-      });
-      const fetchedStations = result.data?.lineStations ?? [];
+      // 駅一覧と種別一覧は互いに独立したクエリなので並列で取得する
+      const [{ data }, fetchedTrainTypesData] = await Promise.all([
+        fetchStationsByLineId({
+          variables: { lineId, stationId: lineStationId },
+        }),
+        line.station?.hasTrainTypes
+          ? fetchTrainTypes({
+              variables: {
+                stationId: lineStationId,
+              },
+            })
+          : null,
+      ]);
+      const fetchedStations = data?.lineStations ?? [];
 
       const pendingStation =
         fetchedStations.find((s) => s.id === lineStationId) ?? null;
@@ -133,13 +143,9 @@ export const useLineSelection = (): UseLineSelectionResult => {
         pendingStations: fetchedStations,
       }));
 
-      if (line.station?.hasTrainTypes) {
-        const result = await fetchTrainTypes({
-          variables: {
-            stationId: lineStationId,
-          },
-        });
-        const fetchedTrainTypes = result.data?.stationTrainTypes ?? [];
+      if (fetchedTrainTypesData) {
+        const fetchedTrainTypes =
+          fetchedTrainTypesData.data?.stationTrainTypes ?? [];
         const designatedTrainTypeId =
           fetchedStations.find((s) => s.id === lineStationId)?.trainType?.id ??
           null;

--- a/src/providers/DeepLinkProvider.tsx
+++ b/src/providers/DeepLinkProvider.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 const DeepLinkProvider = ({ children }: Props) => {
-  const { initialUrlProcessed, isLoading, error } = useDeepLink();
+  const { initialUrlProcessed, error } = useDeepLink();
   useEffect(() => {
     if (error) {
       console.error(error);
@@ -19,7 +19,12 @@ const DeepLinkProvider = ({ children }: Props) => {
       );
     }
   }, [error]);
-  if (!initialUrlProcessed || (isLoading && !error)) {
+  // ゲートは初期URLの処理完了までに限定する。initialUrlProcessed は
+  // handleUrl の await 完了後（=初期リンクのフェッチ解決後）に立つため、
+  // 初回起動のちらつき防止はこれだけで足りる。isLoading を条件に含めると、
+  // 稼働中に受けたランタイムディープリンクの解決中もツリー全体が null になり、
+  // 表示中の画面が一瞬消えてナビゲーション状態も破棄されてしまう。
+  if (!initialUrlProcessed) {
     return null;
   }
 

--- a/src/screens/AndroidSettings.tsx
+++ b/src/screens/AndroidSettings.tsx
@@ -3,14 +3,11 @@ import { useAtom, useAtomValue } from 'jotai';
 import React, { useCallback, useRef, useState } from 'react';
 import {
   Alert,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Pressable,
   Animated as RNAnimated,
   StyleSheet,
   View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -58,17 +55,16 @@ const AndroidSettingsScreen: React.FC = () => {
     }
   }, [pictureInPictureEnabled, setPictureInPicture]);
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.ScrollView
+        <RNAnimated.ScrollView
           onScroll={handleScroll}
           scrollEventThrottle={16}
           contentContainerStyle={[
@@ -113,7 +109,7 @@ const AndroidSettingsScreen: React.FC = () => {
           >
             OK
           </Button>
-        </Animated.ScrollView>
+        </RNAnimated.ScrollView>
       </View>
       <SettingsHeader
         title={translate('androidSettings')}

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -11,8 +11,6 @@ import React, {
   useState,
 } from 'react';
 import {
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Platform,
   Animated as RNAnimated,
   StyleSheet,
@@ -20,7 +18,6 @@ import {
   View,
 } from 'react-native';
 import { isClip } from 'react-native-app-clip';
-import Animated from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CardChevron } from '~/components/CardChevron';
 import { Heading } from '~/components/Heading';
@@ -376,17 +373,16 @@ const AppSettingsScreen: React.FC = () => {
     [navigation]
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.ScrollView
+        <RNAnimated.ScrollView
           style={StyleSheet.absoluteFill}
           onScroll={handleScroll}
           scrollEventThrottle={16}
@@ -486,7 +482,7 @@ const AppSettingsScreen: React.FC = () => {
               {!isDevApp && isBetaBuild ? translate('betaNotice') : ''}
             </Typography>
           ) : null}
-        </Animated.ScrollView>
+        </RNAnimated.ScrollView>
       </SafeAreaView>
       <SettingsHeader
         title={translate('settings')}

--- a/src/screens/BatterySettings.tsx
+++ b/src/screens/BatterySettings.tsx
@@ -3,11 +3,8 @@ import { useAtom, useAtomValue } from 'jotai';
 import React, { useCallback, useRef, useState } from 'react';
 import {
   Alert,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Pressable,
   Animated as RNAnimated,
-  ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
@@ -106,17 +103,16 @@ const BatterySettingsScreen: React.FC = () => {
     }
   }, [powerSavingLocationEnabled, setPowerSavingLocationEnabled]);
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <ScrollView
+        <RNAnimated.ScrollView
           contentContainerStyle={
             headerHeight
               ? { marginTop: headerHeight, paddingBottom: headerHeight }
@@ -140,7 +136,7 @@ const BatterySettingsScreen: React.FC = () => {
           >
             OK
           </Button>
-        </ScrollView>
+        </RNAnimated.ScrollView>
       </View>
       <SettingsHeader
         title={translate('batterySettings')}

--- a/src/screens/EnabledLanguagesSettings.tsx
+++ b/src/screens/EnabledLanguagesSettings.tsx
@@ -4,15 +4,12 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   type GestureResponderEvent,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Platform,
   Pressable,
   Animated as RNAnimated,
   StyleSheet,
   View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -250,17 +247,16 @@ const EnabledLanguagesSettings: React.FC = () => {
     []
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.FlatList
+        <RNAnimated.FlatList
           data={SETTING_ITEMS}
           keyExtractor={keyExtractor}
           getItemLayout={getItemLayout}
@@ -272,6 +268,7 @@ const EnabledLanguagesSettings: React.FC = () => {
           ]}
           renderItem={renderItem}
           onScroll={handleScroll}
+          scrollEventThrottle={16}
           ListFooterComponent={
             <ListFooter onPressOK={() => navigation.goBack()} />
           }

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -3,11 +3,8 @@ import { useAtom, useAtomValue } from 'jotai';
 import React, { useCallback, useRef, useState } from 'react';
 import {
   Alert,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Pressable,
   Animated as RNAnimated,
-  ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
@@ -130,17 +127,16 @@ const ExperimentalSettingsScreen: React.FC = () => {
     }
   }, [tuning.telemetryEnabled, setTuning]);
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <ScrollView
+        <RNAnimated.ScrollView
           contentContainerStyle={
             headerHeight
               ? { marginTop: headerHeight, paddingBottom: headerHeight }
@@ -177,7 +173,7 @@ const ExperimentalSettingsScreen: React.FC = () => {
           >
             OK
           </Button>
-        </ScrollView>
+        </RNAnimated.ScrollView>
       </View>
       <SettingsHeader
         title={translate('experimentalSettings')}

--- a/src/screens/Licenses.tsx
+++ b/src/screens/Licenses.tsx
@@ -4,15 +4,12 @@ import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Linking,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Platform,
   Animated as RNAnimated,
   StyleSheet,
   TouchableOpacity,
   View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -342,17 +339,16 @@ const Licenses: React.FC = () => {
     []
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.FlatList
+        <RNAnimated.FlatList
           data={LICENSE_ITEMS}
           keyExtractor={keyExtractor}
           getItemLayout={getItemLayout}
@@ -364,6 +360,7 @@ const Licenses: React.FC = () => {
           ]}
           renderItem={renderItem}
           onScroll={handleScroll}
+          scrollEventThrottle={16}
           ListFooterComponent={
             <ListFooter
               isLEDTheme={isLEDTheme}

--- a/src/screens/NotificationSettings.tsx
+++ b/src/screens/NotificationSettings.tsx
@@ -3,14 +3,11 @@ import { useAtom, useAtomValue } from 'jotai';
 import React, { useCallback, useRef, useState } from 'react';
 import {
   Alert,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Pressable,
   Animated as RNAnimated,
   StyleSheet,
   View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -59,17 +56,16 @@ const NotificationSettingsScreen: React.FC = () => {
     }
   }, [wrongDirectionNotifyEnabled, setNotifyState]);
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.ScrollView
+        <RNAnimated.ScrollView
           onScroll={handleScroll}
           scrollEventThrottle={16}
           contentContainerStyle={[
@@ -114,7 +110,7 @@ const NotificationSettingsScreen: React.FC = () => {
           >
             OK
           </Button>
-        </Animated.ScrollView>
+        </RNAnimated.ScrollView>
       </View>
       <SettingsHeader
         title={translate('notificationSettings')}

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -447,6 +447,8 @@ const RouteSearchScreen = () => {
 
     return (
       <View
+        ref={index === 0 ? searchResultsRef : undefined}
+        onLayout={index === 0 ? measureSearchResults : undefined}
         style={[
           index >= numColumns && styles.rowSpacing,
           // タブレットではセル幅が listWidth / numColumns 固定になるため、

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -1,3 +1,8 @@
+import {
+  FlashList,
+  type FlashListProps,
+  type ListRenderItemInfo,
+} from '@shopify/flash-list';
 import { useQueryClient } from '@tanstack/react-query';
 import { Orientation } from 'expo-screen-orientation';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -8,15 +13,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  Alert,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  Animated as RNAnimated,
-  StyleSheet,
-  View,
-} from 'react-native';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import { Alert, Animated as RNAnimated, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { Station, TrainType } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
@@ -119,9 +116,25 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 16,
   },
+  // 従来は行間に EmptyLineSeparator(height: 8) を挟んでいたが、
+  // FlashList の ItemSeparatorComponent は numColumns 使用時に各セル内へ描画されるため
+  // 2行目以降のセルに paddingTop で同じ間隔を再現する
+  rowSpacing: {
+    paddingTop: 8,
+  },
 });
 
 const SEARCH_STATION_RESULT_LIMIT = 100;
+
+// タブレット表示で従来のレイアウト(flexDirection: 'row', gap: 16)と同じカード間隔
+const CARD_COLUMN_GAP = 16;
+
+// onScroll に useNativeDriver: true の Animated.event を直接アタッチするため
+// FlashList を RN Animated 対応コンポーネントにラップする
+// (FlashListRef が getScrollableNode を公開しているため native イベントが接続できる)
+const AnimatedFlashList = RNAnimated.createAnimatedComponent(
+  FlashList as unknown as React.ComponentType<FlashListProps<Station>>
+);
 
 const RouteSearchScreen = () => {
   const [nowHeaderHeight, setNowHeaderHeight] = useState(0);
@@ -429,55 +442,30 @@ const RouteSearchScreen = () => {
     [handleLineSelected, fetchRouteTypesLoading]
   );
 
-  const renderPlaceholders = useCallback((rowIndex: number, count: number) => {
-    if (!isTablet || count <= 0) {
-      return null;
-    }
+  const renderItem = ({ item, index }: ListRenderItemInfo<Station>) => {
+    const columnIndex = index % numColumns;
 
-    return Array.from({ length: count }).map((_, i) => (
-      <Animated.View
-        layout={LinearTransition.springify()}
-        // biome-ignore lint/suspicious/noArrayIndexKey: プレースホルダーは静的で順序が変わらないため問題なし
-        key={`placeholder-${rowIndex}-${i}`}
-        style={{ flex: 1 }}
-      />
-    ));
-  }, []);
+    return (
+      <View
+        style={[
+          index >= numColumns && styles.rowSpacing,
+          // タブレットではセル幅が listWidth / numColumns 固定になるため、
+          // 各セルの左右 padding を列位置に応じて振り分けることで
+          // 従来の gap: 16 と同一のカード幅・カード間隔を再現する
+          isTablet && {
+            paddingLeft: (CARD_COLUMN_GAP * columnIndex) / numColumns,
+            paddingRight:
+              (CARD_COLUMN_GAP * (numColumns - 1 - columnIndex)) / numColumns,
+          },
+        ]}
+      >
+        {renderCard(item)}
+      </View>
+    );
+  };
 
-  const renderStationRow = useCallback(
-    (rowStations: Station[], rowIndex: number) => {
-      return (
-        <>
-          {rowIndex > 0 && <EmptyLineSeparator />}
-          <Animated.View
-            layout={LinearTransition.springify()}
-            style={
-              isTablet
-                ? {
-                    flexDirection: 'row',
-                    gap: 16,
-                  }
-                : undefined
-            }
-          >
-            {rowStations.map((item, colIndex) => {
-              return (
-                <Animated.View
-                  layout={LinearTransition.springify()}
-                  key={item.id ?? `station-${rowIndex}-${colIndex}`}
-                  style={isTablet ? { flex: 1 } : undefined}
-                >
-                  {renderCard(item)}
-                </Animated.View>
-              );
-            })}
-            {renderPlaceholders(rowIndex, numColumns - rowStations.length)}
-          </Animated.View>
-        </>
-      );
-    },
-    [numColumns, renderCard, renderPlaceholders]
-  );
+  const keyExtractor = (s: Station, index: number) =>
+    `${s.groupId ?? 0}-${s.id ?? index}`;
 
   const handleTrainTypeSelected = useCallback(
     async (trainType: TrainType) => {
@@ -516,11 +504,11 @@ const RouteSearchScreen = () => {
     ]
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
+  // NowHeader のスクロール連動アニメーションを native driver で駆動する
+  // (AnimatedFlashList にアタッチされ、スクロールイベントは UI スレッドで scrollY へ反映される)
+  const handleScroll = RNAnimated.event(
+    [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+    { useNativeDriver: true }
   );
 
   const currentStationInRoutes = useMemo<Station | null>(
@@ -618,54 +606,42 @@ const RouteSearchScreen = () => {
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.nonLEDBg]}>
-        <Animated.ScrollView
+        <AnimatedFlashList
           style={StyleSheet.absoluteFill}
+          data={searchResults}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          numColumns={numColumns}
           onScroll={handleScroll}
           scrollEventThrottle={16}
           contentContainerStyle={[
             styles.listContainerStyle,
             nowHeaderHeight ? { paddingTop: nowHeaderHeight } : null,
           ]}
-        >
-          <View style={styles.listHeaderContainer}>
-            <View
-              ref={searchBarRef}
-              style={styles.searchBarContainer}
-              onLayout={measureSearchBar}
-            >
-              <SearchBar onSearch={handleSearch} />
+          ListHeaderComponent={
+            <View style={styles.listHeaderContainer}>
+              <View
+                ref={searchBarRef}
+                style={styles.searchBarContainer}
+                onLayout={measureSearchBar}
+              >
+                <SearchBar onSearch={handleSearch} />
+              </View>
+              <Heading style={styles.searchResultHeading}>
+                {translate('searchResult')}
+              </Heading>
             </View>
-            <Heading style={styles.searchResultHeading}>
-              {translate('searchResult')}
-            </Heading>
-          </View>
-
-          <View ref={searchResultsRef} onLayout={measureSearchResults}>
-            {!searchResults.length ? (
+          }
+          ListEmptyComponent={
+            <View ref={searchResultsRef} onLayout={measureSearchResults}>
               <EmptyResult
                 loading={byNameLoading || fetchRouteTypesLoading}
                 hasSearched={hasSearched}
               />
-            ) : (
-              Array.from({
-                length: Math.ceil(searchResults.length / numColumns),
-              }).map((_, rowIndex) => {
-                const rowStations = searchResults.slice(
-                  rowIndex * numColumns,
-                  (rowIndex + 1) * numColumns
-                );
-                const rowKey = rowStations.map((s) => s.id).join('-');
-                return (
-                  <React.Fragment key={rowKey}>
-                    {renderStationRow(rowStations, rowIndex)}
-                  </React.Fragment>
-                );
-              })
-            )}
-          </View>
-
-          <EmptyLineSeparator />
-        </Animated.ScrollView>
+            </View>
+          }
+          ListFooterComponent={EmptyLineSeparator}
+        />
       </SafeAreaView>
 
       <NowHeader

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -8,8 +8,6 @@ import React, {
   useState,
 } from 'react';
 import {
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   RefreshControl,
   Animated as RNAnimated,
   StyleSheet,
@@ -208,12 +206,11 @@ const SelectLineScreen = () => {
   );
 
   // --- スクロールハンドラ ---
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -304,7 +301,7 @@ const SelectLineScreen = () => {
   return (
     <>
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.ScrollView
+        <RNAnimated.ScrollView
           style={StyleSheet.absoluteFill}
           onScroll={handleScroll}
           scrollEventThrottle={16}
@@ -382,7 +379,7 @@ const SelectLineScreen = () => {
             </>
           )}
           <EmptyLineSeparator />
-        </Animated.ScrollView>
+        </RNAnimated.ScrollView>
       </SafeAreaView>
 
       {/* 固定ヘッダー */}

--- a/src/screens/TTSSettings.tsx
+++ b/src/screens/TTSSettings.tsx
@@ -4,15 +4,12 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   type GestureResponderEvent,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Pressable,
   Animated as RNAnimated,
   StyleSheet,
   View,
 } from 'react-native';
 import { isClip } from 'react-native-app-clip';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -369,17 +366,16 @@ const TTSSettingsScreen: React.FC = () => {
     ]
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.FlatList
+        <RNAnimated.FlatList
           data={SETTING_ITEMS}
           keyExtractor={(item) => item.id}
           contentContainerStyle={[
@@ -389,6 +385,7 @@ const TTSSettingsScreen: React.FC = () => {
           ]}
           renderItem={renderItem}
           onScroll={handleScroll}
+          scrollEventThrottle={16}
           ListFooterComponent={
             <ListFooter
               ttsLanguageItems={TTS_LANGUAGE_ITEMS}

--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -6,15 +6,12 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   type GestureResponderEvent,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Platform,
   Pressable,
   Animated as RNAnimated,
   StyleSheet,
   View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Button from '~/components/Button';
 import FooterTabBar from '~/components/FooterTabBar';
 import { SettingsHeader } from '~/components/SettingsHeader';
@@ -231,17 +228,16 @@ const ThemeSettingsScreen: React.FC = () => {
     []
   );
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollY.setValue(e.nativeEvent.contentOffset.y);
-    },
-    [scrollY]
-  );
+  const handleScroll = useRef(
+    RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+      useNativeDriver: true,
+    })
+  ).current;
 
   return (
     <>
       <View style={[styles.root, !isLEDTheme && styles.screenBg]}>
-        <Animated.FlatList
+        <RNAnimated.FlatList
           data={visibleItems}
           keyExtractor={keyExtractor}
           getItemLayout={getItemLayout}
@@ -253,6 +249,7 @@ const ThemeSettingsScreen: React.FC = () => {
           ]}
           renderItem={renderItem}
           onScroll={handleScroll}
+          scrollEventThrottle={16}
           ListFooterComponent={
             <ListFooter onPressOK={() => navigation.goBack()} />
           }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6422 のプロファイリングで検出したがスコープ外として残していた改善項目のフォローアップです。JS スレッドを塞いでいたアニメーション・非仮想化リスト・直列フェッチ・ディープリンク処理の過剰なゲートを解消します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useLineSelection`: 互いに独立した駅一覧と種別一覧のフェッチを `Promise.all` で並列化（`Main.tsx` の既存パターンに整合）。路線選択から方面モーダル表示までの待ち時間が RTT 1 本分短縮
- `PadArch`: 乗車中常時走るシェブロンの無限ループアニメーション（opacity / translateY）を `useNativeDriver: true` 化し、60fps の補間を JS スレッドから排除（height 補間の `fillHeight` は対象外のまま）
- 設定系 10 画面: スクロール連動ヘッダーの `scrollY.setValue` を JS ハンドラから `Animated.event(..., { useNativeDriver: true })` へ移行。Reanimated の `Animated.ScrollView` では RN の AnimatedEvent がネイティブにアタッチされないことを確認したため、対象画面のスクロールコンポーネントを RN 本体の `Animated.ScrollView` / `Animated.FlatList` に統一
- `RouteSearchScreen`: 件数無制限の検索結果を手動行チャンク + `.map()` の全件マウントから `FlashList`（`numColumns` 対応・`createAnimatedComponent` ラップでヘッダー連動もネイティブ駆動）へ移行。カード幅・余白は従来と同一になるよう列位置別 padding で再現。検索結果変化時の `LinearTransition` レイアウトアニメーションは FlashList のリサイクルと両立しないため削除
- `DeepLinkProvider`: ゲート条件を「初期 URL の処理完了まで」に限定。従来は稼働中に受けたランタイムディープリンクの解決中も `isLoading` でツリー全体が null になり、表示中の画面が消えてナビゲーション状態が破棄されていた

調査のみ（変更なし）: `useAndroidWearable` の毎秒のメッセージ組み立ては Wear OS 端末の接続状態ゲートで止められるが、ネイティブ側 (`NodeClient.connectedNodes` + リスナー) の実装と実機 Wear OS 端末での検証が必要なため今回は見送り。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

フルスイート 192 スイート / 2044 テスト全パス。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 設定画面全体のスクロール連動アニメーションを最適化し、ヘッダー表示や追従エフェクトの動作をより滑らかにしました。
  * 検索結果一覧の表示方式を改善し、複数列レイアウトでの間隔や空状態の表示を整えました。
  * 路線選択時の駅・列車種別情報の読み込みを効率化しました。
  * ディープリンク処理中に画面がちらついたり、一時的に消えたりする問題を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->