### PR TITLE
ネイティブTTSの漢字誤読対策と英語文への日本語混入時に日本語音声で合成される問題の修正

### DIFF
--- a/src/hooks/tts/templates.ts
+++ b/src/hooks/tts/templates.ts
@@ -21,7 +21,7 @@ const TOKYO_METRO: ThemeTemplate = {
     '次は{nextStationJa}{#if isNextStopTerminus}、終点{/if}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
     '{#if shouldAnnounceAfterNextStop}',
-    '{nextStationJa}の次は{#if isAfterNextStopTerminus}、終点{/if}、{afterNextStationJa}に停まります。',
+    '{nextStationJa}の次は{#if isAfterNextStopTerminus}、終点{/if}、{afterNextStationJa}にとまります。',
     '{/if}',
     '{#if hasBetweenStations}{betweenStationsListJa}へおいでのお客様はお乗り換えです。{/if}',
     '{#if isNextStopThroughBoundary}',
@@ -107,11 +107,11 @@ const JR_WEST: ThemeTemplate = {
     '{boundForJa}ゆきです。',
     '{/if}',
     '{#if shouldAnnounceJrWestStopList}',
-    '{jrWestStopsListJa}の順に停まります。',
+    '{jrWestStopsListJa}の順にとまります。',
     '{#if lastAnnouncedStopIsBound}{:else}{lastAnnouncedStopJa}から先は、後ほどご案内いたします。{/if}',
     '{/if}',
     '次は{#if nextStationIsBound}終点・{/if}{nextStationJa}、{nextStationJa}です。',
-    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}に停まります。{/if}'
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}にとまります。{/if}'
   ),
   ARRIVING: t(
     '{#if nextStationIsBound}',
@@ -122,7 +122,7 @@ const JR_WEST: ThemeTemplate = {
     '{:else}',
     'まもなく{nextStationJa}、{nextStationJa}です。',
     '{#if hasTransferLines}{transferLinesListJa}はお乗り換えです。{/if}',
-    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}に停まります。{/if}',
+    '{#if shouldAnnounceAfterNextStop}{nextStationJa}を出ますと、次は{afterNextStationJa}にとまります。{/if}',
     '{/if}'
   ),
 };

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -213,6 +213,38 @@ describe('useTTS', () => {
     );
   });
 
