### PR TITLE
AIチャット画面のメッセージや提案カードに控えめな出現アニメーションを追加

### DIFF
--- a/docs/spec/ai-agent/ui.md
+++ b/docs/spec/ai-agent/ui.md
@@ -175,8 +175,16 @@ Figma デザインは人力ではなく Figma MCP で本書を入力として起
   追加時に `scrollToEnd({ animated: true })`。
 - 上下パディング 16、横パディング 24（既存画面と同一）。
   バブル間隔 12、同一話者の連続バブル間は 4。
-- 出現アニメーション: Reanimated `LinearTransition.springify()`
+- 並び替えアニメーション: Reanimated `LinearTransition.springify()`
   （SelectLineScreen の路線リストと同じ既存イディオム）。
+- 出現・消滅アニメーション: バブルは `FadeInDown`（250ms）で下から
+  フェードイン、エラー時の巻き戻しと会話リセットは `FadeOut`（150ms）。
+  タイピングインジケータ・空状態（アイコン → タイトル → 例文チップの
+  段階フェード）・提案カード（提案順の時差フェード）・ヘッダーの
+  リセットボタン・送信ボタンの有効/無効切り替えにも同系統の短い
+  フェードを適用する。いずれも Reanimated 既定の
+  `ReduceMotion.System` に従い、OS の視差効果を減らす設定では
+  自動的に無効化される。
 
 #### メッセージバブル
 

--- a/src/__mocks__/react-native-reanimated-mock.js
+++ b/src/__mocks__/react-native-reanimated-mock.js
@@ -7,6 +7,20 @@ const linearTransition = {
   duration: () => linearTransition,
 };
 
