### PR TITLE
AIエージェントの応答をSSEストリーミングで逐次表示するよう対応

### DIFF
--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -191,11 +191,60 @@ Firebase callable 互換（`{ data: {...} }` → `{ result: {...} }`）とし、
 
 ### ストリーミング
 
-PoC では非ストリーミングとする。アプリに SSE の前例がなく、想定する応答は
-短い（後述の `max_tokens` 制限）ため、体感遅延はローディング表示で許容範囲
-に収まる見込み。将来ストリーミングが必要になった場合は、Expo SDK 52+ の
-`expo/fetch`（ストリーミング対応 fetch）+ SSE で設計し直す
-（未決事項に記載）。
+対話応答は SSE によるストリーミング配信に対応する（当初 PoC は
+非ストリーミングだったが、2026-07-31 のオーナー指示でスコープ内に昇格。
+tool use ループを挟むと確定応答まで 10〜20 秒かかり、体感遅延を
+ローディング表示だけで吸収しきれないため）。既存の `POST /agent/chat`
+（非ストリーミング）は旧クライアント互換のためそのまま残し、
+ストリーミング用に `POST /agent/chat/stream` を新設する。
+新クライアントはストリーミング側のみを使う（失敗時に非ストリーミングへ
+自動フォールバックはしない。エラー処理を単純に保つため）。
+
+#### エンドポイント（/agent/chat/stream）
+
+- リクエスト: `/agent/chat` と完全に同一（callable 互換の
+  `{ data: { messages, locale, currentStationGroupId } }` +
+  セッション JWT）。入力制約・認証・キルスイッチ・レート制限・
+  トピックゲート・タイムアウト予算もすべて同一。
+- レスポンス: ステータス 200 + `Content-Type: text/event-stream`。
+- ストリーム開始前に判定できるエラー（401 / 400 / 429 / 503 など）は
+  従来どおり callable 互換の JSON エラーで返す（SSE にしない）。
+  ストリーム開始後（200 送出後）のエラーは `error` イベントで通知する。
+
+#### SSE イベント仕様
+
+| イベント | data（JSON） | 意味 |
+| --- | --- | --- |
+| `delta` | `{ "text": "..." }` | `reply` 本文の増分テキスト |
+| `tool` | `{}` | ツール実行中の合図（UI は「駅を検索しています」等を表示してよい） |
+| `done` | `AgentChatResult`（非ストリーミングの `result` と同一形） | 最終確定応答 |
+| `error` | `{ "code": "..." }` | ストリーム開始後のエラー |
+
+- **`done` が正**: クライアントは `delta` の蓄積表示を `done` の `reply`
+  で置き換える（partial JSON 由来の取りこぼしを確定値で補正する）。
+- `suggestions` は途中では流さない。サーバ側検証（ツール結果との突合）を
+  経た確定値のみ `done` に載せる（実在性保証の二段構えを変えない）。
+- 謝絶（`refused: true`）は `delta` なしで即 `done` を送る。
+- クライアントは未知のイベント名を無視する（前方互換）。
+- `done` または `error` の後、サーバはストリームを閉じる。どちらも来ずに
+  ストリームが切れた場合、クライアントはネットワークエラーとして扱う。
+
+#### サーバ実装方針（trainlcd-worker）
+
+- `runAgentTurn` の `generateText` を `streamText` に置き換える
+  （ツール定義・構造化出力・`stopWhen` / `prepareStep`・
+  `maxRetries: 0`・`maxOutputTokens` は同一設定）。非ストリーミングの
+  `/agent/chat` も同じ `streamText` 実装を共有し、イベントを流さず
+  最終結果だけ await する（エージェントループの実装を二重化しない）。
+- `delta` は `partialOutputStream`（構造化出力の partial JSON）から
+  `reply` フィールドの前回比差分を取り出して送出する。
+- `fullStream` の tool-call イベントを `tool` イベントに変換する。
+  ツール入力（検索語）は会話本文相当のため、本文ログと同様に送らない。
+- レート制限の払い戻し: ストリーム開始後にエラーで終わったターンも
+  非ストリーミングと同じ基準で払い戻す。
+- LangSmith トレース（dev のみ）は wrapAISDK が `streamText` も
+  ラップするため既存機構のまま機能する。AI Gateway は SSE を
+  パススルーする（本文ログ無効化ヘッダも同一に付与）。
 
 ## エージェント本体設計（BFF 側）
 
