### PR TITLE
AIチャットの入力をエンターキーで即送信するよう変更

### DIFF
--- a/src/screens/DestinationAgent/AgentInputBar.test.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.test.tsx
@@ -30,6 +30,13 @@ const defaultProps = {
   rateLimited: false,
 };
 
+// 送信を抑止すべき状態。Enter 経路・送信ボタン経路の双方で同じ条件を検証する
+const suppressedCases: [string, Partial<typeof defaultProps>][] = [
+  ['空白のみの入力', { value: '   ' }],
+  ['送信中', { sending: true }],
+  ['日次上限に達している場合', { rateLimited: true }],
+];
+
 const renderBar = (props: Partial<typeof defaultProps> = {}) => {
   const view = render(<AgentInputBar {...defaultProps} {...props} />);
   return {
@@ -58,6 +65,8 @@ describe('AgentInputBar', () => {
     // multiline は維持したまま Enter だけを送信に割り当てる
     expect(input.props.multiline).toBe(true);
     expect(input.props.submitBehavior).toBe('submit');
+    // Enter が改行ではなく送信であることをキーラベルでも示す
+    expect(input.props.returnKeyType).toBe('send');
   });
 
   it('空白のみの入力ではEnterで送信しない', () => {
@@ -100,4 +109,22 @@ describe('AgentInputBar', () => {
 
     expect(onSend).toHaveBeenCalledTimes(1);
   });
+
+  // Enter と送信ボタンが同じ canSend 判定を共有していることを、抑止側からも固定する
+  it.each(suppressedCases)(
+    '%sでは送信ボタンも無効化される',
+    (_label, props) => {
+      const onSend = jest.fn();
+      const { getByLabelText } = render(
+        <AgentInputBar {...defaultProps} onSend={onSend} {...props} />
+      );
+      const button = getByLabelText('destinationAgentSend');
+
+      expect(button).toBeDisabled();
+
+      fireEvent.press(button);
+
+      expect(onSend).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/screens/DestinationAgent/AgentInputBar.test.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { AgentInputBar } from './AgentInputBar';
+
+// 実体はフォント読み込みで非同期 setState するため、act 警告を避けて素の View に差し替える
+jest.mock('@expo/vector-icons', () => {
+  const { View } = require('react-native');
+  return { Ionicons: View };
+});
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: true,
+}));
+
+// 実体は expo/fetch やセッション層を引き込むため、定数だけを差し替える
+jest.mock('~/hooks/useDestinationAgent', () => ({
+  AGENT_MAX_MESSAGE_LENGTH: 500,
+}));
+
+const defaultProps = {
+  value: '渋谷まで行きたい',
+  onChangeText: jest.fn(),
+  onSend: jest.fn(),
+  sending: false,
+  rateLimited: false,
+};
+
+const renderBar = (props: Partial<typeof defaultProps> = {}) => {
+  const view = render(<AgentInputBar {...defaultProps} {...props} />);
+  return {
+    ...view,
+    input: view.getByPlaceholderText('destinationAgentPlaceholder'),
+  };
+};
+
+describe('AgentInputBar', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Enterキーで即送信する', () => {
+    const onSend = jest.fn();
+    const { input } = renderBar({ onSend });
+
+    fireEvent(input, 'submitEditing');
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enterが改行として消費されないよう送信へ振り替える', () => {
+    const { input } = renderBar();
+
+    // multiline は維持したまま Enter だけを送信に割り当てる
+    expect(input.props.multiline).toBe(true);
+    expect(input.props.submitBehavior).toBe('submit');
+  });
+
+  it('空白のみの入力ではEnterで送信しない', () => {
+    const onSend = jest.fn();
+    const { input } = renderBar({ value: '   ', onSend });
+
+    fireEvent(input, 'submitEditing');
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('送信中はEnterで多重送信しない', () => {
+    const onSend = jest.fn();
+    const { input } = renderBar({ sending: true, onSend });
+
+    fireEvent(input, 'submitEditing');
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('日次上限に達している場合はEnterで送信しない', () => {
+    const onSend = jest.fn();
+    const view = render(
+      <AgentInputBar {...defaultProps} onSend={onSend} rateLimited />
+    );
+
+    fireEvent(
+      view.getByPlaceholderText('destinationAgentRateLimited'),
+      'submitEditing'
+    );
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('送信ボタンからも同じ条件で送信できる', () => {
+    const onSend = jest.fn();
+    const { getByLabelText } = renderBar({ onSend });
+
+    fireEvent.press(getByLabelText('destinationAgentSend'));
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
-import { type RefObject, useMemo } from 'react';
+import { type RefObject, useCallback, useMemo } from 'react';
 import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import Animated, {
   FadeIn,
@@ -89,6 +89,15 @@ export const AgentInputBar = ({
 
   const canSend = !sending && !rateLimited && value.trim().length > 0;
 
+  // Enter による送信。送信ボタンと同じ可否判定を通し、空文字や送信中の
+  // 二重送信を弾く(親側にも防衛はあるが、入力バー単体で完結させる)
+  const handleSubmitEditing = useCallback(() => {
+    if (!canSend) {
+      return;
+    }
+    onSend();
+  }, [canSend, onSend]);
+
   // 送信可否の切り替えを瞬時の明滅にせず、短いフェードで馴染ませる。
   // TouchableOpacity 自身の押下フィードバックと干渉しないようラッパー側で持つ
   const sendButtonAnimatedStyle = useAnimatedStyle(
@@ -111,6 +120,16 @@ export const AgentInputBar = ({
           onChangeText={onChangeText}
           editable={!rateLimited}
           multiline
+          // multiline のままだと Enter が改行として消費されるため、送信イベントへ
+          // 振り替える。'blurAndSubmit' ではなく 'submit' にしてキーボードを開いた
+          // まま保ち、続けて質問できるようにする。
+          // 日本語入力の確定に使う Enter は IME 側が消費する(iOS は未確定文字列が
+          // あると shouldChangeTextInRange に "\n" が来ず、Android も変換中は
+          // onEditorAction が発火しない)ため、変換確定で送信されることはない。
+          submitBehavior="submit"
+          // Enter が改行ではなく送信であることをキーラベルでも示す
+          returnKeyType="send"
+          onSubmitEditing={handleSubmitEditing}
           maxLength={AGENT_MAX_MESSAGE_LENGTH}
           placeholder={translate(
             rateLimited


### PR DESCRIPTION
## 概要

AIチャット（目的地エージェント）の入力欄で、Enter キーを押した時点で即座にメッセージを送信するようにしました。日本語入力の変換確定に使う Enter では送信されません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AgentInputBar` の `TextInput` に `submitBehavior="submit"` を指定し、`multiline` を維持したまま Enter を改行ではなく送信イベントへ振り替え。`blurAndSubmit` ではなく `submit` にすることで送信後もキーボードが開いたままになり、続けて質問できる
- `returnKeyType="send"` を指定し、Enter が改行ではなく送信であることをキーラベルでも示す
- `onSubmitEditing` は送信ボタンと同じ `canSend` 判定（空文字・送信中・429 到達）を通してから `onSend` を呼ぶ。入力バー単体で空送信と二重送信を弾く
- `AgentInputBar.test.tsx` を新規追加（Enter 送信 / `submitBehavior` の振り替え / 空白のみ・送信中・429 時の送信抑止 / 送信ボタン経路）

### 日本語入力（IME）の確定について

変換確定の Enter は IME 側が消費するため、未確定文字列のまま送信されることはありません。React Native 0.83 の実装を読んで確認しています。

- iOS: multiline の送信は `RCTBackedTextInputDelegateAdapter.mm` の `textView:shouldChangeTextInRange:replacementText:` で `text == "\n"` のときだけ発火する。未確定文字列（marked text）がある状態の Return は UIKit の入力メソッドが先に確定処理として消費するため、`"\n"` としては届かない
- Android: 送信は `ReactTextInputManager.kt` の `OnEditorActionListener` 経由。変換中の Enter は IME が確定として処理し、エディタアクションを発行しない

`onKeyPress` による JS 側のコンポジション判定は意図的に足していません。Android では `onKeyPress` を渡すと `ReactEditText.onCreateInputConnection` が `ReactEditTextInputConnectionWrapper` を挿し込み、変換中の 1 打鍵ごとに JS へイベントが飛ぶため、ネイティブ側で既に解決している問題に対してホットパスのコストだけが増えます。

### 回帰リスクと緩和策

- **ソフトキーボードから改行を入力できなくなる**: `submitBehavior="submit"` は Enter を送信へ振り替えるため、改行の入力手段が失われます。Enter 即送信という要件上は意図した挙動ですが、長文で改行を入れたいケースには影響します
- **`react-native-web` では従来どおり改行のまま**: `react-native-web` は `submitBehavior` を解釈せず `blurOnSubmit` を見るため、web では Enter は改行のままです。`app.config.ts` に web 設定が無く `src/` にも web 分岐が無いため、対象外と判断しました
- **緩和策**: 送信ボタンは従来どおり残しており、Enter 経路とボタン経路は同じ `canSend` 判定を共有します。双方の挙動をユニットテストで固定しました

## テスト

ローカルで以下を実行し、すべて成功しています。

- `npm run lint`: 604 files checked / no fixes applied
- `npm test`: 201 suites / 2166 tests passed
- `npm run typecheck`: エラーなし

実機・シミュレータでの日本語 IME 実動作の確認は未実施です。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5dx7BhYZqs6TfQADwtEiR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 入力欄でEnterキーを押してメッセージを送信できるようになりました。
  * 送信後もキーボードを表示したまま入力を続けられます。

* **バグ修正**
  * 空の入力、送信中、送信上限到達時に誤送信されないよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->