### PR TITLE
AIエージェント画面の入力欄をテキスト1行分の高さに固定

### DIFF
--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -12,8 +12,8 @@ import { translate } from '~/translation';
 // 送信ボタン(48pt)を超え、ボタン上に白い隙間が出る。1行 = 24 + 12*2 = 48pt に固定する
 const INPUT_LINE_HEIGHT = 24;
 const INPUT_VERTICAL_PADDING = 12;
-// 入力が伸びても 4 行までに抑え、それ以上は内部スクロールさせる
-const MAX_INPUT_HEIGHT = 4 * INPUT_LINE_HEIGHT + INPUT_VERTICAL_PADDING * 2;
+// 入力バーは常に1行分(48pt)の固定高。溢れた分は内部スクロールさせる
+const INPUT_HEIGHT = INPUT_LINE_HEIGHT + INPUT_VERTICAL_PADDING * 2;
 // 残量が見えないと困る領域に入ってから出す(500 - 50)
 const COUNTER_VISIBLE_THRESHOLD = 450;
 
@@ -40,8 +40,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     lineHeight: INPUT_LINE_HEIGHT,
-    minHeight: 48,
-    maxHeight: MAX_INPUT_HEIGHT,
+    height: INPUT_HEIGHT,
     paddingLeft: 16,
     paddingRight: 8,
     paddingVertical: INPUT_VERTICAL_PADDING,


### PR DESCRIPTION
## 概要

#6483（AIエージェント画面の送信ボタンのレイアウト崩れ修正）の修正漏れ対応です。入力欄が入力量に応じて最大4行まで伸長する挙動が残っていたため、テキスト1行分（48pt）の固定高に変更しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AgentInputBar` の `TextInput` から伸長用の `minHeight` / `maxHeight`（4行分）を撤去し、`height: 48`（1行分 = 行高24 + 上下パディング12×2）の固定高に変更
- `MAX_INPUT_HEIGHT` 定数を `INPUT_HEIGHT` に置き換え
- `multiline` は維持しているため、溢れた入力は入力欄内で縦スクロールされます

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Refs #6483

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