@@ -410,6 +459,10 @@ few-shot（`CONFIG_KV` の `config:fewshot`）と同じパターンで、`CONFIG
 - クライアントのタイムアウト（30 秒）はサーバ全体期限より長く取り、
   「サーバが先に諦めて確定応答を返す」関係を保つ。タイムアウト後の再送
   は新規ターンとして扱い、以前の処理結果を引き継がない。
+- ストリーミングでも期限体系は同一とする。クライアントの 30 秒は
+  ストリーム受信中でもリクエスト開始からの全体期限として適用し、
+  期限到達で受信途中でも中断する（`delta` 受信でタイマーは延長しない。
+  サーバ側 25 秒が先に尽きて `error` イベントが届くのが正常系）。
 
 ## 技術選定
 
@@ -573,10 +626,33 @@ LLM 4 回（3 イテレーション + 最終応答。ツール結果の蓄積と
 
 ### API 呼び出し
 
-`src/lib/workerApi.ts` の `workerUrl('/agent/chat')` と
-`src/lib/session.ts` の `getSessionToken()` を流用し、`useFeedback` と
-同じ fetch パターンで実装する（新規フック
-`src/hooks/useDestinationAgent.ts`）。タイムアウトは 30 秒。
+`src/lib/workerApi.ts` の `workerUrl('/agent/chat/stream')` と
+`src/lib/session.ts` の `getSessionToken()` を流用する
+（フックは `src/hooks/useDestinationAgent.ts`）。タイムアウトは 30 秒
+（リクエスト開始からの全体期限。「タイムアウト・キャンセル・再試行」参照）。
+
+ストリーミング受信は次の方針で実装する:
+
+- fetch は React Native 標準ではなく `expo/fetch`（Expo SDK 52+ の
+  ストリーミング対応 fetch。本体は WinterCG 準拠）を使い、
+  `res.body`（`ReadableStream`）を逐次読む。
+- SSE のパースは自前の最小実装 `src/utils/sse.ts`（新規・依存ゼロ）で
+  行う。`event:` / `data:` 行とイベント区切り（空行）のみ解釈し、
+  複数行 `data` の連結・コメント行（`:` 開始）の無視・チャンク境界を
+  跨ぐイベントのバッファリングに対応する純関数パーサとして切り出し、
+  Jest でテストする。SSE クライアントライブラリは追加しない
+  （「ライブラリ候補（アプリ）」の新規依存ゼロ方針を維持）。
+- `useDestinationAgent` の `sendMessages` はシグネチャを
+  `sendMessages(messages, { onDelta, onToolStart })` に拡張する。
+  戻り値の `Promise<AgentChatResponse>`（`done` の確定結果 or エラー）は
+  現行と同じ形を保ち、画面側のエラーハンドリング分岐を変えない。
+- 画面側は送信開始時に空の assistant エントリを仮置きし、`onDelta` で
+  本文を追記、`done` で確定値に置き換えてから提案解決
+  （`resolveSuggestions`）と `announceForAccessibility` を行う。
+  `AgentTypingIndicator` は最初の `delta` が届くまで表示し、`tool`
+  イベント受信中は検索中である旨の表示に切り替えてよい（文言・見た目は
+  ui.md で規定）。エラー時は仮置きエントリを取り除き、現行どおり
+  未応答のユーザ発話も履歴から戻す。
 
 ### 提案駅選択 → 既存フローへの接続
 
@@ -624,6 +700,7 @@ LLM 4 回（3 イテレーション + 最終応答。ツール結果の蓄積と
 | 429（レート制限） | 「本日の利用上限に達しました」を表示 |
 | `refused: true` | サーバの定型謝絶文をそのまま表示 |
 | ネットワーク/5xx | `GlobalToast` 表示 + 入力を復元し再送可能に |
+| ストリーム中断（`error` イベント / `done` 前の切断） | ネットワークエラーと同じ扱い（受信途中の `delta` は破棄） |
 | フラグ off | エントリポイント自体を非表示 |
 
 ## セキュリティ・プライバシー
@@ -678,8 +755,10 @@ sapi-bff には既に `routes` / `connectedRoutes` クエリ
 | --- | --- |
 | BFF: バリデーション・提案検証 | 純関数に切り出して Jest |
 | BFF: エージェントループ | LLM クライアントをモックして Jest |
+| BFF: SSE エンコード・`reply` 差分抽出 | 純関数に切り出して Jest |
 | BFF: 結合 | `wrangler dev` + 手動シナリオ |
-| アプリ: フック | `jest.mock` で fetch をモック |
+| アプリ: SSE パーサ | 純関数（`src/utils/sse.ts`）を Jest（チャンク分割・複数行 data 含む） |
+| アプリ: フック | `jest.mock` で fetch をモック（SSE ストリームを ReadableStream で再現） |
 | アプリ: UI | dev ビルドで手動 QA + スクリーンショット |
 
 - エージェントループのテストでは、ツール結果突合・件数切り詰め・
@@ -759,6 +838,19 @@ LangChain を使わず、検証プラットフォームとして LangSmith を�
 | `src/lib/remoteConfig.ts` | `ai_agent_enabled` キー追加 |
 | `assets/translations/ja.json` / `en.json` | UI 文言追加 |
 
+### ストリーミング対応の追加変更分
+
+初期実装（上表）の完了後にストリーミング対応で追加・変更するファイル。
+
+| リポジトリ | ファイル | 内容 |
+| --- | --- | --- |
+| BFF | `agent/stream.ts`（新規） | SSE エンコード・差分抽出（純関数） |
+| BFF | `agent/handler.ts` | `streamText` 化・stream ハンドラ |
+| BFF | `index.ts` | `/agent/chat/stream` ルート追加 |
+| MobileApp | `src/utils/sse.ts`（新規） | 最小 SSE パーサ（純関数） |
+| MobileApp | `src/hooks/useDestinationAgent.ts` | `expo/fetch` + SSE 受信 |
+| MobileApp | `src/screens/DestinationAgent/index.tsx` | `delta` 逐次表示 |
+
 ## 未決事項（オーナー判断が必要）
 
 1. **対話本体のモデル**: 比較検証の初期対象として
@@ -767,5 +859,5 @@ LangChain を使わず、検証プラットフォームとして LangSmith を�
 2. **会話ログの保存方針**: 品質改善のためのサンプリング保存を行うか。
    行う場合はプライバシーポリシーへの明記が必要。
 3. **レート制限の初期値**: 30 ターン/日/人 で妥当か。
-4. **ストリーミング**: PoC 非対応の方針で良いか。体感が悪ければ
-   `expo/fetch` + SSE を Phase 1 で検討。
+4. **ストリーミング**: 決定済み（2026-07-31、オーナー指示で対応する）。
+   設計は「ストリーミング」の節を参照。

--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -1,10 +1,16 @@
 import { renderHook } from '@testing-library/react-native';
+import { fetch } from 'expo/fetch';
 import {
   AGENT_MAX_MESSAGES,
+  AGENT_REQUEST_TIMEOUT_MS,
   type AgentMessage,
   trimAgentMessages,
   useDestinationAgent,
 } from './useDestinationAgent';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(),
+}));
 
 jest.mock('~/lib/workerApi', () => ({
   workerUrl: (path: string) => `https://worker.test${path}`,
@@ -14,25 +20,52 @@ jest.mock('~/lib/session', () => ({
   getSessionToken: jest.fn(async () => 'test-session-token'),
 }));
 
-const fetchMock = jest.fn();
-const origFetch = global.fetch;
-global.fetch = fetchMock as unknown as typeof fetch;
+const fetchMock = fetch as unknown as jest.Mock;
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-afterAll(() => {
-  global.fetch = origFetch;
-});
+const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
 
