### PR TITLE
AI画面のリセットボタン表示をFigmaに合わせて主語を省略

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -350,6 +350,7 @@
   "destinationAgentDisclaimer": "AI suggestions may contain mistakes",
   "destinationAgentRateLimited": "You've reached today's limit. Please try again tomorrow",
   "destinationAgentReset": "Reset conversation",
+  "destinationAgentResetShort": "Reset",
   "destinationAgentResetConfirm": "Clear this conversation?",
   "destinationAgentSuggestionsError": "Failed to load suggestions",
   "destinationAgentRetry": "Retry"

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -351,6 +351,7 @@
   "destinationAgentDisclaimer": "AIの提案は誤りを含む場合があります",
   "destinationAgentRateLimited": "本日の利用上限に達しました。また明日お試しください",
   "destinationAgentReset": "会話をリセット",
+  "destinationAgentResetShort": "リセット",
   "destinationAgentResetConfirm": "会話履歴を消去しますか？",
   "destinationAgentSuggestionsError": "候補の取得に失敗しました",
   "destinationAgentRetry": "再試行"

--- a/src/screens/DestinationAgent/AgentHeader.test.tsx
+++ b/src/screens/DestinationAgent/AgentHeader.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { AgentHeader } from './AgentHeader';
+
+// 実体はフォント読み込みで非同期 setState するため、act 警告を避けて素の View に差し替える
+jest.mock('@expo/vector-icons', () => {
+  const { View } = require('react-native');
+  return { Ionicons: View };
+});
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: true,
+}));
+
+const defaultProps = {
+  showReset: true,
+  onBack: jest.fn(),
+  onReset: jest.fn(),
+};
+
+describe('AgentHeader', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('リセットボタンの表示は主語を省略した短縮ラベルを使う', () => {
+    const { getByText, queryByText } = render(
+      <AgentHeader {...defaultProps} />
+    );
+
+    expect(getByText('destinationAgentResetShort')).toBeTruthy();
+    expect(queryByText('destinationAgentReset')).toBeNull();
+  });
+
+  it('リセットボタンの読み上げは省略前の文言を使う', () => {
+    const { getByLabelText } = render(<AgentHeader {...defaultProps} />);
+
+    expect(getByLabelText('destinationAgentReset')).toBeTruthy();
+  });
+
+  it('showResetがfalseならリセットボタンを表示しない', () => {
+    const { queryByText } = render(
+      <AgentHeader {...defaultProps} showReset={false} />
+    );
+
+    expect(queryByText('destinationAgentResetShort')).toBeNull();
+  });
+
+  it('リセットボタンを押すとonResetが呼ばれる', () => {
+    const onReset = jest.fn();
+    const { getByText } = render(
+      <AgentHeader {...defaultProps} onReset={onReset} />
+    );
+
+    fireEvent.press(getByText('destinationAgentResetShort'));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('戻るボタンを押すとonBackが呼ばれる', () => {
+    const onBack = jest.fn();
+    const { getByLabelText } = render(
+      <AgentHeader {...defaultProps} onBack={onBack} />
+    );
+
+    fireEvent.press(getByLabelText('back'));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/DestinationAgent/AgentHeader.tsx
+++ b/src/screens/DestinationAgent/AgentHeader.tsx
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     height: 56,
   },
-  // 左右を同じ flex にしてタイトルを画面中央に保つ(戻る44ptとリセット約100ptの幅差を吸収)
+  // 左右を同じ flex にしてタイトルを画面中央に保つ(戻る44ptとリセットボタンの幅差を吸収)
   side: {
     flex: 1,
     flexDirection: 'row',
@@ -82,8 +82,9 @@ export const AgentHeader = ({ showReset, onBack, onReset }: Props) => {
             accessibilityLabel={translate('destinationAgentReset')}
             onPress={onReset}
           >
+            {/* 表示は Figma に合わせて主語を省略した短縮ラベル。読み上げは省略前の文言を使う */}
             <Typography style={styles.resetText}>
-              {translate('destinationAgentReset')}
+              {translate('destinationAgentResetShort')}
             </Typography>
           </TouchableOpacity>
         ) : null}


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Figma の AI 画面デザインでは、スマートフォンの画面幅を考慮してヘッダーのリセットボタンが主語を省略した「リセット」表記になっています。一方でアプリの実装は「会話をリセット」のままでデザインと乖離していたため、ボタンの表示文言をデザインに追従させます。

幅の制約を受けるのはヘッダーボタンだけなので、既存キー `destinationAgentReset` を書き換えるのではなく短縮ラベル用のキーを追加し、**表示テキストのみ**を差し替えています。読み上げ（`accessibilityLabel`）と確認ダイアログのタイトルは、主語のある「会話をリセット」のほうが操作対象が明確なため従来どおりです。

| 箇所 | 変更前 | 変更後 |
| ---- | ---- | ---- |
| ヘッダーボタンの表示 | 会話をリセット / Reset conversation | **リセット / Reset** |
| ボタンの `accessibilityLabel` | 会話をリセット | 会話をリセット（変更なし） |
| リセット確認ダイアログのタイトル | 会話をリセット | 会話をリセット（変更なし） |

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `assets/translations/ja.json` / `assets/translations/en.json`: 短縮ラベル用キー `destinationAgentResetShort`（`リセット` / `Reset`）を追加
- `src/screens/DestinationAgent/AgentHeader.tsx`: リセットボタンの表示テキストを `destinationAgentResetShort` に差し替え（`accessibilityLabel` は `destinationAgentReset` を維持）
- `src/screens/DestinationAgent/AgentHeader.tsx`: ヘッダー左右の `flex` によるタイトル中央揃えのコメントから、実態と合わなくなった「リセット約100pt」という具体値の記述を削除
- `src/screens/DestinationAgent/AgentHeader.test.tsx`: 新規追加。表示は短縮ラベル・読み上げは省略前の文言・`showReset` による表示制御・`onReset` / `onBack` の発火を検証

ヘッダーのタイトル中央揃えは左右を同じ `flex` にして幅差を吸収する実装のままなので、ボタンが短くなってもタイトルの中央位置は維持されます。

`@expo/vector-icons` はフォントの非同期読み込みで `act` 警告を出すため、追加したテスト内に限りモックしています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint`: `Checked 598 files` / エラーなし
- `npm test`: 197 suites / 2115 tests すべてパス
- `npm run typecheck`: エラーなし

リグレッションリスクは低いと判断しています。変更対象は AI 画面ヘッダーの表示文言 1 箇所と翻訳キーの追加のみで、既存キー `destinationAgentReset` の値・参照箇所（読み上げ・確認ダイアログ）には手を入れていません。想定される影響範囲は「ヘッダーのリセットボタンの表示幅が縮む」ことのみで、ヘッダーのレイアウトは幅差を吸収する `flex` 構成のため崩れません。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

作業環境にシミュレータ／エミュレータが無く実機確認を行えていないため未添付です。マージ前に実端末での見た目確認をお願いします。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kj166shvxxZxckJGg5adfx


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj166shvxxZxckJGg5adfx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * AIチャットのリセットボタンに、画面上で見やすい短いラベル（「Reset」／「リセット」）を追加しました。
  * 読み上げ時は従来どおり、操作内容が分かる「会話をリセット」相当の説明が提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->