### PR TITLE
ETA実装LineBoardの最後尾ドット右隣に残り分数の単位（分/min./분）を表示

### DIFF
--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
@@ -20,6 +20,10 @@ const renderWithState = (headerState: HeaderTransitionState) => {
 };
 
 describe('EstimatedMinutesUnitLabel', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it.each<HeaderTransitionState>(['CURRENT', 'NEXT', 'ARRIVING'])(
     '日本語State(%s)では「分」を表示する',
     (state) => {

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
@@ -1,11 +1,7 @@
 import { render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
-import type { AvailableLanguage } from '~/constants';
 import type { HeaderTransitionState } from '~/models/HeaderTransitionState';
-import {
-  enabledLanguagesAtom,
-  headerStateAtom,
-} from '~/store/atoms/navigation';
+import { headerStateAtom } from '~/store/atoms/navigation';
 import { EstimatedMinutesUnitLabel } from './EstimatedMinutesUnitLabel';
 
 jest.mock('~/utils/isTablet', () => ({
@@ -13,13 +9,9 @@ jest.mock('~/utils/isTablet', () => ({
   default: false,
 }));
 
-const renderWithState = (
-  headerState: HeaderTransitionState,
-  enabledLanguages: AvailableLanguage[] = ['JA', 'EN', 'ZH', 'KO']
-) => {
+const renderWithState = (headerState: HeaderTransitionState) => {
   const store = createStore();
   store.set(headerStateAtom, headerState);
-  store.set(enabledLanguagesAtom, enabledLanguages);
   return render(
     <Provider store={store}>
       <EstimatedMinutesUnitLabel />
@@ -46,18 +38,13 @@ describe('EstimatedMinutesUnitLabel', () => {
     expect(getByText('min.')).toBeTruthy();
   });
 
-  it('中国語Stateでは英語有効時は「min.」を表示する(LineBoardの英語表示に追従)', () => {
+  it('中国語Stateでは「分钟」を表示する', () => {
     const { getByText } = renderWithState('CURRENT_ZH');
-    expect(getByText('min.')).toBeTruthy();
+    expect(getByText('分钟')).toBeTruthy();
   });
 
-  it('中国語Stateでも英語無効時は「分」を表示する', () => {
-    const { getByText } = renderWithState('CURRENT_ZH', ['JA', 'ZH']);
-    expect(getByText('分')).toBeTruthy();
-  });
-
-  it('韓国語Stateでは「分」を表示する(LineBoardの日本語表示に追従)', () => {
+  it('韓国語Stateでは「분」を表示する', () => {
     const { getByText } = renderWithState('CURRENT_KO');
-    expect(getByText('分')).toBeTruthy();
+    expect(getByText('분')).toBeTruthy();
   });
 });

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type { AvailableLanguage } from '~/constants';
+import type { HeaderTransitionState } from '~/models/HeaderTransitionState';
+import {
+  enabledLanguagesAtom,
+  headerStateAtom,
+} from '~/store/atoms/navigation';
+import { EstimatedMinutesUnitLabel } from './EstimatedMinutesUnitLabel';
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+const renderWithState = (
+  headerState: HeaderTransitionState,
+  enabledLanguages: AvailableLanguage[] = ['JA', 'EN', 'ZH', 'KO']
+) => {
+  const store = createStore();
+  store.set(headerStateAtom, headerState);
+  store.set(enabledLanguagesAtom, enabledLanguages);
+  return render(
+    <Provider store={store}>
+      <EstimatedMinutesUnitLabel />
+    </Provider>
+  );
+};
+
+describe('EstimatedMinutesUnitLabel', () => {
+  it.each<HeaderTransitionState>(['CURRENT', 'NEXT', 'ARRIVING'])(
+    '日本語State(%s)では「分」を表示する',
+    (state) => {
+      const { getByText } = renderWithState(state);
+      expect(getByText('分')).toBeTruthy();
+    }
+  );
+
+  it('かなStateでは「分」を表示する', () => {
+    const { getByText } = renderWithState('CURRENT_KANA');
+    expect(getByText('分')).toBeTruthy();
+  });
+
+  it('英語Stateでは「min.」を表示する', () => {
+    const { getByText } = renderWithState('CURRENT_EN');
+    expect(getByText('min.')).toBeTruthy();
+  });
+
+  it('中国語Stateでは英語有効時は「min.」を表示する(LineBoardの英語表示に追従)', () => {
+    const { getByText } = renderWithState('CURRENT_ZH');
+    expect(getByText('min.')).toBeTruthy();
+  });
+
+  it('中国語Stateでも英語無効時は「分」を表示する', () => {
+    const { getByText } = renderWithState('CURRENT_ZH', ['JA', 'ZH']);
+    expect(getByText('分')).toBeTruthy();
+  });
+
+  it('韓国語Stateでは「分」を表示する(LineBoardの日本語表示に追従)', () => {
+    const { getByText } = renderWithState('CURRENT_KO');
+    expect(getByText('分')).toBeTruthy();
+  });
+});

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.test.tsx
@@ -38,9 +38,9 @@ describe('EstimatedMinutesUnitLabel', () => {
     expect(getByText('min.')).toBeTruthy();
   });
 
-  it('中国語Stateでは「分钟」を表示する', () => {
+  it('中国語Stateでは「分」を表示する', () => {
     const { getByText } = renderWithState('CURRENT_ZH');
-    expect(getByText('分钟')).toBeTruthy();
+    expect(getByText('分')).toBeTruthy();
   });
 
   it('韓国語Stateでは「분」を表示する', () => {

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
@@ -1,7 +1,7 @@
-import { useAtomValue } from 'jotai';
+import { atom, useAtomValue } from 'jotai';
 import type React from 'react';
 import { StyleSheet, type TextStyle } from 'react-native';
-import { isEnAtom } from '~/store/selectors/isEn';
+import { headerStateAtom } from '~/store/atoms/navigation';
 import isTablet from '~/utils/isTablet';
 import Typography from '../../../Typography';
 
@@ -17,21 +17,38 @@ const styles = StyleSheet.create({
   },
 });
 
+// ヘッダーの言語Stateごとの単位表記。headerStateAtomは数秒ごとに
+// ローテーションするため、算出済み文字列のderived atomを購読することで
+// 単位が実際に変わったときだけ再レンダーされるようにする。
+const estimatedMinutesUnitAtom = atom((get) => {
+  const langState = get(headerStateAtom).split('_')[1] ?? 'JA';
+  switch (langState) {
+    case 'EN':
+      return 'min.';
+    case 'ZH':
+      return '分钟';
+    case 'KO':
+      return '분';
+    // JA・KANA
+    default:
+      return '分';
+  }
+});
+
 export type EstimatedMinutesUnitLabelProps = {
   style?: TextStyle;
 };
 
 // ETAの残り分数はドット内に数字のみで表示されるため、最後のドットの右隣に
-// 単位を添えて数字の意味を示す。表示言語はLineBoard全体の言語切替
-// (isEnAtom: 各言語Stateを英語表示か日本語表示かへ集約する) に追従する。
+// 単位を添えて数字の意味を示す。
 export const EstimatedMinutesUnitLabel: React.FC<
   EstimatedMinutesUnitLabelProps
 > = ({ style }) => {
-  const isEn = useAtomValue(isEnAtom);
+  const unit = useAtomValue(estimatedMinutesUnitAtom);
 
   return (
     <Typography style={[styles.text, style]} numberOfLines={1}>
-      {isEn ? 'min.' : '分'}
+      {unit}
     </Typography>
   );
 };

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
@@ -25,11 +25,9 @@ const estimatedMinutesUnitAtom = atom((get) => {
   switch (langState) {
     case 'EN':
       return 'min.';
-    case 'ZH':
-      return '分钟';
     case 'KO':
       return '분';
-    // JA・KANA
+    // JA・KANA・ZH (中国語も単位は「分」で通じるため共通)
     default:
       return '分';
   }

--- a/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
+++ b/src/components/LineBoard/shared/components/EstimatedMinutesUnitLabel.tsx
@@ -1,0 +1,37 @@
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import { StyleSheet, type TextStyle } from 'react-native';
+import { isEnAtom } from '~/store/selectors/isEn';
+import isTablet from '~/utils/isTablet';
+import Typography from '../../../Typography';
+
+const styles = StyleSheet.create({
+  text: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: isTablet ? 21 : 15,
+    // 路線色バーの上に重ねて描画されるため、どの路線色でも判読できるよう縁取る
+    textShadowColor: '#000',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 2,
+  },
+});
+
+export type EstimatedMinutesUnitLabelProps = {
+  style?: TextStyle;
+};
+
+// ETAの残り分数はドット内に数字のみで表示されるため、最後のドットの右隣に
+// 単位を添えて数字の意味を示す。表示言語はLineBoard全体の言語切替
+// (isEnAtom: 各言語Stateを英語表示か日本語表示かへ集約する) に追従する。
+export const EstimatedMinutesUnitLabel: React.FC<
+  EstimatedMinutesUnitLabelProps
+> = ({ style }) => {
+  const isEn = useAtomValue(isEnAtom);
+
+  return (
+    <Typography style={[styles.text, style]} numberOfLines={1}>
+      {isEn ? 'min.' : '分'}
+    </Typography>
+  );
+};

--- a/src/components/LineBoard/shared/components/LineDot.test.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
 import type { Line, Station } from '~/@types/graphql';
-import { LineDot } from './LineDot';
+import { headerStateAtom } from '~/store/atoms/navigation';
+import { LineDot, type LineDotProps } from './LineDot';
 
 // モック設定
 jest.mock('~/hooks/useScale', () => ({
@@ -171,5 +173,58 @@ describe('LineDot', () => {
 
     // PadLineMarksがレンダリングされていることを確認
     expect(getByTestId('pad-line-marks')).toBeTruthy();
+  });
+
+  describe('ETA単位ラベル', () => {
+    const renderWithHeaderState = (
+      props: Partial<LineDotProps>,
+      headerState: 'CURRENT' | 'CURRENT_EN' = 'CURRENT'
+    ) => {
+      const store = createStore();
+      store.set(headerStateAtom, headerState);
+      return render(
+        <Provider store={store}>
+          <LineDot
+            station={mockStation}
+            shouldGrayscale={false}
+            transferLines={mockTransferLines}
+            arrived={false}
+            passed={false}
+            {...props}
+          />
+        </Provider>
+      );
+    };
+
+    beforeEach(() => {
+      const getIsPass = require('~/utils/isPass').default;
+      (getIsPass as jest.Mock).mockReturnValue(false);
+    });
+
+    it('isLastかつestimatedMinutesありの場合、「分」を表示する', () => {
+      const { getByText } = renderWithHeaderState({
+        isLast: true,
+        estimatedMinutes: 5,
+      });
+      expect(getByText('分')).toBeTruthy();
+    });
+
+    it('英語Stateでは「min.」を表示する', () => {
+      const { getByText } = renderWithHeaderState(
+        { isLast: true, estimatedMinutes: 5 },
+        'CURRENT_EN'
+      );
+      expect(getByText('min.')).toBeTruthy();
+    });
+
+    it('isLastでもestimatedMinutesがない場合は表示しない', () => {
+      const { queryByText } = renderWithHeaderState({ isLast: true });
+      expect(queryByText('分')).toBeNull();
+    });
+
+    it('estimatedMinutesがあってもisLastでない場合は表示しない', () => {
+      const { queryByText } = renderWithHeaderState({ estimatedMinutes: 5 });
+      expect(queryByText('分')).toBeNull();
+    });
   });
 });

--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -9,6 +9,7 @@ import PadLineMarks from '../../../PadLineMarks';
 import PassChevronEast from '../../../PassChevronEast';
 import { commonLineBoardStyles as styles } from '../styles/commonStyles';
 import { EstimatedMinutesBadge } from './EstimatedMinutesBadge';
+import { EstimatedMinutesUnitLabel } from './EstimatedMinutesUnitLabel';
 
 const localStyles = StyleSheet.create({
   estimatedMinutesOverlay: {
@@ -17,6 +18,14 @@ const localStyles = StyleSheet.create({
     left: 0,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  // 見えているドット(chevronGradient)のすぐ右にドットと同じ高さで縦中央揃え
+  estimatedMinutesUnitContainer: {
+    position: 'absolute',
+    top: 0,
+    left: isTablet ? 48 + 6 : 32 + 4,
+    height: isTablet ? 36 : 24,
+    justifyContent: 'center',
   },
 });
 
@@ -28,6 +37,8 @@ export type LineDotProps = {
   passed: boolean;
   isOdakyu?: boolean;
   estimatedMinutes?: number | null;
+  // 最後尾セルのドットのときtrue。ETA表示中は右隣に単位(分/min.)を添える
+  isLast?: boolean;
 };
 
 export const LineDot: React.FC<LineDotProps> = ({
@@ -38,6 +49,7 @@ export const LineDot: React.FC<LineDotProps> = ({
   passed,
   isOdakyu = false,
   estimatedMinutes,
+  isLast = false,
 }) => {
   const { widthScale } = useScale();
 
@@ -106,6 +118,14 @@ export const LineDot: React.FC<LineDotProps> = ({
             pointerEvents="none"
           >
             <EstimatedMinutesBadge estimatedMinutes={estimatedMinutes} />
+          </View>
+        ) : null}
+        {isLast && estimatedMinutes != null ? (
+          <View
+            style={localStyles.estimatedMinutesUnitContainer}
+            pointerEvents="none"
+          >
+            <EstimatedMinutesUnitLabel />
           </View>
         ) : null}
       </View>

--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -19,11 +19,11 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  // 見えているドット(chevronGradient)のすぐ右にドットと同じ高さで縦中央揃え
+  // 見えているドット(chevronGradient)の右にドットと同じ高さで縦中央揃え
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: isTablet ? 48 + 6 : 32 + 4,
+    left: isTablet ? 48 + 12 : 32 + 8,
     height: isTablet ? 36 : 24,
     justifyContent: 'center',
   },

--- a/src/components/LineBoard/shared/components/LineDot.tsx
+++ b/src/components/LineBoard/shared/components/LineDot.tsx
@@ -23,7 +23,7 @@ const localStyles = StyleSheet.create({
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: isTablet ? 48 + 12 : 32 + 8,
+    left: isTablet ? 48 + 24 : 32 + 16,
     height: isTablet ? 36 : 24,
     justifyContent: 'center',
   },

--- a/src/components/LineBoard/shared/components/index.ts
+++ b/src/components/LineBoard/shared/components/index.ts
@@ -4,6 +4,8 @@ export type { EmptyStationNameCellProps } from './EmptyStationNameCell';
 export { EmptyStationNameCell } from './EmptyStationNameCell';
 export type { EstimatedMinutesBadgeProps } from './EstimatedMinutesBadge';
 export { EstimatedMinutesBadge } from './EstimatedMinutesBadge';
+export type { EstimatedMinutesUnitLabelProps } from './EstimatedMinutesUnitLabel';
+export { EstimatedMinutesUnitLabel } from './EstimatedMinutesUnitLabel';
 export type { LineDotProps } from './LineDot';
 export { LineDot } from './LineDot';
 export type { StationNameProps } from './StationName';

--- a/src/components/LineBoardE231.test.tsx
+++ b/src/components/LineBoardE231.test.tsx
@@ -57,6 +57,7 @@ jest.mock('./LineBoard/shared/components', () => {
     EstimatedMinutesBadge: jest.fn(({ estimatedMinutes }) => (
       <Text>{estimatedMinutes}</Text>
     )),
+    EstimatedMinutesUnitLabel: jest.fn(() => <Text>分</Text>),
     StationName: jest.fn(() => null),
   };
 });
@@ -165,5 +166,49 @@ describe('LineBoardE231', () => {
       />
     );
     expect(EstimatedMinutesBadge).not.toHaveBeenCalled();
+  });
+
+  it('最後の駅にETAがある場合、単位ラベルが表示される', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const {
+      EstimatedMinutesUnitLabel,
+    } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardE231
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(EstimatedMinutesUnitLabel).toHaveBeenCalled();
+  });
+
+  it('最後の駅以外のETAには単位ラベルが表示されない', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const {
+      EstimatedMinutesBadge,
+      EstimatedMinutesUnitLabel,
+    } = require('./LineBoard/shared/components');
+    const threeStations = [
+      ...mockStations,
+      {
+        id: 3,
+        groupId: 3,
+        name: '横浜',
+        line: mockLine,
+      } as unknown as Station,
+    ];
+    render(
+      <LineBoardE231
+        stations={threeStations}
+        lineColors={['#9acd32', '#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    // 中間駅(id=2)のETAバッジは表示されるが、単位ラベルは最後尾専用
+    expect(EstimatedMinutesBadge).toHaveBeenCalled();
+    expect(EstimatedMinutesUnitLabel).not.toHaveBeenCalled();
   });
 });

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -19,6 +19,7 @@ import isTablet from '../utils/isTablet';
 import { ChevronE231 } from './ChevronE231';
 import {
   EstimatedMinutesBadge,
+  EstimatedMinutesUnitLabel,
   StationName,
 } from './LineBoard/shared/components';
 import {
@@ -100,6 +101,14 @@ const localStyles = StyleSheet.create({
     height: isTablet ? 36 : 24,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  // ドット矩形(dotInner)のすぐ右にドットと同じ高さで縦中央揃え
+  estimatedMinutesUnitContainer: {
+    position: 'absolute',
+    top: 0,
+    left: isTablet ? 44 + 6 : 36 + 4,
+    height: isTablet ? 36 : 24,
+    justifyContent: 'center',
   },
   marksContainer: {
     top: 38,
@@ -258,6 +267,16 @@ const StationNameCell: React.FC<StationNameCellProps> = ({
                     <EstimatedMinutesBadge
                       estimatedMinutes={estimatedMinutes}
                     />
+                  </View>
+                ) : null}
+                {stations.length - 1 === index &&
+                estimatedMinutes != null &&
+                !(passed && !arrived) ? (
+                  <View
+                    style={localStyles.estimatedMinutesUnitContainer}
+                    pointerEvents="none"
+                  >
+                    <EstimatedMinutesUnitLabel />
                   </View>
                 ) : null}
               </View>

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -102,11 +102,11 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  // ドット矩形(dotInner)のすぐ右にドットと同じ高さで縦中央揃え
+  // ドット矩形(dotInner)の右にドットと同じ高さで縦中央揃え
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: isTablet ? 44 + 6 : 36 + 4,
+    left: isTablet ? 44 + 12 : 36 + 8,
     height: isTablet ? 36 : 24,
     justifyContent: 'center',
   },

--- a/src/components/LineBoardE231.tsx
+++ b/src/components/LineBoardE231.tsx
@@ -106,7 +106,7 @@ const localStyles = StyleSheet.create({
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: isTablet ? 44 + 12 : 36 + 8,
+    left: isTablet ? 44 + 24 : 36 + 16,
     height: isTablet ? 36 : 24,
     justifyContent: 'center',
   },

--- a/src/components/LineBoardEast.test.tsx
+++ b/src/components/LineBoardEast.test.tsx
@@ -204,6 +204,25 @@ describe('LineBoardEast', () => {
     );
   });
 
+  it('最後の駅のLineDotにのみisLast=trueが渡される', () => {
+    const { LineDot } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardEast
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+        hasTerminus={false}
+      />
+    );
+    expect(LineDot).toHaveBeenCalledWith(
+      expect.objectContaining({ station: mockStations[0], isLast: false }),
+      undefined
+    );
+    expect(LineDot).toHaveBeenCalledWith(
+      expect.objectContaining({ station: mockStations[1], isLast: true }),
+      undefined
+    );
+  });
+
   it('isOdakyu時はETAクエリをskipして呼び出す', () => {
     const { useEstimateArrivalTimes } = require('~/hooks');
     render(

--- a/src/components/LineBoardEast.tsx
+++ b/src/components/LineBoardEast.tsx
@@ -412,6 +412,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           passed={passed}
           isOdakyu={isOdakyu}
           estimatedMinutes={estimatedMinutes}
+          isLast={stations.length - 1 === index}
         />
         {stations.length - 1 === index ? (
           isOdakyu ? (

--- a/src/components/LineBoardJO.test.tsx
+++ b/src/components/LineBoardJO.test.tsx
@@ -82,6 +82,7 @@ jest.mock('./LineBoard/shared/components', () => {
     EstimatedMinutesBadge: jest.fn(({ estimatedMinutes }) => (
       <Text>{estimatedMinutes}</Text>
     )),
+    EstimatedMinutesUnitLabel: jest.fn(() => <Text>分</Text>),
     LineDot: jest.fn(() => null),
     StationName: jest.fn(() => null),
   };
@@ -249,6 +250,48 @@ describe('LineBoardJO', () => {
     expect(EstimatedMinutesBadge.mock.calls[0][0]).toEqual(
       expect.objectContaining({ estimatedMinutes: 5 })
     );
+  });
+
+  it('最後の駅にETAがある場合、単位ラベルが表示される', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const {
+      EstimatedMinutesUnitLabel,
+    } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardJO
+        stations={mockStations}
+        lineColors={['#9acd32', '#9acd32']}
+      />
+    );
+    expect(EstimatedMinutesUnitLabel).toHaveBeenCalled();
+  });
+
+  it('最後の駅以外のETAには単位ラベルが表示されない', () => {
+    const { useEstimatedMinutesByStationId } = require('~/hooks');
+    useEstimatedMinutesByStationId.mockReturnValueOnce(new Map([[2, 5]]));
+    const {
+      EstimatedMinutesBadge,
+      EstimatedMinutesUnitLabel,
+    } = require('./LineBoard/shared/components');
+    const threeStations = [
+      ...mockStations,
+      {
+        id: 3,
+        groupId: 3,
+        name: '横浜',
+        line: mockLine,
+      } as unknown as Station,
+    ];
+    render(
+      <LineBoardJO
+        stations={threeStations}
+        lineColors={['#9acd32', '#9acd32', '#9acd32']}
+      />
+    );
+    // 中間駅(id=2)のETAバッジは表示されるが、単位ラベルは最後尾専用
+    expect(EstimatedMinutesBadge).toHaveBeenCalled();
+    expect(EstimatedMinutesUnitLabel).not.toHaveBeenCalled();
   });
 
   it('通過駅の場合、PassChevronEastが表示される', () => {

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -53,11 +53,11 @@ const localStyles = StyleSheet.create({
     bottom: isTablet ? '40%' : undefined,
     marginLeft: isTablet ? 48 : 32,
   },
-  // barDot(未通過時は32px)のすぐ右にドットと同じ高さで縦中央揃え
+  // barDot(未通過時は32px)の右にドットと同じ高さで縦中央揃え
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: 32 + 6,
+    left: 32 + 12,
     height: 32,
     justifyContent: 'center',
   },

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -21,7 +21,10 @@ import isTablet from '../utils/isTablet';
 import { getNumberingColor } from '../utils/numbering';
 import { ChevronJO } from './ChevronJO';
 import { JOCurrentArrowEdge } from './JOCurrentArrowEdge';
-import { EstimatedMinutesBadge } from './LineBoard/shared/components';
+import {
+  EstimatedMinutesBadge,
+  EstimatedMinutesUnitLabel,
+} from './LineBoard/shared/components';
 import { useIncludesLongStationName } from './LineBoard/shared/hooks/useBarStyles';
 import {
   BAR_BOTTOM_JO,
@@ -49,6 +52,14 @@ const localStyles = StyleSheet.create({
     height: '100%',
     bottom: isTablet ? '40%' : undefined,
     marginLeft: isTablet ? 48 : 32,
+  },
+  // barDot(未通過時は32px)のすぐ右にドットと同じ高さで縦中央揃え
+  estimatedMinutesUnitContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 32 + 6,
+    height: 32,
+    justifyContent: 'center',
   },
 });
 
@@ -395,6 +406,14 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
               >
                 {estimatedMinutes != null ? (
                   <EstimatedMinutesBadge estimatedMinutes={estimatedMinutes} />
+                ) : null}
+                {i === stations.length - 1 && estimatedMinutes != null ? (
+                  <View
+                    style={localStyles.estimatedMinutesUnitContainer}
+                    pointerEvents="none"
+                  >
+                    <EstimatedMinutesUnitLabel />
+                  </View>
                 ) : null}
               </View>
             )}

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -57,7 +57,7 @@ const localStyles = StyleSheet.create({
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: 32 + 12,
+    left: 32 + 24,
     height: 32,
     justifyContent: 'center',
   },

--- a/src/components/LineBoardJRKyushu.test.tsx
+++ b/src/components/LineBoardJRKyushu.test.tsx
@@ -179,6 +179,25 @@ describe('LineBoardJRKyushu', () => {
     );
   });
 
+  it('最後の駅のLineDotにのみisLast=trueが渡される', () => {
+    const { LineDot } = require('./LineBoard/shared/components');
+    render(
+      <LineBoardJRKyushu
+        stations={mockStations}
+        lineColors={['#f60', '#f60']}
+        hasTerminus={false}
+      />
+    );
+    expect(LineDot).toHaveBeenCalledWith(
+      expect.objectContaining({ station: mockStations[0], isLast: false }),
+      undefined
+    );
+    expect(LineDot).toHaveBeenCalledWith(
+      expect.objectContaining({ station: mockStations[1], isLast: true }),
+      undefined
+    );
+  });
+
   it('NumberingIconコンポーネントが駅番号付きの駅に対してレンダリングされる', () => {
     const NumberingIcon = require('./NumberingIcon').default;
     render(

--- a/src/components/LineBoardJRKyushu.tsx
+++ b/src/components/LineBoardJRKyushu.tsx
@@ -357,6 +357,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           arrived={arrived}
           passed={passed}
           estimatedMinutes={estimatedMinutes}
+          isLast={stations.length - 1 === index}
         />
 
         {stations.length - 1 === index ? (

--- a/src/components/LineBoardSaikyo.tsx
+++ b/src/components/LineBoardSaikyo.tsx
@@ -254,6 +254,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           arrived={arrived}
           passed={passed}
           estimatedMinutes={estimatedMinutes}
+          isLast={stations.length - 1 === index}
         />
         {stations.length - 1 === index && (
           <BarTerminalSaikyo

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -465,6 +465,7 @@ const StationNameCellBase: React.FC<StationNameCellProps> = ({
           arrived={arrived}
           passed={passed}
           estimatedMinutes={estimatedMinutes}
+          isLast={isLastStation}
         />
         {isLastStation ? (
           <BarTerminalEast


### PR DESCRIPTION
## 概要

ETA（残り分数）を実装しているLineBoardで、最後尾の駅ドットの右隣に単位ラベルを表示するようにした。単位はヘッダーの言語Stateに追従し、日本語・かな・中国語では「分」、英語では「min.」、韓国語では「분」を表示する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 共有コンポーネント `EstimatedMinutesUnitLabel` を新設。ヘッダー言語Stateから単位文字列（分 / min. / 분）を導出するderived atomを購読し、単位が実際に変わったときだけ再レンダーされるようにした
- 共有 `LineDot` に `isLast` プロパティを追加し、最後尾セルかつETA数字表示中のみドット右隣へ単位ラベルを描画（LineBoardEast / LineBoardSaikyo / LineBoardToei / LineBoardJRKyushu が対象）
- 独自ドット実装の LineBoardE231 / LineBoardJO にも同条件で単位ラベルを追加
- ラベルは白太字＋黒縁取り（textShadow）で路線色バー上でも判読できるようにし、ドットとの間隔をタブレット24px / スマホ16pxに設定
- 単体テストを追加・更新（言語Stateごとの表記、最後尾ドットのみに表示されること）

補足: LineBoardYamanotePad（PadArch）もETAを実装しているが、アーチ状レイアウトでドット右隣に駅名が配置されており衝突するため今回は対象外とした。小田急テーマ（LineBoardEastの `isOdakyu`）はETA自体が対象外のため表示されない。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
