### PR TITLE
AIエージェントに行き先を相談できるチャット画面とエントリバナーを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -337,5 +337,20 @@
   "batterySettings": "Battery",
   "powerSavingLocationTitle": "Power-saving location mode",
   "powerSavingLocationDescription": "When enabled, location accuracy is lowered to a battery-friendly level and iOS pauses tracking automatically while you are stopped, further reducing battery drain and heat on long rides. The lower accuracy may delay or shift station detection and arrival announcements. The relaxed update frequency is already part of the default settings. It also turns on automatically while your device is in low-power mode.",
-  "passStationLabel": "Pass"
+  "passStationLabel": "Pass",
+  "destinationAgentEntryTitle": "Don't know the station name?",
+  "destinationAgentEntrySubtitle": "Ask AI where to go",
+  "destinationAgentTitle": "Ask AI for destinations",
+  "destinationAgentPlaceholder": "Type a message",
+  "destinationAgentSend": "Send",
+  "destinationAgentEmptyTitle": "Tell me what kind of place you want to visit",
+  "destinationAgentExample1": "I want a station with an ocean view",
+  "destinationAgentExample2": "Take me to a hot spring town",
+  "destinationAgentExample3": "How do I use this app?",
+  "destinationAgentDisclaimer": "AI suggestions may contain mistakes",
+  "destinationAgentRateLimited": "You've reached today's limit. Please try again tomorrow",
+  "destinationAgentReset": "Reset conversation",
+  "destinationAgentResetConfirm": "Clear this conversation?",
+  "destinationAgentSuggestionsError": "Failed to load suggestions",
+  "destinationAgentRetry": "Retry"
 }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -338,5 +338,20 @@
   "batterySettings": "バッテリー",
   "powerSavingLocationTitle": "省電力測位モード",
   "powerSavingLocationDescription": "有効にすると、測位精度を電池優先まで下げ、停車中はiOSが測位を自動休止して、長時間の乗車での電池消費と発熱をさらに減らします。精度の低下により駅の判定や到着案内が遅れたりずれたりする場合があります。位置情報の更新頻度の緩和は標準設定に組み込まれています。端末の省電力モード中は自動的に有効になります。",
