### PR TITLE
AIエージェント送信時のトークン先読みと検索中表示でストリーミング開始までの体感遅延を改善

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -348,6 +348,7 @@
   "destinationAgentExample2": "Take me to a hot spring town",
   "destinationAgentExample3": "How do I use this app?",
   "destinationAgentDisclaimer": "AI suggestions may contain mistakes",
+  "destinationAgentSearching": "Searching for stations…",
   "destinationAgentRateLimited": "You've reached today's limit. Please try again tomorrow",
   "destinationAgentReset": "Reset conversation",
   "destinationAgentResetShort": "Reset",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -349,6 +349,7 @@
   "destinationAgentExample2": "温泉のある観光地に行きたい",
   "destinationAgentExample3": "このアプリの使い方を知りたい",
   "destinationAgentDisclaimer": "AIの提案は誤りを含む場合があります",
+  "destinationAgentSearching": "駅を検索しています…",
   "destinationAgentRateLimited": "本日の利用上限に達しました。また明日お試しください",
   "destinationAgentReset": "会話をリセット",
   "destinationAgentResetShort": "リセット",

--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -261,7 +261,8 @@ sequenceDiagram
   participant S as sapi-bff
 
   App->>W: POST /agent/chat（messages, locale）
-  W->>W: JWT検証・入力バリデーション・レート制限
+  W->>W: JWT検証・入力バリデーション
+  Note over W: キルスイッチ・日次上限チェック・<br>トピックゲート・FAQ / 現在駅解決を並列実行
   W->>WAI: トピックゲート（3値分類）
   alt off_topic（対象外）
     Note over W: 本体LLMを呼ばない
@@ -441,6 +442,12 @@ few-shot（`CONFIG_KV` の `config:fewshot`）と同じパターンで、`CONFIG
 - 日次上限は KV に `agent-rl:<installId>:<yyyymmdd>` のカウンタ
   （TTL 25 時間）で実装する。KV の結果整合で厳密さは劣るが PoC には
   十分。厳密なレート制限が必要になったら Durable Objects へ移行する。
+- カウンタは「チェック（KV get）」と「消費（KV put）」を分離する。
+  チェックは前段の並列処理で行い、消費は本体ターンの開始が確定した
+  時点で `ctx.waitUntil` に逃がす（KV put は 100〜300ms 級のため、
+  最初の delta までの直列経路に置かない）。謝絶（off_topic）は消費前に
+  確定するためターンを消費しない。エラー・タイムアウトで応答を返せ
+  なかったターンは消費済みカウンタを払い戻す。
 - 上限到達時は 429 と定型メッセージを返し、クライアントはそれを
   表示する。
 

--- a/docs/spec/ai-agent/ui.md
+++ b/docs/spec/ai-agent/ui.md
@@ -234,6 +234,11 @@ Figma デザインは人力ではなく Figma MCP で本書を入力として起
   フェードループアニメーションを表示。応答受信で本文に置換する。
 - LED テーマ時はアニメーションを点滅（opacity 2 段階）に落とし、
   ドット絵的な質感と揃える。
+- `tool` イベント受信中（駅検索の tool use ループ中）は、3 点ドットの
+  右に `destinationAgentSearching` の文言を副次テキストの配色
+  （`#737373` / LED 時 `#ccc`）で並べる。最初の `delta` 受信または応答
+  確定で文言を消す。表示開始時に
+  `AccessibilityInfo.announceForAccessibility` で 1 回だけ読み上げる。
 - サーバ側タイムアウトは最大 25 秒 + クライアント 30 秒
   （architecture.md）。10 秒経過で補助文言を追加表示する案は不採用
   （判断チェックリストで確定）。タイムアウトまでインジケータのみを
@@ -400,6 +405,9 @@ flowchart LR
 - `destinationAgentDisclaimer`
   - ja: AIの提案は誤りを含む場合があります
   - en: AI suggestions may contain mistakes
+- `destinationAgentSearching`
+  - ja: 駅を検索しています…
+  - en: Searching for stations…
 - `destinationAgentRateLimited`
   - ja: 本日の利用上限に達しました。また明日お試しください
   - en: You've reached today's limit. Please try again tomorrow

