### PR TITLE
Androidビルドの環境変数参照とPR作成ルールを更新

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,14 +1,14 @@
 name: Build Android
 
 env:
-  STAGING_API_URL: ${{ secrets.STAGING_API_URL }}
-  DEV_ROUTE_RESOLVER_API_URL: ${{ secrets.DEV_ROUTE_RESOLVER_API_URL }}
-  PRODUCTION_ROUTE_RESOLVER_API_URL: ${{ secrets.PRODUCTION_ROUTE_RESOLVER_API_URL }}
-  DEV_WORKER_API_URL: ${{ secrets.DEV_WORKER_API_URL }}
-  PRODUCTION_WORKER_API_URL: ${{ secrets.PRODUCTION_WORKER_API_URL }}
-  ENABLE_EXPERIMENTAL_TELEMETRY: ${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}
-  EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: ${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}
-  EXPERIMENTAL_TELEMETRY_TOKEN: ${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}
+  STAGING_API_URL: "${{ secrets.STAGING_API_URL }}"
+  PRODUCTION_API_URL: "${{ secrets.PRODUCTION_API_URL }}"
+  DEV_ROUTE_RESOLVER_API_URL: "${{ secrets.DEV_ROUTE_RESOLVER_API_URL }}"
+  PRODUCTION_ROUTE_RESOLVER_API_URL: "${{ secrets.PRODUCTION_ROUTE_RESOLVER_API_URL }}"
+  DEV_WORKER_API_URL: "${{ secrets.DEV_WORKER_API_URL }}"
+  PRODUCTION_WORKER_API_URL: "${{ secrets.PRODUCTION_WORKER_API_URL }}"
+  ENABLE_EXPERIMENTAL_TELEMETRY: "${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}"
+  EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: "${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}"
 
 on:
   push:
@@ -165,8 +165,35 @@ jobs:
                   f.write(f"{key}={escape(value)}\n")
           PY
 
+      - name: Validate build environment
+        env:
+          BUILD_VARIANT: "${{ steps.build_vars.outputs.variant }}"
+        run: |
+          if [ "$BUILD_VARIANT" = "prodRelease" ]; then
+            required_variables=(
+              PRODUCTION_API_URL
+              PRODUCTION_ROUTE_RESOLVER_API_URL
+              PRODUCTION_WORKER_API_URL
+            )
+          else
+            required_variables=(
+              STAGING_API_URL
+              DEV_ROUTE_RESOLVER_API_URL
+              DEV_WORKER_API_URL
+            )
+          fi
+
+          for variable_name in "${required_variables[@]}"; do
+            if [ -z "${!variable_name:-}" ]; then
+              echo "::error::Required environment variable is not configured: $variable_name"
+              exit 1
+            fi
+          done
+
       - name: Build ${{ steps.build_vars.outputs.variant }}
         working-directory: android
+        env:
+          EXPERIMENTAL_TELEMETRY_TOKEN: "${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}"
         run: ./gradlew ${{ steps.build_vars.outputs.gradle_task }} --no-daemon
 
       - name: Upload AAB artifact

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,5 +1,15 @@
 name: Build Android
 
+env:
+  STAGING_API_URL: ${{ secrets.STAGING_API_URL }}
+  DEV_ROUTE_RESOLVER_API_URL: ${{ secrets.DEV_ROUTE_RESOLVER_API_URL }}
+  PRODUCTION_ROUTE_RESOLVER_API_URL: ${{ secrets.PRODUCTION_ROUTE_RESOLVER_API_URL }}
+  DEV_WORKER_API_URL: ${{ secrets.DEV_WORKER_API_URL }}
+  PRODUCTION_WORKER_API_URL: ${{ secrets.PRODUCTION_WORKER_API_URL }}
+  ENABLE_EXPERIMENTAL_TELEMETRY: ${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}
+  EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: ${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}
+  EXPERIMENTAL_TELEMETRY_TOKEN: ${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}
+
 on:
   push:
     branches:
@@ -116,18 +126,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Write .env.local (prod)
-        if: steps.build_vars.outputs.variant == 'prodRelease'
-        env:
-          DOTENV_CONTENT: ${{ secrets.DOTENV_LOCAL_PRODUCTION }}
-        run: printf '%s' "$DOTENV_CONTENT" > .env.local
-
-      - name: Write .env.local (dev)
-        if: steps.build_vars.outputs.variant != 'prodRelease'
-        env:
-          DOTENV_CONTENT: ${{ secrets.DOTENV_LOCAL }}
-        run: printf '%s' "$DOTENV_CONTENT" > .env.local
 
       - name: Decode Sentry properties
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 - Commit messages must be single-sentence statements in Japanese (e.g., `テレメトリー送信機をリファクタリングしてnull状態を回避`); prefix production hot fixes with `Hotfix:`.
 - Keep commits logically scoped (implementation, tests, docs) and mention generated artifacts in the description.
 - Pull requests must follow `.github/pull_request_template.md`; do not add or remove sections from the template without maintainer approval.
+- Open pull requests as ready for review by default; use Draft only when the user explicitly requests it.
 - Pull requests must be assigned to `@TinyKitten`.
 - Pull requests must include:
   - Purpose and summary of key changes.


### PR DESCRIPTION
## 概要

Androidビルドで使用する環境変数を、環境別の `.env.local` 一括Secretから個別のGitHub Secrets参照へ移行します。あわせて、リポジトリの自動化ガイドへ通常PRを既定とする運用ルールを追加します。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- Androidビルドワークフローのトップレベル `env` に、アプリが利用する8個の環境変数を個別Secretとして定義
- production／development用の `.env.local` 書き出しステップを削除
- `AGENTS.md` に、明示指定がない場合はDraftではなく通常PRを作成するルールを追加
- リスク: 個別Secretが未登録の場合、対応するビルド時環境変数が空になります
- 緩和策: 必要な変数を `.env.example` と照合し、すべてワークフローへ列挙しています

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

YAML構文チェック、`git diff --check`、`npm run lint`、`npm test -- --runInBand`、`npm run typecheck` を実行しました。ローカルNode.jsは24.18.1で、指定の22.xとは異なります。

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Androidビルドで、環境別のAPI URLと実験的テレメトリ設定を安全に適用できるようになりました。
  * ビルド時の環境設定手順を簡素化しました。
* **ドキュメント**
  * プルリクエストは原則としてレビュー準備完了状態で作成する運用方針を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