-  "passStationLabel": "通過"
+  "passStationLabel": "通過",
+  "destinationAgentEntryTitle": "駅名がわからなくても大丈夫",
+  "destinationAgentEntrySubtitle": "AIに行き先を相談する",
+  "destinationAgentTitle": "AIに行き先を相談",
+  "destinationAgentPlaceholder": "メッセージを入力",
+  "destinationAgentSend": "送信",
+  "destinationAgentEmptyTitle": "行きたい場所のイメージをことばで教えてください",
+  "destinationAgentExample1": "海が見える駅に行きたい",
+  "destinationAgentExample2": "温泉のある観光地に行きたい",
+  "destinationAgentExample3": "このアプリの使い方を知りたい",
+  "destinationAgentDisclaimer": "AIの提案は誤りを含む場合があります",
+  "destinationAgentRateLimited": "本日の利用上限に達しました。また明日お試しください",
+  "destinationAgentReset": "会話をリセット",
+  "destinationAgentResetConfirm": "会話履歴を消去しますか？",
+  "destinationAgentSuggestionsError": "候補の取得に失敗しました",
+  "destinationAgentRetry": "再試行"
 }

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -53,6 +53,7 @@ const Chip: React.FC<Props> = ({
   return (
     <TouchableOpacity
       activeOpacity={1}
+      accessibilityRole="button"
       onPress={onPress}
       style={[
         styles.chip,

--- a/src/hooks/useAIAgentFeatureEnabled.ts
+++ b/src/hooks/useAIAgentFeatureEnabled.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react';
+import {
+  isAIAgentFeatureEnabled,
+  subscribeRemoteConfig,
+} from '~/lib/remoteConfig';
+import { isDevApp } from '~/utils/isDevApp';
+
+// AIエージェント機能キルスイッチ(ai_agent_enabled)のリアクティブ版。
+// setupRemoteConfig は起動時に非同期で完了するため、同期読みだけではコールドスタート時の
+// キャッシュ更新に追従できない。useTTSFeatureEnabled と同じくキャッシュ更新を購読する。
+// PoC 期間中は本番ビルドへ一切露出させないため isDevApp との AND でゲートする
+// (Phase 2 で本番開放する際にこの条件を外す)。
+export const useAIAgentFeatureEnabled = (): boolean => {
+  const remoteEnabled = useSyncExternalStore(
+    subscribeRemoteConfig,
+    isAIAgentFeatureEnabled
+  );
+  return isDevApp && remoteEnabled;
+};

--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -1,0 +1,241 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  AGENT_MAX_MESSAGES,
+  type AgentMessage,
+  trimAgentMessages,
+  useDestinationAgent,
+} from './useDestinationAgent';
+
+jest.mock('~/lib/workerApi', () => ({
+  workerUrl: (path: string) => `https://worker.test${path}`,
+}));
+
+jest.mock('~/lib/session', () => ({
+  getSessionToken: jest.fn(async () => 'test-session-token'),
+}));
+
+const fetchMock = jest.fn();
+const origFetch = global.fetch;
+global.fetch = fetchMock as unknown as typeof fetch;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  global.fetch = origFetch;
+});
+
+const mockJsonResponse = (body: unknown, status = 200) => {
+  fetchMock.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+};
+
+const renderSendMessages = () => {
+  const { result } = renderHook(() => useDestinationAgent());
+  return result.current.sendMessages;
+};
+
+const getRequestBody = () => JSON.parse(fetchMock.mock.calls[0][1].body);
+
+describe('trimAgentMessages', () => {
+  it('12件を超える履歴は古いものから捨てる', () => {
+    const messages: AgentMessage[] = Array.from({ length: 15 }, (_, i) => ({
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `message-${i}`,
+    }));
+
+    const trimmed = trimAgentMessages(messages);
+
+    expect(trimmed).toHaveLength(AGENT_MAX_MESSAGES);
+    expect(trimmed[0].content).toBe('message-3');
+    expect(trimmed[AGENT_MAX_MESSAGES - 1].content).toBe('message-14');
+  });
+
+  it('1メッセージ500文字を超える本文は切り詰める', () => {
+    const trimmed = trimAgentMessages([
+      { role: 'user', content: 'あ'.repeat(600) },
+    ]);
+
+    expect(trimmed[0].content).toHaveLength(500);
+  });
+
+  it('上限内の履歴はそのまま通す', () => {
+    const messages: AgentMessage[] = [
+      { role: 'user', content: '海が見える駅に行きたい' },
+    ];
+
+    expect(trimAgentMessages(messages)).toEqual(messages);
+  });
+});
+
+describe('useDestinationAgent', () => {
+  it('正常応答を reply / suggestions / refused に詰めて返す', async () => {
+    mockJsonResponse({
+      result: {
+        reply: '海の見える駅でしたら、こちらはいかがでしょうか。',
+        suggestions: [
+          {
+            stationId: 1130205,
+            stationGroupId: 1130205,
+            name: '鎌倉',
+            nameRoman: 'Kamakura',
+            lineNames: ['JR横須賀線'],
+          },
+        ],
+        refused: false,
+      },
+    });
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: '海が見たい' }]);
+
+    expect(res).toEqual({
+      ok: true,
+      data: {
+        reply: '海の見える駅でしたら、こちらはいかがでしょうか。',
+        suggestions: [
+          {
+            stationId: 1130205,
+            stationGroupId: 1130205,
+            name: '鎌倉',
+            nameRoman: 'Kamakura',
+            lineNames: ['JR横須賀線'],
+          },
+        ],
+        refused: false,
+      },
+    });
+  });
+
+  it('セッショントークン付きで callable 互換のワイヤ形式を送る', async () => {
+    mockJsonResponse({
+      result: { reply: 'ok', suggestions: [], refused: false },
+    });
+
+    const sendMessages = renderSendMessages();
+    await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://worker.test/agent/chat');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer test-session-token');
+    expect(getRequestBody()).toEqual({
+      data: {
+        messages: [{ role: 'user', content: 'テスト' }],
+        locale: expect.stringMatching(/^(ja|en)$/),
+      },
+    });
+  });
+
+  it('12件を超える履歴は切り詰めてから送信する', async () => {
+    mockJsonResponse({
+      result: { reply: 'ok', suggestions: [], refused: false },
+    });
+
+    const sendMessages = renderSendMessages();
+    await sendMessages(
+      Array.from({ length: 15 }, (_, i) => ({
+        role: 'user' as const,
+        content: `message-${i}`,
+      }))
+    );
+
+    const body = getRequestBody();
+    expect(body.data.messages).toHaveLength(AGENT_MAX_MESSAGES);
+    expect(body.data.messages[0].content).toBe('message-3');
+  });
+
+  it('refused: true をそのまま返す', async () => {
+    mockJsonResponse({
+      result: { reply: 'ご案内できません。', suggestions: [], refused: true },
+    });
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: '今日の天気は' }]);
+
+    expect(res).toEqual({
+      ok: true,
+      data: { reply: 'ご案内できません。', suggestions: [], refused: true },
+    });
+  });
+
+  it('形の合わない suggestions 要素は落とす', async () => {
+    mockJsonResponse({
+      result: {
+        reply: 'ok',
+        suggestions: [
+          {
+            stationId: 1,
+            stationGroupId: 1,
+            name: 'A',
+            nameRoman: 'A',
+            lineNames: [],
+          },
+          { name: 'B' },
+          null,
+        ],
+        refused: false,
+      },
+    });
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.data.suggestions).toHaveLength(1);
+      expect(res.data.suggestions[0].stationId).toBe(1);
+    }
+  });
+
+  it('429 は rateLimited を返す', async () => {
+    mockJsonResponse({}, 429);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'rateLimited' });
+  });
+
+  it('5xx は network を返す', async () => {
+    mockJsonResponse({}, 503);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+
+  it('ネットワークエラーは network を返す', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+
+  it('中断(タイムアウト)は timeout を返す', async () => {
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValueOnce(abortError);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'timeout' });
+  });
+
+  it('reply を欠く壊れた応答は network 扱いにする', async () => {
+    mockJsonResponse({ result: { suggestions: [] } });
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+});

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -1,0 +1,142 @@
+import { useAtomValue } from 'jotai';
+import { useCallback } from 'react';
+import { getSessionToken } from '~/lib/session';
+import { workerUrl } from '~/lib/workerApi';
+import { stationAtom } from '~/store/atoms/station';
+import { isJapanese } from '~/translation';
+
+export type AgentMessageRole = 'user' | 'assistant';
+
+export type AgentMessage = {
+  role: AgentMessageRole;
+  content: string;
+};
+
+export type AgentSuggestion = {
+  stationId: number;
+  stationGroupId: number;
+  name: string;
+  nameRoman: string;
+  lineNames: string[];
+};
+
+export type AgentChatResult = {
+  reply: string;
+  suggestions: AgentSuggestion[];
+  refused: boolean;
+};
+
+// UI 側で表示を分岐するためのエラー種別。
+// - rateLimited: 429(日次上限)。入力バーを無効化し定型文を表示する
+// - timeout: クライアント側 30 秒タイムアウト
+// - network: ネットワーク断・5xx・その他 HTTP エラー・レスポンス破損
+export type AgentErrorKind = 'rateLimited' | 'timeout' | 'network';
+
+export type AgentChatResponse =
+  | { ok: true; data: AgentChatResult }
+  | { ok: false; error: AgentErrorKind };
+
+// サーバー側の入力制約(architecture.md)。超過分はクライアントで先に切り詰めてから送る。
+export const AGENT_MAX_MESSAGES = 12;
+export const AGENT_MAX_MESSAGE_LENGTH = 500;
+// サーバー全体の期限(25 秒)より長く取り、サーバーが先に諦めて確定応答を返す関係を保つ。
+export const AGENT_REQUEST_TIMEOUT_MS = 30_000;
+
+// 会話履歴をサーバー制約に合わせて切り詰める。件数超過時は古いものから捨て、
+// 各メッセージ本文は先頭 500 文字までに切る。
+export const trimAgentMessages = (messages: AgentMessage[]): AgentMessage[] =>
+  messages.slice(-AGENT_MAX_MESSAGES).map((message) => ({
+    role: message.role,
+    content: message.content.slice(0, AGENT_MAX_MESSAGE_LENGTH),
+  }));
+
+const isAgentSuggestion = (value: unknown): value is AgentSuggestion => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const suggestion = value as Partial<AgentSuggestion>;
+  return (
+    typeof suggestion.stationId === 'number' &&
+    typeof suggestion.stationGroupId === 'number'
+  );
+};
+
+export const useDestinationAgent = (): {
+  sendMessages: (messages: AgentMessage[]) => Promise<AgentChatResponse>;
+} => {
+  const station = useAtomValue(stationAtom);
+  const currentStationGroupId = station?.groupId ?? undefined;
+
+  const sendMessages = useCallback(
+    async (messages: AgentMessage[]): Promise<AgentChatResponse> => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        AGENT_REQUEST_TIMEOUT_MS
+      );
+
+      try {
+        const idToken = await getSessionToken();
+        if (!idToken) {
+          return { ok: false, error: 'network' };
+        }
+
+        const res = await fetch(workerUrl('/agent/chat'), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json; charset=UTF-8',
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({
+            data: {
+              messages: trimAgentMessages(messages),
+              locale: isJapanese ? 'ja' : 'en',
+              ...(currentStationGroupId != null
+                ? { currentStationGroupId }
+                : {}),
+            },
+          }),
+          signal: controller.signal,
+        });
+
+        if (res.status === 429) {
+          return { ok: false, error: 'rateLimited' };
+        }
+        if (!res.ok) {
+          return { ok: false, error: 'network' };
+        }
+
+        const json = (await res.json()) as {
+          result?: Partial<AgentChatResult>;
+        };
+        const result = json?.result;
+        if (!result || typeof result.reply !== 'string') {
+          return { ok: false, error: 'network' };
+        }
+
+        return {
+          ok: true,
+          data: {
+            reply: result.reply,
+            // サーバー応答は untrusted として扱い、形の合わない要素は落とす
+            suggestions: Array.isArray(result.suggestions)
+              ? result.suggestions.filter(isAgentSuggestion)
+              : [],
+            refused: result.refused === true,
+          },
+        };
+      } catch (err) {
+        // AbortController による中断はタイムアウトのみ(呼び出し側からの中断経路は無い)
+        if (err instanceof Error && err.name === 'AbortError') {
+          return { ok: false, error: 'timeout' };
+        }
+        return { ok: false, error: 'network' };
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+    [currentStationGroupId]
+  );
+
+  return { sendMessages };
+};

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -1,0 +1,383 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useMemo, useState } from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import { graphqlQueryKey } from '~/lib/gql';
+import {
+  GET_LINE_GROUP_STATIONS,
+  GET_LINE_STATIONS,
+  GET_ROUTE_TYPES_LIGHT,
+} from '~/lib/graphql/queries';
+import lineState, { pendingLineAtom } from '~/store/atoms/line';
+import navigationState from '~/store/atoms/navigation';
+import stationState, {
+  stationAtom,
+  wantedDestinationAtom,
+} from '~/store/atoms/station';
+import {
+  computeCurrentStationInRoutes,
+  getStationWithMatchingLine,
+} from '~/utils/routeSearch';
+import { findLocalType } from '~/utils/trainTypeString';
+import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
+
+type GetRouteTypesData = {
+  routeTypes: {
+    nextPageToken: string | null;
+    trainTypes: TrainType[];
+  };
+};
+
+type GetRouteTypesVariables = {
+  fromStationGroupId: number;
+  toStationGroupId: number;
+  pageSize?: number;
+  pageToken?: string;
+  viaLineId?: number;
+};
+
+type GetLineStationsData = {
+  lineStations: Station[];
+};
+
+type GetLineStationsVariables = {
+  lineId: number;
+  stationId?: number;
+};
+
+type GetLineGroupStationsData = {
+  lineGroupStations: Station[];
+};
+
+type GetLineGroupStationsVariables = {
+  lineGroupId: number;
+};
+
+// GET_ROUTE_TYPES_LIGHT の pageSize。RouteSearchScreen の検索結果上限と同値。
+const ROUTE_TYPES_PAGE_SIZE = 100;
+
+export type UseDestinationSelectionResult = {
+  /** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
+  handleDestinationSelected: (selectedStation: Station) => Promise<void>;
+  /** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
+  handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
+  selectBoundModalVisible: boolean;
+  trainTypeListModalVisible: boolean;
+  selectedDestination: Station | null;
+  wantedDestination: Station | null;
+  /** TrainTypeListModal に渡す現在駅の路線 */
+  trainTypeModalLine: Line | null;
+  /** 種別取得中フラグ(カードのサブタイトルスケルトン・空状態のローディングに使う) */
+  fetchRouteTypesLoading: boolean;
+  /** SelectBoundModal / TrainTypeListModal に渡すローディング集約 */
+  modalLoading: boolean;
+  /** SelectBoundModal に渡すエラー集約 */
+  modalError: Error | null;
+  handleCloseSelectBoundModal: () => void;
+  handleSelectBoundModalCloseAnimationEnd: () => void;
+  handleBoundSelected: () => void;
+  handleCloseTrainTypeListModal: () => void;
+};
+
+// RouteSearchScreen の検索結果タップと DestinationAgentScreen の提案カードタップで
+// 共通に使う行き先決定ロジック。種別・方向・区間の整合性ロジックを複製しないため、
+// 両画面はこのフック経由で同一の既存フロー(SelectBoundModal → selectedBound 確定)へ合流する。
+export const useDestinationSelection = (): UseDestinationSelectionResult => {
+  const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
+  const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
+    useState(false);
+  const [selectedDestination, setSelectedDestination] =
+    useState<Station | null>(null);
+
+  const station = useAtomValue(stationAtom);
+  const wantedDestination = useAtomValue(wantedDestinationAtom);
+  const pendingLine = useAtomValue(pendingLineAtom);
+  const setStationState = useSetAtom(stationState);
+  const setNavigationState = useSetAtom(navigationState);
+  const setLineState = useSetAtom(lineState);
+
+  const queryClient = useQueryClient();
+
+  const [
+    fetchRouteTypes,
+    {
+      data: routeTypesData,
+      loading: fetchRouteTypesLoading,
+      error: fetchRouteTypesError,
+    },
+  ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
+    GET_ROUTE_TYPES_LIGHT
+  );
+
+  const [
+    fetchStationsByLineId,
+    {
+      loading: fetchStationsByLineIdLoading,
+      error: fetchStationsByLineIdError,
+    },
+  ] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
+    GET_LINE_STATIONS
+  );
+
+  const [
+    fetchStationsByLineGroupId,
+    {
+      loading: fetchStationsByLineGroupIdLoading,
+      error: fetchStationsByLineGroupIdError,
+    },
+  ] = useLazyGraphQLQuery<
+    GetLineGroupStationsData,
+    GetLineGroupStationsVariables
+  >(GET_LINE_GROUP_STATIONS);
+
+  const handleDestinationSelected = useCallback(
+    async (selectedStation: Station) => {
+      setSelectBoundModalVisible(true);
+      setSelectedDestination(selectedStation);
+
+      const newPendingLine = selectedStation.line ?? null;
+
+      setNavigationState((prev) => ({
+        ...prev,
+        trainType: null,
+        pendingTrainType: null,
+      }));
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations: [],
+        wantedDestination: null,
+      }));
+      setLineState((prev) => ({
+        ...prev,
+        pendingLine: newPendingLine,
+      }));
+
+      // Guard: ensure both lineId and stationId are present before calling the query
+      if (
+        !selectedStation.groupId ||
+        !selectedStation.line?.id ||
+        !station?.groupId
+      ) {
+        return;
+      }
+
+      const result = await fetchRouteTypes({
+        variables: {
+          fromStationGroupId: station.groupId,
+          toStationGroupId: selectedStation.groupId,
+          pageSize: ROUTE_TYPES_PAGE_SIZE,
+          viaLineId: selectedStation.line.id,
+        },
+      });
+
+      const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
+
+      if (!fetchedTrainTypes?.length) {
+        if (!selectedStation.line?.id) {
+          return;
+        }
+        // 列車種別が存在しない場合は選択した行き先駅の路線を使用
+        setLineState((prev) => ({
+          ...prev,
+          pendingLine: selectedStation.line ?? null,
+        }));
+        // 現在の駅の路線情報を選択した路線に合わせて更新
+        const updatedStation = getStationWithMatchingLine(
+          station,
+          selectedStation.line ?? null
+        );
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation: updatedStation,
+          station: updatedStation,
+        }));
+        const stationsByLineIdRes = await fetchStationsByLineId({
+          variables: {
+            lineId: selectedStation.line.id,
+          },
+        });
+        const stations = stationsByLineIdRes.data?.lineStations ?? [];
+        setStationState((prev) => ({
+          ...prev,
+          pendingStations: stations,
+        }));
+        return;
+      }
+
+      // 先に選択される列車種別を決定
+      const localTrainType =
+        findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
+
+      if (!localTrainType?.groupId) {
+        return;
+      }
+
+      // 選択された列車種別のみを使って路線を決定
+      const newCurrentStation = computeCurrentStationInRoutes(
+        station,
+        newPendingLine,
+        [localTrainType]
+      );
+      if (newCurrentStation) {
+        setStationState((prev) => {
+          const isSamePendingStation =
+            prev.pendingStation?.groupId === newCurrentStation.groupId;
+          const isSameStationLine =
+            prev.station?.line?.id === newCurrentStation.line?.id;
+
+          if (isSamePendingStation && isSameStationLine) {
+            return prev;
+          }
+          return {
+            ...prev,
+            pendingStation: isSamePendingStation
+              ? prev.pendingStation
+              : newCurrentStation,
+            // stationのlineも列車種別とマッチする路線に更新
+            station: prev.station
+              ? { ...prev.station, line: newCurrentStation.line }
+              : prev.station,
+          };
+        });
+        // pendingLineを現在の駅にマッチする路線に更新
+        if (newCurrentStation.line) {
+          setLineState((prev) => ({
+            ...prev,
+            pendingLine: newCurrentStation.line ?? null,
+          }));
+        }
+      }
+
+      const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
+        variables: { lineGroupId: localTrainType.groupId },
+      });
+      const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations: stations,
+      }));
+      setNavigationState((prev) => ({
+        ...prev,
+        fetchedTrainTypes,
+        pendingTrainType: localTrainType,
+      }));
+    },
+    [
+      station,
+      fetchStationsByLineId,
+      fetchStationsByLineGroupId,
+      fetchRouteTypes,
+      setNavigationState,
+      setStationState,
+      setLineState,
+    ]
+  );
+
+  const handleTrainTypeSelected = useCallback(
+    async (trainType: TrainType) => {
+      if (!trainType.groupId) return;
+
+      setSelectBoundModalVisible(true);
+
+      setNavigationState((prev) => ({
+        ...prev,
+        pendingTrainType: trainType,
+      }));
+
+      // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
+      queryClient.removeQueries({
+        queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
+          lineGroupId: trainType.groupId,
+        }),
+      });
+
+      const pendingStationsData = await fetchStationsByLineGroupId({
+        variables: {
+          lineGroupId: trainType.groupId,
+        },
+      });
+      const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations,
+      }));
+    },
+    [
+      fetchStationsByLineGroupId,
+      setStationState,
+      setNavigationState,
+      queryClient,
+    ]
+  );
+
+  const currentStationInRoutes = useMemo<Station | null>(
+    () =>
+      computeCurrentStationInRoutes(
+        station,
+        pendingLine,
+        routeTypesData?.routeTypes?.trainTypes ?? []
+      ),
+    [station, pendingLine, routeTypesData?.routeTypes]
+  );
+
+  const trainTypeModalLine = useMemo(() => {
+    const currentLine = currentStationInRoutes?.line;
+    const currentStationLines = station?.lines ?? [];
+
+    if (
+      currentLine &&
+      currentStationLines.some(
+        (stationLine) => stationLine.id === currentLine.id
+      )
+    ) {
+      return currentLine;
+    }
+
+    return station?.line ?? currentStationLines[0] ?? null;
+  }, [currentStationInRoutes?.line, station?.line, station?.lines]);
+
+  const handleCloseSelectBoundModal = useCallback(() => {
+    setSelectBoundModalVisible(false);
+  }, []);
+
+  const handleSelectBoundModalCloseAnimationEnd = useCallback(() => {
+    setSelectedDestination(null);
+  }, []);
+
+  const handleBoundSelected = useCallback(() => {
+    setSelectBoundModalVisible(false);
+    setTrainTypeListModalVisible(false);
+  }, []);
+
+  const handleCloseTrainTypeListModal = useCallback(() => {
+    setTrainTypeListModalVisible(false);
+  }, []);
+
+  const modalLoading =
+    fetchRouteTypesLoading ||
+    fetchStationsByLineIdLoading ||
+    fetchStationsByLineGroupIdLoading;
+
+  const modalError =
+    fetchRouteTypesError ??
+    fetchStationsByLineIdError ??
+    fetchStationsByLineGroupIdError ??
+    null;
+
+  return {
+    handleDestinationSelected,
+    handleTrainTypeSelected,
+    selectBoundModalVisible,
+    trainTypeListModalVisible,
+    selectedDestination,
+    wantedDestination,
+    trainTypeModalLine,
+    fetchRouteTypesLoading,
+    modalLoading,
+    modalError,
+    handleCloseSelectBoundModal,
+    handleSelectBoundModalCloseAnimationEnd,
+    handleBoundSelected,
+    handleCloseTrainTypeListModal,
+  };
+};

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -3,6 +3,7 @@ import {
   getEtaFallbackArrivalConfirmMarginSec,
   getEtaFallbackMaxDurationMin,
   getMaxPermitAccuracy,
+  isAIAgentFeatureEnabled,
   isEtaAssistEnabled,
   isForceNotArrivedOnLowAccuracyEnabled,
   isTTSFeatureEnabled,
@@ -195,6 +196,38 @@ describe('isTTSFeatureEnabled（サーバー側キルスイッチ）', () => {
       'remote config fetch failed: 503'
     );
     expect(isTTSFeatureEnabled()).toBe(true);
+  });
+});
+
+describe('isAIAgentFeatureEnabled（サーバー側キルスイッチ）', () => {
+  it('falls back to false before setup', () => {
+    expect(isAIAgentFeatureEnabled()).toBe(false);
+  });
+
+  it('RemoteがONなら有効', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500, ai_agent_enabled: true });
+    await setupRemoteConfig();
+    expect(isAIAgentFeatureEnabled()).toBe(true);
+  });
+
+  it('RemoteがOFFなら無効', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500, ai_agent_enabled: false });
+    await setupRemoteConfig();
+    expect(isAIAgentFeatureEnabled()).toBe(false);
+  });
+
+  it('falls back to false when the boolean is missing', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500 });
+    await setupRemoteConfig();
+    expect(isAIAgentFeatureEnabled()).toBe(false);
+  });
+
+  it('falls back to false when fetching remote config fails', async () => {
+    mockRemoteConfig({}, false);
+    await expect(setupRemoteConfig()).rejects.toThrow(
+      'remote config fetch failed: 503'
+    );
+    expect(isAIAgentFeatureEnabled()).toBe(false);
   });
 });
 

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -19,6 +19,9 @@ export const REMOTE_CONFIG_KEYS = {
   // TTS(自動アナウンス)機能の有効/無効。false のとき設定画面のTTSトグルを無効化し、
   // 音声合成バックエンド障害時などにサーバー側から機能を止められるようにする。
   TTS_ENABLED: 'tts_enabled',
+  // AIエージェント(行き先相談)機能の有効/無効。障害・コスト超過時にサーバー側から
+  // エントリポイントごと機能を止められるようにするキルスイッチ。
+  AI_AGENT_ENABLED: 'ai_agent_enabled',
 } as const;
 
 type RemoteConfigResponse = {
@@ -28,6 +31,7 @@ type RemoteConfigResponse = {
   eta_fallback_arrival_confirm_margin_sec?: number;
   eta_fallback_max_duration_min?: number;
   tts_enabled?: boolean;
+  ai_agent_enabled?: boolean;
 };
 
 // 精度超過時に到着判定を未到着へ強制する機能のフォールバック既定値。
@@ -44,6 +48,10 @@ const ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK = 30;
 // TTS機能のフォールバック既定値。キルスイッチ用途のため、未配信・取得失敗時は
 // 既存挙動（利用可能）を維持する true をフォールバックとする。
 const TTS_ENABLED_FALLBACK = true;
+
+// AIエージェント機能のフォールバック既定値。LLM 利用料が発生する機能のため、
+// 未配信・取得失敗時は安全側に倒して無効とする。
+const AI_AGENT_ENABLED_FALLBACK = false;
 
 // リモート設定の数値は「有限かつ正」のみ受理する(0・負値・非数はフォールバックへ倒す)。
 // 真偽値や配列は Number() で 1 や 5 に化けるため、number 型に限定してから検証する。
@@ -63,6 +71,7 @@ let cachedEtaAssistEnabled: boolean | null = null;
 let cachedEtaFallbackArrivalConfirmMarginSec: number | null = null;
 let cachedEtaFallbackMaxDurationMin: number | null = null;
 let cachedTTSEnabled: boolean | null = null;
+let cachedAIAgentEnabled: boolean | null = null;
 
 // setupRemoteConfig は起動時に非同期で完了するため、初回レンダー後にキャッシュが
 // 更新されても React は再レンダーしない。UI(FxTTS・設定画面)が useSyncExternalStore
@@ -91,6 +100,7 @@ export const resetRemoteConfigCache = (): void => {
   cachedEtaFallbackArrivalConfirmMarginSec = null;
   cachedEtaFallbackMaxDurationMin = null;
   cachedTTSEnabled = null;
+  cachedAIAgentEnabled = null;
   notifyRemoteConfigListeners();
 };
 
@@ -129,6 +139,9 @@ export const setupRemoteConfig = async (): Promise<void> => {
   }
   if (typeof data.tts_enabled === 'boolean') {
     cachedTTSEnabled = data.tts_enabled;
+  }
+  if (typeof data.ai_agent_enabled === 'boolean') {
+    cachedAIAgentEnabled = data.ai_agent_enabled;
   }
   notifyRemoteConfigListeners();
 };
