### PR TITLE
ヘッダーのdividerの影がboxShadow移行後に数px下へずれる問題を修正

### DIFF
--- a/src/components/HeaderEast/config.ts
+++ b/src/components/HeaderEast/config.ts
@@ -37,7 +37,6 @@ export const tokyoMetroConfig: HeaderEastThemeConfig = {
   gradientColors: ['#fcfcfc', '#fcfcfc', '#eee', '#fcfcfc', '#fcfcfc'] as const,
   gradientLocations: [0, 0.45, 0.5, 0.6, 0.6] as const,
   rootStyle: {
-    boxShadow: '0px 2px 2px rgba(51, 51, 51, 0.25)',
     paddingBottom: 4,
   },
   textColor: '#555',
@@ -46,6 +45,12 @@ export const tokyoMetroConfig: HeaderEastThemeConfig = {
   divider: {
     height: isTablet ? 6 : 4,
     color: 'dynamic',
+    extraStyle: {
+      // boxShadow はルートのボーダーボックス基準で描画されるため、
+      // ルート(paddingBottom: 4 の透明領域を持つ)に付けると影が divider から
+      // 数px下に離れてしまう。divider 自身に付けて境界線に密着させる。
+      boxShadow: '0px 2px 2px rgba(51, 51, 51, 0.25)',
+    },
   },
   numberingIcon: {
     wrapped: true,

--- a/src/components/HeaderJRKyushu.tsx
+++ b/src/components/HeaderJRKyushu.tsx
@@ -13,7 +13,6 @@ import Typography from './Typography';
 
 const styles = StyleSheet.create({
   root: {
-    boxShadow: '0px 2px 2px rgba(51, 51, 51, 0.25)',
     paddingBottom: 4,
     zIndex: 9999,
   },
@@ -98,6 +97,10 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
     height: isTablet ? 6 : 4,
     backgroundColor: '#E50012',
+    // boxShadow はルートのボーダーボックス基準で描画されるため、
+    // ルート(paddingBottom: 4 の透明領域を持つ)に付けると影が divider から
+    // 数px下に離れてしまう。divider 自身に付けて境界線に密着させる。
+    boxShadow: '0px 2px 2px rgba(51, 51, 51, 0.25)',
   },
   headerTexts: {
     flexDirection: 'row',


### PR DESCRIPTION
## 概要

#6491 で iOS 向けの影設定を RN の `boxShadow` に置き換えて以降、ヘッダー下部の divider に付くべき影が数ピクセル下にずれて表示されるようになっていたのを修正します。

原因は、影の指定がヘッダーの**ルート View** に付いたままだったことです。旧来の iOS `shadowColor` / `shadowOffset` は（`shadowPath` 未設定・背景色なしの View では）レイヤーが実際に描画した内容のアルファ形状から影を生成するため、影は divider の下端に密着していました。一方 `boxShadow` は View のボーダーボックス基準で描画されます。ルート View は `paddingBottom: 4` の透明領域を持つため、ボーダーボックス下端が divider より 4px 下になり、さらに `offsetY` 2px 分ずれて、divider と影の間に隙間が見える状態になっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/HeaderEast/config.ts`: `tokyoMetroConfig` の `boxShadow` を `rootStyle` から `divider.extraStyle` へ移動
- `src/components/HeaderJRKyushu.tsx`: 同じ構造・同じ症状だったため、`boxShadow` を `styles.root` から `styles.divider` へ移動
- レイアウト高さを変えないよう、ルートの `paddingBottom: 4` は据え置き
- 移動理由が非自明なため、両ファイルに意図を説明するコメントを追記

影の値（`0px 2px 2px rgba(51, 51, 51, 0.25)`）自体は変更していません。`tyConfig` の divider（`0px 2px 0px #ccc`）は元から divider 側に付いていたため影響なし。他ヘッダーに legacy shadow 指定が残っていないことも確認済みです。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカルでの実行結果:

- `npm run lint`: Checked 601 files, No fixes applied
- `npm test`: 199 suites / 2156 tests すべて pass
- `npm run typecheck`: エラーなし

なお、シミュレータ・実機での目視確認は環境の都合で未実施です。UI の最終確認をお願いします。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNc6WmcBhgkxJP1Y5k1gCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNc6WmcBhgkxJP1Y5k1gCB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ヘッダーの区切り線に影を表示するよう調整しました。
  * 影の見た目は維持したまま、表示位置を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->