### PR TITLE
LineBoardJOのETA単位ラベルをスマホのみ4px右にずらす

### DIFF
--- a/src/components/LineBoardJO.test.tsx
+++ b/src/components/LineBoardJO.test.tsx
@@ -379,7 +379,7 @@ describe('LineBoardJO', () => {
       expect(unitContainer).toBeTruthy();
       const style = StyleSheet.flatten(unitContainer?.props.style as ViewStyle);
       expect(style.position).toBe('absolute');
-      expect(style.left).toBe(32); // ドット幅32px + 間隔0px
+      expect(style.left).toBe(36); // ドット幅32px + 間隔4px
       expect(style.top).toBe(0);
       expect(style.height).toBe(32); // ドットと同じ高さで縦中央揃え
     });

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -67,7 +67,7 @@ const localStyles = StyleSheet.create({
   estimatedMinutesUnitContainer: {
     position: 'absolute',
     top: 0,
-    left: DOT_SIZE_JO + (isTablet ? 8 : 0),
+    left: DOT_SIZE_JO + (isTablet ? 8 : 4),
     height: DOT_SIZE_JO,
     justifyContent: 'center',
   },


### PR DESCRIPTION
## 概要

LineBoardJO のETA単位ラベル（分/min.）の表示位置を、スマートフォンのみ 4px 右へ移動します。タブレットの表示位置は変更ありません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `LineBoardJO` の単位ラベルコンテナの `left` を `DOT_SIZE_JO + (isTablet ? 8 : 0)` から `DOT_SIZE_JO + (isTablet ? 8 : 4)` に変更し、スマホのみ 4px 右へ移動
- レイアウト計算（スマホ）のテスト期待値を `left: 32` → `36` に更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