@@ -193,4 +206,14 @@ export const isTTSFeatureEnabled = (): boolean => {
     return cachedTTSEnabled;
   }
   return TTS_ENABLED_FALLBACK;
+};
+
+// AIエージェント(行き先相談)機能の有効/無効を同期的に取得する。setupRemoteConfig 完了後は
+// 取得済みのリモート値を、未設定・取得失敗時はフォールバック(false=無効)を返す。
+// false のときはエントリポイント自体を描画しない(サーバー側キルスイッチ)。
+export const isAIAgentFeatureEnabled = (): boolean => {
+  if (cachedAIAgentEnabled != null) {
+    return cachedAIAgentEnabled;
+  }
+  return AI_AGENT_ENABLED_FALLBACK;
 };

--- a/src/screens/DestinationAgent/AgentEmptyState.tsx
+++ b/src/screens/DestinationAgent/AgentEmptyState.tsx
@@ -1,0 +1,72 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useAtomValue } from 'jotai';
+import { StyleSheet, View } from 'react-native';
+import Chip from '~/components/Chip';
+import Typography from '~/components/Typography';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+
+const EXAMPLE_KEYS = [
+  'destinationAgentExample1',
+  'destinationAgentExample2',
+  'destinationAgentExample3',
+] as const;
+
+const styles = StyleSheet.create({
+  root: {
+    alignItems: 'center',
+    gap: 20,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  examples: {
+    gap: 12,
+  },
+  // Chip の既定値(paddingHorizontal 8 / paddingVertical 4 / borderRadius 16)を
+  // 例文チップ用に広げる。角丸 18 は LED テーマでも維持する(Figma 確定)。
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+  },
+  // Chip の非 active 背景は白固定のため、LED テーマは Figma どおり画面背景色に上書きする
+  ledChip: {
+    backgroundColor: '#212121',
+  },
+});
+
+type Props = {
+  onSelectExample: (text: string) => void;
+};
+
+export const AgentEmptyState = ({ onSelectExample }: Props) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <View style={styles.root}>
+      <Ionicons name="sparkles" size={48} color="#008ffe" />
+      <Typography style={styles.title}>
+        {translate('destinationAgentEmptyTitle')}
+      </Typography>
+      <View style={styles.examples}>
+        {EXAMPLE_KEYS.map((key) => {
+          const text = translate(key);
+          return (
+            <Chip
+              key={key}
+              color="#008ffe"
+              style={[styles.chip, isLEDTheme && styles.ledChip]}
+              onPress={() => onSelectExample(text)}
+            >
+              {text}
+            </Chip>
+          );
+        })}
+      </View>
+    </View>
+  );
+};

