### PR TITLE
iOSアーカイブのDistribution署名を明示

### DIFF
--- a/.github/workflows/build_ios_canary.yml
+++ b/.github/workflows/build_ios_canary.yml
@@ -156,6 +156,7 @@ jobs:
             -authenticationKeyPath "$API_KEY_PATH" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             CURRENT_PROJECT_VERSION="$PROJECT_VERSION" \
             archive
 

--- a/.github/workflows/build_ios_production.yml
+++ b/.github/workflows/build_ios_production.yml
@@ -156,6 +156,7 @@ jobs:
             -authenticationKeyPath "$API_KEY_PATH" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             CURRENT_PROJECT_VERSION="$PROJECT_VERSION" \
             archive
 


### PR DESCRIPTION
## 概要

iOSのProductionおよびCanaryアーカイブで、Apple Distribution証明書を使用するよう署名設定を明示します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- ProductionとCanaryの`xcodebuild archive`に`CODE_SIGN_IDENTITY="Apple Distribution"`を追加しました。
- CIがDistribution証明書のみをインストールしている一方、Watch AppのRelease設定がApple Developmentを要求し、Development provisioning profileを解決できなかった不整合を修正します。
- 変更はGitHub Actionsの署名指定に限定され、アプリコードやXcodeプロジェクトには影響しません。

回帰リスクは、Apple Distributionによるarchive時の自動署名解決に限定されます。`-allowProvisioningUpdates`とApp Store Connect API認証は既存のまま維持し、ProductionとCanaryで同じ指定を適用しています。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

実行済み:

- Node.jsのYAMLパーサーによる両ワークフローの構文検証
- `git diff --check`

macOS/Xcodeがない環境のため、実際のarchiveはGitHub Actionsで確認します。

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし
