### PR TITLE
AIエージェント画面の送信ボタンのレイアウト崩れとヘッダータイトルの中央ズレを修正

### DIFF
--- a/src/screens/DestinationAgent/AgentHeader.tsx
+++ b/src/screens/DestinationAgent/AgentHeader.tsx
@@ -12,6 +12,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     height: 56,
   },
+  // 左右を同じ flex にしてタイトルを画面中央に保つ(戻る44ptとリセット約100ptの幅差を吸収)
+  side: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  sideRight: {
+    justifyContent: 'flex-end',
+  },
   backButton: {
     width: 44,
     height: 44,
@@ -19,7 +28,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   title: {
-    flex: 1,
+    flexShrink: 1,
     fontSize: 18,
     fontWeight: 'bold',
     textAlign: 'center',
@@ -35,11 +44,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#008ffe',
   },
-  // リセット非表示時もタイトルが中央に留まるよう戻るボタンと同じ幅を確保する
-  resetPlaceholder: {
-    width: 44,
-    height: 44,
-  },
 });
 
 type Props = {
@@ -53,35 +57,37 @@ export const AgentHeader = ({ showReset, onBack, onReset }: Props) => {
 
   return (
     <View style={styles.root}>
-      <TouchableOpacity
-        style={styles.backButton}
-        accessibilityRole="button"
-        accessibilityLabel={translate('back')}
-        onPress={onBack}
-      >
-        <Ionicons
-          name="chevron-back"
-          size={28}
-          color={isLEDTheme ? '#fff' : '#333'}
-        />
-      </TouchableOpacity>
+      <View style={styles.side}>
+        <TouchableOpacity
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel={translate('back')}
+          onPress={onBack}
+        >
+          <Ionicons
+            name="chevron-back"
+            size={28}
+            color={isLEDTheme ? '#fff' : '#333'}
+          />
+        </TouchableOpacity>
+      </View>
       <Typography style={styles.title}>
         {translate('destinationAgentTitle')}
       </Typography>
-      {showReset ? (
-        <TouchableOpacity
-          style={styles.resetButton}
-          accessibilityRole="button"
-          accessibilityLabel={translate('destinationAgentReset')}
-          onPress={onReset}
-        >
-          <Typography style={styles.resetText}>
-            {translate('destinationAgentReset')}
-          </Typography>
-        </TouchableOpacity>
-      ) : (
-        <View style={styles.resetPlaceholder} />
-      )}
+      <View style={[styles.side, styles.sideRight]}>
+        {showReset ? (
+          <TouchableOpacity
+            style={styles.resetButton}
+            accessibilityRole="button"
+            accessibilityLabel={translate('destinationAgentReset')}
+            onPress={onReset}
+          >
+            <Typography style={styles.resetText}>
+              {translate('destinationAgentReset')}
+            </Typography>
+          </TouchableOpacity>
+        ) : null}
+      </View>
     </View>
   );
 };

--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -1,21 +1,19 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import { type RefObject, useMemo } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import Typography from '~/components/Typography';
 import { FONTS } from '~/constants';
 import { AGENT_MAX_MESSAGE_LENGTH } from '~/hooks/useDestinationAgent';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 
-// 入力が伸びても 4 行までに抑え、それ以上は内部スクロールさせる(fontSize 16 の 4 行分 + 上下padding)
-const MAX_INPUT_HEIGHT = 4 * 24 + 16;
+// 行高を明示しないと日本語フォールバックフォントの行高(約32pt)で1行時の高さが
+// 送信ボタン(48pt)を超え、ボタン上に白い隙間が出る。1行 = 24 + 12*2 = 48pt に固定する
+const INPUT_LINE_HEIGHT = 24;
+const INPUT_VERTICAL_PADDING = 12;
+// 入力が伸びても 4 行までに抑え、それ以上は内部スクロールさせる
+const MAX_INPUT_HEIGHT = 4 * INPUT_LINE_HEIGHT + INPUT_VERTICAL_PADDING * 2;
 // 残量が見えないと困る領域に入ってから出す(500 - 50)
 const COUNTER_VISIBLE_THRESHOLD = 450;
 
@@ -41,11 +39,12 @@ const styles = StyleSheet.create({
   textInput: {
     flex: 1,
     fontSize: 16,
+    lineHeight: INPUT_LINE_HEIGHT,
     minHeight: 48,
     maxHeight: MAX_INPUT_HEIGHT,
     paddingLeft: 16,
     paddingRight: 8,
-    paddingVertical: Platform.OS === 'android' ? 8 : 14,
+    paddingVertical: INPUT_VERTICAL_PADDING,
     includeFontPadding: false,
   },
   button: {


### PR DESCRIPTION
## 概要

AIエージェント行き先相談画面（PoC #6475）の 2 件のレイアウト不具合を修正する。

1. 利用上限（429）到達時などに、テキスト入力右端の送信ボタンが入力バーからずれて見えるレイアウト崩れ
2. ヘッダータイトル「AIに行き先を相談」が設計（左右中央）に対して左にズレている問題

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AgentInputBar`: `TextInput` に `lineHeight: 24` と `paddingVertical: 12` を明示し、1 行時の高さを送信ボタンと同じ 48pt に固定。日本語プレースホルダーがフォールバックフォントで描画されると行高が約 32pt に膨らみ、バー全体が約 60pt になって下端揃えの送信ボタン（48pt）の上に白い隙間ができていた。`MAX_INPUT_HEIGHT` も同じ定数から算出するよう更新し、不要になったプラットフォーム別 `paddingVertical` 分岐と `Platform` import を削除。
- `AgentHeader`: 戻るボタン（44pt）と「会話をリセット」ボタン（約 100pt）の幅差でタイトルが左に寄っていたため、左右を同じ `flex: 1` のラッパー View で挟む構造に変更してタイトルを画面の左右中央に配置。リセット非表示時のプレースホルダー View は不要になったため削除。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest src/screens/DestinationAgent`（6 件）もパス。視覚的な変更のため、dev ビルドでの実機確認（上限到達状態の入力バー、LED テーマ、リセットボタン非表示時のヘッダー）を推奨。

## 関連Issue

Refs #6475

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ヘッダーの戻るボタン、タイトル、リセットボタンの配置を整え、タイトルが中央に保たれるよう改善しました。
  * リセットボタンが表示されない場合も、不要な空白が発生しないよう調整しました。
  * 複数行入力時の行間や余白を見直し、入力欄の高さがより安定するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->