### PR TITLE
AndroidビルドワークフローのSSH書き換え範囲をMobileAppFontsサブモジュールに限定し本体リポジトリのcloneを修正

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -71,7 +71,7 @@ jobs:
           ssh-private-key: ${{ secrets.FONTS_SSH_KEY }}
 
       - name: Use SSH for GitHub submodules
-        run: git config --global url."git@github.com:".insteadOf "https://github.com/"
+        run: git config --global url."git@github.com:TrainLCD/MobileAppFonts.git".insteadOf "https://github.com/TrainLCD/MobileAppFonts.git"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
       - name: Revoke submodule SSH access
         run: |
-          git config --global --unset-all url."git@github.com:".insteadOf || true
+          git config --global --unset-all url."git@github.com:TrainLCD/MobileAppFonts.git".insteadOf || true
           if [ -n "${SSH_AGENT_PID:-}" ]; then
             kill "$SSH_AGENT_PID" || true
           fi


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Android ビルドワークフロー（`.github/workflows/build_android.yml`）で、サブモジュール用の SSH URL 書き換えが `github.com` 全体に及んでいたため、後続の `actions/checkout` による本体リポジトリの取得までSSH経由になり `Permission denied (publickey)` で clone 自体が失敗していました（[Run #29683473036](https://github.com/TrainLCD/MobileApp/actions/runs/29683473036)）。書き換え対象を非公開フォントサブモジュール `TrainLCD/MobileAppFonts.git` 一つに限定し、本体リポジトリは通常どおり `GITHUB_TOKEN` の HTTPS 認証で clone されるように修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `Use SSH for GitHub submodules` ステップの `git config --global url."git@github.com:".insteadOf "https://github.com/"` を `git@github.com:TrainLCD/MobileAppFonts.git` / `https://github.com/TrainLCD/MobileAppFonts.git` の対応に限定
- `Revoke submodule SSH access` ステップの `--unset-all` 対象も同じURLに合わせて修正

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: `src/` 配下などアプリ本体のコード変更が無いため

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJX4GYtiC5d45YWdX6novv)_