-const mockJsonResponse = (body: unknown, status = 200) => {
+/** チャンク列を順に返す最小の ReadableStreamDefaultReader 相当を作る */
+const mockStreamResponse = (chunks: (string | Uint8Array)[], status = 200) => {
+  let index = 0;
+  const cancel = jest.fn(async () => undefined);
   fetchMock.mockResolvedValueOnce({
     ok: status >= 200 && status < 300,
     status,
-    json: async () => body,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (index >= chunks.length) {
+            return { done: true, value: undefined };
+          }
+          const chunk = chunks[index];
+          index += 1;
+          return {
+            done: false,
+            value: typeof chunk === 'string' ? encode(chunk) : chunk,
+          };
+        },
+        cancel,
+      }),
+    },
+  });
+  return { cancel };
+};
+
+const mockErrorResponse = (status: number) => {
+  fetchMock.mockResolvedValueOnce({
+    ok: false,
+    status,
+    body: null,
   });
 };
+
+/** done イベントだけを流す SSE 本文 */
+const doneEvent = (result: unknown) =>
+  `event: done\ndata: ${JSON.stringify(result)}\n\n`;
 
 const renderSendMessages = () => {
   const { result } = renderHook(() => useDestinationAgent());
@@ -73,9 +106,9 @@ describe('trimAgentMessages', () => {
 });
 
 describe('useDestinationAgent', () => {
-  it('正常応答を reply / suggestions / refused に詰めて返す', async () => {
-    mockJsonResponse({
-      result: {
+  it('done イベントを reply / suggestions / refused に詰めて返す', async () => {
+    mockStreamResponse([
+      doneEvent({
         reply: '海の見える駅でしたら、こちらはいかがでしょうか。',
         suggestions: [
           {
@@ -87,8 +120,8 @@ describe('useDestinationAgent', () => {
           },
         ],
         refused: false,
-      },
-    });
+      }),
+    ]);
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: '海が見たい' }]);
@@ -111,18 +144,19 @@ describe('useDestinationAgent', () => {
     });
   });
 
-  it('セッショントークン付きで callable 互換のワイヤ形式を送る', async () => {
-    mockJsonResponse({
-      result: { reply: 'ok', suggestions: [], refused: false },
-    });
+  it('セッショントークン付きで callable 互換のワイヤ形式をストリーミング用エンドポイントへ送る', async () => {
+    mockStreamResponse([
+      doneEvent({ reply: 'ok', suggestions: [], refused: false }),
+    ]);
 
     const sendMessages = renderSendMessages();
     await sendMessages([{ role: 'user', content: 'テスト' }]);
 
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('https://worker.test/agent/chat');
+    expect(url).toBe('https://worker.test/agent/chat/stream');
     expect(init.method).toBe('POST');
     expect(init.headers.Authorization).toBe('Bearer test-session-token');
+    expect(init.headers.accept).toBe('text/event-stream');
     expect(getRequestBody()).toEqual({
       data: {
         messages: [{ role: 'user', content: 'テスト' }],
@@ -132,9 +166,9 @@ describe('useDestinationAgent', () => {
   });
 
   it('12件を超える履歴は切り詰めてから送信する', async () => {
-    mockJsonResponse({
-      result: { reply: 'ok', suggestions: [], refused: false },
-    });
+    mockStreamResponse([
+      doneEvent({ reply: 'ok', suggestions: [], refused: false }),
+    ]);
 
     const sendMessages = renderSendMessages();
     await sendMessages(
@@ -149,10 +183,99 @@ describe('useDestinationAgent', () => {
     expect(body.data.messages[0].content).toBe('message-3');
   });
 
-  it('refused: true をそのまま返す', async () => {
-    mockJsonResponse({
-      result: { reply: 'ご案内できません。', suggestions: [], refused: true },
+  it('delta を受信順に onDelta へ渡し、done の確定値を返す', async () => {
+    mockStreamResponse([
+      'event: delta\ndata: {"text":"海の"}\n\n',
+      'event: delta\ndata: {"text":"見える駅"}\n\n',
+      doneEvent({
+        reply: '海の見える駅はこちらです。',
+        suggestions: [],
+        refused: false,
+      }),
+    ]);
+
+    const onDelta = jest.fn();
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: '海が見たい' }], {
+      onDelta,
     });
+
+    expect(onDelta.mock.calls.map(([text]) => text)).toEqual([
+      '海の',
+      '見える駅',
+    ]);
+    expect(res).toEqual({
+      ok: true,
+      data: {
+        reply: '海の見える駅はこちらです。',
+        suggestions: [],
+        refused: false,
+      },
+    });
+  });
+
+  it('チャンク境界を跨いだイベントも取りこぼさない', async () => {
+    const payload = `event: delta\ndata: {"text":"あい"}\n\n${doneEvent({
+      reply: 'あいうえお',
+      suggestions: [],
+      refused: false,
+    })}`;
+    const bytes = encode(payload);
+
+    mockStreamResponse([
+      bytes.slice(0, 25),
+      bytes.slice(25, 60),
+      bytes.slice(60),
+    ]);
+
+    const onDelta = jest.fn();
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }], {
+      onDelta,
+    });
+
+    expect(onDelta).toHaveBeenCalledWith('あい');
+    expect(res.ok).toBe(true);
+  });
+
+  it('tool イベントで onToolStart を呼ぶ', async () => {
+    mockStreamResponse([
+      'event: tool\ndata: {}\n\n',
+      doneEvent({ reply: 'ok', suggestions: [], refused: false }),
+    ]);
+
+    const onToolStart = jest.fn();
+    const sendMessages = renderSendMessages();
+    await sendMessages([{ role: 'user', content: 'テスト' }], { onToolStart });
+
+    expect(onToolStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('未知のイベントは無視する', async () => {
+    mockStreamResponse([
+      'event: future\ndata: {"foo":1}\n\n',
+      ': keep-alive\n\n',
+      doneEvent({ reply: 'ok', suggestions: [], refused: false }),
+    ]);
+
+    const onDelta = jest.fn();
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }], {
+      onDelta,
+    });
+
+    expect(onDelta).not.toHaveBeenCalled();
+    expect(res.ok).toBe(true);
+  });
+
+  it('refused: true をそのまま返す', async () => {
+    mockStreamResponse([
+      doneEvent({
+        reply: 'ご案内できません。',
+        suggestions: [],
+        refused: true,
+      }),
+    ]);
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: '今日の天気は' }]);
@@ -164,8 +287,8 @@ describe('useDestinationAgent', () => {
   });
 
   it('形の合わない suggestions 要素は落とす', async () => {
-    mockJsonResponse({
-      result: {
+    mockStreamResponse([
+      doneEvent({
         reply: 'ok',
         suggestions: [
           {
@@ -179,8 +302,8 @@ describe('useDestinationAgent', () => {
           null,
         ],
         refused: false,
-      },
-    });
+      }),
+    ]);
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
@@ -193,7 +316,7 @@ describe('useDestinationAgent', () => {
   });
 
   it('429 は rateLimited を返す', async () => {
-    mockJsonResponse({}, 429);
+    mockErrorResponse(429);
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
@@ -202,7 +325,7 @@ describe('useDestinationAgent', () => {
   });
 
   it('5xx は network を返す', async () => {
-    mockJsonResponse({}, 503);
+    mockErrorResponse(503);
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
@@ -230,8 +353,85 @@ describe('useDestinationAgent', () => {
     expect(res).toEqual({ ok: false, error: 'timeout' });
   });
 
-  it('reply を欠く壊れた応答は network 扱いにする', async () => {
-    mockJsonResponse({ result: { suggestions: [] } });
+  it('30 秒でストリーム受信を打ち切り timeout を返す', async () => {
+    jest.useFakeTimers();
+
+    let rejectRead: ((error: Error) => void) | undefined;
+    const cancel = jest.fn(async () => undefined);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: () =>
+            new Promise((_resolve, reject) => {
+              rejectRead = reject;
+            }),
+          cancel,
+        }),
+      },
+    });
+
+    const sendMessages = renderSendMessages();
+    const promise = sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    // read 待ちに入るまでマイクロタスクを流してからタイムアウトを進める
+    await jest.advanceTimersByTimeAsync(AGENT_REQUEST_TIMEOUT_MS);
+    // expo/fetch は中断時に AbortError ではなく通常の Error を投げる
+    rejectRead?.(new Error('fetch failed: canceled'));
+
+    await expect(promise).resolves.toEqual({ ok: false, error: 'timeout' });
+
+    jest.useRealTimers();
+  });
+
+  it('error イベントは network を返し、受信済み delta は確定値にしない', async () => {
+    mockStreamResponse([
+      'event: delta\ndata: {"text":"途中まで"}\n\n',
+      'event: error\ndata: {"code":"internal"}\n\n',
+    ]);
+
+    const onDelta = jest.fn();
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }], {
+      onDelta,
+    });
+
+    expect(onDelta).toHaveBeenCalledWith('途中まで');
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+
+  it('done 前にストリームが切れた場合は network を返す', async () => {
+    mockStreamResponse(['event: delta\ndata: {"text":"途中まで"}\n\n']);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+
+  it('reply を欠く壊れた done は network 扱いにする', async () => {
+    mockStreamResponse([doneEvent({ suggestions: [] })]);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(res).toEqual({ ok: false, error: 'network' });
+  });
+
+  it('done を受け取ったらストリームを解放する', async () => {
+    const { cancel } = mockStreamResponse([
+      doneEvent({ reply: 'ok', suggestions: [], refused: false }),
+    ]);
+
+    const sendMessages = renderSendMessages();
+    await sendMessages([{ role: 'user', content: 'テスト' }]);
+
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('本文の無いレスポンスは network を返す', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, body: null });
 
     const sendMessages = renderSendMessages();
     const res = await sendMessages([{ role: 'user', content: 'テスト' }]);

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -1,9 +1,11 @@
+import { fetch } from 'expo/fetch';
 import { useAtomValue } from 'jotai';
 import { useCallback } from 'react';
 import { getSessionToken } from '~/lib/session';
 import { workerUrl } from '~/lib/workerApi';
 import { stationAtom } from '~/store/atoms/station';
 import { isJapanese } from '~/translation';
+import { createSSEParser, type SSEEvent } from '~/utils/sse';
 
 export type AgentMessageRole = 'user' | 'assistant';
 
@@ -29,12 +31,22 @@ export type AgentChatResult = {
 // UI 側で表示を分岐するためのエラー種別。
 // - rateLimited: 429(日次上限)。入力バーを無効化し定型文を表示する
 // - timeout: クライアント側 30 秒タイムアウト
-// - network: ネットワーク断・5xx・その他 HTTP エラー・レスポンス破損
+// - network: ネットワーク断・5xx・その他 HTTP エラー・レスポンス破損・
+//   ストリーム中断(error イベント / done 前の切断)
 export type AgentErrorKind = 'rateLimited' | 'timeout' | 'network';
 
 export type AgentChatResponse =
   | { ok: true; data: AgentChatResult }
   | { ok: false; error: AgentErrorKind };
+
+// ストリーミング受信中の通知。確定応答は sendMessages の戻り値で受け取るため、
+// ここでは途中経過の描画に必要なものだけを扱う。
+export type AgentStreamHandlers = {
+  /** reply 本文の増分。done で確定値に置き換えられる前提の暫定表示用 */
+  onDelta?: (text: string) => void;
+  /** ツール実行開始の合図(tool イベント) */
+  onToolStart?: () => void;
+};
 
 // サーバー側の入力制約(architecture.md)。超過分はクライアントで先に切り詰めてから送る。
 export const AGENT_MAX_MESSAGES = 12;
@@ -61,19 +73,95 @@ const isAgentSuggestion = (value: unknown): value is AgentSuggestion => {
   );
 };
 
+const parseEventData = (data: string): Record<string, unknown> | null => {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+};
+
+// done イベントの本文(AgentChatResult と同一形)を検証して確定応答へ変換する
+const toChatResult = (data: string): AgentChatResult | null => {
+  const parsed = parseEventData(data);
+  if (!parsed || typeof parsed.reply !== 'string') {
+    return null;
+  }
+  return {
+    reply: parsed.reply,
+    // サーバー応答は untrusted として扱い、形の合わない要素は落とす
+    suggestions: Array.isArray(parsed.suggestions)
+      ? parsed.suggestions.filter(isAgentSuggestion)
+      : [],
+    refused: parsed.refused === true,
+  };
+};
+
+/**
+ * SSE イベントを 1 件処理する。ストリームを終える場合(done / error)のみ
+ * 確定応答を返し、それ以外(delta / tool / 未知イベント)は null を返す。
+ */
+const handleStreamEvent = (
+  event: SSEEvent,
+  handlers: AgentStreamHandlers | undefined
+): AgentChatResponse | null => {
+  switch (event.event) {
+    case 'delta': {
+      const text = parseEventData(event.data)?.text;
+      if (typeof text === 'string' && text.length) {
+        handlers?.onDelta?.(text);
+      }
+      return null;
+    }
+    case 'tool':
+      handlers?.onToolStart?.();
+      return null;
+    case 'done': {
+      const result = toChatResult(event.data);
+      return result
+        ? { ok: true, data: result }
+        : { ok: false, error: 'network' };
+    }
+    case 'error':
+      // ストリーム開始後のエラーはネットワークエラーと同じ扱い
+      // (受信済みの delta は画面側で破棄される)
+      return { ok: false, error: 'network' };
+    default:
+      // 未知のイベント名は無視する(前方互換)
+      return null;
+  }
+};
+
 export const useDestinationAgent = (): {
-  sendMessages: (messages: AgentMessage[]) => Promise<AgentChatResponse>;
+  sendMessages: (
+    messages: AgentMessage[],
+    handlers?: AgentStreamHandlers
+  ) => Promise<AgentChatResponse>;
 } => {
   const station = useAtomValue(stationAtom);
   const currentStationGroupId = station?.groupId ?? undefined;
 
   const sendMessages = useCallback(
-    async (messages: AgentMessage[]): Promise<AgentChatResponse> => {
+    async (
+      messages: AgentMessage[],
+      handlers?: AgentStreamHandlers
+    ): Promise<AgentChatResponse> => {
       const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        AGENT_REQUEST_TIMEOUT_MS
-      );
+      // expo/fetch は中断時に AbortError(name 付き)を投げるとは限らないため、
+      // タイムアウトかどうかは自前のフラグで判定する
+      let timedOut = false;
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, AGENT_REQUEST_TIMEOUT_MS);
 
       try {
         const idToken = await getSessionToken();
@@ -81,10 +169,12 @@ export const useDestinationAgent = (): {
           return { ok: false, error: 'network' };
         }
 
-        const res = await fetch(workerUrl('/agent/chat'), {
+        // ストリーミング対応の expo/fetch を使い、res.body を逐次読む
+        const res = await fetch(workerUrl('/agent/chat/stream'), {
           method: 'POST',
           headers: {
             'content-type': 'application/json; charset=UTF-8',
+            accept: 'text/event-stream',
             Authorization: `Bearer ${idToken}`,
           },
           body: JSON.stringify({
@@ -99,35 +189,49 @@ export const useDestinationAgent = (): {
           signal: controller.signal,
         });
 
+        // ストリーム開始前のエラーは従来どおり HTTP ステータスで判定する
         if (res.status === 429) {
           return { ok: false, error: 'rateLimited' };
         }
-        if (!res.ok) {
+        if (!res.ok || !res.body) {
           return { ok: false, error: 'network' };
         }
 
-        const json = (await res.json()) as {
-          result?: Partial<AgentChatResult>;
-        };
-        const result = json?.result;
-        if (!result || typeof result.reply !== 'string') {
-          return { ok: false, error: 'network' };
+        const reader = res.body.getReader();
+        const parser = createSSEParser();
+        let result: AgentChatResponse | null = null;
+
+        try {
+          while (!result) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            if (!value) {
+              continue;
+            }
+            for (const event of parser.push(value)) {
+              const handled = handleStreamEvent(event, handlers);
+              if (handled) {
+                result = handled;
+                break;
+              }
+            }
+          }
+        } finally {
+          // done を受け取って抜けた場合も含め、残りのストリームは読まない
+          // (解放待ちで応答を遅らせないため完了は待たない)
+          void reader.cancel().catch(() => undefined);
         }
 
-        return {
-          ok: true,
-          data: {
-            reply: result.reply,
-            // サーバー応答は untrusted として扱い、形の合わない要素は落とす
-            suggestions: Array.isArray(result.suggestions)
-              ? result.suggestions.filter(isAgentSuggestion)
-              : [],
-            refused: result.refused === true,
-          },
-        };
+        if (result) {
+          return result;
+        }
+        // done も error も来ずにストリームが切れた場合はネットワークエラー扱い
+        return { ok: false, error: timedOut ? 'timeout' : 'network' };
       } catch (err) {
         // AbortController による中断はタイムアウトのみ(呼び出し側からの中断経路は無い)
-        if (err instanceof Error && err.name === 'AbortError') {
+        if (timedOut || (err instanceof Error && err.name === 'AbortError')) {
           return { ok: false, error: 'timeout' };
         }
         return { ok: false, error: 'network' };

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -60,6 +60,11 @@ type ChatEntry = {
    * 疑似発話なので会話履歴を汚さないよう false にする。
    */
   includeInHistory: boolean;
+  /**
+   * ストリーミング受信中の仮置きエントリか。delta を追記している間 true で、
+   * done の確定値に置き換えた時点で false になる。
+   */
+  streaming?: boolean;
 };
 
 type SuggestionState = {
@@ -189,13 +194,18 @@ const DestinationAgentScreen = () => {
     return `agent-entry-${entryIdRef.current}`;
   }, []);
 
-  // 新規メッセージが積まれたら最下部へスクロールする
+  // 追従スクロールの発火キー。新規メッセージの追加だけでなく、
+  // ストリーミング中に末尾エントリの本文が伸びたときも変化させる
+  const scrollAnchor = `${entries.length}:${
+    entries[entries.length - 1]?.content.length ?? 0
+  }`;
+
   useEffect(() => {
-    if (!entries.length) {
+    if (scrollAnchor.startsWith('0:')) {
       return;
     }
     scrollRef.current?.scrollToEnd({ animated: true });
-  }, [entries.length]);
+  }, [scrollAnchor]);
 
   // 提案は軽量情報(stationId 等)しか持たないため、CommonCard が必要とする
   // Line オブジェクトを得るために Station 完全体を一括再取得する。
@@ -257,8 +267,20 @@ const DestinationAgentScreen = () => {
         content: text,
         includeInHistory: true,
       };
+      // 送信開始時点で空の assistant エントリを仮置きし、delta で本文を伸ばす。
+      // サーバへ送る履歴には含めないため nextEntries とは分けて持つ。
+      const streamingEntry: ChatEntry = {
+        id: createEntryId(),
+        role: 'assistant',
+        content: '',
+        includeInHistory: true,
+        streaming: true,
+      };
       const nextEntries = [...entries, userEntry];
-      setEntries(nextEntries);
+      setEntries([...nextEntries, streamingEntry]);
+
+      // 会話リセット後に届いた delta / done は捨てる
+      const isStale = () => conversationGenRef.current !== conversationGen;
 
       // sendMessages は reject しない設計だが、万一の例外でも送信フラグが
       // 立ったままにならないよう finally で解除する
@@ -267,7 +289,23 @@ const DestinationAgentScreen = () => {
         res = await sendMessages(
           nextEntries
             .filter((entry) => entry.includeInHistory)
-            .map((entry) => ({ role: entry.role, content: entry.content }))
+            .map((entry) => ({ role: entry.role, content: entry.content })),
+          {
+            onDelta: (delta) => {
+              if (isStale()) {
+                return;
+              }
+              setEntries((prev) =>
+                prev.map((entry) =>
+                  entry.id === streamingEntry.id
+                    ? { ...entry, content: entry.content + delta }
+                    : entry
+                )
+              );
+            },
+            // ツール実行中もタイピングインジケータのまま待たせる(専用文言は設けない)
+            onToolStart: () => undefined,
+          }
         );
       } finally {
         sendingRef.current = false;
@@ -275,23 +313,29 @@ const DestinationAgentScreen = () => {
       }
 
       // 応答待ちの間に会話がリセットされていたら結果を破棄する
-      if (conversationGenRef.current !== conversationGen) {
+      if (isStale()) {
         return;
       }
 
       if (res.ok) {
-        const assistantEntry: ChatEntry = {
-          id: createEntryId(),
-          role: 'assistant',
-          content: res.data.reply,
-          suggestions: res.data.suggestions,
-          includeInHistory: true,
-        };
-        setEntries((prev) => [...prev, assistantEntry]);
-        AccessibilityInfo.announceForAccessibility(res.data.reply);
+        // done が正。蓄積した delta を確定値で置き換える
+        const { reply, suggestions } = res.data;
+        setEntries((prev) =>
+          prev.map((entry) =>
+            entry.id === streamingEntry.id
+              ? {
+                  ...entry,
+                  content: reply,
+                  suggestions,
+                  streaming: false,
+                }
+              : entry
+          )
+        );
+        AccessibilityInfo.announceForAccessibility(reply);
 
-        if (res.data.suggestions.length) {
-          void resolveSuggestions(assistantEntry.id, res.data.suggestions);
+        if (suggestions.length) {
+          void resolveSuggestions(streamingEntry.id, suggestions);
         }
         return;
       }
@@ -299,7 +343,7 @@ const DestinationAgentScreen = () => {
       if (res.error === 'rateLimited') {
         setRateLimited(true);
         setEntries((prev) => [
-          ...prev,
+          ...prev.filter((entry) => entry.id !== streamingEntry.id),
           {
             id: createEntryId(),
             role: 'assistant',
@@ -310,8 +354,13 @@ const DestinationAgentScreen = () => {
         return;
       }
 
-      // ネットワーク / 5xx / タイムアウト: 未応答のユーザ発話を履歴に残さない
-      setEntries((prev) => prev.filter((entry) => entry.id !== userEntry.id));
+      // ネットワーク / 5xx / タイムアウト / ストリーム中断: 仮置きエントリと
+      // 未応答のユーザ発話を履歴に残さない(受信途中の delta も破棄される)
+      setEntries((prev) =>
+        prev.filter(
+          (entry) => entry.id !== userEntry.id && entry.id !== streamingEntry.id
+        )
+      );
       // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する
       setInputText((prev) => (prev.length ? prev : text));
       showToast({
@@ -436,6 +485,9 @@ const DestinationAgentScreen = () => {
   );
 
   const isEmpty = entries.length === 0;
+  // 最初の delta が届くまではタイピングインジケータで待たせる
+  const streamingContent =
+    entries.find((entry) => entry.streaming)?.content ?? '';
 
   return (
     <SafeAreaView
@@ -466,23 +518,29 @@ const DestinationAgentScreen = () => {
           {isEmpty ? (
             <AgentEmptyState onSelectExample={handleSend} />
           ) : (
-            entries.map((entry, index) => (
-              // 出現アニメーションは SelectLineScreen の路線リストと同じ既存イディオム(ui.md)
-              <Animated.View
-                key={entry.id}
-                layout={LinearTransition.springify()}
-                style={
-                  entries[index - 1]?.role === entry.role
-                    ? styles.sameSpeakerSpacing
-                    : undefined
-                }
-              >
-                <AgentMessageBubble role={entry.role} content={entry.content} />
-                {renderSuggestions(entry)}
-              </Animated.View>
-            ))
+            entries.map((entry, index) =>
+              // 本文が空の仮置きエントリはバブルを出さない(タイピングインジケータが代わり)
+              entry.streaming && !entry.content ? null : (
+                // 出現アニメーションは SelectLineScreen の路線リストと同じ既存イディオム(ui.md)
+                <Animated.View
+                  key={entry.id}
+                  layout={LinearTransition.springify()}
+                  style={
+                    entries[index - 1]?.role === entry.role
+                      ? styles.sameSpeakerSpacing
+                      : undefined
+                  }
+                >
+                  <AgentMessageBubble
+                    role={entry.role}
+                    content={entry.content}
+                  />
+                  {renderSuggestions(entry)}
+                </Animated.View>
+              )
+            )
           )}
-          {sending && <AgentTypingIndicator />}
+          {sending && !streamingContent && <AgentTypingIndicator />}
         </ScrollView>
 
         {isEmpty && (

--- a/src/utils/sse.test.ts
+++ b/src/utils/sse.test.ts
@@ -1,0 +1,153 @@
+import { createSSEParser, parseSSEChunk } from './sse';
+
+const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+describe('parseSSEChunk', () => {
+  it('event と data の組を 1 イベントとして取り出す', () => {
+    const { events, rest } = parseSSEChunk(
+      '',
+      'event: delta\ndata: {"text":"こん"}\n\n'
+    );
+
+    expect(events).toEqual([{ event: 'delta', data: '{"text":"こん"}' }]);
+    expect(rest).toBe('');
+  });
+
+  it('1 チャンクに含まれる複数イベントを順番に取り出す', () => {
+    const { events } = parseSSEChunk(
+      '',
+      'event: delta\ndata: {"text":"a"}\n\nevent: delta\ndata: {"text":"b"}\n\nevent: done\ndata: {"reply":"ab"}\n\n'
+    );
+
+    expect(events.map((event) => event.event)).toEqual([
+      'delta',
+      'delta',
+      'done',
+    ]);
+    expect(events[2].data).toBe('{"reply":"ab"}');
+  });
+
+  it('複数行の data は改行で連結する', () => {
+    const { events } = parseSSEChunk(
+      '',
+      'event: done\ndata: {\ndata: "a":1}\n\n'
+    );
+
+    expect(events).toEqual([{ event: 'done', data: '{\n"a":1}' }]);
+  });
+
+  it('コメント行(: 始まり)は無視する', () => {
+    const { events } = parseSSEChunk(
+      '',
+      ': keep-alive\n\nevent: delta\ndata: {"text":"a"}\n\n'
+    );
+
+    expect(events).toEqual([{ event: 'delta', data: '{"text":"a"}' }]);
+  });
+
+  it('event 行が無い場合は既定のイベント名 message を使う', () => {
+    const { events } = parseSSEChunk('', 'data: hello\n\n');
+
+    expect(events).toEqual([{ event: 'message', data: 'hello' }]);
+  });
+
+  it('id や retry など解釈しないフィールドは読み飛ばす', () => {
+    const { events } = parseSSEChunk(
+      '',
+      'id: 1\nretry: 3000\nevent: tool\ndata: {}\n\n'
+    );
+
+    expect(events).toEqual([{ event: 'tool', data: '{}' }]);
+  });
+
+  it('コロン直後の空白は 1 文字だけ取り除く', () => {
+    const { events } = parseSSEChunk('', 'event: delta\ndata:  leading\n\n');
+
+    expect(events).toEqual([{ event: 'delta', data: ' leading' }]);
+  });
+
+  it('CRLF 区切りも解釈する', () => {
+    const { events } = parseSSEChunk(
+      '',
+      'event: delta\r\ndata: {"text":"a"}\r\n\r\n'
+    );
+
+    expect(events).toEqual([{ event: 'delta', data: '{"text":"a"}' }]);
+  });
+
+  it('未完のイベントは rest へ持ち越して次のチャンクで解釈する', () => {
+    const first = parseSSEChunk('', 'event: delta\ndata: {"te');
+    expect(first.events).toEqual([]);
+    expect(first.rest).toBe('event: delta\ndata: {"te');
+
+    const second = parseSSEChunk(first.rest, 'xt":"a"}\n\n');
+    expect(second.events).toEqual([{ event: 'delta', data: '{"text":"a"}' }]);
+    expect(second.rest).toBe('');
+  });
+
+  it('区切りの空行だけが次チャンクに来る場合も取りこぼさない', () => {
+    const first = parseSSEChunk('', 'event: done\ndata: {}\n');
+    expect(first.events).toEqual([]);
+
+    const second = parseSSEChunk(first.rest, '\n');
+    expect(second.events).toEqual([{ event: 'done', data: '{}' }]);
+  });
+});
+
+describe('createSSEParser', () => {
+  it('イベント途中で分割されたバイト列を結合して解釈する', () => {
+    const parser = createSSEParser();
+    const payload =
+      'event: delta\ndata: {"text":"a"}\n\nevent: done\ndata: {}\n\n';
+    const bytes = encode(payload);
+
+    const events = [
+      ...parser.push(bytes.slice(0, 10)),
+      ...parser.push(bytes.slice(10, 33)),
+      ...parser.push(bytes.slice(33)),
+    ];
+
+    expect(events).toEqual([
+      { event: 'delta', data: '{"text":"a"}' },
+      { event: 'done', data: '{}' },
+    ]);
+  });
+
+  it('マルチバイト文字の途中で分割されても文字化けしない', () => {
+    const parser = createSSEParser();
+    const bytes = encode('event: delta\ndata: {"text":"海が見える"}\n\n');
+    // 「海」(3 バイト)の途中に当たる位置で分割する
+    const splitAt = encode('event: delta\ndata: {"text":"').length + 1;
+
+    const events = [
+      ...parser.push(bytes.slice(0, splitAt)),
+      ...parser.push(bytes.slice(splitAt)),
+    ];
+
+    expect(events).toEqual([{ event: 'delta', data: '{"text":"海が見える"}' }]);
+  });
+
+  it('1 バイトずつ流し込んでも全イベントを復元できる', () => {
+    const parser = createSSEParser();
+    const bytes = encode(
+      'event: delta\ndata: {"text":"あ"}\n\nevent: delta\ndata: {"text":"い"}\n\n'
+    );
+
+    const events = Array.from(bytes).flatMap((byte) =>
+      parser.push(new Uint8Array([byte]))
+    );
+
+    expect(events).toEqual([
+      { event: 'delta', data: '{"text":"あ"}' },
+      { event: 'delta', data: '{"text":"い"}' },
+    ]);
+  });
+
+  it('未完のまま終わったイベントは返さない', () => {
+    const parser = createSSEParser();
+
+    expect(parser.push(encode('event: delta\ndata: {"text":"a"}\n'))).toEqual(
+      []
+    );
+  });
+});

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -1,0 +1,122 @@
+/**
+ * 最小の SSE(text/event-stream)パーサ。依存ゼロ。
+ *
+ * SSE クライアントライブラリを追加しない方針(docs/spec/ai-agent/architecture.md
+ * 「クライアント設計 > API 呼び出し」)のため、必要な範囲だけを自前で実装する。
+ * 解釈するのは `event:` / `data:` 行とイベント区切り(空行)のみで、
+ * `id:` / `retry:` などその他のフィールドは無視する。
+ */
+
+export type SSEEvent = {
+  /** イベント名。`event:` 行が無い場合は SSE 仕様の既定値 `message` */
+  event: string;
+  /** 複数行の `data:` を改行で連結した本文 */
+  data: string;
+};
+
+export type SSEParseResult = {
+  /** チャンク境界をまたいで完成したイベント列 */
+  events: SSEEvent[];
+  /** 次のチャンクへ持ち越す未完の残余 */
+  rest: string;
+};
+
+/**
+ * 1 イベント分のブロック(空行で区切られた行の集合)を解釈する。
+ * 解釈できるフィールドが無いブロック(コメント行のみのキープアライブ等)は null。
+ */
+const parseEventBlock = (block: string): SSEEvent | null => {
+  let event = '';
+  const dataLines: string[] = [];
+  let hasField = false;
+
+  for (const line of block.split('\n')) {
+    // 空行は区切りとして消費済みなので残っていても無視。
+    // `:` 始まりはコメント行(キープアライブ)なので無視する。
+    if (line.length === 0 || line.startsWith(':')) {
+      continue;
+    }
+
+    const colonIndex = line.indexOf(':');
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+    const rawValue = colonIndex === -1 ? '' : line.slice(colonIndex + 1);
+    // 仕様どおり、コロン直後の空白 1 文字だけを取り除く
+    const value = rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue;
+
+    if (field === 'event') {
+      event = value;
+      hasField = true;
+    } else if (field === 'data') {
+      dataLines.push(value);
+      hasField = true;
+    }
+  }
+
+  if (!hasField) {
+    return null;
+  }
+
+  return {
+    event: event.length ? event : 'message',
+    data: dataLines.join('\n'),
+  };
+};
+
+/**
+ * 前回の残余と新しいチャンク文字列から、完成したイベント列と次の残余を返す純関数。
+ *
+ * 改行は `\n` / `\r\n` を解釈する(SSE 仕様が許す単独 `\r` 区切りは、
+ * 実運用のサーバが使わないため非対応)。イベントの途中でチャンクが切れた場合は
+ * 未完部分を `rest` として返し、次回の呼び出しで結合して解釈する。
+ */
+export const parseSSEChunk = (
+  pending: string,
+  chunk: string
+): SSEParseResult => {
+  const buffer = `${pending}${chunk}`.replace(/\r\n/g, '\n');
+  const events: SSEEvent[] = [];
+
+  let rest = buffer;
+  let separatorIndex = rest.indexOf('\n\n');
+  while (separatorIndex !== -1) {
+    const event = parseEventBlock(rest.slice(0, separatorIndex));
+    if (event) {
+      events.push(event);
+    }
+    rest = rest.slice(separatorIndex + 2);
+    separatorIndex = rest.indexOf('\n\n');
+  }
+
+  return { events, rest };
+};
+
+export type SSEParser = {
+  /**
+   * バイト列チャンクを流し込み、そのチャンクまでで完成したイベント列を得る。
+   * マルチバイト文字がチャンク境界で分断されても `TextDecoder` の
+   * ストリーミングデコードで正しく連結される。
+   */
+  push: (chunk: Uint8Array) => SSEEvent[];
+};
+
+/**
+ * バイト列を受け取る逐次パーサを生成する。
+ *
+ * `TextDecoder` は Expo の WinterCG 互換ランタイム(expo/src/winter/runtime.native.ts)が
+ * グローバルへ導入するため、Hermes 上でもそのまま利用できる。
+ */
+export const createSSEParser = (): SSEParser => {
+  const decoder = new TextDecoder('utf-8');
+  let pending = '';
+
+  return {
+    push: (chunk: Uint8Array): SSEEvent[] => {
+      const { events, rest } = parseSSEChunk(
+        pending,
+        decoder.decode(chunk, { stream: true })
+      );
+      pending = rest;
+      return events;
+    },
+  };
+};


### PR DESCRIPTION
## 概要

AI エージェント（行き先相談チャット）の応答を SSE によるストリーミングで逐次表示するよう対応しました。従来は tool use ループを含む確定応答（最大 20 秒程度）をローディング表示だけで待たせていましたが、`POST /agent/chat/stream` から `reply` 本文の増分（`delta`）を受信して随時描画します。設計書 `docs/spec/ai-agent/architecture.md` の「ストリーミング」節（従来スコープ外 → 今回スコープ内へ昇格）を先に更新し、その設計に沿って実装しています。

BFF 側のエンドポイント実装（`streamText` 化 + SSE 配信）は TrainLCD/BFF リポジトリ側で別途 PR を作成します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `docs/spec/ai-agent/architecture.md`: ストリーミング節を SSE 配信設計へ全面更新（エンドポイント仕様・イベント仕様 `delta` / `tool` / `done` / `error`・サーバ / クライアント実装方針・タイムアウト・エラーハンドリング・変更ファイル一覧・未決事項 4 の決定化）
- `src/utils/sse.ts`（新規）: 依存ゼロの最小 SSE パーサ。純関数 `parseSSEChunk`（複数行 `data` の連結・コメント行無視・CRLF・チャンク跨ぎのバッファリング）と、`TextDecoder(stream: true)` を内包した逐次パーサ `createSSEParser`
- `src/hooks/useDestinationAgent.ts`: `expo/fetch` で `/agent/chat/stream` に POST し `res.body` を逐次読取。`sendMessages(messages, handlers?)` に拡張（`onDelta` / `onToolStart`）。戻り値の形とエラー種別（`rateLimited` / `timeout` / `network`）は現行維持。`expo/fetch` は中断時に DOM 準拠の `AbortError` を投げないため、30 秒タイムアウトは自前フラグで判定
- `src/screens/DestinationAgent/index.tsx`: 送信開始時に仮置きの assistant バブルを追加し `delta` で本文を追記、`done` の確定値で置き換えてから提案カード解決と読み上げを実行。エラー時は仮置きと未応答のユーザ発話を除去。会話リセット世代ガードとストリーミング中の追従スクロールに対応
- `src/utils/sse.test.ts`（新規）・`src/hooks/useDestinationAgent.test.ts`: SSE パーサ 14 件・フック 22 件（`expo/fetch` を `ReadableStream` でモックし、チャンク分割・マルチバイト境界・中断系を検証)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は全体で 198 suites / 2138 tests パス。dev ビルドでのストリーミング表示の手動 QA（BFF 側デプロイ後の結合確認）は未実施です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AIエージェントがストリーミング応答に対応しました。
  * 生成中の文章を逐次表示し、ツール実行の開始状態も表示します。
  * 応答完了時に最終メッセージへ自動更新します。
* **改善**
  * タイムアウト、通信エラー、レート制限などを適切に処理します。
  * 会話リセット後の遅延応答を破棄し、表示の不整合を防止します。
* **ドキュメント**
  * ストリーミングAPI、イベント仕様、エラー処理、テスト方針を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->