### PR TITLE
自動化エージェントのgit-flow運用規則を明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 
 ## Commit & Pull Request Protocol
 
-- Follow git-flow for every working branch: create `feature/*` and `fix/*` branches from `dev`, use `release/*` for releases, and reserve `hotfix/*` from `master` for urgent production fixes. Do not create tool-specific prefixes such as `agent/*`.
+- Follow git-flow for every working branch: create `feature/*`, `fix/*`, and `release/*` branches from `dev`, and reserve `hotfix/*` from `master` for urgent production fixes. Do not create tool-specific prefixes such as `agent/*`.
 - Commit messages must be single-sentence statements in Japanese (e.g., `テレメトリー送信機をリファクタリングしてnull状態を回避`); prefix production hot fixes with `Hotfix:`.
 - Keep commits logically scoped (implementation, tests, docs) and mention generated artifacts in the description.
 - Pull requests must follow `.github/pull_request_template.md`; do not add or remove sections from the template without maintainer approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 
 ## Commit & Pull Request Protocol
 
+- Follow git-flow for every working branch: create `feature/*` and `fix/*` branches from `dev`, use `release/*` for releases, and reserve `hotfix/*` from `master` for urgent production fixes. Do not create tool-specific prefixes such as `agent/*`.
 - Commit messages must be single-sentence statements in Japanese (e.g., `テレメトリー送信機をリファクタリングしてnull状態を回避`); prefix production hot fixes with `Hotfix:`.
 - Keep commits logically scoped (implementation, tests, docs) and mention generated artifacts in the description.
 - Pull requests must follow `.github/pull_request_template.md`; do not add or remove sections from the template without maintainer approval.


### PR DESCRIPTION
## 概要

自動化エージェントがリポジトリのgit-flow規則を毎回一貫して適用できるよう、ブランチ運用を`AGENTS.md`に明記します。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `feature/*`と`fix/*`は`dev`から作成することを明記しました。
- リリースには`release/*`、`master`からの緊急本番修正には`hotfix/*`を使うことを明記しました。
- `agent/*`などのツール固有プレフィックスを禁止しました。

運用文書のみの変更であり、アプリおよびCIの実行動作への回帰リスクはありません。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

実行済み:

- `git diff --check`
- Markdown差分の目視確認

`markdownlint-cli2`はローカルにインストールされていないため未実行です。

## 関連Issue

なし

## スクリーンショット（任意）

ドキュメントのみの変更のためなし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コミットおよびプルリクエストのブランチ運用ルールを更新しました。
  * 機能開発、修正、リリース、緊急修正に対応するブランチ作成手順を明確化しました。
  * ツール固有のブランチ名プレフィックスに関する禁止事項を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->