### PR TITLE
TTS再生完了後もダッキングが残存する不具合を修正し、発話直前のみduckOthersを有効化するよう変更

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -733,7 +733,10 @@ describe('useTTS', () => {
 
     // 発話開始直後（ダッキング有効中）に設定変更でbackgroundEnabledが変わる
     expect(mockSetAudioModeAsync).toHaveBeenLastCalledWith(
-      expect.objectContaining({ interruptionMode: 'duckOthers' })
+      expect.objectContaining({
+        interruptionMode: 'duckOthers',
+        interruptionModeAndroid: 'duckOthers',
+      })
     );
 
     mockSetAudioModeAsync.mockClear();
@@ -746,9 +749,12 @@ describe('useTTS', () => {
     await flushAsync();
 
     // backgroundEnabled変更の再設定でダッキングがmixWithOthersへ巻き戻らない
+    // （Android側のinterruptionModeAndroidのみ戻る退行も検知できるよう
+    // 両方のプロパティを検証する）
     expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         interruptionMode: 'duckOthers',
+        interruptionModeAndroid: 'duckOthers',
         shouldPlayInBackground: true,
       })
     );

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -646,4 +646,86 @@ describe('useTTS', () => {
 
     expect(mockSpeechStop).toHaveBeenCalled();
   });
+
+  it('発話開始直前にダッキングを有効化し、全発話完了後に解除する', async () => {
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+    await flushAsync();
+
+    // マウント時点では非ダッキング（mixWithOthers）が既定
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'mixWithOthers' })
+    );
+
+    // 発話開始直前にダッキングが有効化される
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'duckOthers' })
+    );
+
+    mockSetAudioModeAsync.mockClear();
+
+    // 保留中の発話が無い状態で全発話を完了させると、ダッキングが解除される
+    act(() => {
+      finishAllUtterances();
+    });
+    await flushAsync();
+
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'mixWithOthers' })
+    );
+  });
+
+  it('保留中の発話がある場合はダッキングを解除せず継続する', async () => {
+    const { useTTSText } = jest.requireMock('./useTTSText') as {
+      useTTSText: jest.Mock;
+    };
+
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    const { rerender } = renderHook(() => useTTS(), {
+      wrapper: createWrapper(store),
+    });
+    await flushAsync();
+
+    useTTSText.mockReturnValue({
+      text: ['ja text 2', 'en text 2'],
+    });
+    rerender({});
+
+    mockSetAudioModeAsync.mockClear();
+
+    // 保留中の次の発話があるため、完了直後はダッキングを解除しない
+    act(() => {
+      finishAllUtterances();
+    });
+    await flushAsync();
+
+    expect(mockSetAudioModeAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'mixWithOthers' })
+    );
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'duckOthers' })
+    );
+  });
+
+  it('発話中にアンマウントされた場合もダッキングを解除する', async () => {
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    const { unmount } = renderHook(() => useTTS(), {
+      wrapper: createWrapper(store),
+    });
+    await flushAsync();
+
+    mockSetAudioModeAsync.mockClear();
+
+    unmount();
+
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'mixWithOthers' })
+    );
+  });
 });

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -664,6 +664,19 @@ describe('useTTS', () => {
       expect.objectContaining({ interruptionMode: 'duckOthers' })
     );
 
+    // duckOthers の呼び出し有無だけでなく、Speech.speak より前に呼ばれる
+    // ことも検証する（speak の後にダッキングする退行を検知するため）
+    const duckCallOrder = mockSetAudioModeAsync.mock.calls
+      .map((call, index) =>
+        (call[0] as { interruptionMode: string }).interruptionMode ===
+        'duckOthers'
+          ? mockSetAudioModeAsync.mock.invocationCallOrder[index]
+          : null
+      )
+      .filter((order): order is number => order !== null)[0];
+    const firstSpeakCallOrder = mockSpeak.mock.invocationCallOrder[0];
+    expect(duckCallOrder).toBeLessThan(firstSpeakCallOrder);
+
     mockSetAudioModeAsync.mockClear();
 
     // 保留中の発話が無い状態で全発話を完了させると、ダッキングが解除される
@@ -708,6 +721,39 @@ describe('useTTS', () => {
     );
     expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
       expect.objectContaining({ interruptionMode: 'duckOthers' })
+    );
+  });
+
+  it('発話中にbackgroundEnabledが変化してもダッキングを維持する', async () => {
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+    await flushAsync();
+
+    // 発話開始直後（ダッキング有効中）に設定変更でbackgroundEnabledが変わる
+    expect(mockSetAudioModeAsync).toHaveBeenLastCalledWith(
+      expect.objectContaining({ interruptionMode: 'duckOthers' })
+    );
+
+    mockSetAudioModeAsync.mockClear();
+    act(() => {
+      store.set(speechState, {
+        ...defaultSpeechState,
+        backgroundEnabled: true,
+      });
+    });
+    await flushAsync();
+
+    // backgroundEnabled変更の再設定でダッキングがmixWithOthersへ巻き戻らない
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interruptionMode: 'duckOthers',
+        shouldPlayInBackground: true,
+      })
+    );
+    expect(mockSetAudioModeAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ interruptionMode: 'mixWithOthers' })
     );
   });
 

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -158,17 +158,21 @@ export const useTTS = (): void => {
 
   // OS ネイティブ TTS は expo-audio のプレイヤーを使わないが、iOS の
   // AVSpeechSynthesizer はアプリの音声セッションを共有するため、
-  // サイレントスイッチ中の読み上げ・バックグラウンド再生・他アプリ音声の
-  // ダッキングはここで設定した audio mode に従う。
+  // サイレントスイッチ中の読み上げ・バックグラウンド再生はここで設定した
+  // audio mode に従う。他アプリ音声のダッキングは発話開始直前にのみ有効化し
+  // （setDuckingActiveAsync 参照）、ここでは非ダッキング状態を既定にする。
+  const backgroundEnabledRef = useRef(backgroundEnabled);
+  backgroundEnabledRef.current = backgroundEnabled;
+
   useEffect(() => {
     (async () => {
       try {
         await setAudioModeAsync({
           allowsRecording: false,
           shouldPlayInBackground: backgroundEnabled,
-          interruptionMode: 'duckOthers',
+          interruptionMode: 'mixWithOthers',
           playsInSilentMode: true,
-          interruptionModeAndroid: 'duckOthers',
+          interruptionModeAndroid: 'mixWithOthers',
           shouldRouteThroughEarpiece: false,
         });
       } catch (e) {
@@ -176,6 +180,25 @@ export const useTTS = (): void => {
       }
     })();
   }, [backgroundEnabled]);
+
+  // 発話中だけ他アプリ音声をダッキングし、完了後は mixWithOthers へ戻す。
+  // duckOthers を張ったままにすると、AVAudioSession は再生停止後も
+  // 他アプリの音量を復元しないことがあり、ダッキングが残存し続けるため、
+  // interruptionMode 自体を切り替えて明示的に解除する。
+  const setDuckingActiveAsync = useCallback(async (duck: boolean) => {
+    try {
+      await setAudioModeAsync({
+        allowsRecording: false,
+        shouldPlayInBackground: backgroundEnabledRef.current,
+        interruptionMode: duck ? 'duckOthers' : 'mixWithOthers',
+        playsInSilentMode: true,
+        interruptionModeAndroid: duck ? 'duckOthers' : 'mixWithOthers',
+        shouldRouteThroughEarpiece: false,
+      });
+    } catch (e) {
+      console.warn('[useTTS] setAudioModeAsync (ducking) failed:', e);
+    }
+  }, []);
 
   // playingRefのリセットとpending処理を一元化してデッドロックを防止
   const finishPlaying = useCallback(() => {
@@ -188,8 +211,12 @@ export const useTTS = (): void => {
     if (pending) {
       pendingRef.current = null;
       speechWithTextRef.current?.(pending.textJa, pending.textEn);
+    } else {
+      // 後続の発話が控えていない場合のみ解除する。pending がある場合は
+      // 直後に再度発話が始まりダッキングを再度張るため、解除は不要。
+      void setDuckingActiveAsync(false);
     }
-  }, []);
+  }, [setDuckingActiveAsync]);
 
   // 発話開始時に安全タイムアウトを張る。OS の TTS エンジンから完了・エラー・
   // 停止のいずれのコールバックも届かないままハングした場合でも、playingRef を
@@ -311,6 +338,15 @@ export const useTTS = (): void => {
           return;
         }
 
+        // 実際に読み上げる直前にのみ他アプリ音声のダッキングを有効化する
+        await setDuckingActiveAsync(true);
+        if (isStaleRun()) {
+          // このrunは既に無効化されている（タイムアウトやアンマウントで
+          // 別経路がクリーンアップ済み）。直前で張ったダッキングだけ解除する
+          void setDuckingActiveAsync(false);
+          return;
+        }
+
         if (firstSpeechRef.current) {
           firstSpeechRef.current = false;
           suppressPostFirstSpeechRef.current = true;
@@ -352,6 +388,7 @@ export const useTTS = (): void => {
     [
       armPlaybackWatchdog,
       finishPlaying,
+      setDuckingActiveAsync,
       shouldSpeakEnglish,
       shouldSpeakJapanese,
       waitForVoicesReady,
@@ -431,6 +468,8 @@ export const useTTS = (): void => {
         Speech.stop();
       } catch {}
       playingRef.current = false;
+      // 発話中にアンマウントされた場合、ダッキングが張られたまま残るのを防ぐ
+      void setDuckingActiveAsync(false);
     };
-  }, []);
+  }, [setDuckingActiveAsync]);
 };

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -163,42 +163,45 @@ export const useTTS = (): void => {
   // （setDuckingActiveAsync 参照）、ここでは非ダッキング状態を既定にする。
   const backgroundEnabledRef = useRef(backgroundEnabled);
   backgroundEnabledRef.current = backgroundEnabled;
+  // 直近に要求したダッキング状態。backgroundEnabled 変更時の再設定で
+  // 発話中のダッキングを誤って mixWithOthers に巻き戻さないよう保持する
+  const duckingActiveRef = useRef(false);
 
-  useEffect(() => {
-    (async () => {
+  const applyAudioModeAsync = useCallback(
+    async (duck: boolean, shouldPlayInBackground: boolean) => {
       try {
         await setAudioModeAsync({
           allowsRecording: false,
-          shouldPlayInBackground: backgroundEnabled,
-          interruptionMode: 'mixWithOthers',
+          shouldPlayInBackground,
+          interruptionMode: duck ? 'duckOthers' : 'mixWithOthers',
           playsInSilentMode: true,
-          interruptionModeAndroid: 'mixWithOthers',
+          interruptionModeAndroid: duck ? 'duckOthers' : 'mixWithOthers',
           shouldRouteThroughEarpiece: false,
         });
       } catch (e) {
         console.warn('[useTTS] setAudioModeAsync failed:', e);
       }
-    })();
-  }, [backgroundEnabled]);
+    },
+    []
+  );
+
+  useEffect(() => {
+    // backgroundEnabled の変更を反映する際も、発話中なら現在のダッキング
+    // 状態（duckingActiveRef）を維持したまま再設定する
+    void applyAudioModeAsync(duckingActiveRef.current, backgroundEnabled);
+  }, [backgroundEnabled, applyAudioModeAsync]);
 
   // 発話中だけ他アプリ音声をダッキングし、完了後は mixWithOthers へ戻す。
   // duckOthers を張ったままにすると、AVAudioSession は再生停止後も
   // 他アプリの音量を復元しないことがあり、ダッキングが残存し続けるため、
   // interruptionMode 自体を切り替えて明示的に解除する。
-  const setDuckingActiveAsync = useCallback(async (duck: boolean) => {
-    try {
-      await setAudioModeAsync({
-        allowsRecording: false,
-        shouldPlayInBackground: backgroundEnabledRef.current,
-        interruptionMode: duck ? 'duckOthers' : 'mixWithOthers',
-        playsInSilentMode: true,
-        interruptionModeAndroid: duck ? 'duckOthers' : 'mixWithOthers',
-        shouldRouteThroughEarpiece: false,
-      });
-    } catch (e) {
-      console.warn('[useTTS] setAudioModeAsync (ducking) failed:', e);
-    }
-  }, []);
+  const setDuckingActiveAsync = useCallback(
+    async (duck: boolean) => {
+      duckingActiveRef.current = duck;
+      await applyAudioModeAsync(duck, backgroundEnabledRef.current);
+    },
+    [applyAudioModeAsync]
+  );
 
   // playingRefのリセットとpending処理を一元化してデッドロックを防止
   const finishPlaying = useCallback(() => {


### PR DESCRIPTION
## 概要



## 変更の種類



- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容



- `src/hooks/useTTS.ts`: `expo-audio` の audio mode 既定を `duckOthers` から `mixWithOthers`（非ダッキング）に変更し、実際に `Speech.speak()` を呼ぶ直前にのみ `duckOthers` を有効化する `setDuckingActiveAsync` を追加
- 全発話完了時（pending な発話が無い場合）にダッキングを `mixWithOthers` へ明示的に解除するよう `finishPlaying` を修正
- 発話中のアンマウントや、タイムアウト・世代交代による無効化が発生した場合もダッキングを解除するようにフォールバックを追加
- 発話中に `backgroundEnabled` 設定が変化しても、直近に要求したダッキング状態（`duckingActiveRef`）を維持したまま audio mode を再設定するよう修正し、設定変更で発話中のダッキングが誤って解除される不具合を防止（CodeRabbitレビュー指摘対応）
- `src/hooks/useTTS.test.ts`: 発話直前のダッキング有効化、全発話完了後の解除、pending 発話継続中は解除しないこと、アンマウント時の解除、`Speech.speak` より前にダッキングする呼び出し順序、発話中の `backgroundEnabled` 変化でダッキング（iOS/Android 双方の interruptionMode）を維持することを検証する回帰テストを追加

## テスト



- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue



## スクリーンショット（任意）




---
_Generated by [Claude Code](https://claude.ai/code/session_01JasivPGu8vLpL5nbg4KCMW)_



## Summary by CodeRabbit

* **改善**
  * 音声読み上げ中のみ、他のアプリの音声を適切に小さくするよう改善しました。
  * 読み上げ完了時や中断時、画面を離れた際には、他の音声が通常どおり再生されるようになりました。
  * 待機中の読み上げがある場合は、音声が途切れないよう音量調整を維持します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 音声読み上げ中だけ、他アプリの音声を適切に小さくするダッキング挙動を改善しました（発話直前に反映）。
  * 読み上げの完了・中断・アンマウント時には、通常の音量状態へ確実に戻るよう改善しました。
  * バックグラウンド再生設定の変更や連続した発話時も、ダッキング状態を適切に維持するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->