### PR TITLE
TTS読み上げ音量を機種既定値に依存せず常に最大へ明示指定

### DIFF
--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -27,6 +27,10 @@ const PLAYBACK_TIMEOUT_MS = 300_000;
 const JA_SPEECH_LANGUAGE = 'ja-JP';
 const EN_SPEECH_LANGUAGE = 'en-US';
 
+// expo-speech は volume 未指定時の既定値が機種・OSバージョンにより最大音量
+// より低くなることがあるため、常に最大値を明示指定して音量が下がる余地を無くす。
+const MAX_SPEECH_VOLUME = 1.0;
+
 // 発話開始前に音声選択（getAvailableVoicesAsync）の完了を待つ上限（ミリ秒）。
 // Android の TTS エンジン初期化がハングした場合でも、この時間を超えたら
 // 音声未指定のまま発話へ進み、アナウンス全体が止まらないようにする。
@@ -377,6 +381,7 @@ export const useTTS = (): void => {
         for (const utterance of utterances) {
           Speech.speak(utterance.text, {
             language: utterance.language,
+            volume: MAX_SPEECH_VOLUME,
             ...(utterance.voice ? { voice: utterance.voice } : {}),
             onDone: settle,
             onStopped: settle,


### PR DESCRIPTION
## 概要

TTSアナウンスの音量が低すぎるというユーザー報告への対応です。`expo-speech` の `Speech.speak()` に `volume` オプションが未指定のままだったため、端末・OSバージョンのデフォルト音量に発話音量が左右されていました。常に最大音量 (`1.0`) を明示指定するようにしました。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useTTS.ts`: `MAX_SPEECH_VOLUME = 1.0` 定数を追加
- 日本語・英語いずれの `Speech.speak()` 呼び出しにも `volume: MAX_SPEECH_VOLUME` を明示指定し、機種依存の既定音量より下がらないようにした

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`src/hooks/useTTS.test.ts` の既存テスト21件は `expect.objectContaining` で検証しているため、`volume` フィールド追加後も全てpassすることを確認済みです。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BgzF4RLN4ktyqHVafTJC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 音声読み上げの音量を最大レベルに固定し、端末やOSによる既定音量の差を抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->