--- a/src/screens/DestinationAgent/AgentEntryBanner.tsx
+++ b/src/screens/DestinationAgent/AgentEntryBanner.tsx
@@ -1,0 +1,96 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { useAtomValue } from 'jotai';
+import { useCallback } from 'react';
+import {
+  type StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { CardChevron } from '~/components/CardChevron';
+import Typography from '~/components/Typography';
+import { useAIAgentFeatureEnabled } from '~/hooks/useAIAgentFeatureEnabled';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+
+const styles = StyleSheet.create({
+  root: {
+    height: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    gap: 12,
+  },
+  bg: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    // CommonCard と同じ影値
+    shadowColor: '#333',
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 2,
+  },
+  ledBg: {
+    backgroundColor: '#212121',
+    borderColor: '#fff',
+    borderWidth: 1,
+  },
+  texts: {
+    flex: 1,
+    gap: 2,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: '#008ffe',
+  },
+});
+
+type Props = {
+  style?: StyleProp<ViewStyle>;
+};
+
+// RouteSearchScreen の検索バー直下に置く AI 相談へのエントリポイント。
+// フィーチャーフラグ off 時はバナー自体を描画しない(ui.md のエントリポイント方針)。
+export const AgentEntryBanner = ({ style }: Props) => {
+  const navigation = useNavigation();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const enabled = useAIAgentFeatureEnabled();
+
+  const handlePress = useCallback(() => {
+    navigation.navigate('DestinationAgent' as never);
+  }, [navigation]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityLabel={`${translate('destinationAgentEntryTitle')} ${translate('destinationAgentEntrySubtitle')}`}
+      onPress={handlePress}
+      style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg, style]}
+    >
+      <Ionicons name="sparkles" size={24} color="#008ffe" />
+      <View style={styles.texts}>
+        <Typography style={styles.title}>
+          {translate('destinationAgentEntryTitle')}
+        </Typography>
+        <Typography style={styles.subtitle}>
+          {translate('destinationAgentEntrySubtitle')}
+        </Typography>
+      </View>
+      {/* 既定の stroke(#fff) は白背景で不可視になるため、AppSettings と同じくテーマに応じて指定する */}
+      <CardChevron stroke={isLEDTheme ? '#fff' : '#000'} />
+    </TouchableOpacity>
+  );
+};

--- a/src/screens/DestinationAgent/AgentHeader.tsx
+++ b/src/screens/DestinationAgent/AgentHeader.tsx
@@ -1,0 +1,87 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useAtomValue } from 'jotai';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import Typography from '~/components/Typography';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    height: 56,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  resetButton: {
+    minWidth: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingHorizontal: 8,
+  },
+  resetText: {
+    fontSize: 14,
+    color: '#008ffe',
+  },
+  // リセット非表示時もタイトルが中央に留まるよう戻るボタンと同じ幅を確保する
+  resetPlaceholder: {
+    width: 44,
+    height: 44,
+  },
+});
+
+type Props = {
+  showReset: boolean;
+  onBack: () => void;
+  onReset: () => void;
+};
+
+export const AgentHeader = ({ showReset, onBack, onReset }: Props) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <View style={styles.root}>
+      <TouchableOpacity
+        style={styles.backButton}
+        accessibilityRole="button"
+        accessibilityLabel={translate('back')}
+        onPress={onBack}
+      >
+        <Ionicons
+          name="chevron-back"
+          size={28}
+          color={isLEDTheme ? '#fff' : '#333'}
+        />
+      </TouchableOpacity>
+      <Typography style={styles.title}>
+        {translate('destinationAgentTitle')}
+      </Typography>
+      {showReset ? (
+        <TouchableOpacity
+          style={styles.resetButton}
+          accessibilityRole="button"
+          accessibilityLabel={translate('destinationAgentReset')}
+          onPress={onReset}
+        >
+          <Typography style={styles.resetText}>
+            {translate('destinationAgentReset')}
+          </Typography>
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.resetPlaceholder} />
+      )}
+    </View>
+  );
+};

--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -1,0 +1,142 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useAtomValue } from 'jotai';
+import { type RefObject, useMemo } from 'react';
+import {
+  Platform,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Typography from '~/components/Typography';
+import { FONTS } from '~/constants';
+import { AGENT_MAX_MESSAGE_LENGTH } from '~/hooks/useDestinationAgent';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { translate } from '~/translation';
+
+// 入力が伸びても 4 行までに抑え、それ以上は内部スクロールさせる(fontSize 16 の 4 行分 + 上下padding)
+const MAX_INPUT_HEIGHT = 4 * 24 + 16;
+// 残量が見えないと困る領域に入ってから出す(500 - 50)
+const COUNTER_VISIBLE_THRESHOLD = 450;
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    minHeight: 48,
+    // SearchBar と同じ影値
+    shadowColor: '#333',
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 4,
+  },
+  bg: {
+    backgroundColor: '#fcfcfc',
+    borderRadius: 8,
+  },
+  ledBg: {
+    backgroundColor: '#333',
+  },
+  textInput: {
+    flex: 1,
+    fontSize: 16,
+    minHeight: 48,
+    maxHeight: MAX_INPUT_HEIGHT,
+    paddingLeft: 16,
+    paddingRight: 8,
+    paddingVertical: Platform.OS === 'android' ? 8 : 14,
+    includeFontPadding: false,
+  },
+  button: {
+    width: 48,
+    height: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  counter: {
+    fontSize: 12,
+    textAlign: 'right',
+    marginTop: 4,
+  },
+});
+
+type Props = {
+  value: string;
+  onChangeText: (text: string) => void;
+  onSend: () => void;
+  /** 送信中。多重送信を防ぐため送信ボタンを無効化する */
+  sending: boolean;
+  /** 429(日次上限)到達。入力自体を受け付けない */
+  rateLimited: boolean;
+  inputRef?: RefObject<TextInput | null>;
+};
+
+export const AgentInputBar = ({
+  value,
+  onChangeText,
+  onSend,
+  sending,
+  rateLimited,
+  inputRef,
+}: Props) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  const fontFamily = useMemo(
+    () => (isLEDTheme ? FONTS.JFDotJiskan24h : FONTS.RobotoRegular),
+    [isLEDTheme]
+  );
+
+  const canSend = !sending && !rateLimited && value.trim().length > 0;
+
+  return (
+    <View>
+      <View style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}>
+        <TextInput
+          ref={inputRef}
+          style={[
+            styles.textInput,
+            { color: isLEDTheme ? '#fff' : '#000', fontFamily },
+          ]}
+          value={value}
+          onChangeText={onChangeText}
+          editable={!rateLimited}
+          multiline
+          maxLength={AGENT_MAX_MESSAGE_LENGTH}
+          placeholder={translate(
+            rateLimited
+              ? 'destinationAgentRateLimited'
+              : 'destinationAgentPlaceholder'
+          )}
+          placeholderTextColor={isLEDTheme ? '#ababab' : '#8c8c8c'}
+        />
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={translate('destinationAgentSend')}
+          accessibilityState={{ disabled: !canSend }}
+          disabled={!canSend}
+          onPress={onSend}
+          style={[
+            styles.button,
+            !canSend && styles.buttonDisabled,
+            {
+              backgroundColor: isLEDTheme ? '#000' : '#212121',
+              borderTopRightRadius: isLEDTheme ? 0 : 8,
+              borderBottomRightRadius: isLEDTheme ? 0 : 8,
+            },
+          ]}
+        >
+          <Ionicons name="arrow-up" size={21} color="#fff" />
+        </TouchableOpacity>
+      </View>
+      {value.length > COUNTER_VISIBLE_THRESHOLD && (
+        <Typography style={styles.counter}>
+          {`${value.length}/${AGENT_MAX_MESSAGE_LENGTH}`}
+        </Typography>
+      )}
+    </View>
+  );
+};

--- a/src/screens/DestinationAgent/AgentMessageBubble.test.ts
+++ b/src/screens/DestinationAgent/AgentMessageBubble.test.ts
@@ -1,0 +1,43 @@
+import { parseBoldSegments } from './AgentMessageBubble';
+
+describe('parseBoldSegments', () => {
+  it('強調を含まない文はそのまま 1 セグメントで返す', () => {
+    expect(parseBoldSegments('こんにちは。')).toEqual([
+      { text: 'こんにちは。', bold: false },
+    ]);
+  });
+
+  it('**text** を太字セグメントに分解する', () => {
+    expect(parseBoldSegments('おすすめは**鎌倉**です。')).toEqual([
+      { text: 'おすすめは', bold: false },
+      { text: '鎌倉', bold: true },
+      { text: 'です。', bold: false },
+    ]);
+  });
+
+  it('複数の強調を順に分解する', () => {
+    expect(parseBoldSegments('**鎌倉**と**熱海**が候補です')).toEqual([
+      { text: '鎌倉', bold: true },
+      { text: 'と', bold: false },
+      { text: '熱海', bold: true },
+      { text: 'が候補です', bold: false },
+    ]);
+  });
+
+  it('閉じられていない ** は文字どおり残す', () => {
+    expect(parseBoldSegments('これは**未閉鎖です')).toEqual([
+      { text: 'これは**未閉鎖です', bold: false },
+    ]);
+  });
+
+  it('改行をまたぐ強調も解釈する', () => {
+    expect(parseBoldSegments('**海の見える\n駅**です')).toEqual([
+      { text: '海の見える\n駅', bold: true },
+      { text: 'です', bold: false },
+    ]);
+  });
+
+  it('空文字は空配列を返す', () => {
+    expect(parseBoldSegments('')).toEqual([]);
+  });
+});

--- a/src/screens/DestinationAgent/AgentMessageBubble.tsx
+++ b/src/screens/DestinationAgent/AgentMessageBubble.tsx
@@ -1,0 +1,81 @@
+import { useAtomValue } from 'jotai';
+import { StyleSheet, View } from 'react-native';
+import Typography from '~/components/Typography';
+import type { AgentMessageRole } from '~/hooks/useDestinationAgent';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+
+// ユーザバブルは白文字とのコントラスト比 4.5:1 以上(WCAG AA)を満たす色を使う。
+// 既存アクセント #008ffe は約 3.5:1 で AA を満たさないためバブル背景には使わない。
+const USER_BUBBLE_COLOR = '#0071CE';
+
+const styles = StyleSheet.create({
+  root: {
+    maxWidth: '80%',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  user: {
+    alignSelf: 'flex-end',
+    backgroundColor: USER_BUBBLE_COLOR,
+  },
+  assistant: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#fff',
+  },
+  radius: {
+    borderRadius: 12,
+  },
+  shadow: {
+    shadowColor: '#333',
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 2,
+  },
+  ledBorder: {
+    borderColor: '#fff',
+    borderWidth: 1,
+  },
+  ledUser: {
+    backgroundColor: '#333',
+  },
+  ledAssistant: {
+    backgroundColor: '#212121',
+  },
+  text: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  userText: {
+    color: '#fff',
+  },
+});
+
+type Props = {
+  role: AgentMessageRole;
+  content: string;
+};
+
+export const AgentMessageBubble = ({ role, content }: Props) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const isUser = role === 'user';
+
+  return (
+    <View
+      accessibilityRole="text"
+      style={[
+        styles.root,
+        isUser ? styles.user : styles.assistant,
+        isLEDTheme
+          ? [styles.ledBorder, isUser ? styles.ledUser : styles.ledAssistant]
+          : [styles.radius, !isUser && styles.shadow],
+      ]}
+    >
+      <Typography
+        style={[styles.text, (isUser || isLEDTheme) && styles.userText]}
+      >
+        {content}
+      </Typography>
+    </View>
+  );
+};

