### PR TITLE
ETAアンカーの記録を停車駅到着・発車時のみに限定し通過駅では更新しないよう修正

### DIFF
--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
+import { StopCondition } from '~/@types/graphql';
 import { createStation } from '~/utils/test/factories';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
 import {
@@ -15,6 +16,7 @@ import { useEtaAnchor } from './useEtaAnchor';
 const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
 
 const stationA = createStation(1);
+const passStation = createStation(2, { stopCondition: StopCondition.Not });
 const boundStation = createStation(99);
 
 const renderWithStore = (
@@ -99,6 +101,35 @@ describe('useEtaAnchor', () => {
       kind: 'DEPARTED',
       observedAtMs: 2_001_000,
     });
+  });
+
+  it('通過駅への到着ではアンカーが記録されない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_000_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: passStation });
+
+    expect(store.get(etaAnchorAtom)).toBeNull();
+
+    // 定期更新でも記録されないままであることを確認する
+    act(() => {
+      jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
+    });
+    expect(store.get(etaAnchorAtom)).toBeNull();
+  });
+
+  it('通過駅からの発車では DEPARTED が記録されない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_100_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: passStation });
+    expect(store.get(etaAnchorAtom)).toBeNull();
+
+    act(() => {
+      store.set(arrivedAtom, false);
+    });
+
+    expect(store.get(etaAnchorAtom)).toBeNull();
   });
 
   it('selectedBound が null になると anchor が null にクリアされる', () => {

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -6,6 +6,7 @@ import {
   selectedBoundAtom,
   stationAtom,
 } from '../store/atoms/station';
+import getIsPass from '../utils/isPass';
 import { useInterval } from './useInterval';
 
 // AT_STATION の observedAtMs 更新周期。arrived/station が変化しない間も
@@ -16,6 +17,11 @@ const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
  * GPSで最後に確定した駅イベント(到着中/発車)を etaAnchorAtom へ記録するフック。
  * このアンカーは ETA 推定フェーズ(getEtaPhaseNow)の仮想時計の起点として使われ、
  * 精度劣化時の到着しきい値緩和(R1)の対象駅判定に用いられる。
+ *
+ * 通過駅(getIsPass)は記録対象外とする。ETAのstops(useEtaFallback)は
+ * stopsHere === true の停車駅のみを持つため、通過駅IDでアンカーを記録しても
+ * estimateEtaPhase側でi0が見つからずnullになるだけで、無駄にアンカーを
+ * 上書きして直前の有効な停車駅アンカーを消してしまう。
  */
 export const useEtaAnchor = (): void => {
   const arrived = useAtomValue(arrivedAtom);
@@ -43,13 +49,18 @@ export const useEtaAnchor = (): void => {
       return;
     }
 
-    if (arrived && station?.id != null) {
+    if (arrived && station?.id != null && !getIsPass(station)) {
       setAnchor({
         stationId: station.id,
         kind: 'AT_STATION',
         observedAtMs: Date.now(),
       });
-    } else if (prevArrived && !arrived && prevStation?.id != null) {
+    } else if (
+      prevArrived &&
+      !arrived &&
+      prevStation?.id != null &&
+      !getIsPass(prevStation)
+    ) {
       // 到着中→非到着への遷移(=発車)を検出した瞬間にだけ一発記録する。ETAは位置を
       // 駆動せず到着しきい値の緩和(R1)にしか使わないため、仮に静止中の強制未到着で
       // 記録されても、R1は最寄り駅とETA停車駅が一致するときだけ効き、GPS復帰で自己修復する。
@@ -67,7 +78,12 @@ export const useEtaAnchor = (): void => {
   // arrived/station が変化しない間も経過時間だけは進むため、数秒おきに
   // observedAtMsを更新し続ける(仮想時計の基準時刻を最新に保つ)
   useInterval(() => {
-    if (selectedBound != null && arrived && station?.id != null) {
+    if (
+      selectedBound != null &&
+      arrived &&
+      station?.id != null &&
+      !getIsPass(station)
+    ) {
       setAnchor({
         stationId: station.id,
         kind: 'AT_STATION',


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

駅通過時にもETAアンカー(GPSで最後に確定した駅イベント)が記録されてしまい、停車を伴わない通過駅で有効なアンカーが上書き・消失していた挙動を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useEtaAnchor` で `AT_STATION` / `DEPARTED` アンカーの記録対象から通過駅(`getIsPass`)を除外
- 5秒間隔の `AT_STATION` 定期更新でも同様に通過駅を除外
- 通過駅への到着・発車ではアンカーが更新されないことを確認するテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQBuDmdJEhNX2xkB1jreQk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 通過駅が到着時刻や発車時刻の基準として誤って記録される問題を修正しました。
  * 通過駅に対する定期的な時刻更新を抑止し、到着・発車情報の精度を向上しました。
  * 通過駅から発車した際に、誤った発車記録が残らないよう改善しました。

* **テスト**
  * 通過駅の到着、定期更新、発車に関する動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->