### PR TITLE
ETA数字を拡大しPadArchに単位ラベルを追加、AndroidのTLC文字縦位置を補正

### DIFF
--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -86,8 +86,8 @@ const localStyles = StyleSheet.create({
     alignItems: 'center',
   },
   estimatedMinutesText: {
-    fontSize: isTablet ? 38 : 28,
-    lineHeight: isTablet ? 40 : 30,
+    fontSize: isTablet ? 38 : 24,
+    lineHeight: isTablet ? 40 : 26,
   },
 });
 

--- a/src/components/LineBoardJO.tsx
+++ b/src/components/LineBoardJO.tsx
@@ -53,6 +53,11 @@ const LEGACY_DOT_SIZE = 32;
 const DOT_SIZE_JO = BAR_HEIGHT_JO - 8;
 // 終端矢印が画面右端から離れすぎないよう、最終セグメントを右へ延長する
 const BAR_TAIL_EXTENSION_JO = isTablet ? 24 : 14;
+// ETA数字はドット幅を超えるサイズで表示するため、ドット中心に重ねる
+// 絶対配置コンテナの寸法。width未指定の絶対配置子は親(ドット)幅上限で
+// 測られて数字が折り返されるため、明示widthが必須
+const ESTIMATED_MINUTES_BADGE_WIDTH = isTablet ? 96 : 64;
+const ESTIMATED_MINUTES_BADGE_HEIGHT = isTablet ? 40 : 30;
 
 // Local style overrides specific to JO
 const localStyles = StyleSheet.create({
@@ -70,6 +75,19 @@ const localStyles = StyleSheet.create({
     left: DOT_SIZE_JO + (isTablet ? 8 : 4),
     height: DOT_SIZE_JO,
     justifyContent: 'center',
+  },
+  estimatedMinutesBadgeContainer: {
+    position: 'absolute',
+    left: (DOT_SIZE_JO - ESTIMATED_MINUTES_BADGE_WIDTH) / 2,
+    top: (DOT_SIZE_JO - ESTIMATED_MINUTES_BADGE_HEIGHT) / 2,
+    width: ESTIMATED_MINUTES_BADGE_WIDTH,
+    height: ESTIMATED_MINUTES_BADGE_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  estimatedMinutesText: {
+    fontSize: isTablet ? 38 : 28,
+    lineHeight: isTablet ? 40 : 30,
   },
 });
 
@@ -416,13 +434,16 @@ const LineBoardJO: React.FC<Props> = ({ stations, lineColors }: Props) => {
                     bottom: getBottom(i),
                     width: dotSize,
                     height: dotSize,
-                    justifyContent: 'center',
-                    alignItems: 'center',
                   },
                 ]}
               >
                 {estimatedMinutes != null ? (
-                  <EstimatedMinutesBadge estimatedMinutes={estimatedMinutes} />
+                  <View style={localStyles.estimatedMinutesBadgeContainer}>
+                    <EstimatedMinutesBadge
+                      estimatedMinutes={estimatedMinutes}
+                      style={localStyles.estimatedMinutesText}
+                    />
+                  </View>
                 ) : null}
                 {i === stations.length - 1 && estimatedMinutes != null ? (
                   <View

--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -68,6 +68,14 @@ const styles = StyleSheet.create({
     lineHeight: isTablet
       ? Math.round(24 * 1.5 * TLC_SCALE)
       : Math.round(24 * TLC_SCALE),
+    // Androidはグリフが行ボックス下寄りに描画されTLCが下がって見えるため
+    // 上方向に補正して上下中央に揃える(iOSは補正不要)。
+    // 負マージンだと下のアイコンごと動いてバッジ全体が縮むため、
+    // レイアウトに影響しないtransformで文字だけを持ち上げる
+    transform:
+      Platform.OS === 'android'
+        ? [{ translateY: Math.round(-6 * TLC_SCALE) }]
+        : [],
   },
   tlcIconRoot: {
     width: isTablet

--- a/src/components/PadArch.tsx
+++ b/src/components/PadArch.tsx
@@ -1,4 +1,4 @@
-import { darken } from 'polished';
+import { darken, readableColor } from 'polished';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Animated, Easing, StyleSheet, View } from 'react-native';
 import { Path, Svg } from 'react-native-svg';
@@ -224,8 +224,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   estimatedMinutesText: {
-    fontSize: 28,
-    lineHeight: 30,
+    fontSize: 42,
+    lineHeight: 45,
+  },
+  // ETA数字はドット内に単位なしで表示されるため、最上段ドットの右下に
+  // カッコ付きの単位「(分)/(min)」を添えて数字の意味を示す(PadArch固有表記)。
+  // Yogaはwidth未指定の絶対配置子を親幅上限で測るため明示widthが必須
+  estimatedMinutesUnitOverlay: {
+    position: 'absolute',
+    width: 68,
+    height: 18,
+    justifyContent: 'center',
+  },
+  estimatedMinutesUnitText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    lineHeight: 18,
   },
   clipViewStyle: {
     overflow: 'hidden',
@@ -539,6 +553,14 @@ const PadArch: React.FC<Props> = ({
     [stations, trainTypeLines, hexLineColor, windowHeight]
   );
 
+  // 単位ラベルは最上段のバンド色の上に重なるため、黒字の視認性が悪い
+  // 暗色バンドの場合のみ白へ切り替える(デフォルトは駅名と同じ#333)
+  const estimatedMinutesUnitColor = useMemo(
+    () =>
+      readableColor(colorSegments[0]?.color ?? hexLineColor, '#333', '#fff'),
+    [colorSegments, hexLineColor]
+  );
+
   const dynamicStyles = useMemo(() => {
     const chevronY = (4 * windowHeight) / 7 + 84;
     const chevronArrivedY = (4 * windowHeight) / 7;
@@ -796,6 +818,29 @@ const PadArch: React.FC<Props> = ({
                     estimatedMinutes={estimatedMinutes}
                     style={styles.estimatedMinutesText}
                   />
+                </View>
+              ) : null}
+              {i === 0 && estimatedMinutes != null ? (
+                <View
+                  style={[
+                    styles.estimatedMinutesUnitOverlay,
+                    {
+                      // ドット(68px)の右側、縦はドット中央より少し下寄り
+                      left: dotStyle.left + 68 + 4,
+                      top: dotStyle.top + (68 - 18) / 2 + 6,
+                    },
+                  ]}
+                  pointerEvents="none"
+                >
+                  <Typography
+                    style={[
+                      styles.estimatedMinutesUnitText,
+                      { color: estimatedMinutesUnitColor },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {isEn ? '(min)' : '(分)'}
+                  </Typography>
                 </View>
               ) : null}
               <View


### PR DESCRIPTION
## 概要

ETA（到着予想時分）数字を拡大して視認性を高め、PadArch には数字の意味を示す単位ラベル「(分)/(min)」を追加しました。あわせて Android で TLC（スリーレターコード）の文字がバッジ内で下寄りに見える問題を修正しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `LineBoardJO.tsx`: ETA 数字のフォントを拡大（スマホ 22→24px、タブレット 30→38px）。ドット幅を超えるサイズになるため、明示 width の絶対配置コンテナでドット中心に重ねる構成に変更（width 未指定の絶対配置子は親＝ドット幅上限で測られて数字が折り返されるため）
- `PadArch.tsx`: ETA 数字を 28→42px に拡大し、最上段ドットの右横に単位ラベル「(分)/(min)」を追加。ラベルはバンド色の上に重なるため、`readableColor` で暗色バンドのときのみ文字色を白（既定は駅名と同じ `#333`）に切り替え
- `NumberingIconSquare.tsx`: Android では TLC のグリフが行ボックス下寄りに描画されて下がって見えるため、レイアウトに影響しない `transform` で文字だけを上方向に補正（iOS は補正不要）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 未通過駅のETAバッジをドット中央に重ねて表示し、視認性を向上しました。
  * ETAの単位（分／min）を表示するようになりました。
  * 背景色に応じて単位ラベルの文字色を調整し、読みやすくしました。
  * Androidで駅番号テキストの上下位置を補正し、表示のずれを軽減しました。
  * ETA数値のサイズや配置を調整し、全体のバランスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->