### PR TITLE
AI候補の連結経路を行き先選択へ引き継ぐ

### DIFF
--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -353,6 +353,12 @@ describe('useDestinationAgent', () => {
             name: 'A',
             nameRoman: 'A',
             lineNames: [],
+            routeLineGroupIds: [10, 20, 30],
+          },
+          {
+            stationId: 2,
+            stationGroupId: 2,
+            routeLineGroupIds: [20, 'invalid'],
           },
           { name: 'B' },
           null,
@@ -368,6 +374,7 @@ describe('useDestinationAgent', () => {
     if (res.ok) {
       expect(res.data.suggestions).toHaveLength(1);
       expect(res.data.suggestions[0].stationId).toBe(1);
+      expect(res.data.suggestions[0].routeLineGroupIds).toEqual([10, 20, 30]);
     }
   });
 

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -21,6 +21,7 @@ export type AgentSuggestion = {
   name: string;
   nameRoman: string;
   lineNames: string[];
+  routeLineGroupIds?: number[];
 };
 
 export type AgentChatResult = {
@@ -68,9 +69,13 @@ const isAgentSuggestion = (value: unknown): value is AgentSuggestion => {
     return false;
   }
   const suggestion = value as Partial<AgentSuggestion>;
+  const routeLineGroupIds = suggestion.routeLineGroupIds;
   return (
     typeof suggestion.stationId === 'number' &&
-    typeof suggestion.stationGroupId === 'number'
+    typeof suggestion.stationGroupId === 'number' &&
+    (routeLineGroupIds === undefined ||
+      (Array.isArray(routeLineGroupIds) &&
+        routeLineGroupIds.every((id) => Number.isFinite(id))))
   );
 };
 

--- a/src/hooks/useDestinationSelection.test.ts
+++ b/src/hooks/useDestinationSelection.test.ts
@@ -1,0 +1,47 @@
+import {
+  type Station,
+  StopCondition,
+  type TrainTypeNested,
+} from '~/@types/graphql';
+import { getConnectedRouteSegment } from './useDestinationSelection';
+
+jest.mock('~/lib/gql', () => ({
+  gqlRequest: jest.fn(),
+  graphqlQueryKey: jest.fn(),
+}));
+
+const station = (groupId: number): Station =>
+  ({ id: groupId, groupId }) as Station;
+
+describe('getConnectedRouteSegment', () => {
+  const route = [1, 2, 3, 4, 5].map(station);
+
+  it('現在駅から目的駅までに切り詰める', () => {
+    expect(getConnectedRouteSegment(route, 2, 4)).toEqual([
+      station(2),
+      station(3),
+      station(4),
+    ]);
+  });
+
+  it('逆向きの経路は現在駅から目的駅の順に並べる', () => {
+    expect(getConnectedRouteSegment(route, 4, 2)).toEqual([
+      station(4),
+      station(3),
+      station(2),
+    ]);
+  });
+
+  it('連結APIの駅情報をそのまま保持する', () => {
+    const trainType = { groupId: 10, name: '快速' } as TrainTypeNested;
+    const route = [
+      { ...station(1), trainType, stopCondition: StopCondition.All },
+      { ...station(2), trainType, stopCondition: StopCondition.Not },
+    ];
+
+    const result = getConnectedRouteSegment(route, 1, 2);
+
+    expect(result[0].trainType).toBe(trainType);
+    expect(result[1].stopCondition).toBe(StopCondition.Not);
+  });
+});

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import { graphqlQueryKey } from '~/lib/gql';
 import {
+  GET_CONNECTED_LINE_GROUP_STATIONS,
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
   GET_ROUTE_TYPES_LIGHT,
@@ -53,12 +54,23 @@ type GetLineGroupStationsVariables = {
   lineGroupId: number;
 };
 
+type GetConnectedLineGroupStationsData = {
+  connectedLineGroupStations: Station[];
+};
+
+type GetConnectedLineGroupStationsVariables = {
+  lineGroupIds: number[];
+};
+
 // GET_ROUTE_TYPES_LIGHT の pageSize。RouteSearchScreen の検索結果上限と同値。
 const ROUTE_TYPES_PAGE_SIZE = 100;
 
 export type UseDestinationSelectionResult = {
   /** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
-  handleDestinationSelected: (selectedStation: Station) => Promise<void>;
+  handleDestinationSelected: (
+    selectedStation: Station,
+    routeLineGroupIds?: number[]
+  ) => Promise<void>;
   /** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
   handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
   selectBoundModalVisible: boolean;
@@ -77,6 +89,24 @@ export type UseDestinationSelectionResult = {
   handleSelectBoundModalCloseAnimationEnd: () => void;
   handleBoundSelected: () => void;
   handleCloseTrainTypeListModal: () => void;
+};
+
+export const getConnectedRouteSegment = (
+  stations: Station[],
+  currentStationGroupId: number,
+  destinationStationGroupId: number
+): Station[] => {
+  const currentIndex = stations.findIndex(
+    (station) => station.groupId === currentStationGroupId
+  );
+  const destinationIndex = stations.findIndex(
+    (station) => station.groupId === destinationStationGroupId
+  );
+  if (currentIndex === -1 || destinationIndex === -1) return [];
+
+  return currentIndex <= destinationIndex
+    ? stations.slice(currentIndex, destinationIndex + 1)
+    : stations.slice(destinationIndex, currentIndex + 1).reverse();
 };
 
 // RouteSearchScreen の検索結果タップと DestinationAgentScreen の提案カードタップで
@@ -130,8 +160,13 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     GetLineGroupStationsVariables
   >(GET_LINE_GROUP_STATIONS);
 
+  const [fetchConnectedLineGroupStations] = useLazyGraphQLQuery<
+    GetConnectedLineGroupStationsData,
+    GetConnectedLineGroupStationsVariables
+  >(GET_CONNECTED_LINE_GROUP_STATIONS);
+
   const handleDestinationSelected = useCallback(
-    async (selectedStation: Station) => {
+    async (selectedStation: Station, routeLineGroupIds?: number[]) => {
       setSelectBoundModalVisible(true);
       setSelectedDestination(selectedStation);
 
@@ -141,6 +176,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         ...prev,
         trainType: null,
         pendingTrainType: null,
+        fetchedTrainTypes: [],
       }));
       setStationState((prev) => ({
         ...prev,
@@ -151,6 +187,36 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         ...prev,
         pendingLine: newPendingLine,
       }));
+
+      if (
+        routeLineGroupIds?.length &&
+        station?.groupId != null &&
+        selectedStation.groupId != null
+      ) {
+        const result = await fetchConnectedLineGroupStations({
+          variables: { lineGroupIds: routeLineGroupIds },
+        });
+        const pendingStations = getConnectedRouteSegment(
+          result.data?.connectedLineGroupStations ?? [],
+          station.groupId,
+          selectedStation.groupId
+        );
+        const pendingStation = pendingStations[0];
+        const wantedDestination = pendingStations.at(-1);
+        if (!pendingStation || !wantedDestination) return;
+
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation,
+          pendingStations,
+          wantedDestination,
+        }));
+        setLineState((prev) => ({
+          ...prev,
+          pendingLine: pendingStation.line ?? newPendingLine,
+        }));
+        return;
+      }
 
       // Guard: ensure both lineId and stationId are present before calling the query
       if (
@@ -266,6 +332,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
       station,
       fetchStationsByLineId,
       fetchStationsByLineGroupId,
+      fetchConnectedLineGroupStations,
       fetchRouteTypes,
       setNavigationState,
       setStationState,

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -370,6 +370,15 @@ export const GET_LINE_GROUP_STATIONS = gql`
   }
 `;
 
+export const GET_CONNECTED_LINE_GROUP_STATIONS = gql`
+  ${STATION_FRAGMENT}
+  query GetConnectedLineGroupStations($lineGroupIds: [Int!]!) {
+    connectedLineGroupStations(lineGroupIds: $lineGroupIds) {
+      ...StationFields
+    }
+  }
+`;
+
 // Query for getting multiple stations by their IDs (per-operator unique row IDs)
 export const GET_STATIONS_BY_IDS = gql`
   ${STATION_FRAGMENT}

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -505,7 +505,15 @@ const DestinationAgentScreen = () => {
                       ? line.nameShort || undefined
                       : line.nameRoman || undefined
                   }
-                  onPress={() => handleDestinationSelected(suggestedStation)}
+                  onPress={() =>
+                    handleDestinationSelected(
+                      suggestedStation,
+                      entry.suggestions?.find(
+                        (suggestion) =>
+                          suggestion.stationId === suggestedStation.id
+                      )?.routeLineGroupIds
+                    )
+                  }
                 />
               </Animated.View>
             );


### PR DESCRIPTION
## クローズ理由

BFF側で連結経路全体を一意な仮想 `lineGroupId` を持つ通常の列車種別として返す方式へ変更しました。

これによりMobileAppは既存の「種別 → 方面 → 停車駅」処理をそのまま利用でき、このPRのアプリ固有実装は不要になりました。

関連: TrainLCD/BFF#40
