### PR TITLE
AndroidビルドワークフローにGoogle Play内部テストトラックへのAABアップロードを追加

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -15,6 +15,11 @@ on:
         options:
           - devRelease
           - prodRelease
+      upload_to_play:
+        description: "Upload the AAB to Google Play (internal track)"
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: build-android-${{ github.ref }}
@@ -34,6 +39,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           INPUT_VARIANT: ${{ github.event.inputs.variant }}
+          UPLOAD_TO_PLAY: ${{ github.event.inputs.upload_to_play }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             variant="$INPUT_VARIANT"
@@ -59,11 +65,19 @@ jobs:
           if [ "$variant" = "prodRelease" ]; then
             echo "gradle_task=:app:bundleProdRelease" >> "$GITHUB_OUTPUT"
             echo "output_dir=prodRelease" >> "$GITHUB_OUTPUT"
+            echo "package_name=me.tinykitten.trainlcd" >> "$GITHUB_OUTPUT"
           else
             echo "gradle_task=:app:bundleDevRelease" >> "$GITHUB_OUTPUT"
             echo "output_dir=devRelease" >> "$GITHUB_OUTPUT"
+            echo "package_name=me.tinykitten.trainlcd.dev" >> "$GITHUB_OUTPUT"
           fi
           echo "variant=$variant" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$UPLOAD_TO_PLAY" = "false" ]; then
+            echo "upload_to_play=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload_to_play=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup SSH for submodules
         uses: webfactory/ssh-agent@v0.9.1
@@ -163,3 +177,14 @@ jobs:
           name: app-${{ steps.build_vars.outputs.variant }}
           path: android/app/build/outputs/bundle/${{ steps.build_vars.outputs.output_dir }}/*.aab
           if-no-files-found: error
+
+      - name: Upload to Google Play (internal track)
+        if: steps.build_vars.outputs.upload_to_play == 'true'
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ steps.build_vars.outputs.package_name }}
+          releaseFiles: android/app/build/outputs/bundle/${{ steps.build_vars.outputs.output_dir }}/*.aab
+          track: internal
+          status: completed
+          mappingFile: android/app/build/outputs/mapping/${{ steps.build_vars.outputs.output_dir }}/mapping.txt


### PR DESCRIPTION
## 概要

`build_android.yml` がAABのビルドとArtifactアップロードで止まっており、Google Playへの提出が手作業だったため、ビルド後にGoogle Play内部テストトラックへ自動アップロードするステップを追加しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- ビルド成功後に `r0adkll/upload-google-play@v1.1.3` でAABをGoogle Playの内部テスト（internal）トラックへアップロードするステップを追加
- R8難読化が有効なため `mapping.txt` も同時にアップロードし、Play Consoleでのクラッシュレポート復号に対応
- `build_vars` ステップでvariantに応じたパッケージ名を出力（`prodRelease` → `me.tinykitten.trainlcd` / `devRelease` → `me.tinykitten.trainlcd.dev`）
- `workflow_dispatch` に `upload_to_play` 入力（既定 `true`）を追加し、手動実行時にビルドのみの運用も可能に（push トリガーでは常にアップロード）

### 必要なセットアップ

- リポジトリシークレット **`PLAY_SERVICE_ACCOUNT_JSON`** の登録が必要です（Google CloudサービスアカウントのJSONキー）。Play Console側で該当サービスアカウントを招待し、両アプリに対してテストトラックへのリリース権限を付与してください。
- 各アプリの初回AABアップロードはPlay Consoleから手動で行っておく必要があります（API経由の初回アップロードは不可のため）。

### 設計判断

`prodRelease` もproductionトラックへの直接公開ではなくinternalトラックへのアップロードとし、ストア公開はPlay Console上でのトラック昇格で行う運用を想定しています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: アプリコードの変更なし（CIワークフローのみ）。YAML構文チェック（`python3 -c "import yaml; ..."`）は実施済み。実際のアップロード動作はシークレット登録後の `workflow_dispatch` 実行での確認が必要です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Androidビルドを手動実行する際、Google Playへのアップロード有無を選択できるようになりました。
  * ビルド成果物をGoogle Playの内部テストトラックへ自動アップロードできるようになりました。
  * 本番版と開発版で、適切なGoogle Playパッケージ名が使用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->