### PR TITLE
Androidでバックグラウンド復帰後にメイン画面から前の画面へ戻れなくなる問題を修正

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,6 +21,7 @@ export { useDeepLink } from './useDeepLink';
 export { useDisplayCurrentStation } from './useDisplayCurrentStation';
 export { useDisplayNextStation } from './useDisplayNextStation';
 export { useDistanceToNextStation } from './useDistanceToNextStation';
+export { useEnsureSelectLineInHistory } from './useEnsureSelectLineInHistory';
 export { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
 export { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 export { useEstimatedMinutesByStationId } from './useEstimatedMinutesByStationId';

--- a/src/hooks/useEnsureSelectLineInHistory.test.tsx
+++ b/src/hooks/useEnsureSelectLineInHistory.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react-native';
+import { useEnsureSelectLineInHistory } from './useEnsureSelectLineInHistory';
+
+const mockGetState = jest.fn();
+const mockDispatch = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    getState: mockGetState,
+    dispatch: mockDispatch,
+  }),
+}));
+
+describe('useEnsureSelectLineInHistory', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('スタックがMain単独の場合はSelectLineを履歴の下へ差し込むresetを発行する', () => {
+    mockGetState.mockReturnValue({
+      index: 0,
+      routes: [{ key: 'Main-abc', name: 'Main', params: undefined }],
+    });
+
+    renderHook(() => useEnsureSelectLineInHistory());
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'RESET',
+        payload: {
+          index: 1,
+          routes: [
+            { name: 'SelectLine' },
+            // 既存のMainルートのkeyを保持して再マウントを防ぐ
+            { key: 'Main-abc', name: 'Main', params: undefined },
+          ],
+        },
+      })
+    );
+  });
+
+  it('SelectLineが既に履歴へ存在する場合は何もしない', () => {
+    mockGetState.mockReturnValue({
+      index: 1,
+      routes: [
+        { key: 'SelectLine-abc', name: 'SelectLine' },
+        { key: 'Main-abc', name: 'Main' },
+      ],
+    });
+
+    renderHook(() => useEnsureSelectLineInHistory());
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('スタックがSelectLine単独の場合は何もしない', () => {
+    mockGetState.mockReturnValue({
+      index: 0,
+      routes: [{ key: 'SelectLine-abc', name: 'SelectLine' }],
+    });
+
+    renderHook(() => useEnsureSelectLineInHistory());
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('ナビゲーション状態が取得できない場合は何もしない', () => {
+    mockGetState.mockReturnValue(undefined);
+
+    renderHook(() => useEnsureSelectLineInHistory());
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEnsureSelectLineInHistory.ts
+++ b/src/hooks/useEnsureSelectLineInHistory.ts
@@ -1,0 +1,40 @@
+import { CommonActions, useNavigation } from '@react-navigation/native';
+import { useEffect } from 'react';
+
+// Android で Activity が再生成されると、JS ランタイム（Jotai の selectedBound）は
+// 生存したまま React ツリーだけが作り直される。このとき MainStack は
+// initialRouteName='Main' で初期化されるため履歴に SelectLine が存在せず、
+// 戻る操作が pop できずアプリがバックグラウンドへ落ちてしまう。
+// スタックが Main 単独で初期化された場合に限り、既存の Main ルートのキーを
+// 保持したまま（Main を再マウントさせず beforeRemove も発火させずに）
+// SelectLine を履歴の下へ差し込み、通常どおり戻れる状態へ復元する。
+export const useEnsureSelectLineInHistory = (): void => {
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const state = navigation.getState();
+    if (
+      !state ||
+      state.routes.length !== 1 ||
+      state.routes[0]?.name !== 'Main'
+    ) {
+      return;
+    }
+
+    const mainRoute = state.routes[0];
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 1,
+        routes: [
+          { name: 'SelectLine' },
+          // key を引き継ぐことで Main は再マウントされず beforeRemove も発火しない
+          {
+            key: mainRoute.key,
+            name: mainRoute.name,
+            params: mainRoute.params,
+          },
+        ],
+      })
+    );
+  }, [navigation]);
+};

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -37,6 +37,7 @@ import {
   useCurrentLine,
   useCurrentStation,
   useCurrentTrainType,
+  useEnsureSelectLineInHistory,
   useEtaAnchor,
   useEtaFallback,
   useFirstStop,
@@ -276,6 +277,10 @@ const MainScreen: React.FC = () => {
   const currentStationRef = useRef(currentStation);
   const stationsRef = useRef(stations);
   const navigation = useNavigation();
+
+  // Activity再生成からの復帰などでスタックがMain単独になった場合に
+  // SelectLineを履歴へ復元し、戻る操作でアプリが落ちないようにする
+  useEnsureSelectLineInHistory();
 
   const handleCloseSelectBoundModal = useCallback(() => {
     setIsSelectBoundModalOpen(false);


### PR DESCRIPTION
## 概要

Android でメイン画面へ遷移したあとアプリをバックグラウンドへ移し、OS が Activity を破棄した状態から復帰すると、戻る操作で前の画面（路線選択画面）へ戻れなくなる問題を修正しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useEnsureSelectLineInHistory` フックを新規追加。`Main` 画面マウント時にナビゲーション状態を検査し、スタックが `Main` 単独で初期化されていた場合のみ `CommonActions.reset` で `SelectLine` を履歴の下へ差し込む
- 既存の `Main` ルートの `key` を引き継ぐことで `Main` の再マウントと `beforeRemove`（乗車状態リセット）の発火を防止
- `Main` 画面で同フックを呼び出し
- 復元 reset の発行・`key` 保持・通常遷移時の no-op を検証するユニットテストを追加

### 原因

`MainStack` は `initialRouteName={selectedBound ? 'Main' : 'SelectLine'}` でスタックを初期化します。Android ではバックグラウンド中に OS が Activity を破棄すると、復帰時に JS ランタイム（Jotai の `selectedBound`）は生存したまま React ツリーだけが再構築されるため、スタックが `[Main]` 単独で初期化され履歴に `SelectLine` が存在しませんでした。その結果、戻る操作で pop する先がなくアプリがバックグラウンドへ落ちるだけになっていました。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * Androidで画面再生成後にナビゲーション履歴が失われ、戻る操作で期待どおりに戻れない問題を修正しました。
  * 既存の画面情報を維持したまま、必要な履歴を自動的に復元します。

* **テスト**
  * 履歴復元が必要な場合と、不要な場合の動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->