--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { fetch } from 'expo/fetch';
+import { getSessionToken } from '~/lib/session';
 import {
   AGENT_MAX_MESSAGES,
   AGENT_REQUEST_TIMEOUT_MS,
@@ -21,6 +22,7 @@ jest.mock('~/lib/session', () => ({
 }));
 
 const fetchMock = fetch as unknown as jest.Mock;
+const getSessionTokenMock = getSessionToken as jest.Mock;
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -106,6 +108,23 @@ describe('trimAgentMessages', () => {
 });
 
 describe('useDestinationAgent', () => {
+  it('マウント時にセッショントークンを先読みする', () => {
+    renderHook(() => useDestinationAgent());
+
+    // 送信の直列経路から /auth/token の往復を外すための先読み。
+    // この時点ではチャット API は呼ばない
+    expect(getSessionTokenMock).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('先読みが失敗しても例外を投げない', async () => {
+    getSessionTokenMock.mockRejectedValueOnce(new Error('network'));
+
+    expect(() => renderHook(() => useDestinationAgent())).not.toThrow();
+    // 未処理の rejection にならないことを確認するためマイクロタスクを流す
+    await Promise.resolve();
+  });
+
   it('done イベントを reply / suggestions / refused に詰めて返す', async () => {
     mockStreamResponse([
       doneEvent({

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -1,6 +1,6 @@
 import { fetch } from 'expo/fetch';
 import { useAtomValue } from 'jotai';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { getSessionToken } from '~/lib/session';
 import { workerUrl } from '~/lib/workerApi';
 import { stationAtom } from '~/store/atoms/station';
@@ -148,6 +148,16 @@ export const useDestinationAgent = (): {
 } => {
   const station = useAtomValue(stationAtom);
   const currentStationGroupId = station?.groupId ?? undefined;
+
+  // セッショントークンを画面マウント時に先読みしておく。アプリ起動後の初回送信では
+  // /auth/token の往復が送信の直列経路に入り、ストリーミング開始までの体感遅延に
+  // 直結するため、ユーザが入力している間に取得を済ませてキャッシュに載せる。
+  // getSessionToken はメモリキャッシュ付きで冪等・アラート等の可視副作用も無いため、
+  // StrictMode による effect の再実行があっても安全(CLAUDE.md の StrictMode 規約)。
+  // 失敗しても握りつぶす(送信時に再度取得され、そこでエラー処理される)。
+  useEffect(() => {
+    void getSessionToken().catch(() => undefined);
+  }, []);
 
   const sendMessages = useCallback(
     async (

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,93 @@
+import { clearSessionToken, getSessionToken } from './session';
+
+jest.mock('./installId', () => ({
+  getInstallId: jest.fn().mockResolvedValue('test-install-id'),
+}));
+
+jest.mock('./workerApi', () => ({
+  workerUrl: (path: string) => `https://worker.test${path}`,
+}));
+
+const fetchMock = jest.fn();
+const origFetch = global.fetch;
+global.fetch = fetchMock as unknown as typeof fetch;
+
+// 解決タイミングを手動制御できる /auth/token 応答を 1 回分積む
+const deferTokenResponse = () => {
+  let resolve!: (value: unknown) => void;
+  fetchMock.mockReturnValueOnce(
+    new Promise((r) => {
+      resolve = r;
+    })
+  );
+  return {
+    resolveWith: (token: string) =>
+      resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ token, expiresIn: 3600 }),
+      }),
+  };
+};
+
+const mockTokenResponse = (token: string) => {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ token, expiresIn: 3600 }),
+  });
+};
+
+const mockTokenFailure = () => {
+  fetchMock.mockResolvedValueOnce({
+    ok: false,
+    status: 503,
+    json: async () => ({}),
+  });
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+  clearSessionToken();
+});
+
+afterAll(() => {
+  global.fetch = origFetch;
+});
+
+describe('getSessionToken', () => {
+  it('取得中に並行して呼び出しても /auth/token への POST は 1 回に共有される', async () => {
+    const deferred = deferTokenResponse();
+
+    // 先読み(画面マウント)と初回送信が競合するシナリオ
+    const first = getSessionToken();
+    const second = getSessionToken();
+    deferred.resolveWith('token-shared');
+
+    await expect(first).resolves.toBe('token-shared');
+    await expect(second).resolves.toBe('token-shared');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャッシュが有効な間は再取得しない', async () => {
+    mockTokenResponse('token-cached');
+    await expect(getSessionToken()).resolves.toBe('token-cached');
+
+    await expect(getSessionToken()).resolves.toBe('token-cached');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('取得失敗(null)は並行呼び出しに共有され、次回の呼び出しで再取得する', async () => {
+    mockTokenFailure();
+    const first = getSessionToken();
+    const second = getSessionToken();
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 失敗は inflight のクリア後なので、次の呼び出しは新規に取得する
+    mockTokenResponse('token-retry');
+    await expect(getSessionToken()).resolves.toBe('token-retry');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -4,18 +4,17 @@ import { workerUrl } from './workerApi';
 // Worker が発行する短期セッショントークン（Firebase ID トークンの代替）。
 // /auth/token から取得し、有効期限手前まではメモリにキャッシュして使い回す。
 let cached: { token: string; expiresAt: number } | null = null;
+// 取得中の Promise。先読み(チャット画面マウント時)と初回送信が競合したとき、
+// /auth/token への POST を 1 回に共有するために保持する
+let inflight: Promise<string | null> | null = null;
 const EXPIRY_SKEW_MS = 60_000;
 
 export const clearSessionToken = (): void => {
   cached = null;
 };
 
-export const getSessionToken = async (): Promise<string | null> => {
+const fetchSessionToken = async (): Promise<string | null> => {
   const now = Date.now();
-  if (cached && cached.expiresAt - EXPIRY_SKEW_MS > now) {
-    return cached.token;
-  }
-
   try {
     const installId = await getInstallId();
     const res = await fetch(workerUrl('/auth/token'), {
@@ -43,4 +42,18 @@ export const getSessionToken = async (): Promise<string | null> => {
     console.warn('[session] failed to fetch session token:', e);
     return null;
   }
+};
+
+export const getSessionToken = async (): Promise<string | null> => {
+  if (cached && cached.expiresAt - EXPIRY_SKEW_MS > Date.now()) {
+    return cached.token;
+  }
+  // 取得中なら同じ Promise を返して二重 POST を避ける。失敗(null)も共有され、
+  // 解決・拒否後は必ずクリアされるため次回呼び出しでは再取得される
+  if (!inflight) {
+    inflight = fetchSessionToken().finally(() => {
+      inflight = null;
+    });
+  }
+  return inflight;
 };

--- a/src/screens/DestinationAgent/AgentTypingIndicator.tsx
+++ b/src/screens/DestinationAgent/AgentTypingIndicator.tsx
@@ -10,6 +10,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import Typography from '~/components/Typography';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 
 // 3 点ドットの位相ずらし(ms)。件数固定なのでキーにも使う
@@ -42,6 +43,17 @@ const styles = StyleSheet.create({
   dot: {
     width: 8,
     height: 8,
+  },
+  label: {
+    fontSize: 14,
+    // ドット群と文言が詰まって見えないよう、root の gap 6 に少し足す
+    marginLeft: 2,
+  },
+  labelColor: {
+    color: '#737373',
+  },
+  labelLEDColor: {
+    color: '#ccc',
   },
 });
 
@@ -94,7 +106,8 @@ const Dot = ({ delay, isLEDTheme }: { delay: number; isLEDTheme: boolean }) => {
 };
 
 // 送信中に表示するタイピングインジケータ。アシスタントバブルと同じ器に 3 点ドットを出す。
-export const AgentTypingIndicator = () => {
+// label を渡すとドットの右に補助文言(ツール実行中の「駅を検索しています…」等)を並べる。
+export const AgentTypingIndicator = ({ label }: { label?: string }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   return (
@@ -106,6 +119,16 @@ export const AgentTypingIndicator = () => {
           isLEDTheme={isLEDTheme}
         />
       ))}
+      {label ? (
+        <Typography
+          style={[
+            styles.label,
+            isLEDTheme ? styles.labelLEDColor : styles.labelColor,
+          ]}
+        >
+          {label}
+        </Typography>
+      ) : null}
     </View>
   );
 };

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -153,6 +153,9 @@ const DestinationAgentScreen = () => {
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [inputText, setInputText] = useState('');
   const [sending, setSending] = useState(false);
+  // tool イベント受信中(駅検索の tool use ループ中)であることを示すフラグ。
+  // 最初の delta が届くか応答が確定した時点で降ろす
+  const [searching, setSearching] = useState(false);
   const [rateLimited, setRateLimited] = useState(false);
   const [suggestionStates, setSuggestionStates] = useState<
     Record<string, SuggestionState>
@@ -258,8 +261,11 @@ const DestinationAgentScreen = () => {
 
       sendingRef.current = true;
       setSending(true);
+      setSearching(false);
       setInputText('');
       const conversationGen = conversationGenRef.current;
+      // 検索中文言の読み上げは 1 送信につき 1 回だけ(tool イベントは複数回届きうる)
+      let searchingAnnounced = false;
 
       const userEntry: ChatEntry = {
         id: createEntryId(),
@@ -295,6 +301,8 @@ const DestinationAgentScreen = () => {
               if (isStale()) {
                 return;
               }
+              // 本文が流れ始めたら検索中表示を畳む(以降はバブルが伸びていく)
+              setSearching(false);
               setEntries((prev) =>
                 prev.map((entry) =>
                   entry.id === streamingEntry.id
@@ -303,13 +311,26 @@ const DestinationAgentScreen = () => {
                 )
               );
             },
-            // ツール実行中もタイピングインジケータのまま待たせる(専用文言は設けない)
-            onToolStart: () => undefined,
+            // 駅検索の tool use ループは数秒かかるため、その間は
+            // タイピングインジケータに検索中である旨を添える
+            onToolStart: () => {
+              if (isStale()) {
+                return;
+              }
+              setSearching(true);
+              if (!searchingAnnounced) {
+                searchingAnnounced = true;
+                AccessibilityInfo.announceForAccessibility(
+                  translate('destinationAgentSearching')
+                );
+              }
+            },
           }
         );
       } finally {
         sendingRef.current = false;
         setSending(false);
+        setSearching(false);
       }
 
       // 応答待ちの間に会話がリセットされていたら結果を破棄する
@@ -540,7 +561,13 @@ const DestinationAgentScreen = () => {
               )
             )
           )}
-          {sending && !streamingContent && <AgentTypingIndicator />}
+          {sending && !streamingContent && (
+            <AgentTypingIndicator
+              label={
+                searching ? translate('destinationAgentSearching') : undefined
+              }
+            />
+          )}
         </ScrollView>
 
         {isEmpty && (


### PR DESCRIPTION
## 概要

AI エージェントのストリーミング対応(#6492)のフォローアップとして、送信からストリーミング開始(最初の `delta` 受信)までの体感遅延を改善しました。クライアント側で対処できる 2 点です:

1. **セッショントークンの先読み**: アプリ起動後の初回送信では `/auth/token` への往復が送信の直列経路に入っていたため、チャット画面マウント時に先読みしてキャッシュに載せ、送信時の待ちを解消
2. **駅検索中の状態表示**: サーバの tool use ループ中(数秒)は従来「・・・」のままだったため、SSE の `tool` イベントを受けてタイピングインジケータに「駅を検索しています…」を添えて進捗が見えるように変更

BFF 側の直列レイテンシ削減(前段処理の並列化・レート制限カウンタ書き込みのクリティカルパス除去・OpenAI 系モデルの reasoning 抑制、毎ターン約 150〜450ms + reasoning 分の削減見込み)は TrainLCD/BFF リポジトリ側で実装済みで、別途 PR を作成します。本 PR には対応する設計書の追随を含みます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useDestinationAgent.ts`: マウント時に `getSessionToken()` を先読みする `useEffect` を追加(キャッシュ付き・冪等のため StrictMode 再実行にも安全)
- `src/lib/session.ts`: 取得中(in-flight)の Promise を共有し、先読みと初回送信が競合しても `/auth/token` への POST が 1 回になるよう変更(CodeRabbit 指摘対応)
- `src/screens/DestinationAgent/index.tsx`: `searching` state を追加し、`onToolStart`(世代ガード通過時のみ)で検索中表示を点灯、最初の `delta` または応答確定で消灯。読み上げは 1 送信 1 回
- `src/screens/DestinationAgent/AgentTypingIndicator.tsx`: optional な `label` prop を追加し、ドットの右に補助文言を表示(LED テーマ対応)
- `assets/translations/ja.json` / `en.json`: `destinationAgentSearching` キーを追加
- `docs/spec/ai-agent/ui.md`: 検索中表示の仕様を追記
- `docs/spec/ai-agent/architecture.md`: BFF 側レイテンシ改善(前段処理の並列化・レート制限カウンタのチェック / 消費分離)を設計書に反映
- `src/hooks/useDestinationAgent.test.ts`: トークン先読みのテスト 2 件を追加(計 24 件)
- `src/lib/session.test.ts`(新規): 並行呼び出しの POST 共有・失敗後の再取得のテスト 3 件

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は全体で 199 suites / 2143 tests パス。dev への rebase 後にも `npm run typecheck` と対象テストの通過を確認済みです。設計書は `markdownlint-cli2` 0 件。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