+  it('英語文に日本語が混入している場合は除去してから読み上げる', async () => {
+    const { useTTSText } = jest.requireMock('./useTTSText') as {
+      useTTSText: jest.Mock;
+    };
+    // nameRoman 欠落データ等で wrapPhoneme のローマ字フォールバックが効かない
+    // ケース。日本語が混じった英語文は TTS エンジンが言語を誤判定して全文を
+    // 日本語音声で合成してしまうため、除去して英語音声を維持する
+    useTTSText.mockReturnValue({
+      text: ['つぎはあかさかです', 'Arriving at あかさか K 7.'],
+    });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+    await flushAsync();
+
+    expect(mockSpeak).toHaveBeenNthCalledWith(
+      2,
+      'Arriving at K 7.',
+      expect.objectContaining({ language: 'en-US' })
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useTTS] English text contains Japanese characters, stripping:',
+      'Arriving at あかさか K 7.'
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('音声一覧の取得完了を待ってから初回発話を開始する', async () => {
     let resolveVoices: (voices: unknown[]) => void = () => {};
     mockGetAvailableVoicesAsync.mockReturnValue(

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -190,7 +190,7 @@ describe('useTTS', () => {
     };
     useTTSText.mockReturnValue({
       text: [
-        'つぎは<break time="250ms"/>おおさき',
+        '次は<break time="250ms"/><sub alias="オオサキ">大崎</sub>です',
         'The next station is <phoneme alphabet="ipa" ph="oːsaki">Osaki</phoneme>,<break time="200ms"/> J Y <say-as interpret-as="cardinal">24</say-as>.',
       ],
     });
@@ -203,7 +203,7 @@ describe('useTTS', () => {
 
     expect(mockSpeak).toHaveBeenNthCalledWith(
       1,
-      'つぎは、おおさき',
+      '次は、オオサキです',
       expect.objectContaining({ language: 'ja-JP' })
     );
     expect(mockSpeak).toHaveBeenNthCalledWith(

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -8,6 +8,10 @@ import speechState, { resetFirstSpeechAtom } from '../store/atoms/speech';
 import { arrivedAtom, selectedBoundAtom } from '../store/atoms/station';
 import { computeSuppressionDecision } from '../utils/computeSuppressionDecision';
 import { selectBestVoiceIdentifier } from '../utils/nativeTtsVoice';
+import {
+  containsJapaneseCharacters,
+  stripJapaneseCharacters,
+} from '../utils/phoneme';
 import { ssmlToPlainText } from '../utils/ssmlToPlainText';
 import { useCurrentLine } from './useCurrentLine';
 import { usePrevious } from './usePrevious';
@@ -259,12 +263,23 @@ export const useTTS = (): void => {
                 ssmlToPlainText(ja, { breakReplacement: '、' })
               )
             : '';
-        const plainEn =
+        let plainEn =
           shouldSpeakEnglish && canSpeakEn
             ? truncateToSpeechLimit(
                 ssmlToPlainText(en, { breakReplacement: ' ' })
               )
             : '';
+        // nameRoman が欠落した駅データ等では wrapPhoneme のローマ字フォール
+        // バックが効かず、英語文に日本語が残ることがある。日本語が混じった
+        // 英語文は voice を明示指定していても TTS エンジンが言語を誤判定して
+        // 全文を日本語音声で合成してしまうため、最終防衛線として除去する
+        if (containsJapaneseCharacters(plainEn)) {
+          console.warn(
+            '[useTTS] English text contains Japanese characters, stripping:',
+            plainEn
+          );
+          plainEn = stripJapaneseCharacters(plainEn);
+        }
 
         const utterances = [
           plainJa

--- a/src/hooks/useTTSText.bus.test.tsx
+++ b/src/hooks/useTTSText.bus.test.tsx
@@ -271,7 +271,7 @@ describe('useTTSText (bus mode)', () => {
       expect(jaText).toContain('今日も');
       expect(jaText).toContain('このバスは');
       expect(jaText).toContain('次は');
-      expect(jaText).toContain('の順に停まります');
+      expect(jaText).toContain('の順にとまります');
       expect(enText).toContain('Thank you for using');
       expect(enText).toContain('This bus is bound for');
     });

--- a/src/hooks/useTTSText.test.tsx
+++ b/src/hooks/useTTSText.test.tsx
@@ -396,7 +396,7 @@ describe('JR_WEST batch cycling', () => {
     );
 
     const [jaText] = result.current.text;
-    expect(jaText).toContain('の順に停まります');
+    expect(jaText).toContain('の順にとまります');
     expect(jaText).toContain('後ほどご案内いたします');
   });
 
@@ -409,7 +409,7 @@ describe('JR_WEST batch cycling', () => {
     );
 
     const [jaText] = result.current.text;
-    expect(jaText).not.toContain('の順に停まります');
+    expect(jaText).not.toContain('の順にとまります');
   });
 
   test('should re-announce stop list after passing batch boundary', () => {
@@ -424,12 +424,12 @@ describe('JR_WEST batch cycling', () => {
       { wrapper }
     );
 
-    expect(result.current.text[0]).toContain('の順に停まります');
+    expect(result.current.text[0]).toContain('の順にとまります');
 
     // Phase 2: firstSpeech=false, still at station 0 → batch boundary set, station still within batch
     firstSpeech = false;
     rerender({});
-    expect(result.current.text[0]).not.toContain('の順に停まります');
+    expect(result.current.text[0]).not.toContain('の順にとまります');
 
     // Phase 3: move to station 5 (神保町) → past batch boundary → re-announce
     // Station index 5 = 神保町, nextStation = 小川町 (index 6)
@@ -437,7 +437,7 @@ describe('JR_WEST batch cycling', () => {
     stationIndex = 5;
     rerender({});
 
-    expect(result.current.text[0]).toContain('の順に停まります');
+    expect(result.current.text[0]).toContain('の順にとまります');
     expect(result.current.text[1]).toContain('We will be stopping at');
   });
 });

--- a/src/utils/phoneme.test.ts
+++ b/src/utils/phoneme.test.ts
@@ -1,5 +1,9 @@
 import { TtsAlphabet, type TtsSegment } from '~/@types/graphql';
-import { containsJapaneseCharacters, wrapPhoneme } from './phoneme';
+import {
+  containsJapaneseCharacters,
+  stripJapaneseCharacters,
+  wrapPhoneme,
+} from './phoneme';
 
 const ipaSegment = (
   surface: string | null,
@@ -63,6 +67,26 @@ describe('wrapPhoneme', () => {
     );
     expect(result).toBe(
       '<phoneme alphabet="ipa" ph="ɕiɲdʑɯkɯ">Shinjuku</phoneme>'
+    );
+  });
+});
+
+describe('stripJapaneseCharacters', () => {
+  it('英語文に混入した日本語の連続を除去する', () => {
+    expect(stripJapaneseCharacters('Arriving at あかさか K 7.')).toBe(
+      'Arriving at K 7.'
+    );
+  });
+
+  it('全角記号・句読点も含めて除去する', () => {
+    expect(
+      stripJapaneseCharacters('The next stop is 大崎・品川方面、 Osaki.')
+    ).toBe('The next stop is Osaki.');
+  });
+
+  it('日本語を含まないテキストはそのまま返す', () => {
+    expect(stripJapaneseCharacters('Arriving at Akasaka K 7.')).toBe(
+      'Arriving at Akasaka K 7.'
     );
   });
 });

--- a/src/utils/phoneme.ts
+++ b/src/utils/phoneme.ts
@@ -67,6 +67,23 @@ const stripTagsForInspection = (ssml: string): string =>
 export const containsJapaneseCharacters = (text: string): boolean =>
   JAPANESE_CHAR_REGEXP.test(text);
 
+// 日本語文字と全角記号（CJK記号・全角英数を含む）の連続。英語テキストからの
+// 除去に使うため、検知用より広く全角圏の文字を対象にする
+const JAPANESE_RUN_REGEXP = /[　-ヿ㐀-䶿一-鿿豈-﫿＀-￯]+/g;
+
+/**
+ * 英語向けテキストから日本語文字の連続を除去する。
+ * nameRoman が欠落した駅データ等ではローマ字へのフォールバックが効かず、
+ * 英語文に日本語が残ることがある。日本語が混じった英語文は TTS エンジンが
+ * 言語を誤判定して全文を日本語音声で合成してしまうため、固有名詞が欠けても
+ * 正しい英語音声で読み上げる方を優先する（最終防衛線）。
+ */
+export const stripJapaneseCharacters = (text: string): string =>
+  text
+    .replace(JAPANESE_RUN_REGEXP, ' ')
+    .replace(/[\t ]+/g, ' ')
+    .trim();
+
 /**
  * TtsSegment 配列を SSML 文字列に変換する。連続する IPA セグメントは単一の phoneme タグに結合する。segments が空の場合は fallback を返す。
  *

--- a/src/utils/ssmlToPlainText.test.ts
+++ b/src/utils/ssmlToPlainText.test.ts
@@ -18,6 +18,30 @@ describe('ssmlToPlainText', () => {
     ).toBe('the Yamanote Line, and the Saikyo Line');
   });
 
+  it('sub タグは alias (読み) を採用して漢字誤読を防ぐ', () => {
+    expect(
+      ssmlToPlainText(
+        '次は<sub alias="シンジュクサンチョウメ">新宿三丁目</sub>です。'
+      )
+    ).toBe('次はシンジュクサンチョウメです。');
+  });
+
+  it('sub タグの alias 内の実体参照を復元する', () => {
+    expect(ssmlToPlainText('<sub alias="A &amp; B">エーアンドビー</sub>')).toBe(
+      'A & B'
+    );
+  });
+
+  it('複数の sub タグをそれぞれ alias に置き換える', () => {
+    expect(
+      ssmlToPlainText(
+        '<sub alias="トウキョウメトロマルノウチセン">東京メトロ丸ノ内線</sub>、<sub alias="トウキョウメトロフクトシンセン">東京メトロ副都心線</sub>はお乗り換えです。'
+      )
+    ).toBe(
+      'トウキョウメトロマルノウチセン、トウキョウメトロフクトシンセンはお乗り換えです。'
+    );
+  });
+
   it('phoneme タグは中身の表記テキストを残す', () => {
     expect(
       ssmlToPlainText(

--- a/src/utils/ssmlToPlainText.ts
+++ b/src/utils/ssmlToPlainText.ts
@@ -2,6 +2,8 @@
 // 旧外部 TTS API (Azure Speech) 向けの SSML 断片を生成する。OS ネイティブ TTS
 // (expo-speech) は SSML を解釈せずタグをそのまま読み上げてしまうため、
 // 読み上げ直前にプレーンテキストへ変換する。
+// - <sub alias="読み">表記</sub> は alias (カタカナ読み) を採用する。表記の
+//   漢字をそのまま残すと TTS エンジンが誤読するため (例: 固有の駅名読み)
 // - <break time="..."/> はポーズ相当の区切り文字に置き換える (言語別に指定)
 // - <phoneme ph="...">表記</phoneme> や <say-as>5</say-as> は中身のテキストを残す
 //   (IPA 発音記号は失われるが、fallbackText / surface が読み上げ可能な表記を持つ)
@@ -20,6 +22,12 @@ export const ssmlToPlainText = (
   const breakReplacement = options?.breakReplacement ?? '、';
   return (
     ssml
+      // <sub alias="読み">表記</sub> は読み (alias) を残す。SSML の意味論どおり
+      // 表記の代わりに alias を読み上げさせる (漢字誤読の防止)
+      .replace(
+        /<sub\b[^>]*\balias="([^"]*)"[^>]*>([^<]*)<\/sub>/gi,
+        (_match, alias) => alias
+      )
       .replace(/<break\b[^>]*>/gi, breakReplacement)
       .replace(/<[^>]+>/g, '')
       // 実体参照の復元はタグ除去の後に行う。先に &lt; を戻すと本文由来の


### PR DESCRIPTION
## 概要

OS ネイティブ TTS の読み上げにおける言語・読みの不整合への対策です。iOS で「に停まります」が「にていります」と読まれる報告を受けたひらがな化と `<sub>` タグのカタカナ読み採用に加えて、英語文に日本語が混入した際に日本語音声で全文が合成される問題の最終防衛線（発話前の日本語除去）を追加しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ssmlToPlainText` で `<sub alias="読み">表記</sub>` を alias（カタカナ読み）へ置き換えるよう修正。これまでタグ除去で中身の漢字が残り、駅名・路線名に対してデータが持つ正しい読み（`nameKatakana` 由来）が捨てられてエンジン任せの漢字読みになっていた
- TTS テンプレートの「〜に停まります」「〜の順に停まります」（4 箇所）をひらがな表記「とまります」へ変更（iOS の読み上げで「にていります」と誤読されるため）。TTS 専用テンプレートのため画面表示には影響しない
- 英語発話の直前に日本語文字の混入を検知した場合、警告ログを出力して除去する最終防衛線を追加（`stripJapaneseCharacters`）。`nameRoman` が欠落した駅データでは `wrapPhoneme` のローマ字フォールバックが効かず英語文に日本語が残ることがあり、日本語が混じった英語文は voice を明示指定していても TTS エンジンが言語を誤判定して全文を日本語音声で合成してしまうため、固有名詞が欠けても正しい英語音声で読む方を優先する
- 単体テスト追加: `ssmlToPlainText` の sub タグ処理、`stripJapaneseCharacters`、`useTTS` の日本語混入時の除去・警告

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint` / `npm run typecheck` / `npm test`（193 スイート / 2077 件）すべてパス。

補足: 英語文への日本語混入が検知された場合は `[useTTS] English text contains Japanese characters, stripping:` の警告と対象テキストが Metro コンソールに出力されます。該当駅のデータ（`nameRoman` / `nameTtsSegments`）修正の手がかりになります。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 日本語の駅案内表現を「とまります」に統一し、音声案内の表記を自然にしました。
  - SSMLの読み仮名を正しく反映し、駅名などの誤読を防止しました。
  - 英語音声に混入した日本語を自動除去し、英語として正しく読み上げられるよう改善しました。
  - SSML内の複数の読み仮名や特殊文字にも対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->