--- a/src/screens/DestinationAgent/AgentMessageBubble.tsx
+++ b/src/screens/DestinationAgent/AgentMessageBubble.tsx
@@ -8,6 +8,19 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 // 既存アクセント #008ffe は約 3.5:1 で AA を満たさないためバブル背景には使わない。
 const USER_BUBBLE_COLOR = '#0071CE';
 
+// AI 応答は Markdown の強調(**text**)を含むことがある。フル Markdown は
+// 解釈せず、太字だけをインライン装飾として描画する(閉じない ** は文字どおり残す)
+const BOLD_SEGMENT_REGEX = /\*\*([^*][\s\S]*?)\*\*/;
+
+export type BubbleSegment = { text: string; bold: boolean };
+
+export const parseBoldSegments = (content: string): BubbleSegment[] =>
+  content
+    .split(BOLD_SEGMENT_REGEX)
+    // split の捕捉グループにより奇数インデックスが太字部分になる
+    .map((text, index) => ({ text, bold: index % 2 === 1 }))
+    .filter((segment) => segment.text.length > 0);
+
 const styles = StyleSheet.create({
   root: {
     maxWidth: '80%',
@@ -46,6 +59,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 24,
   },
+  boldText: {
+    fontWeight: 'bold',
+  },
   userText: {
     color: '#fff',
   },
@@ -74,7 +90,23 @@ export const AgentMessageBubble = ({ role, content }: Props) => {
       <Typography
         style={[styles.text, (isUser || isLEDTheme) && styles.userText]}
       >
-        {content}
+        {parseBoldSegments(content).map((segment, index) =>
+          segment.bold ? (
+            <Typography
+              // 並び順以外に安定な識別子がない静的リスト
+              key={`bold-${index}-${segment.text}`}
+              style={[
+                styles.text,
+                styles.boldText,
+                (isUser || isLEDTheme) && styles.userText,
+              ]}
+            >
+              {segment.text}
+            </Typography>
+          ) : (
+            segment.text
+          )
+        )}
       </Typography>
     </View>
   );

--- a/src/screens/DestinationAgent/AgentTypingIndicator.tsx
+++ b/src/screens/DestinationAgent/AgentTypingIndicator.tsx
@@ -1,0 +1,115 @@
+import { useAtomValue } from 'jotai';
+import { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+
+// 3 点ドットの位相ずらし(ms)。件数固定なのでキーにも使う
+const DOT_DELAYS = [0, 150, 300] as const;
+const DIM_OPACITY = 0.25;
+// LED テーマはドット絵的な質感に揃えるため、補間せず 2 段階で点滅させる
+const LED_STEP_DURATION = 0;
+const FADE_DURATION = 400;
+const LED_HOLD_DURATION = 400;
+
+const styles = StyleSheet.create({
+  root: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 6,
+  },
+  bg: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    shadowColor: '#333',
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 2,
+  },
+  ledBg: {
+    backgroundColor: '#212121',
+    borderColor: '#fff',
+    borderWidth: 1,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+  },
+});
+
+const Dot = ({ delay, isLEDTheme }: { delay: number; isLEDTheme: boolean }) => {
+  const opacity = useSharedValue(DIM_OPACITY);
+
+  useEffect(() => {
+    opacity.value = withDelay(
+      delay,
+      withRepeat(
+        isLEDTheme
+          ? withSequence(
+              withTiming(1, { duration: LED_STEP_DURATION }),
+              withDelay(
+                LED_HOLD_DURATION,
+                withTiming(DIM_OPACITY, { duration: LED_STEP_DURATION })
+              ),
+              withDelay(
+                LED_HOLD_DURATION,
+                withTiming(1, { duration: LED_STEP_DURATION })
+              )
+            )
+          : withSequence(
+              withTiming(1, { duration: FADE_DURATION }),
+              withTiming(DIM_OPACITY, { duration: FADE_DURATION })
+            ),
+        -1,
+        false
+      )
+    );
+    return () => {
+      cancelAnimation(opacity);
+    };
+  }, [delay, isLEDTheme, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  return (
+    <Animated.View
+      style={[
+        styles.dot,
+        {
+          backgroundColor: isLEDTheme ? '#fff' : '#333',
+          borderRadius: isLEDTheme ? 0 : 4,
+        },
+        animatedStyle,
+      ]}
+    />
+  );
+};
+
+// 送信中に表示するタイピングインジケータ。アシスタントバブルと同じ器に 3 点ドットを出す。
+export const AgentTypingIndicator = () => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <View style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}>
+      {DOT_DELAYS.map((delay) => (
+        <Dot
+          key={`agent-typing-dot-${delay}`}
+          delay={delay}
+          isLEDTheme={isLEDTheme}
+        />
+      ))}
+    </View>
+  );
+};

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -257,14 +257,19 @@ const DestinationAgentScreen = () => {
       const nextEntries = [...entries, userEntry];
       setEntries(nextEntries);
 
-      const res = await sendMessages(
-        nextEntries
-          .filter((entry) => entry.includeInHistory)
-          .map((entry) => ({ role: entry.role, content: entry.content }))
-      );
-
-      sendingRef.current = false;
-      setSending(false);
+      // sendMessages は reject しない設計だが、万一の例外でも送信フラグが
+      // 立ったままにならないよう finally で解除する
+      let res: Awaited<ReturnType<typeof sendMessages>>;
+      try {
+        res = await sendMessages(
+          nextEntries
+            .filter((entry) => entry.includeInHistory)
+            .map((entry) => ({ role: entry.role, content: entry.content }))
+        );
+      } finally {
+        sendingRef.current = false;
+        setSending(false);
+      }
 
       // 応答待ちの間に会話がリセットされていたら結果を破棄する
       if (conversationGenRef.current !== conversationGen) {

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -1,0 +1,531 @@
+import { useNavigation } from '@react-navigation/native';
+import { useAtomValue } from 'jotai';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  type TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Animated, { LinearTransition } from 'react-native-reanimated';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import type { Station } from '~/@types/graphql';
+import { CommonCard } from '~/components/CommonCard';
+import { SelectBoundModal } from '~/components/SelectBoundModal';
+import { TrainTypeListModal } from '~/components/TrainTypeListModal';
+import Typography from '~/components/Typography';
+import {
+  type AgentMessageRole,
+  type AgentSuggestion,
+  useDestinationAgent,
+} from '~/hooks/useDestinationAgent';
+import { useDestinationSelection } from '~/hooks/useDestinationSelection';
+import { useLazyGraphQLQuery } from '~/hooks/useLazyGraphQLQuery';
+import { GET_STATIONS_BY_IDS } from '~/lib/graphql/queries';
+import { stationAtom } from '~/store/atoms/station';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { isJapanese, translate } from '~/translation';
+import isTablet from '~/utils/isTablet';
+import { showToast } from '~/utils/toast';
+import { AgentEmptyState } from './AgentEmptyState';
+import { AgentHeader } from './AgentHeader';
+import { AgentInputBar } from './AgentInputBar';
+import { AgentMessageBubble } from './AgentMessageBubble';
+import { AgentTypingIndicator } from './AgentTypingIndicator';
+
+type GetStationsByIdsData = {
+  stations: Station[];
+};
+
+type GetStationsByIdsVariables = {
+  ids: number[];
+};
+
+type ChatEntry = {
+  id: string;
+  role: AgentMessageRole;
+  content: string;
+  suggestions?: AgentSuggestion[];
+  /**
+   * サーバへ送る messages に含めるか。429 の定型文はクライアント生成の
+   * 疑似発話なので会話履歴を汚さないよう false にする。
+   */
+  includeInHistory: boolean;
+};
+
+type SuggestionState = {
+  status: 'loading' | 'loaded' | 'error';
+  stations: Station[];
+};
+
+// タブレットでバブルが横に伸びすぎると可読性が落ちるため中央寄せの最大幅を設ける
+const TABLET_CONTENT_MAX_WIDTH = 700;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  bg: {
+    backgroundColor: '#FAFAFA',
+  },
+  ledBg: {
+    backgroundColor: '#212121',
+  },
+  flex: {
+    flex: 1,
+  },
+  contentWidth: {
+    width: '100%',
+    alignSelf: 'center',
+    maxWidth: isTablet ? TABLET_CONTENT_MAX_WIDTH : undefined,
+  },
+  listContent: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    gap: 12,
+  },
+  emptyContent: {
+    justifyContent: 'center',
+  },
+  // 同一話者が連続する場合の間隔(既定の 12 から詰める)
+  sameSpeakerSpacing: {
+    marginTop: -8,
+  },
+  suggestions: {
+    gap: 8,
+  },
+  suggestionsError: {
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  errorText: {
+    fontSize: 14,
+  },
+  retryText: {
+    fontSize: 14,
+    color: '#008ffe',
+  },
+  disclaimer: {
+    fontSize: 12,
+    textAlign: 'center',
+    paddingHorizontal: 24,
+    marginBottom: 12,
+  },
+  disclaimerColor: {
+    color: '#737373',
+  },
+  disclaimerLEDColor: {
+    color: '#ccc',
+  },
+  inputBarContainer: {
+    paddingHorizontal: 24,
+  },
+});
+
+const SUGGESTION_SKELETON_HEIGHT = 72;
+
+const SAFE_AREA_EDGES = ['top', 'left', 'right'] as const;
+
+const DestinationAgentScreen = () => {
+  const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const station = useAtomValue(stationAtom);
+
+  const [entries, setEntries] = useState<ChatEntry[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [sending, setSending] = useState(false);
+  const [rateLimited, setRateLimited] = useState(false);
+  const [suggestionStates, setSuggestionStates] = useState<
+    Record<string, SuggestionState>
+  >({});
+
+  const scrollRef = useRef<ScrollView>(null);
+  const inputRef = useRef<TextInput>(null);
+  const entryIdRef = useRef(0);
+  // 多重送信の最終防衛線。state 更新の非同期性に依存しないよう ref でも持つ
+  const sendingRef = useRef(false);
+  // 会話の世代。リセット時にインクリメントし、リセット前に送った
+  // リクエストの遅延応答が新しい(空の)会話へ紛れ込むのを防ぐ
+  const conversationGenRef = useRef(0);
+
+  const { sendMessages } = useDestinationAgent();
+  const {
+    handleDestinationSelected,
+    handleTrainTypeSelected,
+    selectBoundModalVisible,
+    trainTypeListModalVisible,
+    selectedDestination,
+    wantedDestination,
+    trainTypeModalLine,
+    modalLoading,
+    modalError,
+    handleCloseSelectBoundModal,
+    handleSelectBoundModalCloseAnimationEnd,
+    handleBoundSelected,
+    handleCloseTrainTypeListModal,
+  } = useDestinationSelection();
+
+  const [fetchStationsByIds] = useLazyGraphQLQuery<
+    GetStationsByIdsData,
+    GetStationsByIdsVariables
+  >(GET_STATIONS_BY_IDS);
+
+  const createEntryId = useCallback(() => {
+    entryIdRef.current += 1;
+    return `agent-entry-${entryIdRef.current}`;
+  }, []);
+
+  // 新規メッセージが積まれたら最下部へスクロールする
+  useEffect(() => {
+    if (!entries.length) {
+      return;
+    }
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [entries.length]);
+
+  // 提案は軽量情報(stationId 等)しか持たないため、CommonCard が必要とする
+  // Line オブジェクトを得るために Station 完全体を一括再取得する。
+  const resolveSuggestions = useCallback(
+    async (entryId: string, suggestions: AgentSuggestion[]) => {
+      const ids = suggestions
+        .map((suggestion) => suggestion.stationId)
+        .filter((id) => Number.isFinite(id));
+
+      if (!ids.length) {
+        return;
+      }
+
+      setSuggestionStates((prev) => ({
+        ...prev,
+        [entryId]: { status: 'loading', stations: [] },
+      }));
+
+      const res = await fetchStationsByIds({ variables: { ids } });
+      const fetched = res.data?.stations ?? [];
+
+      if (res.error || !fetched.length) {
+        setSuggestionStates((prev) => ({
+          ...prev,
+          [entryId]: { status: 'error', stations: [] },
+        }));
+        return;
+      }
+
+      const byId = new Map(fetched.map((s) => [s.id, s]));
+      // 提案順(モデルが提示した優先順)を保つ
+      const ordered = ids
+        .map((id) => byId.get(id))
+        .filter((s): s is Station => s != null);
+
+      setSuggestionStates((prev) => ({
+        ...prev,
+        [entryId]: { status: 'loaded', stations: ordered },
+      }));
+    },
+    [fetchStationsByIds]
+  );
+
+  const handleSend = useCallback(
+    async (rawText: string) => {
+      const text = rawText.trim();
+      if (!text || sendingRef.current || rateLimited) {
+        return;
+      }
+
+      sendingRef.current = true;
+      setSending(true);
+      setInputText('');
+      const conversationGen = conversationGenRef.current;
+
+      const userEntry: ChatEntry = {
+        id: createEntryId(),
+        role: 'user',
+        content: text,
+        includeInHistory: true,
+      };
+      const nextEntries = [...entries, userEntry];
+      setEntries(nextEntries);
+
+      const res = await sendMessages(
+        nextEntries
+          .filter((entry) => entry.includeInHistory)
+          .map((entry) => ({ role: entry.role, content: entry.content }))
+      );
+
+      sendingRef.current = false;
+      setSending(false);
+
+      // 応答待ちの間に会話がリセットされていたら結果を破棄する
+      if (conversationGenRef.current !== conversationGen) {
+        return;
+      }
+
+      if (res.ok) {
+        const assistantEntry: ChatEntry = {
+          id: createEntryId(),
+          role: 'assistant',
+          content: res.data.reply,
+          suggestions: res.data.suggestions,
+          includeInHistory: true,
+        };
+        setEntries((prev) => [...prev, assistantEntry]);
+        AccessibilityInfo.announceForAccessibility(res.data.reply);
+
+        if (res.data.suggestions.length) {
+          void resolveSuggestions(assistantEntry.id, res.data.suggestions);
+        }
+        return;
+      }
+
+      if (res.error === 'rateLimited') {
+        setRateLimited(true);
+        setEntries((prev) => [
+          ...prev,
+          {
+            id: createEntryId(),
+            role: 'assistant',
+            content: translate('destinationAgentRateLimited'),
+            includeInHistory: false,
+          },
+        ]);
+        return;
+      }
+
+      // ネットワーク / 5xx / タイムアウト: 未応答のユーザ発話を履歴に残さない
+      setEntries((prev) => prev.filter((entry) => entry.id !== userEntry.id));
+      setInputText(text);
+      showToast({
+        type: 'error',
+        text1: translate('errorTitle'),
+        text2: translate('apiErrorText'),
+      });
+    },
+    [entries, rateLimited, createEntryId, sendMessages, resolveSuggestions]
+  );
+
+  const handleReset = useCallback(() => {
+    // ユーザ起点の onPress なので Alert.alert を直接呼んでよい(CLAUDE.md の StrictMode 規約)
+    Alert.alert(
+      translate('destinationAgentReset'),
+      translate('destinationAgentResetConfirm'),
+      [
+        { text: translate('cancel'), style: 'cancel' },
+        {
+          text: 'OK',
+          style: 'destructive',
+          onPress: () => {
+            conversationGenRef.current += 1;
+            setEntries([]);
+            setSuggestionStates({});
+            setInputText('');
+            setRateLimited(false);
+          },
+        },
+      ]
+    );
+  }, []);
+
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const renderSuggestions = useCallback(
+    (entry: ChatEntry) => {
+      if (!entry.suggestions?.length) {
+        return null;
+      }
+      const state = suggestionStates[entry.id];
+
+      if (!state || state.status === 'loading') {
+        return (
+          <View style={styles.suggestions}>
+            {entry.suggestions.map((suggestion) => (
+              <SkeletonPlaceholder
+                key={`${entry.id}-${suggestion.stationId}`}
+                borderRadius={isLEDTheme ? 0 : 8}
+                speed={1500}
+              >
+                <SkeletonPlaceholder.Item
+                  width="100%"
+                  height={SUGGESTION_SKELETON_HEIGHT}
+                />
+              </SkeletonPlaceholder>
+            ))}
+          </View>
+        );
+      }
+
+      if (state.status === 'error') {
+        return (
+          <View style={styles.suggestionsError}>
+            <Typography style={styles.errorText}>
+              {translate('destinationAgentSuggestionsError')}
+            </Typography>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel={translate('destinationAgentRetry')}
+              onPress={() => {
+                if (entry.suggestions) {
+                  void resolveSuggestions(entry.id, entry.suggestions);
+                }
+              }}
+            >
+              <Typography style={styles.retryText}>
+                {translate('destinationAgentRetry')}
+              </Typography>
+            </TouchableOpacity>
+          </View>
+        );
+      }
+
+      return (
+        <View style={styles.suggestions}>
+          {state.stations.map((suggestedStation) => {
+            const line = suggestedStation.line;
+            if (!line) {
+              return null;
+            }
+            return (
+              <CommonCard
+                key={`${entry.id}-${suggestedStation.id}`}
+                targetStation={suggestedStation}
+                line={line}
+                title={
+                  isJapanese
+                    ? suggestedStation.name || undefined
+                    : suggestedStation.nameRoman || undefined
+                }
+                subtitle={
+                  isJapanese
+                    ? line.nameShort || undefined
+                    : line.nameRoman || undefined
+                }
+                onPress={() => handleDestinationSelected(suggestedStation)}
+              />
+            );
+          })}
+        </View>
+      );
+    },
+    [
+      suggestionStates,
+      isLEDTheme,
+      resolveSuggestions,
+      handleDestinationSelected,
+    ]
+  );
+
+  const isEmpty = entries.length === 0;
+
+  return (
+    <SafeAreaView
+      style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}
+      // 下端は入力バー側で insets.bottom を確保するため除外する
+      edges={SAFE_AREA_EDGES}
+    >
+      <AgentHeader
+        showReset={!isEmpty}
+        onBack={handleBack}
+        onReset={handleReset}
+      />
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          ref={scrollRef}
+          style={styles.flex}
+          contentContainerStyle={[
+            styles.contentWidth,
+            styles.listContent,
+            isEmpty && styles.emptyContent,
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          {isEmpty ? (
+            <AgentEmptyState onSelectExample={handleSend} />
+          ) : (
+            entries.map((entry, index) => (
+              // 出現アニメーションは SelectLineScreen の路線リストと同じ既存イディオム(ui.md)
+              <Animated.View
+                key={entry.id}
+                layout={LinearTransition.springify()}
+                style={
+                  entries[index - 1]?.role === entry.role
+                    ? styles.sameSpeakerSpacing
+                    : undefined
+                }
+              >
+                <AgentMessageBubble role={entry.role} content={entry.content} />
+                {renderSuggestions(entry)}
+              </Animated.View>
+            ))
+          )}
+          {sending && <AgentTypingIndicator />}
+        </ScrollView>
+
+        {isEmpty && (
+          <Typography
+            style={[
+              styles.disclaimer,
+              isLEDTheme ? styles.disclaimerLEDColor : styles.disclaimerColor,
+            ]}
+          >
+            {translate('destinationAgentDisclaimer')}
+          </Typography>
+        )}
+
+        <View
+          style={[
+            styles.contentWidth,
+            styles.inputBarContainer,
+            { paddingBottom: insets.bottom + 8 },
+          ]}
+        >
+          <AgentInputBar
+            value={inputText}
+            onChangeText={setInputText}
+            onSend={() => handleSend(inputText)}
+            sending={sending}
+            rateLimited={rateLimited}
+            inputRef={inputRef}
+          />
+        </View>
+      </KeyboardAvoidingView>
+
+      <SelectBoundModal
+        visible={selectBoundModalVisible}
+        onClose={handleCloseSelectBoundModal}
+        onCloseAnimationEnd={handleSelectBoundModalCloseAnimationEnd}
+        onBoundSelect={handleBoundSelected}
+        loading={modalLoading}
+        error={modalError}
+        onTrainTypeSelect={handleTrainTypeSelected}
+        targetDestination={selectedDestination}
+      />
+      <TrainTypeListModal
+        visible={trainTypeListModalVisible}
+        line={trainTypeModalLine}
+        destination={wantedDestination}
+        boardingStation={station}
+        onClose={handleCloseTrainTypeListModal}
+        onSelect={handleTrainTypeSelected}
+        loading={modalLoading}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default React.memo(DestinationAgentScreen);

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -101,10 +101,13 @@ const styles = StyleSheet.create({
   sameSpeakerSpacing: {
     marginTop: -8,
   },
+  // バブル直下の提案カード群。バブルとの間隔・カード同士の間隔とも Figma 指定の 12
   suggestions: {
-    gap: 8,
+    marginTop: 12,
+    gap: 12,
   },
   suggestionsError: {
+    marginTop: 12,
     gap: 8,
     alignItems: 'flex-start',
   },

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -312,7 +312,8 @@ const DestinationAgentScreen = () => {
 
       // ネットワーク / 5xx / タイムアウト: 未応答のユーザ発話を履歴に残さない
       setEntries((prev) => prev.filter((entry) => entry.id !== userEntry.id));
-      setInputText(text);
+      // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する
+      setInputText((prev) => (prev.length ? prev : text));
       showToast({
         type: 'error',
         text1: translate('errorTitle'),

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -3,9 +3,8 @@ import {
   type FlashListProps,
   type ListRenderItemInfo,
 } from '@shopify/flash-list';
-import { useQueryClient } from '@tanstack/react-query';
 import { Orientation } from 'expo-screen-orientation';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import React, {
   useCallback,
   useEffect,
@@ -15,7 +14,7 @@ import React, {
 } from 'react';
 import { Alert, Animated as RNAnimated, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import type { Station, TrainType } from '~/@types/graphql';
+import type { Station } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
 import { EmptyLineSeparator } from '~/components/EmptyLineSeparator';
 import { EmptyResult } from '~/components/EmptyResult';
@@ -26,45 +25,17 @@ import { SearchBar } from '~/components/SearchBar';
 import { SelectBoundModal } from '~/components/SelectBoundModal';
 import { TrainTypeListModal } from '~/components/TrainTypeListModal';
 import WalkthroughOverlay from '~/components/WalkthroughOverlay';
+import { useAIAgentFeatureEnabled } from '~/hooks/useAIAgentFeatureEnabled';
+import { useDestinationSelection } from '~/hooks/useDestinationSelection';
 import { useDeviceOrientation } from '~/hooks/useDeviceOrientation';
 import { useLazyGraphQLQuery } from '~/hooks/useLazyGraphQLQuery';
 import { useRouteSearchWalkthrough } from '~/hooks/useRouteSearchWalkthrough';
-import { graphqlQueryKey } from '~/lib/gql';
-import {
-  GET_LINE_GROUP_STATIONS,
-  GET_LINE_STATIONS,
-  GET_ROUTE_TYPES_LIGHT,
-  GET_STATIONS_BY_NAME,
-} from '~/lib/graphql/queries';
-import navigationState from '~/store/atoms/navigation';
+import { GET_STATIONS_BY_NAME } from '~/lib/graphql/queries';
+import { AgentEntryBanner } from '~/screens/DestinationAgent/AgentEntryBanner';
 import isTablet from '~/utils/isTablet';
-import {
-  computeCurrentStationInRoutes,
-  getStationWithMatchingLine,
-} from '~/utils/routeSearch';
-import { findLocalType } from '~/utils/trainTypeString';
-import lineState, { pendingLineAtom } from '../store/atoms/line';
-import stationState, {
-  stationAtom,
-  wantedDestinationAtom,
-} from '../store/atoms/station';
+import { stationAtom } from '../store/atoms/station';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import { isJapanese, translate } from '../translation';
-
-type GetRouteTypesData = {
-  routeTypes: {
-    nextPageToken: string | null;
-    trainTypes: TrainType[];
-  };
-};
-
-type GetRouteTypesVariables = {
-  fromStationGroupId: number;
-  toStationGroupId: number;
-  pageSize?: number;
-  pageToken?: string;
-  viaLineId?: number;
-};
 
 type GetStationsByNameData = {
   stationsByName: Station[];
@@ -74,23 +45,6 @@ type GetStationsByNameVariables = {
   name: string;
   limit?: number;
   fromStationGroupId?: number;
-};
-
-type GetLineStationsData = {
-  lineStations: Station[];
-};
-
-type GetLineStationsVariables = {
-  lineId: number;
-  stationId?: number;
-};
-
-type GetLineGroupStationsData = {
-  lineGroupStations: Station[];
-};
-
-type GetLineGroupStationsVariables = {
-  lineGroupId: number;
 };
 
 const styles = StyleSheet.create({
@@ -104,17 +58,24 @@ const styles = StyleSheet.create({
   listHeaderContainer: {
     marginTop: 16,
   },
-  searchBarContainer: {
-    marginBottom: 48,
-  },
   listContainerStyle: {
     paddingHorizontal: 24,
     paddingBottom: 128,
   },
+  // AI相談バナーは検索バーと検索結果見出しの間の余白(従来 marginBottom: 48)に置く。
+  // バナー非表示時に従来と同じ余白を保つため、間隔は見出し側の marginTop で確保する。
+  agentEntryBanner: {
+    marginTop: 16,
+  },
   searchResultHeading: {
     fontSize: 24,
     fontWeight: 'bold',
+    marginTop: 48,
     marginBottom: 16,
+  },
+  // バナー表示時はバナーとの間隔を Figma 指定の 24 に詰める
+  searchResultHeadingWithBanner: {
+    marginTop: 24,
   },
   // 従来は行間に EmptyLineSeparator(height: 8) を挟んでいたが、
   // FlashList の ItemSeparatorComponent は numColumns 使用時に各セル内へ描画されるため
@@ -138,13 +99,8 @@ const AnimatedFlashList = RNAnimated.createAnimatedComponent(
 
 const RouteSearchScreen = () => {
   const [nowHeaderHeight, setNowHeaderHeight] = useState(0);
-  const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
-  const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
-    useState(false);
   const [searchResults, setSearchResults] = useState<Station[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
-  const [selectedDestination, setSelectedDestination] =
-    useState<Station | null>(null);
 
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const orientation = useDeviceOrientation();
@@ -160,11 +116,25 @@ const RouteSearchScreen = () => {
   );
 
   const station = useAtomValue(stationAtom);
-  const wantedDestination = useAtomValue(wantedDestinationAtom);
-  const setStationState = useSetAtom(stationState);
-  const setNavigationState = useSetAtom(navigationState);
-  const pendingLine = useAtomValue(pendingLineAtom);
-  const setLineState = useSetAtom(lineState);
+  // AgentEntryBanner と同じフラグを購読し、バナー表示時の見出し余白を Figma 指定へ切り替える
+  const aiAgentEnabled = useAIAgentFeatureEnabled();
+
+  const {
+    handleDestinationSelected,
+    handleTrainTypeSelected,
+    selectBoundModalVisible,
+    trainTypeListModalVisible,
+    selectedDestination,
+    wantedDestination,
+    trainTypeModalLine,
+    fetchRouteTypesLoading,
+    modalLoading,
+    modalError,
+    handleCloseSelectBoundModal,
+    handleSelectBoundModalCloseAnimationEnd,
+    handleBoundSelected,
+    handleCloseTrainTypeListModal,
+  } = useDestinationSelection();
 
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
@@ -203,44 +173,10 @@ const RouteSearchScreen = () => {
     setHasSearched(false);
   }, [station?.groupId]);
 
-  const [
-    fetchRouteTypes,
-    {
-      data: routeTypesData,
-      loading: fetchRouteTypesLoading,
-      error: fetchRouteTypesError,
-    },
-  ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
-    GET_ROUTE_TYPES_LIGHT
-  );
-
   const [fetchByName, { loading: byNameLoading, error: byNameError }] =
     useLazyGraphQLQuery<GetStationsByNameData, GetStationsByNameVariables>(
       GET_STATIONS_BY_NAME
     );
-
-  const [
-    fetchStationsByLineId,
-    {
-      loading: fetchStationsByLineIdLoading,
-      error: fetchStationsByLineIdError,
-    },
-  ] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
-    GET_LINE_STATIONS
-  );
-
-  const [
-    fetchStationsByLineGroupId,
-    {
-      loading: fetchStationsByLineGroupIdLoading,
-      error: fetchStationsByLineGroupIdError,
-    },
-  ] = useLazyGraphQLQuery<
-    GetLineGroupStationsData,
-    GetLineGroupStationsVariables
-  >(GET_LINE_GROUP_STATIONS);
-
-  const queryClient = useQueryClient();
 
   const handleSearch = useCallback(
     async (query: string) => {
@@ -273,149 +209,6 @@ const RouteSearchScreen = () => {
     }
   }, [byNameError]);
 
-  const handleLineSelected = useCallback(
-    async (selectedStation: Station) => {
-      setSelectBoundModalVisible(true);
-      setSelectedDestination(selectedStation);
-
-      const newPendingLine = selectedStation.line ?? null;
-
-      setNavigationState((prev) => ({
-        ...prev,
-        trainType: null,
-        pendingTrainType: null,
-      }));
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations: [],
-        wantedDestination: null,
-      }));
-      setLineState((prev) => ({
-        ...prev,
-        pendingLine: newPendingLine,
-      }));
-
-      // Guard: ensure both lineId and stationId are present before calling the query
-      if (
-        !selectedStation.groupId ||
-        !selectedStation.line?.id ||
-        !station?.groupId
-      ) {
-        return;
-      }
-
-      const result = await fetchRouteTypes({
-        variables: {
-          fromStationGroupId: station.groupId,
-          toStationGroupId: selectedStation.groupId,
-          pageSize: SEARCH_STATION_RESULT_LIMIT,
-          viaLineId: selectedStation.line.id,
-        },
-      });
-
-      const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
-
-      if (!fetchedTrainTypes?.length) {
-        if (!selectedStation.line?.id) {
-          return;
-        }
-        // 列車種別が存在しない場合は選択した行き先駅の路線を使用
-        setLineState((prev) => ({
-          ...prev,
-          pendingLine: selectedStation.line ?? null,
-        }));
-        // 現在の駅の路線情報を選択した路線に合わせて更新
-        const updatedStation = getStationWithMatchingLine(
-          station,
-          selectedStation.line ?? null
-        );
-        setStationState((prev) => ({
-          ...prev,
-          pendingStation: updatedStation,
-          station: updatedStation,
-        }));
-        const stationsByLineIdRes = await fetchStationsByLineId({
-          variables: {
-            lineId: selectedStation.line.id,
-          },
-        });
-        const stations = stationsByLineIdRes.data?.lineStations ?? [];
-        setStationState((prev) => ({
-          ...prev,
-          pendingStations: stations,
-        }));
-        return;
-      }
-
-      // 先に選択される列車種別を決定
-      const localTrainType =
-        findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
-
-      if (!localTrainType?.groupId) {
-        return;
-      }
-
-      // 選択された列車種別のみを使って路線を決定
-      const newCurrentStation = computeCurrentStationInRoutes(
-        station,
-        newPendingLine,
-        [localTrainType]
-      );
-      if (newCurrentStation) {
-        setStationState((prev) => {
-          const isSamePendingStation =
-            prev.pendingStation?.groupId === newCurrentStation.groupId;
-          const isSameStationLine =
-            prev.station?.line?.id === newCurrentStation.line?.id;
-
-          if (isSamePendingStation && isSameStationLine) {
-            return prev;
-          }
-          return {
-            ...prev,
-            pendingStation: isSamePendingStation
-              ? prev.pendingStation
-              : newCurrentStation,
-            // stationのlineも列車種別とマッチする路線に更新
-            station: prev.station
-              ? { ...prev.station, line: newCurrentStation.line }
-              : prev.station,
-          };
-        });
-        // pendingLineを現在の駅にマッチする路線に更新
-        if (newCurrentStation.line) {
-          setLineState((prev) => ({
-            ...prev,
-            pendingLine: newCurrentStation.line ?? null,
-          }));
-        }
-      }
-
-      const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
-        variables: { lineGroupId: localTrainType.groupId },
-      });
-      const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations: stations,
-      }));
-      setNavigationState((prev) => ({
-        ...prev,
-        fetchedTrainTypes,
-        pendingTrainType: localTrainType,
-      }));
-    },
-    [
-      station,
-      fetchStationsByLineId,
-      fetchStationsByLineGroupId,
-      fetchRouteTypes,
-      setNavigationState,
-      setStationState,
-      setLineState,
-    ]
-  );
-
   const renderCard = useCallback(
     (item: Station) => {
       const line = item.line;
@@ -435,11 +228,11 @@ const RouteSearchScreen = () => {
               : line.nameRoman || undefined
           }
           loading={fetchRouteTypesLoading}
-          onPress={() => handleLineSelected(item)}
+          onPress={() => handleDestinationSelected(item)}
         />
       );
     },
-    [handleLineSelected, fetchRouteTypesLoading]
+    [handleDestinationSelected, fetchRouteTypesLoading]
   );
 
   const renderItem = ({ item, index }: ListRenderItemInfo<Station>) => {
@@ -469,75 +262,12 @@ const RouteSearchScreen = () => {
   const keyExtractor = (s: Station, index: number) =>
     `${s.groupId ?? 0}-${s.id ?? index}`;
 
-  const handleTrainTypeSelected = useCallback(
-    async (trainType: TrainType) => {
-      if (!trainType.groupId) return;
-
-      setSelectBoundModalVisible(true);
-
-      setNavigationState((prev) => ({
-        ...prev,
-        pendingTrainType: trainType,
-      }));
-
-      // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
-      queryClient.removeQueries({
-        queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
-          lineGroupId: trainType.groupId,
-        }),
-      });
-
-      const pendingStationsData = await fetchStationsByLineGroupId({
-        variables: {
-          lineGroupId: trainType.groupId,
-        },
-      });
-      const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations,
-      }));
-    },
-    [
-      fetchStationsByLineGroupId,
-      setStationState,
-      setNavigationState,
-      queryClient,
-    ]
-  );
-
   // NowHeader のスクロール連動アニメーションを native driver で駆動する
   // (AnimatedFlashList にアタッチされ、スクロールイベントは UI スレッドで scrollY へ反映される)
   const handleScroll = RNAnimated.event(
     [{ nativeEvent: { contentOffset: { y: scrollY } } }],
     { useNativeDriver: true }
   );
-
-  const currentStationInRoutes = useMemo<Station | null>(
-    () =>
-      computeCurrentStationInRoutes(
-        station,
-        pendingLine,
-        routeTypesData?.routeTypes?.trainTypes ?? []
-      ),
-    [station, pendingLine, routeTypesData?.routeTypes]
-  );
-
-  const currentStationLineForTrainTypeModal = useMemo(() => {
-    const currentLine = currentStationInRoutes?.line;
-    const currentStationLines = station?.lines ?? [];
-
-    if (
-      currentLine &&
-      currentStationLines.some(
-        (stationLine) => stationLine.id === currentLine.id
-      )
-    ) {
-      return currentLine;
-    }
-
-    return station?.line ?? currentStationLines[0] ?? null;
-  }, [currentStationInRoutes?.line, station?.line, station?.lines]);
 
   // ウォークスルーのレイアウト計測
   const measureSearchBar = useCallback(() => {
@@ -622,14 +352,16 @@ const RouteSearchScreen = () => {
           ]}
           ListHeaderComponent={
             <View style={styles.listHeaderContainer}>
-              <View
-                ref={searchBarRef}
-                style={styles.searchBarContainer}
-                onLayout={measureSearchBar}
-              >
+              <View ref={searchBarRef} onLayout={measureSearchBar}>
                 <SearchBar onSearch={handleSearch} />
               </View>
-              <Heading style={styles.searchResultHeading}>
+              <AgentEntryBanner style={styles.agentEntryBanner} />
+              <Heading
+                style={[
+                  styles.searchResultHeading,
+                  aiAgentEnabled && styles.searchResultHeadingWithBanner,
+                ]}
+              >
                 {translate('searchResult')}
               </Heading>
             </View>
@@ -656,44 +388,22 @@ const RouteSearchScreen = () => {
 
       <SelectBoundModal
         visible={selectBoundModalVisible}
-        onClose={() => {
-          setSelectBoundModalVisible(false);
-        }}
-        onCloseAnimationEnd={() => {
-          setSelectedDestination(null);
-        }}
-        onBoundSelect={() => {
-          setSelectBoundModalVisible(false);
-          setTrainTypeListModalVisible(false);
-        }}
-        loading={
-          fetchRouteTypesLoading ||
-          fetchStationsByLineIdLoading ||
-          fetchStationsByLineGroupIdLoading
-        }
-        error={
-          fetchRouteTypesError ??
-          fetchStationsByLineIdError ??
-          fetchStationsByLineGroupIdError ??
-          null
-        }
+        onClose={handleCloseSelectBoundModal}
+        onCloseAnimationEnd={handleSelectBoundModalCloseAnimationEnd}
+        onBoundSelect={handleBoundSelected}
+        loading={modalLoading}
+        error={modalError}
         onTrainTypeSelect={handleTrainTypeSelected}
         targetDestination={selectedDestination}
       />
       <TrainTypeListModal
         visible={trainTypeListModalVisible}
-        line={currentStationLineForTrainTypeModal}
+        line={trainTypeModalLine}
         destination={wantedDestination}
         boardingStation={station}
-        onClose={() => {
-          setTrainTypeListModalVisible(false);
-        }}
+        onClose={handleCloseTrainTypeListModal}
         onSelect={handleTrainTypeSelected}
-        loading={
-          fetchStationsByLineIdLoading ||
-          fetchStationsByLineGroupIdLoading ||
-          fetchRouteTypesLoading
-        }
+        loading={modalLoading}
       />
 
       {currentStep && (

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from 'jotai';
 import React, { useMemo } from 'react';
 import AndroidSettings from '~/screens/AndroidSettings';
 import BatterySettings from '~/screens/BatterySettings';
+import DestinationAgentScreen from '~/screens/DestinationAgent';
 import ExperimentalSettings from '~/screens/ExperimentalSettings';
 import Licenses from '~/screens/Licenses';
 import NotificationSettings from '~/screens/NotificationSettings';
@@ -128,6 +129,11 @@ const MainStack: React.FC = () => {
           options={optionsWithCustomStyle}
           name="RouteSearch"
           component={RouteSearchScreen}
+        />
+        <Stack.Screen
+          options={optionsWithCustomStyle}
+          name="DestinationAgent"
+          component={DestinationAgentScreen}
         />
         <Stack.Screen
           options={optionsWithCustomStyle}


### PR DESCRIPTION
## 概要

Issue-driven 開発の親タスク #6473 で定義された「駅名を知らなくても連想できる言葉で行き先を決定できる」体験の PoC として、AI エージェントと対話して行き先を決めるチャット画面をアプリ側に実装しました。設計は `docs/spec/ai-agent/architecture.md`（#6476）/ `docs/spec/ai-agent/ui.md`（#6478）で FIX 済みの内容に、Figma の確定デザイン（v10 ファイル node 1650-91）を反映しています。

BFF 側（`/agent/chat`）は TrainLCD/BFF リポジトリで別途実装予定のためスコープ外です。機能は Remote Config `ai_agent_enabled`（既定 `false`）と `isDevApp` の二重ゲートで守られており、本番ビルドには露出しません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/screens/DestinationAgent/`（新規）: チャット画面 `DestinationAgentScreen` と専用コンポーネント（`AgentHeader` / `AgentMessageBubble` / `AgentTypingIndicator` / `AgentEmptyState` / `AgentInputBar` / `AgentEntryBanner`）を co-locate。空状態（例文チップ・免責）、タイピングインジケータ、LED テーマ分岐、タブレット最大幅 700 対応を含む
- `AgentMessageBubble` は AI 応答の Markdown 強調（`**text**`）を太字としてインライン描画（フル Markdown は解釈しない）
- `src/hooks/useDestinationAgent.ts`（新規）: `/agent/chat` 呼び出しフック。callable 互換ワイヤ形式 + セッション JWT、履歴 12 件 / 500 字のクライアント側切り詰め、30 秒タイムアウト、`rateLimited` / `timeout` / `network` のエラー分類
- `src/hooks/useDestinationSelection.ts`（新規）: `RouteSearchScreen` の行き先決定ロジック（`GET_ROUTE_TYPES_LIGHT` → 種別決定 → `pendingStations` 構築）を共有フックへ抽出し、検索結果タップと提案カードタップを同一の `SelectBoundModal` フローへ合流
- `src/hooks/useAIAgentFeatureEnabled.ts`（新規）: `ai_agent_enabled` の `useSyncExternalStore` 購読 + PoC 期間中の `isDevApp` AND ゲート
- `src/lib/remoteConfig.ts`: `ai_agent_enabled` キー追加（フォールバック `false` のキルスイッチ）
- `src/screens/RouteSearchScreen.tsx`: 選択ロジックを共有フックへ移設し、検索バー直下に AI 相談エントリバナーを追加（フラグ off 時は非表示・従来レイアウト維持）
- `src/stacks/MainStack.tsx`: `DestinationAgent` 画面を登録
- `assets/translations/{ja,en}.json`: UI 文言 15 キー追加
- `src/components/Chip.tsx`: `accessibilityRole="button"` を付与
- 提案駅は `GET_STATIONS_BY_IDS` で `Station` 完全体を再取得してから `CommonCard` で描画（`lineNames` の名称一致による路線解決は不使用）。ユーザバブルは WCAG AA 準拠の `#0071CE`
- テスト追加: `useDestinationAgent.test.ts`（正常 / refused / 429 / 5xx / ネットワーク / タイムアウト / 切り詰め）、`remoteConfig.test.ts` に 5 ケース

### リグレッションリスクと緩和

- `RouteSearchScreen` の選択ロジック共有フック化が最大のリスク。ロジックは挙動を変えずに移設し、既存 `RouteSearchScreen.test.tsx` が**無修正で通過**することを確認済み
- 新機能側は二重フラグゲートにより off が既定。障害時は KV の `ai_agent_enabled` を `false` にするだけで全クライアントから機能が消える

### 開発プロセス（#6475 の実装備考）

- 実装: Claude Opus 5 / ローカルレビュー: Claude Fable 5（レビューで Figma 余白差異・出現アニメーション・LED チップ背景・リセット競合の 4 点を修正）
- CodeRabbit CLI は実行環境未導入のため未実施。本 PR 上の CodeRabbit レビューで代替

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカルで `npm run lint`（596 ファイル指摘なし）/ `npx jest`（195 suites / 2104 tests 全通過）/ `npm run typecheck`（エラーなし）を実行。BFF 未実装のため実機での結合確認と UI 手動 QA（キーボード追従・LED テーマ・multiline 高さ）は未実施で、dev ビルドで別途行います。

## 関連Issue

Closes #6475

Refs #6473

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SRZ31WjnRgkhn3N9LoNyY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 目的地をAIに相談し、駅候補やエラー時の再試行を行える「目的地エージェント」画面を追加しました。
  * ルート検索画面にAI相談バナーの導線を追加しました。
* **アクセシビリティ**
  * ボタン要素に適切なロール／ラベルを設定しました。
* **テスト**
  * 会話履歴のトリム、送信結果（429/ネットワーク/タイムアウト等）、候補抽出、太字装飾の挙動を検証するテストを追加しました。
* **ローカライズ**
  * 英語・日本語のUI文言を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