+// FadeIn 等の entering/exiting アニメーションビルダー共通のチェーン可能スタブ
+const animationBuilder = {
+  springify: () => animationBuilder,
+  damping: () => animationBuilder,
+  stiffness: () => animationBuilder,
+  mass: () => animationBuilder,
+  duration: () => animationBuilder,
+  delay: () => animationBuilder,
+  easing: () => animationBuilder,
+  reduceMotion: () => animationBuilder,
+  withCallback: () => animationBuilder,
+  build: () => () => ({ initialValues: {}, animations: {} }),
+};
+
 const ReanimatedMock = {
   View: ReactNative.View,
   Text: ReactNative.Text,
@@ -23,6 +37,12 @@ const ReanimatedMock = {
   useAnimatedScrollHandler: () => jest.fn(),
   useAnimatedGestureHandler: () => jest.fn(),
   LinearTransition: linearTransition,
+  FadeIn: animationBuilder,
+  FadeInDown: animationBuilder,
+  FadeInUp: animationBuilder,
+  FadeOut: animationBuilder,
+  FadeOutDown: animationBuilder,
+  FadeOutUp: animationBuilder,
   withTiming: (value) => value,
   withSpring: (value) => value,
   withDecay: (value) => value,

--- a/src/screens/DestinationAgent/AgentEmptyState.tsx
+++ b/src/screens/DestinationAgent/AgentEmptyState.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import { StyleSheet, View } from 'react-native';
+import Animated, { FadeInDown } from 'react-native-reanimated';
 import Chip from '~/components/Chip';
 import Typography from '~/components/Typography';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
@@ -11,6 +12,11 @@ const EXAMPLE_KEYS = [
   'destinationAgentExample2',
   'destinationAgentExample3',
 ] as const;
+
+// アイコン → タイトル → 例文チップの順に上から視線が流れるよう段階的にフェードインする。
+// 画面初回マウントだけでなく会話リセット時の再マウントでも再生される
+const ENTER_DURATION = 250;
+const ENTER_STAGGER = 60;
 
 const styles = StyleSheet.create({
   root: {
@@ -48,22 +54,34 @@ export const AgentEmptyState = ({ onSelectExample }: Props) => {
 
   return (
     <View style={styles.root}>
-      <Ionicons name="sparkles" size={48} color="#008ffe" />
-      <Typography style={styles.title}>
-        {translate('destinationAgentEmptyTitle')}
-      </Typography>
+      <Animated.View entering={FadeInDown.duration(ENTER_DURATION)}>
+        <Ionicons name="sparkles" size={48} color="#008ffe" />
+      </Animated.View>
+      <Animated.View
+        entering={FadeInDown.delay(ENTER_STAGGER).duration(ENTER_DURATION)}
+      >
+        <Typography style={styles.title}>
+          {translate('destinationAgentEmptyTitle')}
+        </Typography>
+      </Animated.View>
       <View style={styles.examples}>
-        {EXAMPLE_KEYS.map((key) => {
+        {EXAMPLE_KEYS.map((key, index) => {
           const text = translate(key);
           return (
-            <Chip
+            <Animated.View
               key={key}
-              color="#008ffe"
-              style={[styles.chip, isLEDTheme && styles.ledChip]}
-              onPress={() => onSelectExample(text)}
+              entering={FadeInDown.delay(ENTER_STAGGER * (index + 2)).duration(
+                ENTER_DURATION
+              )}
             >
-              {text}
-            </Chip>
+              <Chip
+                color="#008ffe"
+                style={[styles.chip, isLEDTheme && styles.ledChip]}
+                onPress={() => onSelectExample(text)}
+              >
+                {text}
+              </Chip>
+            </Animated.View>
           );
         })}
       </View>

--- a/src/screens/DestinationAgent/AgentHeader.tsx
+++ b/src/screens/DestinationAgent/AgentHeader.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import Typography from '~/components/Typography';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
@@ -76,17 +77,23 @@ export const AgentHeader = ({ showReset, onBack, onReset }: Props) => {
       </Typography>
       <View style={[styles.side, styles.sideRight]}>
         {showReset ? (
-          <TouchableOpacity
-            style={styles.resetButton}
-            accessibilityRole="button"
-            accessibilityLabel={translate('destinationAgentReset')}
-            onPress={onReset}
+          // 会話開始・リセットに連動して出入りするため、フェードで切り替えを和らげる
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            exiting={FadeOut.duration(150)}
           >
-            {/* 表示は Figma に合わせて主語を省略した短縮ラベル。読み上げは省略前の文言を使う */}
-            <Typography style={styles.resetText}>
-              {translate('destinationAgentResetShort')}
-            </Typography>
-          </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.resetButton}
+              accessibilityRole="button"
+              accessibilityLabel={translate('destinationAgentReset')}
+              onPress={onReset}
+            >
+              {/* 表示は Figma に合わせて主語を省略した短縮ラベル。読み上げは省略前の文言を使う */}
+              <Typography style={styles.resetText}>
+                {translate('destinationAgentResetShort')}
+              </Typography>
+            </TouchableOpacity>
+          </Animated.View>
         ) : null}
       </View>
     </View>

--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -2,6 +2,12 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import { type RefObject, useMemo } from 'react';
 import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import Typography from '~/components/Typography';
 import { FONTS } from '~/constants';
 import { AGENT_MAX_MESSAGE_LENGTH } from '~/hooks/useDestinationAgent';
@@ -48,9 +54,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  buttonDisabled: {
-    opacity: 0.5,
-  },
   counter: {
     fontSize: 12,
     textAlign: 'right',
@@ -86,6 +89,15 @@ export const AgentInputBar = ({
 
   const canSend = !sending && !rateLimited && value.trim().length > 0;
 
+  // 送信可否の切り替えを瞬時の明滅にせず、短いフェードで馴染ませる。
+  // TouchableOpacity 自身の押下フィードバックと干渉しないようラッパー側で持つ
+  const sendButtonAnimatedStyle = useAnimatedStyle(
+    () => ({
+      opacity: withTiming(canSend ? 1 : 0.5, { duration: 150 }),
+    }),
+    [canSend]
+  );
+
   return (
     <View>
       <View style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}>
@@ -107,29 +119,35 @@ export const AgentInputBar = ({
           )}
           placeholderTextColor={isLEDTheme ? '#ababab' : '#8c8c8c'}
         />
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessibilityLabel={translate('destinationAgentSend')}
-          accessibilityState={{ disabled: !canSend }}
-          disabled={!canSend}
-          onPress={onSend}
-          style={[
-            styles.button,
-            !canSend && styles.buttonDisabled,
-            {
-              backgroundColor: isLEDTheme ? '#000' : '#212121',
-              borderTopRightRadius: isLEDTheme ? 0 : 8,
-              borderBottomRightRadius: isLEDTheme ? 0 : 8,
-            },
-          ]}
-        >
-          <Ionicons name="arrow-up" size={21} color="#fff" />
-        </TouchableOpacity>
+        <Animated.View style={sendButtonAnimatedStyle}>
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel={translate('destinationAgentSend')}
+            accessibilityState={{ disabled: !canSend }}
+            disabled={!canSend}
+            onPress={onSend}
+            style={[
+              styles.button,
+              {
+                backgroundColor: isLEDTheme ? '#000' : '#212121',
+                borderTopRightRadius: isLEDTheme ? 0 : 8,
+                borderBottomRightRadius: isLEDTheme ? 0 : 8,
+              },
+            ]}
+          >
+            <Ionicons name="arrow-up" size={21} color="#fff" />
+          </TouchableOpacity>
+        </Animated.View>
       </View>
       {value.length > COUNTER_VISIBLE_THRESHOLD && (
-        <Typography style={styles.counter}>
-          {`${value.length}/${AGENT_MAX_MESSAGE_LENGTH}`}
-        </Typography>
+        <Animated.View
+          entering={FadeIn.duration(150)}
+          exiting={FadeOut.duration(100)}
+        >
+          <Typography style={styles.counter}>
+            {`${value.length}/${AGENT_MAX_MESSAGE_LENGTH}`}
+          </Typography>
+        </Animated.View>
       )}
     </View>
   );

--- a/src/screens/DestinationAgent/AgentTypingIndicator.tsx
+++ b/src/screens/DestinationAgent/AgentTypingIndicator.tsx
@@ -1,8 +1,10 @@
 import { useAtomValue } from 'jotai';
 import { useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, {
   cancelAnimation,
+  FadeIn,
+  LinearTransition,
   useAnimatedStyle,
   useSharedValue,
   withDelay,
@@ -111,7 +113,11 @@ export const AgentTypingIndicator = ({ label }: { label?: string }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
 
   return (
-    <View style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}>
+    // 検索中ラベルの出し入れでバブル幅が変わるため、幅の変化をスプリングで馴染ませる
+    <Animated.View
+      layout={LinearTransition.springify()}
+      style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}
+    >
       {DOT_DELAYS.map((delay) => (
         <Dot
           key={`agent-typing-dot-${delay}`}
@@ -120,15 +126,17 @@ export const AgentTypingIndicator = ({ label }: { label?: string }) => {
         />
       ))}
       {label ? (
-        <Typography
-          style={[
-            styles.label,
-            isLEDTheme ? styles.labelLEDColor : styles.labelColor,
-          ]}
-        >
-          {label}
-        </Typography>
+        <Animated.View entering={FadeIn.duration(200)}>
+          <Typography
+            style={[
+              styles.label,
+              isLEDTheme ? styles.labelLEDColor : styles.labelColor,
+            ]}
+          >
+            {label}
+          </Typography>
+        </Animated.View>
       ) : null}
-    </View>
+    </Animated.View>
   );
 };

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -12,7 +12,12 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated, {
+  FadeIn,
+  FadeInDown,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -428,7 +433,10 @@ const DestinationAgentScreen = () => {
 
       if (!state || state.status === 'loading') {
         return (
-          <View style={styles.suggestions}>
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            style={styles.suggestions}
+          >
             {entry.suggestions.map((suggestion) => (
               <SkeletonPlaceholder
                 key={`${entry.id}-${suggestion.stationId}`}
@@ -441,13 +449,16 @@ const DestinationAgentScreen = () => {
                 />
               </SkeletonPlaceholder>
             ))}
-          </View>
+          </Animated.View>
         );
       }
 
       if (state.status === 'error') {
         return (
-          <View style={styles.suggestionsError}>
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            style={styles.suggestionsError}
+          >
             <Typography style={styles.errorText}>
               {translate('destinationAgentSuggestionsError')}
             </Typography>
@@ -464,34 +475,39 @@ const DestinationAgentScreen = () => {
                 {translate('destinationAgentRetry')}
               </Typography>
             </TouchableOpacity>
-          </View>
+          </Animated.View>
         );
       }
 
       return (
         <View style={styles.suggestions}>
-          {state.stations.map((suggestedStation) => {
+          {state.stations.map((suggestedStation, index) => {
             const line = suggestedStation.line;
             if (!line) {
               return null;
             }
             return (
-              <CommonCard
+              // 提案順(モデルの優先順)が視線誘導として伝わるよう上から順に時差フェード
+              <Animated.View
                 key={`${entry.id}-${suggestedStation.id}`}
-                targetStation={suggestedStation}
-                line={line}
-                title={
-                  isJapanese
-                    ? suggestedStation.name || undefined
-                    : suggestedStation.nameRoman || undefined
-                }
-                subtitle={
-                  isJapanese
-                    ? line.nameShort || undefined
-                    : line.nameRoman || undefined
-                }
-                onPress={() => handleDestinationSelected(suggestedStation)}
-              />
+                entering={FadeInDown.delay(index * 60).duration(250)}
+              >
+                <CommonCard
+                  targetStation={suggestedStation}
+                  line={line}
+                  title={
+                    isJapanese
+                      ? suggestedStation.name || undefined
+                      : suggestedStation.nameRoman || undefined
+                  }
+                  subtitle={
+                    isJapanese
+                      ? line.nameShort || undefined
+                      : line.nameRoman || undefined
+                  }
+                  onPress={() => handleDestinationSelected(suggestedStation)}
+                />
+              </Animated.View>
             );
           })}
         </View>
@@ -537,14 +553,20 @@ const DestinationAgentScreen = () => {
           keyboardShouldPersistTaps="handled"
         >
           {isEmpty ? (
-            <AgentEmptyState onSelectExample={handleSend} />
+            // 出現側の段階フェードは AgentEmptyState 内で行い、初回送信時はふっと消す
+            <Animated.View exiting={FadeOut.duration(150)}>
+              <AgentEmptyState onSelectExample={handleSend} />
+            </Animated.View>
           ) : (
             entries.map((entry, index) =>
               // 本文が空の仮置きエントリはバブルを出さない(タイピングインジケータが代わり)
               entry.streaming && !entry.content ? null : (
-                // 出現アニメーションは SelectLineScreen の路線リストと同じ既存イディオム(ui.md)
+                // 並び替えは SelectLineScreen の路線リストと同じ既存イディオム(ui.md)。
+                // 出現は下からのフェード、エラー時の巻き戻し・リセットはフェードアウトで消す
                 <Animated.View
                   key={entry.id}
+                  entering={FadeInDown.duration(250)}
+                  exiting={FadeOut.duration(150)}
                   layout={LinearTransition.springify()}
                   style={
                     entries[index - 1]?.role === entry.role
@@ -562,23 +584,31 @@ const DestinationAgentScreen = () => {
             )
           )}
           {sending && !streamingContent && (
-            <AgentTypingIndicator
-              label={
-                searching ? translate('destinationAgentSearching') : undefined
-              }
-            />
+            // 応答待ちの合図なので唐突に出さず、バブルと同じ下からのフェードで馴染ませる
+            <Animated.View
+              entering={FadeInDown.duration(200)}
+              exiting={FadeOut.duration(150)}
+            >
+              <AgentTypingIndicator
+                label={
+                  searching ? translate('destinationAgentSearching') : undefined
+                }
+              />
+            </Animated.View>
           )}
         </ScrollView>
 
         {isEmpty && (
-          <Typography
-            style={[
-              styles.disclaimer,
-              isLEDTheme ? styles.disclaimerLEDColor : styles.disclaimerColor,
-            ]}
-          >
-            {translate('destinationAgentDisclaimer')}
-          </Typography>
+          <Animated.View exiting={FadeOut.duration(150)}>
+            <Typography
+              style={[
+                styles.disclaimer,
+                isLEDTheme ? styles.disclaimerLEDColor : styles.disclaimerColor,
+              ]}
+            >
+              {translate('destinationAgentDisclaimer')}
+            </Typography>
+          </Animated.View>
         )}
 
         <View

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -599,7 +599,10 @@ const DestinationAgentScreen = () => {
         </ScrollView>
 
         {isEmpty && (
-          <Animated.View exiting={FadeOut.duration(150)}>
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            exiting={FadeOut.duration(150)}
+          >
             <Typography
               style={[
                 styles.disclaimer,


### PR DESCRIPTION
## 概要

AIチャット（行き先相談）画面の動きが無骨だったため、既存の `LinearTransition.springify()` イディオムと調和する控えめなフェード系アニメーションを追加しました。いずれも Reanimated 既定の `ReduceMotion.System` に従うため、OS の「視差効果を減らす」設定では自動的に無効化されます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- メッセージバブルの出現を `FadeInDown`（250ms）に、エラー時の巻き戻し・会話リセット時の消滅を `FadeOut`（150ms）にした（`index.tsx`）
- タイピングインジケータの出現・消滅をフェードにし、「駅を検索しています…」ラベル表示時のバブル幅変化をスプリングで馴染ませた（`index.tsx` / `AgentTypingIndicator.tsx`）
- 提案カードのスケルトン・エラー表示をフェードインにし、読み込み完了後のカードを提案順に 60ms ずつの時差フェードで表示するようにした（`index.tsx`）
- 空状態をアイコン → タイトル → 例文チップの順に段階フェードインし、初回送信時はフェードアウトで消すようにした（`AgentEmptyState.tsx` / `index.tsx`）
- 送信ボタンの有効/無効の opacity 切り替えを 150ms のアニメーションにし、残り文字数カウンターの出現・消滅もフェードにした（`AgentInputBar.tsx`）
- ヘッダーのリセットボタンの表示・非表示をフェードで切り替えるようにした（`AgentHeader.tsx`）
- プロジェクト独自の reanimated モックに `FadeIn` / `FadeInDown` / `FadeOut` 等のチェーン可能なビルダースタブを追加（`src/__mocks__/react-native-reanimated-mock.js`）
- `docs/spec/ai-agent/ui.md` のアニメーション仕様の記載を実装に合わせて更新

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

Refs #6475

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * AIエージェント画面のメッセージ、提案カード、空状態、入力欄、タイピングインジケーターなどに、自然なフェードやスライド、レイアウトアニメーションを追加。
  * 提案カードや例文チップを順番に表示し、画面の変化を分かりやすくしました。
  * OSの「視差効果を減らす」設定に従い、アニメーションを自動的に無効化します。
* **改善**
  * 送信ボタン、文字数カウンター、リセットボタンの表示切り替えを滑らかにしました。
  * ローディングやエラー、免責文などの表示・非表示を自然に切り替えます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->