### PR TITLE
経路検索で複数種別のConnectedRoutesを利用

### DIFF
--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -1,492 +1,492 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { useAtomValue, useSetAtom } from "jotai";
-import { useCallback, useMemo, useRef, useState } from "react";
-import type { Line, Station, TrainType } from "~/@types/graphql";
-import { graphqlQueryKey } from "~/lib/gql";
+import { useQueryClient } from '@tanstack/react-query';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import { graphqlQueryKey } from '~/lib/gql';
 import {
-	GET_CONNECTED_ROUTES,
-	GET_LINE_GROUP_STATIONS,
-	GET_LINE_STATIONS,
-	GET_ROUTE_TYPES_LIGHT,
-} from "~/lib/graphql/queries";
-import lineState, { pendingLineAtom } from "~/store/atoms/line";
-import navigationState from "~/store/atoms/navigation";
+  GET_CONNECTED_ROUTES,
+  GET_LINE_GROUP_STATIONS,
+  GET_LINE_STATIONS,
+  GET_ROUTE_TYPES_LIGHT,
+} from '~/lib/graphql/queries';
+import lineState, { pendingLineAtom } from '~/store/atoms/line';
+import navigationState from '~/store/atoms/navigation';
 import stationState, {
-	stationAtom,
-	wantedDestinationAtom,
-} from "~/store/atoms/station";
+  stationAtom,
+  wantedDestinationAtom,
+} from '~/store/atoms/station';
 import {
-	buildConnectedRouteTrainType,
-	computeCurrentStationInRoutes,
-	type ConnectedRoute,
-	getStationWithMatchingLine,
-} from "~/utils/routeSearch";
-import { findLocalType } from "~/utils/trainTypeString";
-import { useLazyGraphQLQuery } from "./useLazyGraphQLQuery";
+  buildConnectedRouteTrainType,
+  computeCurrentStationInRoutes,
+  type ConnectedRoute,
+  getStationWithMatchingLine,
+} from '~/utils/routeSearch';
+import { findLocalType } from '~/utils/trainTypeString';
+import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
 
 type GetRouteTypesData = {
-	routeTypes: {
-		nextPageToken: string | null;
-		trainTypes: TrainType[];
-	};
+  routeTypes: {
+    nextPageToken: string | null;
+    trainTypes: TrainType[];
+  };
 };
 
 type GetRouteTypesVariables = {
-	fromStationGroupId: number;
-	toStationGroupId: number;
-	pageSize?: number;
-	pageToken?: string;
-	viaLineId?: number;
+  fromStationGroupId: number;
+  toStationGroupId: number;
+  pageSize?: number;
+  pageToken?: string;
+  viaLineId?: number;
 };
 
 type GetConnectedRoutesData = {
-	connectedRoutes: ConnectedRoute[];
+  connectedRoutes: ConnectedRoute[];
 };
 
 type GetConnectedRoutesVariables = {
-	fromStationGroupId: number;
-	toStationGroupId: number;
+  fromStationGroupId: number;
+  toStationGroupId: number;
 };
 
 type GetLineStationsData = {
-	lineStations: Station[];
+  lineStations: Station[];
 };
 
 type GetLineStationsVariables = {
-	lineId: number;
-	stationId?: number;
+  lineId: number;
+  stationId?: number;
 };
 
 type GetLineGroupStationsData = {
-	lineGroupStations: Station[];
+  lineGroupStations: Station[];
 };
 
 type GetLineGroupStationsVariables = {
-	lineGroupId: number;
+  lineGroupId: number;
 };
 
 // GET_ROUTE_TYPES_LIGHT の pageSize。RouteSearchScreen の検索結果上限と同値。
 const ROUTE_TYPES_PAGE_SIZE = 100;
 
 export type UseDestinationSelectionResult = {
-	/** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
-	handleDestinationSelected: (selectedStation: Station) => Promise<void>;
-	/** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
-	handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
-	selectBoundModalVisible: boolean;
-	trainTypeListModalVisible: boolean;
-	selectedDestination: Station | null;
-	wantedDestination: Station | null;
-	/** TrainTypeListModal に渡す現在駅の路線 */
-	trainTypeModalLine: Line | null;
-	/** 種別取得中フラグ(カードのサブタイトルスケルトン・空状態のローディングに使う) */
-	fetchRouteTypesLoading: boolean;
-	/** SelectBoundModal / TrainTypeListModal に渡すローディング集約 */
-	modalLoading: boolean;
-	/** SelectBoundModal に渡すエラー集約 */
-	modalError: Error | null;
-	handleCloseSelectBoundModal: () => void;
-	handleSelectBoundModalCloseAnimationEnd: () => void;
-	handleBoundSelected: () => void;
-	handleCloseTrainTypeListModal: () => void;
+  /** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
+  handleDestinationSelected: (selectedStation: Station) => Promise<void>;
+  /** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
+  handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
+  selectBoundModalVisible: boolean;
+  trainTypeListModalVisible: boolean;
+  selectedDestination: Station | null;
+  wantedDestination: Station | null;
+  /** TrainTypeListModal に渡す現在駅の路線 */
+  trainTypeModalLine: Line | null;
+  /** 種別取得中フラグ(カードのサブタイトルスケルトン・空状態のローディングに使う) */
+  fetchRouteTypesLoading: boolean;
+  /** SelectBoundModal / TrainTypeListModal に渡すローディング集約 */
+  modalLoading: boolean;
+  /** SelectBoundModal に渡すエラー集約 */
+  modalError: Error | null;
+  handleCloseSelectBoundModal: () => void;
+  handleSelectBoundModalCloseAnimationEnd: () => void;
+  handleBoundSelected: () => void;
+  handleCloseTrainTypeListModal: () => void;
 };
 
 // RouteSearchScreen の検索結果タップと DestinationAgentScreen の提案カードタップで
 // 共通に使う行き先決定ロジック。種別・方向・区間の整合性ロジックを複製しないため、
 // 両画面はこのフック経由で同一の既存フロー(SelectBoundModal → selectedBound 確定)へ合流する。
 export const useDestinationSelection = (): UseDestinationSelectionResult => {
-	const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
-	const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
-		useState(false);
-	const [selectedDestination, setSelectedDestination] =
-		useState<Station | null>(null);
+  const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
+  const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
+    useState(false);
+  const [selectedDestination, setSelectedDestination] =
+    useState<Station | null>(null);
 
-	const station = useAtomValue(stationAtom);
-	const wantedDestination = useAtomValue(wantedDestinationAtom);
-	const pendingLine = useAtomValue(pendingLineAtom);
-	const setStationState = useSetAtom(stationState);
-	const setNavigationState = useSetAtom(navigationState);
-	const setLineState = useSetAtom(lineState);
+  const station = useAtomValue(stationAtom);
+  const wantedDestination = useAtomValue(wantedDestinationAtom);
+  const pendingLine = useAtomValue(pendingLineAtom);
+  const setStationState = useSetAtom(stationState);
+  const setNavigationState = useSetAtom(navigationState);
+  const setLineState = useSetAtom(lineState);
 
-	const queryClient = useQueryClient();
-	const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
+  const queryClient = useQueryClient();
+  const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
 
-	const [
-		fetchRouteTypes,
-		{
-			data: routeTypesData,
-			loading: fetchRouteTypesLoading,
-			error: fetchRouteTypesError,
-		},
-	] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
-		GET_ROUTE_TYPES_LIGHT,
-	);
+  const [
+    fetchRouteTypes,
+    {
+      data: routeTypesData,
+      loading: fetchRouteTypesLoading,
+      error: fetchRouteTypesError,
+    },
+  ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
+    GET_ROUTE_TYPES_LIGHT
+  );
 
-	const [
-		fetchConnectedRoutes,
-		{ loading: fetchConnectedRoutesLoading, error: fetchConnectedRoutesError },
-	] = useLazyGraphQLQuery<GetConnectedRoutesData, GetConnectedRoutesVariables>(
-		GET_CONNECTED_ROUTES,
-	);
+  const [
+    fetchConnectedRoutes,
+    { loading: fetchConnectedRoutesLoading, error: fetchConnectedRoutesError },
+  ] = useLazyGraphQLQuery<GetConnectedRoutesData, GetConnectedRoutesVariables>(
+    GET_CONNECTED_ROUTES
+  );
 
-	const [
-		fetchStationsByLineId,
-		{
-			loading: fetchStationsByLineIdLoading,
-			error: fetchStationsByLineIdError,
-		},
-	] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
-		GET_LINE_STATIONS,
-	);
+  const [
+    fetchStationsByLineId,
+    {
+      loading: fetchStationsByLineIdLoading,
+      error: fetchStationsByLineIdError,
+    },
+  ] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
+    GET_LINE_STATIONS
+  );
 
-	const [
-		fetchStationsByLineGroupId,
-		{
-			loading: fetchStationsByLineGroupIdLoading,
-			error: fetchStationsByLineGroupIdError,
-		},
-	] = useLazyGraphQLQuery<
-		GetLineGroupStationsData,
-		GetLineGroupStationsVariables
-	>(GET_LINE_GROUP_STATIONS);
+  const [
+    fetchStationsByLineGroupId,
+    {
+      loading: fetchStationsByLineGroupIdLoading,
+      error: fetchStationsByLineGroupIdError,
+    },
+  ] = useLazyGraphQLQuery<
+    GetLineGroupStationsData,
+    GetLineGroupStationsVariables
+  >(GET_LINE_GROUP_STATIONS);
 
-	const handleDestinationSelected = useCallback(
-		async (selectedStation: Station) => {
-			setSelectBoundModalVisible(true);
-			setSelectedDestination(selectedStation);
-			connectedRouteStationsRef.current.clear();
+  const handleDestinationSelected = useCallback(
+    async (selectedStation: Station) => {
+      setSelectBoundModalVisible(true);
+      setSelectedDestination(selectedStation);
+      connectedRouteStationsRef.current.clear();
 
-			const newPendingLine = selectedStation.line ?? null;
+      const newPendingLine = selectedStation.line ?? null;
 
-			setNavigationState((prev) => ({
-				...prev,
-				trainType: null,
-				pendingTrainType: null,
-			}));
-			setStationState((prev) => ({
-				...prev,
-				pendingStations: [],
-				wantedDestination: null,
-			}));
-			setLineState((prev) => ({
-				...prev,
-				pendingLine: newPendingLine,
-			}));
+      setNavigationState((prev) => ({
+        ...prev,
+        trainType: null,
+        pendingTrainType: null,
+      }));
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations: [],
+        wantedDestination: null,
+      }));
+      setLineState((prev) => ({
+        ...prev,
+        pendingLine: newPendingLine,
+      }));
 
-			// Guard: ensure both lineId and stationId are present before calling the query
-			if (
-				!selectedStation.groupId ||
-				!selectedStation.line?.id ||
-				!station?.groupId
-			) {
-				return;
-			}
+      // Guard: ensure both lineId and stationId are present before calling the query
+      if (
+        !selectedStation.groupId ||
+        !selectedStation.line?.id ||
+        !station?.groupId
+      ) {
+        return;
+      }
 
-			const result = await fetchRouteTypes({
-				variables: {
-					fromStationGroupId: station.groupId,
-					toStationGroupId: selectedStation.groupId,
-					pageSize: ROUTE_TYPES_PAGE_SIZE,
-					viaLineId: selectedStation.line.id,
-				},
-			});
+      const result = await fetchRouteTypes({
+        variables: {
+          fromStationGroupId: station.groupId,
+          toStationGroupId: selectedStation.groupId,
+          pageSize: ROUTE_TYPES_PAGE_SIZE,
+          viaLineId: selectedStation.line.id,
+        },
+      });
 
-			const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
+      const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
 
-			if (!fetchedTrainTypes.length) {
-				const connectedRoutesResult = await fetchConnectedRoutes({
-					variables: {
-						fromStationGroupId: station.groupId,
-						toStationGroupId: selectedStation.groupId,
-					},
-				});
-				const connectedRoutes =
-					connectedRoutesResult.data?.connectedRoutes ?? [];
-				const connectedTrainTypes = connectedRoutes
-					.map(buildConnectedRouteTrainType)
-					.filter((trainType): trainType is TrainType => !!trainType);
+      if (!fetchedTrainTypes.length) {
+        const connectedRoutesResult = await fetchConnectedRoutes({
+          variables: {
+            fromStationGroupId: station.groupId,
+            toStationGroupId: selectedStation.groupId,
+          },
+        });
+        const connectedRoutes =
+          connectedRoutesResult.data?.connectedRoutes ?? [];
+        const connectedTrainTypes = connectedRoutes
+          .map(buildConnectedRouteTrainType)
+          .filter((trainType): trainType is TrainType => !!trainType);
 
-				connectedRouteStationsRef.current = new Map(
-					connectedRoutes.flatMap((route) =>
-						route.id && route.stops
-							? ([[route.id, route.stops]] as [number, Station[]][])
-							: [],
-					),
-				);
+        connectedRouteStationsRef.current = new Map(
+          connectedRoutes.flatMap((route) =>
+            route.id && route.stops
+              ? ([[route.id, route.stops]] as [number, Station[]][])
+              : []
+          )
+        );
 
-				const connectedTrainType =
-					findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
-				if (connectedTrainType?.groupId) {
-					const connectedStations =
-						connectedRouteStationsRef.current.get(connectedTrainType.groupId) ??
-						[];
-					const newCurrentStation = computeCurrentStationInRoutes(
-						station,
-						newPendingLine,
-						[connectedTrainType],
-					);
+        const connectedTrainType =
+          findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
+        if (connectedTrainType?.groupId) {
+          const connectedStations =
+            connectedRouteStationsRef.current.get(connectedTrainType.groupId) ??
+            [];
+          const newCurrentStation = computeCurrentStationInRoutes(
+            station,
+            newPendingLine,
+            [connectedTrainType]
+          );
 
-					setStationState((prev) => ({
-						...prev,
-						pendingStation: newCurrentStation,
-						station:
-							prev.station && newCurrentStation?.line
-								? { ...prev.station, line: newCurrentStation.line }
-								: prev.station,
-						pendingStations: connectedStations,
-					}));
-					if (newCurrentStation?.line) {
-						setLineState((prev) => ({
-							...prev,
-							pendingLine: newCurrentStation.line,
-						}));
-					}
-					setNavigationState((prev) => ({
-						...prev,
-						fetchedTrainTypes: connectedTrainTypes,
-						pendingTrainType: connectedTrainType,
-					}));
-					return;
-				}
+          setStationState((prev) => ({
+            ...prev,
+            pendingStation: newCurrentStation,
+            station:
+              prev.station && newCurrentStation?.line
+                ? { ...prev.station, line: newCurrentStation.line }
+                : prev.station,
+            pendingStations: connectedStations,
+          }));
+          if (newCurrentStation?.line) {
+            setLineState((prev) => ({
+              ...prev,
+              pendingLine: newCurrentStation.line,
+            }));
+          }
+          setNavigationState((prev) => ({
+            ...prev,
+            fetchedTrainTypes: connectedTrainTypes,
+            pendingTrainType: connectedTrainType,
+          }));
+          return;
+        }
 
-				if (!selectedStation.line?.id) {
-					return;
-				}
-				// 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
-				setLineState((prev) => ({
-					...prev,
-					pendingLine: selectedStation.line ?? null,
-				}));
-				// 現在の駅の路線情報を選択した路線に合わせて更新
-				const updatedStation = getStationWithMatchingLine(
-					station,
-					selectedStation.line ?? null,
-				);
-				setStationState((prev) => ({
-					...prev,
-					pendingStation: updatedStation,
-					station: updatedStation,
-				}));
-				const stationsByLineIdRes = await fetchStationsByLineId({
-					variables: {
-						lineId: selectedStation.line.id,
-					},
-				});
-				const stations = stationsByLineIdRes.data?.lineStations ?? [];
-				setStationState((prev) => ({
-					...prev,
-					pendingStations: stations,
-				}));
-				return;
-			}
+        if (!selectedStation.line?.id) {
+          return;
+        }
+        // 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
+        setLineState((prev) => ({
+          ...prev,
+          pendingLine: selectedStation.line ?? null,
+        }));
+        // 現在の駅の路線情報を選択した路線に合わせて更新
+        const updatedStation = getStationWithMatchingLine(
+          station,
+          selectedStation.line ?? null
+        );
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation: updatedStation,
+          station: updatedStation,
+        }));
+        const stationsByLineIdRes = await fetchStationsByLineId({
+          variables: {
+            lineId: selectedStation.line.id,
+          },
+        });
+        const stations = stationsByLineIdRes.data?.lineStations ?? [];
+        setStationState((prev) => ({
+          ...prev,
+          pendingStations: stations,
+        }));
+        return;
+      }
 
-			// 先に選択される列車種別を決定
-			const localTrainType =
-				findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
+      // 先に選択される列車種別を決定
+      const localTrainType =
+        findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
 
-			if (!localTrainType?.groupId) {
-				return;
-			}
+      if (!localTrainType?.groupId) {
+        return;
+      }
 
-			// 選択された列車種別のみを使って路線を決定
-			const newCurrentStation = computeCurrentStationInRoutes(
-				station,
-				newPendingLine,
-				[localTrainType],
-			);
-			if (newCurrentStation) {
-				setStationState((prev) => {
-					const isSamePendingStation =
-						prev.pendingStation?.groupId === newCurrentStation.groupId;
-					const isSameStationLine =
-						prev.station?.line?.id === newCurrentStation.line?.id;
+      // 選択された列車種別のみを使って路線を決定
+      const newCurrentStation = computeCurrentStationInRoutes(
+        station,
+        newPendingLine,
+        [localTrainType]
+      );
+      if (newCurrentStation) {
+        setStationState((prev) => {
+          const isSamePendingStation =
+            prev.pendingStation?.groupId === newCurrentStation.groupId;
+          const isSameStationLine =
+            prev.station?.line?.id === newCurrentStation.line?.id;
 
-					if (isSamePendingStation && isSameStationLine) {
-						return prev;
-					}
-					return {
-						...prev,
-						pendingStation: isSamePendingStation
-							? prev.pendingStation
-							: newCurrentStation,
-						// stationのlineも列車種別とマッチする路線に更新
-						station: prev.station
-							? { ...prev.station, line: newCurrentStation.line }
-							: prev.station,
-					};
-				});
-				// pendingLineを現在の駅にマッチする路線に更新
-				if (newCurrentStation.line) {
-					setLineState((prev) => ({
-						...prev,
-						pendingLine: newCurrentStation.line ?? null,
-					}));
-				}
-			}
+          if (isSamePendingStation && isSameStationLine) {
+            return prev;
+          }
+          return {
+            ...prev,
+            pendingStation: isSamePendingStation
+              ? prev.pendingStation
+              : newCurrentStation,
+            // stationのlineも列車種別とマッチする路線に更新
+            station: prev.station
+              ? { ...prev.station, line: newCurrentStation.line }
+              : prev.station,
+          };
+        });
+        // pendingLineを現在の駅にマッチする路線に更新
+        if (newCurrentStation.line) {
+          setLineState((prev) => ({
+            ...prev,
+            pendingLine: newCurrentStation.line ?? null,
+          }));
+        }
+      }
 
-			const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
-				variables: { lineGroupId: localTrainType.groupId },
-			});
-			const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
-			setStationState((prev) => ({
-				...prev,
-				pendingStations: stations,
-			}));
-			setNavigationState((prev) => ({
-				...prev,
-				fetchedTrainTypes,
-				pendingTrainType: localTrainType,
-			}));
-		},
-		[
-			station,
-			fetchStationsByLineId,
-			fetchStationsByLineGroupId,
-			fetchRouteTypes,
-			fetchConnectedRoutes,
-			setNavigationState,
-			setStationState,
-			setLineState,
-		],
-	);
+      const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
+        variables: { lineGroupId: localTrainType.groupId },
+      });
+      const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations: stations,
+      }));
+      setNavigationState((prev) => ({
+        ...prev,
+        fetchedTrainTypes,
+        pendingTrainType: localTrainType,
+      }));
+    },
+    [
+      station,
+      fetchStationsByLineId,
+      fetchStationsByLineGroupId,
+      fetchRouteTypes,
+      fetchConnectedRoutes,
+      setNavigationState,
+      setStationState,
+      setLineState,
+    ]
+  );
 
-	const handleTrainTypeSelected = useCallback(
-		async (trainType: TrainType) => {
-			if (!trainType.groupId) return;
+  const handleTrainTypeSelected = useCallback(
+    async (trainType: TrainType) => {
+      if (!trainType.groupId) return;
 
-			setSelectBoundModalVisible(true);
+      setSelectBoundModalVisible(true);
 
-			setNavigationState((prev) => ({
-				...prev,
-				pendingTrainType: trainType,
-			}));
+      setNavigationState((prev) => ({
+        ...prev,
+        pendingTrainType: trainType,
+      }));
 
-			const connectedStations = connectedRouteStationsRef.current.get(
-				trainType.groupId,
-			);
-			if (connectedStations) {
-				const newCurrentStation = computeCurrentStationInRoutes(
-					station,
-					pendingLine,
-					[trainType],
-				);
-				setStationState((prev) => ({
-					...prev,
-					pendingStation: newCurrentStation,
-					station:
-						prev.station && newCurrentStation?.line
-							? { ...prev.station, line: newCurrentStation.line }
-							: prev.station,
-					pendingStations: connectedStations,
-				}));
-				if (newCurrentStation?.line) {
-					setLineState((prev) => ({
-						...prev,
-						pendingLine: newCurrentStation.line,
-					}));
-				}
-				return;
-			}
+      const connectedStations = connectedRouteStationsRef.current.get(
+        trainType.groupId
+      );
+      if (connectedStations) {
+        const newCurrentStation = computeCurrentStationInRoutes(
+          station,
+          pendingLine,
+          [trainType]
+        );
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation: newCurrentStation,
+          station:
+            prev.station && newCurrentStation?.line
+              ? { ...prev.station, line: newCurrentStation.line }
+              : prev.station,
+          pendingStations: connectedStations,
+        }));
+        if (newCurrentStation?.line) {
+          setLineState((prev) => ({
+            ...prev,
+            pendingLine: newCurrentStation.line,
+          }));
+        }
+        return;
+      }
 
-			// キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
-			queryClient.removeQueries({
-				queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
-					lineGroupId: trainType.groupId,
-				}),
-			});
+      // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
+      queryClient.removeQueries({
+        queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
+          lineGroupId: trainType.groupId,
+        }),
+      });
 
-			const pendingStationsData = await fetchStationsByLineGroupId({
-				variables: {
-					lineGroupId: trainType.groupId,
-				},
-			});
-			const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
-			setStationState((prev) => ({
-				...prev,
-				pendingStations,
-			}));
-		},
-		[
-			fetchStationsByLineGroupId,
-			station,
-			pendingLine,
-			setStationState,
-			setNavigationState,
-			setLineState,
-			queryClient,
-		],
-	);
+      const pendingStationsData = await fetchStationsByLineGroupId({
+        variables: {
+          lineGroupId: trainType.groupId,
+        },
+      });
+      const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
+      setStationState((prev) => ({
+        ...prev,
+        pendingStations,
+      }));
+    },
+    [
+      fetchStationsByLineGroupId,
+      station,
+      pendingLine,
+      setStationState,
+      setNavigationState,
+      setLineState,
+      queryClient,
+    ]
+  );
 
-	const currentStationInRoutes = useMemo<Station | null>(
-		() =>
-			computeCurrentStationInRoutes(
-				station,
-				pendingLine,
-				routeTypesData?.routeTypes?.trainTypes ?? [],
-			),
-		[station, pendingLine, routeTypesData?.routeTypes],
-	);
+  const currentStationInRoutes = useMemo<Station | null>(
+    () =>
+      computeCurrentStationInRoutes(
+        station,
+        pendingLine,
+        routeTypesData?.routeTypes?.trainTypes ?? []
+      ),
+    [station, pendingLine, routeTypesData?.routeTypes]
+  );
 
-	const trainTypeModalLine = useMemo(() => {
-		const currentLine = currentStationInRoutes?.line;
-		const currentStationLines = station?.lines ?? [];
+  const trainTypeModalLine = useMemo(() => {
+    const currentLine = currentStationInRoutes?.line;
+    const currentStationLines = station?.lines ?? [];
 
-		if (
-			currentLine &&
-			currentStationLines.some(
-				(stationLine) => stationLine.id === currentLine.id,
-			)
-		) {
-			return currentLine;
-		}
+    if (
+      currentLine &&
+      currentStationLines.some(
+        (stationLine) => stationLine.id === currentLine.id
+      )
+    ) {
+      return currentLine;
+    }
 
-		return station?.line ?? currentStationLines[0] ?? null;
-	}, [currentStationInRoutes?.line, station?.line, station?.lines]);
+    return station?.line ?? currentStationLines[0] ?? null;
+  }, [currentStationInRoutes?.line, station?.line, station?.lines]);
 
-	const handleCloseSelectBoundModal = useCallback(() => {
-		setSelectBoundModalVisible(false);
-	}, []);
+  const handleCloseSelectBoundModal = useCallback(() => {
+    setSelectBoundModalVisible(false);
+  }, []);
 
-	const handleSelectBoundModalCloseAnimationEnd = useCallback(() => {
-		setSelectedDestination(null);
-	}, []);
+  const handleSelectBoundModalCloseAnimationEnd = useCallback(() => {
+    setSelectedDestination(null);
+  }, []);
 
-	const handleBoundSelected = useCallback(() => {
-		setSelectBoundModalVisible(false);
-		setTrainTypeListModalVisible(false);
-	}, []);
+  const handleBoundSelected = useCallback(() => {
+    setSelectBoundModalVisible(false);
+    setTrainTypeListModalVisible(false);
+  }, []);
 
-	const handleCloseTrainTypeListModal = useCallback(() => {
-		setTrainTypeListModalVisible(false);
-	}, []);
+  const handleCloseTrainTypeListModal = useCallback(() => {
+    setTrainTypeListModalVisible(false);
+  }, []);
 
-	const modalLoading =
-		fetchRouteTypesLoading ||
-		fetchConnectedRoutesLoading ||
-		fetchStationsByLineIdLoading ||
-		fetchStationsByLineGroupIdLoading;
+  const modalLoading =
+    fetchRouteTypesLoading ||
+    fetchConnectedRoutesLoading ||
+    fetchStationsByLineIdLoading ||
+    fetchStationsByLineGroupIdLoading;
 
-	const modalError =
-		fetchRouteTypesError ??
-		fetchConnectedRoutesError ??
-		fetchStationsByLineIdError ??
-		fetchStationsByLineGroupIdError ??
-		null;
+  const modalError =
+    fetchRouteTypesError ??
+    fetchConnectedRoutesError ??
+    fetchStationsByLineIdError ??
+    fetchStationsByLineGroupIdError ??
+    null;
 
-	return {
-		handleDestinationSelected,
-		handleTrainTypeSelected,
-		selectBoundModalVisible,
-		trainTypeListModalVisible,
-		selectedDestination,
-		wantedDestination,
-		trainTypeModalLine,
-		fetchRouteTypesLoading,
-		modalLoading,
-		modalError,
-		handleCloseSelectBoundModal,
-		handleSelectBoundModalCloseAnimationEnd,
-		handleBoundSelected,
-		handleCloseTrainTypeListModal,
-	};
+  return {
+    handleDestinationSelected,
+    handleTrainTypeSelected,
+    selectBoundModalVisible,
+    trainTypeListModalVisible,
+    selectedDestination,
+    wantedDestination,
+    trainTypeModalLine,
+    fetchRouteTypesLoading,
+    modalLoading,
+    modalError,
+    handleCloseSelectBoundModal,
+    handleSelectBoundModalCloseAnimationEnd,
+    handleBoundSelected,
+    handleCloseTrainTypeListModal,
+  };
 };

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -17,8 +17,8 @@ import stationState, {
 } from '~/store/atoms/station';
 import {
   buildConnectedRouteTrainType,
-  computeCurrentStationInRoutes,
   type ConnectedRoute,
+  computeCurrentStationInRoutes,
   getStationWithMatchingLine,
 } from '~/utils/routeSearch';
 import { findLocalType } from '~/utils/trainTypeString';

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -1,9 +1,10 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import { graphqlQueryKey } from '~/lib/gql';
 import {
+  GET_CONNECTED_ROUTES,
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
   GET_ROUTE_TYPES_LIGHT,
@@ -15,7 +16,9 @@ import stationState, {
   wantedDestinationAtom,
 } from '~/store/atoms/station';
 import {
+  buildConnectedRouteTrainType,
   computeCurrentStationInRoutes,
+  type ConnectedRoute,
   getStationWithMatchingLine,
 } from '~/utils/routeSearch';
 import { findLocalType } from '~/utils/trainTypeString';
@@ -34,6 +37,15 @@ type GetRouteTypesVariables = {
   pageSize?: number;
   pageToken?: string;
   viaLineId?: number;
+};
+
+type GetConnectedRoutesData = {
+  connectedRoutes: ConnectedRoute[];
+};
+
+type GetConnectedRoutesVariables = {
+  fromStationGroupId: number;
+  toStationGroupId: number;
 };
 
 type GetLineStationsData = {
@@ -97,6 +109,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
   const setLineState = useSetAtom(lineState);
 
   const queryClient = useQueryClient();
+  const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
 
   const [
     fetchRouteTypes,
@@ -108,6 +121,17 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
   ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
     GET_ROUTE_TYPES_LIGHT
   );
+
+  const [
+    fetchConnectedRoutes,
+    {
+      loading: fetchConnectedRoutesLoading,
+      error: fetchConnectedRoutesError,
+    },
+  ] = useLazyGraphQLQuery<
+    GetConnectedRoutesData,
+    GetConnectedRoutesVariables
+  >(GET_CONNECTED_ROUTES);
 
   const [
     fetchStationsByLineId,
@@ -134,6 +158,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     async (selectedStation: Station) => {
       setSelectBoundModalVisible(true);
       setSelectedDestination(selectedStation);
+      connectedRouteStationsRef.current.clear();
 
       const newPendingLine = selectedStation.line ?? null;
 
@@ -172,11 +197,65 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
 
       const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
 
-      if (!fetchedTrainTypes?.length) {
+      if (!fetchedTrainTypes.length) {
+        const connectedRoutesResult = await fetchConnectedRoutes({
+          variables: {
+            fromStationGroupId: station.groupId,
+            toStationGroupId: selectedStation.groupId,
+          },
+        });
+        const connectedRoutes =
+          connectedRoutesResult.data?.connectedRoutes ?? [];
+        const connectedTrainTypes = connectedRoutes
+          .map(buildConnectedRouteTrainType)
+          .filter((trainType): trainType is TrainType => !!trainType);
+
+        connectedRouteStationsRef.current = new Map(
+          connectedRoutes.flatMap((route) =>
+            route.id && route.stops ? [[route.id, route.stops]] : []
+          )
+        );
+
+        const connectedTrainType =
+          findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
+        if (connectedTrainType?.groupId) {
+          const connectedStations =
+            connectedRouteStationsRef.current.get(
+              connectedTrainType.groupId
+            ) ?? [];
+          const newCurrentStation = computeCurrentStationInRoutes(
+            station,
+            newPendingLine,
+            [connectedTrainType]
+          );
+
+          setStationState((prev) => ({
+            ...prev,
+            pendingStation: newCurrentStation,
+            station:
+              prev.station && newCurrentStation?.line
+                ? { ...prev.station, line: newCurrentStation.line }
+                : prev.station,
+            pendingStations: connectedStations,
+          }));
+          if (newCurrentStation?.line) {
+            setLineState((prev) => ({
+              ...prev,
+              pendingLine: newCurrentStation.line,
+            }));
+          }
+          setNavigationState((prev) => ({
+            ...prev,
+            fetchedTrainTypes: connectedTrainTypes,
+            pendingTrainType: connectedTrainType,
+          }));
+          return;
+        }
+
         if (!selectedStation.line?.id) {
           return;
         }
-        // 列車種別が存在しない場合は選択した行き先駅の路線を使用
+        // 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
         setLineState((prev) => ({
           ...prev,
           pendingLine: selectedStation.line ?? null,
@@ -267,6 +346,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
       fetchStationsByLineId,
       fetchStationsByLineGroupId,
       fetchRouteTypes,
+      fetchConnectedRoutes,
       setNavigationState,
       setStationState,
       setLineState,
@@ -283,6 +363,33 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         ...prev,
         pendingTrainType: trainType,
       }));
+
+      const connectedStations = connectedRouteStationsRef.current.get(
+        trainType.groupId
+      );
+      if (connectedStations) {
+        const newCurrentStation = computeCurrentStationInRoutes(
+          station,
+          pendingLine,
+          [trainType]
+        );
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation: newCurrentStation,
+          station:
+            prev.station && newCurrentStation?.line
+              ? { ...prev.station, line: newCurrentStation.line }
+              : prev.station,
+          pendingStations: connectedStations,
+        }));
+        if (newCurrentStation?.line) {
+          setLineState((prev) => ({
+            ...prev,
+            pendingLine: newCurrentStation.line,
+          }));
+        }
+        return;
+      }
 
       // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
       queryClient.removeQueries({
@@ -304,8 +411,11 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     },
     [
       fetchStationsByLineGroupId,
+      station,
+      pendingLine,
       setStationState,
       setNavigationState,
+      setLineState,
       queryClient,
     ]
   );
@@ -355,11 +465,13 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
 
   const modalLoading =
     fetchRouteTypesLoading ||
+    fetchConnectedRoutesLoading ||
     fetchStationsByLineIdLoading ||
     fetchStationsByLineGroupIdLoading;
 
   const modalError =
     fetchRouteTypesError ??
+    fetchConnectedRoutesError ??
     fetchStationsByLineIdError ??
     fetchStationsByLineGroupIdError ??
     null;

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -1,497 +1,492 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useMemo, useRef, useState } from 'react';
-import type { Line, Station, TrainType } from '~/@types/graphql';
-import { graphqlQueryKey } from '~/lib/gql';
+import { useQueryClient } from "@tanstack/react-query";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { Line, Station, TrainType } from "~/@types/graphql";
+import { graphqlQueryKey } from "~/lib/gql";
 import {
-  GET_CONNECTED_ROUTES,
-  GET_LINE_GROUP_STATIONS,
-  GET_LINE_STATIONS,
-  GET_ROUTE_TYPES_LIGHT,
-} from '~/lib/graphql/queries';
-import lineState, { pendingLineAtom } from '~/store/atoms/line';
-import navigationState from '~/store/atoms/navigation';
+	GET_CONNECTED_ROUTES,
+	GET_LINE_GROUP_STATIONS,
+	GET_LINE_STATIONS,
+	GET_ROUTE_TYPES_LIGHT,
+} from "~/lib/graphql/queries";
+import lineState, { pendingLineAtom } from "~/store/atoms/line";
+import navigationState from "~/store/atoms/navigation";
 import stationState, {
-  stationAtom,
-  wantedDestinationAtom,
-} from '~/store/atoms/station';
+	stationAtom,
+	wantedDestinationAtom,
+} from "~/store/atoms/station";
 import {
-  buildConnectedRouteTrainType,
-  computeCurrentStationInRoutes,
-  type ConnectedRoute,
-  getStationWithMatchingLine,
-} from '~/utils/routeSearch';
-import { findLocalType } from '~/utils/trainTypeString';
-import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
+	buildConnectedRouteTrainType,
+	computeCurrentStationInRoutes,
+	type ConnectedRoute,
+	getStationWithMatchingLine,
+} from "~/utils/routeSearch";
+import { findLocalType } from "~/utils/trainTypeString";
+import { useLazyGraphQLQuery } from "./useLazyGraphQLQuery";
 
 type GetRouteTypesData = {
-  routeTypes: {
-    nextPageToken: string | null;
-    trainTypes: TrainType[];
-  };
+	routeTypes: {
+		nextPageToken: string | null;
+		trainTypes: TrainType[];
+	};
 };
 
 type GetRouteTypesVariables = {
-  fromStationGroupId: number;
-  toStationGroupId: number;
-  pageSize?: number;
-  pageToken?: string;
-  viaLineId?: number;
+	fromStationGroupId: number;
+	toStationGroupId: number;
+	pageSize?: number;
+	pageToken?: string;
+	viaLineId?: number;
 };
 
 type GetConnectedRoutesData = {
-  connectedRoutes: ConnectedRoute[];
+	connectedRoutes: ConnectedRoute[];
 };
 
 type GetConnectedRoutesVariables = {
-  fromStationGroupId: number;
-  toStationGroupId: number;
+	fromStationGroupId: number;
+	toStationGroupId: number;
 };
 
 type GetLineStationsData = {
-  lineStations: Station[];
+	lineStations: Station[];
 };
 
 type GetLineStationsVariables = {
-  lineId: number;
-  stationId?: number;
+	lineId: number;
+	stationId?: number;
 };
 
 type GetLineGroupStationsData = {
-  lineGroupStations: Station[];
+	lineGroupStations: Station[];
 };
 
 type GetLineGroupStationsVariables = {
-  lineGroupId: number;
+	lineGroupId: number;
 };
 
 // GET_ROUTE_TYPES_LIGHT の pageSize。RouteSearchScreen の検索結果上限と同値。
 const ROUTE_TYPES_PAGE_SIZE = 100;
 
 export type UseDestinationSelectionResult = {
-  /** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
-  handleDestinationSelected: (selectedStation: Station) => Promise<void>;
-  /** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
-  handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
-  selectBoundModalVisible: boolean;
-  trainTypeListModalVisible: boolean;
-  selectedDestination: Station | null;
-  wantedDestination: Station | null;
-  /** TrainTypeListModal に渡す現在駅の路線 */
-  trainTypeModalLine: Line | null;
-  /** 種別取得中フラグ(カードのサブタイトルスケルトン・空状態のローディングに使う) */
-  fetchRouteTypesLoading: boolean;
-  /** SelectBoundModal / TrainTypeListModal に渡すローディング集約 */
-  modalLoading: boolean;
-  /** SelectBoundModal に渡すエラー集約 */
-  modalError: Error | null;
-  handleCloseSelectBoundModal: () => void;
-  handleSelectBoundModalCloseAnimationEnd: () => void;
-  handleBoundSelected: () => void;
-  handleCloseTrainTypeListModal: () => void;
+	/** 行き先駅カードのタップハンドラ(SelectBoundModal を開いて pendingStations を構築する) */
+	handleDestinationSelected: (selectedStation: Station) => Promise<void>;
+	/** TrainTypeListModal / SelectBoundModal からの種別選択ハンドラ */
+	handleTrainTypeSelected: (trainType: TrainType) => Promise<void>;
+	selectBoundModalVisible: boolean;
+	trainTypeListModalVisible: boolean;
+	selectedDestination: Station | null;
+	wantedDestination: Station | null;
+	/** TrainTypeListModal に渡す現在駅の路線 */
+	trainTypeModalLine: Line | null;
+	/** 種別取得中フラグ(カードのサブタイトルスケルトン・空状態のローディングに使う) */
+	fetchRouteTypesLoading: boolean;
+	/** SelectBoundModal / TrainTypeListModal に渡すローディング集約 */
+	modalLoading: boolean;
+	/** SelectBoundModal に渡すエラー集約 */
+	modalError: Error | null;
+	handleCloseSelectBoundModal: () => void;
+	handleSelectBoundModalCloseAnimationEnd: () => void;
+	handleBoundSelected: () => void;
+	handleCloseTrainTypeListModal: () => void;
 };
 
 // RouteSearchScreen の検索結果タップと DestinationAgentScreen の提案カードタップで
 // 共通に使う行き先決定ロジック。種別・方向・区間の整合性ロジックを複製しないため、
 // 両画面はこのフック経由で同一の既存フロー(SelectBoundModal → selectedBound 確定)へ合流する。
 export const useDestinationSelection = (): UseDestinationSelectionResult => {
-  const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
-  const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
-    useState(false);
-  const [selectedDestination, setSelectedDestination] =
-    useState<Station | null>(null);
+	const [selectBoundModalVisible, setSelectBoundModalVisible] = useState(false);
+	const [trainTypeListModalVisible, setTrainTypeListModalVisible] =
+		useState(false);
+	const [selectedDestination, setSelectedDestination] =
+		useState<Station | null>(null);
 
-  const station = useAtomValue(stationAtom);
-  const wantedDestination = useAtomValue(wantedDestinationAtom);
-  const pendingLine = useAtomValue(pendingLineAtom);
-  const setStationState = useSetAtom(stationState);
-  const setNavigationState = useSetAtom(navigationState);
-  const setLineState = useSetAtom(lineState);
+	const station = useAtomValue(stationAtom);
+	const wantedDestination = useAtomValue(wantedDestinationAtom);
+	const pendingLine = useAtomValue(pendingLineAtom);
+	const setStationState = useSetAtom(stationState);
+	const setNavigationState = useSetAtom(navigationState);
+	const setLineState = useSetAtom(lineState);
 
-  const queryClient = useQueryClient();
-  const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
+	const queryClient = useQueryClient();
+	const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
 
-  const [
-    fetchRouteTypes,
-    {
-      data: routeTypesData,
-      loading: fetchRouteTypesLoading,
-      error: fetchRouteTypesError,
-    },
-  ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
-    GET_ROUTE_TYPES_LIGHT
-  );
+	const [
+		fetchRouteTypes,
+		{
+			data: routeTypesData,
+			loading: fetchRouteTypesLoading,
+			error: fetchRouteTypesError,
+		},
+	] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
+		GET_ROUTE_TYPES_LIGHT,
+	);
 
-  const [
-    fetchConnectedRoutes,
-    {
-      loading: fetchConnectedRoutesLoading,
-      error: fetchConnectedRoutesError,
-    },
-  ] = useLazyGraphQLQuery<
-    GetConnectedRoutesData,
-    GetConnectedRoutesVariables
-  >(GET_CONNECTED_ROUTES);
+	const [
+		fetchConnectedRoutes,
+		{ loading: fetchConnectedRoutesLoading, error: fetchConnectedRoutesError },
+	] = useLazyGraphQLQuery<GetConnectedRoutesData, GetConnectedRoutesVariables>(
+		GET_CONNECTED_ROUTES,
+	);
 
-  const [
-    fetchStationsByLineId,
-    {
-      loading: fetchStationsByLineIdLoading,
-      error: fetchStationsByLineIdError,
-    },
-  ] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
-    GET_LINE_STATIONS
-  );
+	const [
+		fetchStationsByLineId,
+		{
+			loading: fetchStationsByLineIdLoading,
+			error: fetchStationsByLineIdError,
+		},
+	] = useLazyGraphQLQuery<GetLineStationsData, GetLineStationsVariables>(
+		GET_LINE_STATIONS,
+	);
 
-  const [
-    fetchStationsByLineGroupId,
-    {
-      loading: fetchStationsByLineGroupIdLoading,
-      error: fetchStationsByLineGroupIdError,
-    },
-  ] = useLazyGraphQLQuery<
-    GetLineGroupStationsData,
-    GetLineGroupStationsVariables
-  >(GET_LINE_GROUP_STATIONS);
+	const [
+		fetchStationsByLineGroupId,
+		{
+			loading: fetchStationsByLineGroupIdLoading,
+			error: fetchStationsByLineGroupIdError,
+		},
+	] = useLazyGraphQLQuery<
+		GetLineGroupStationsData,
+		GetLineGroupStationsVariables
+	>(GET_LINE_GROUP_STATIONS);
 
-  const handleDestinationSelected = useCallback(
-    async (selectedStation: Station) => {
-      setSelectBoundModalVisible(true);
-      setSelectedDestination(selectedStation);
-      connectedRouteStationsRef.current.clear();
+	const handleDestinationSelected = useCallback(
+		async (selectedStation: Station) => {
+			setSelectBoundModalVisible(true);
+			setSelectedDestination(selectedStation);
+			connectedRouteStationsRef.current.clear();
 
-      const newPendingLine = selectedStation.line ?? null;
+			const newPendingLine = selectedStation.line ?? null;
 
-      setNavigationState((prev) => ({
-        ...prev,
-        trainType: null,
-        pendingTrainType: null,
-      }));
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations: [],
-        wantedDestination: null,
-      }));
-      setLineState((prev) => ({
-        ...prev,
-        pendingLine: newPendingLine,
-      }));
+			setNavigationState((prev) => ({
+				...prev,
+				trainType: null,
+				pendingTrainType: null,
+			}));
+			setStationState((prev) => ({
+				...prev,
+				pendingStations: [],
+				wantedDestination: null,
+			}));
+			setLineState((prev) => ({
+				...prev,
+				pendingLine: newPendingLine,
+			}));
 
-      // Guard: ensure both lineId and stationId are present before calling the query
-      if (
-        !selectedStation.groupId ||
-        !selectedStation.line?.id ||
-        !station?.groupId
-      ) {
-        return;
-      }
+			// Guard: ensure both lineId and stationId are present before calling the query
+			if (
+				!selectedStation.groupId ||
+				!selectedStation.line?.id ||
+				!station?.groupId
+			) {
+				return;
+			}
 
-      const result = await fetchRouteTypes({
-        variables: {
-          fromStationGroupId: station.groupId,
-          toStationGroupId: selectedStation.groupId,
-          pageSize: ROUTE_TYPES_PAGE_SIZE,
-          viaLineId: selectedStation.line.id,
-        },
-      });
+			const result = await fetchRouteTypes({
+				variables: {
+					fromStationGroupId: station.groupId,
+					toStationGroupId: selectedStation.groupId,
+					pageSize: ROUTE_TYPES_PAGE_SIZE,
+					viaLineId: selectedStation.line.id,
+				},
+			});
 
-      const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
+			const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
 
-      if (!fetchedTrainTypes.length) {
-        const connectedRoutesResult = await fetchConnectedRoutes({
-          variables: {
-            fromStationGroupId: station.groupId,
-            toStationGroupId: selectedStation.groupId,
-          },
-        });
-        const connectedRoutes =
-          connectedRoutesResult.data?.connectedRoutes ?? [];
-        const connectedTrainTypes = connectedRoutes
-          .map(buildConnectedRouteTrainType)
-          .filter((trainType): trainType is TrainType => !!trainType);
+			if (!fetchedTrainTypes.length) {
+				const connectedRoutesResult = await fetchConnectedRoutes({
+					variables: {
+						fromStationGroupId: station.groupId,
+						toStationGroupId: selectedStation.groupId,
+					},
+				});
+				const connectedRoutes =
+					connectedRoutesResult.data?.connectedRoutes ?? [];
+				const connectedTrainTypes = connectedRoutes
+					.map(buildConnectedRouteTrainType)
+					.filter((trainType): trainType is TrainType => !!trainType);
 
-        connectedRouteStationsRef.current = new Map(
-          connectedRoutes.flatMap((route) =>
-            route.id && route.stops
-              ? ([[route.id, route.stops]] as [number, Station[]][])
-              : []
-          )
-        );
+				connectedRouteStationsRef.current = new Map(
+					connectedRoutes.flatMap((route) =>
+						route.id && route.stops
+							? ([[route.id, route.stops]] as [number, Station[]][])
+							: [],
+					),
+				);
 
-        const connectedTrainType =
-          findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
-        if (connectedTrainType?.groupId) {
-          const connectedStations =
-            connectedRouteStationsRef.current.get(
-              connectedTrainType.groupId
-            ) ?? [];
-          const newCurrentStation = computeCurrentStationInRoutes(
-            station,
-            newPendingLine,
-            [connectedTrainType]
-          );
+				const connectedTrainType =
+					findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
+				if (connectedTrainType?.groupId) {
+					const connectedStations =
+						connectedRouteStationsRef.current.get(connectedTrainType.groupId) ??
+						[];
+					const newCurrentStation = computeCurrentStationInRoutes(
+						station,
+						newPendingLine,
+						[connectedTrainType],
+					);
 
-          setStationState((prev) => ({
-            ...prev,
-            pendingStation: newCurrentStation,
-            station:
-              prev.station && newCurrentStation?.line
-                ? { ...prev.station, line: newCurrentStation.line }
-                : prev.station,
-            pendingStations: connectedStations,
-          }));
-          if (newCurrentStation?.line) {
-            setLineState((prev) => ({
-              ...prev,
-              pendingLine: newCurrentStation.line,
-            }));
-          }
-          setNavigationState((prev) => ({
-            ...prev,
-            fetchedTrainTypes: connectedTrainTypes,
-            pendingTrainType: connectedTrainType,
-          }));
-          return;
-        }
+					setStationState((prev) => ({
+						...prev,
+						pendingStation: newCurrentStation,
+						station:
+							prev.station && newCurrentStation?.line
+								? { ...prev.station, line: newCurrentStation.line }
+								: prev.station,
+						pendingStations: connectedStations,
+					}));
+					if (newCurrentStation?.line) {
+						setLineState((prev) => ({
+							...prev,
+							pendingLine: newCurrentStation.line,
+						}));
+					}
+					setNavigationState((prev) => ({
+						...prev,
+						fetchedTrainTypes: connectedTrainTypes,
+						pendingTrainType: connectedTrainType,
+					}));
+					return;
+				}
 
-        if (!selectedStation.line?.id) {
-          return;
-        }
-        // 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
-        setLineState((prev) => ({
-          ...prev,
-          pendingLine: selectedStation.line ?? null,
-        }));
-        // 現在の駅の路線情報を選択した路線に合わせて更新
-        const updatedStation = getStationWithMatchingLine(
-          station,
-          selectedStation.line ?? null
-        );
-        setStationState((prev) => ({
-          ...prev,
-          pendingStation: updatedStation,
-          station: updatedStation,
-        }));
-        const stationsByLineIdRes = await fetchStationsByLineId({
-          variables: {
-            lineId: selectedStation.line.id,
-          },
-        });
-        const stations = stationsByLineIdRes.data?.lineStations ?? [];
-        setStationState((prev) => ({
-          ...prev,
-          pendingStations: stations,
-        }));
-        return;
-      }
+				if (!selectedStation.line?.id) {
+					return;
+				}
+				// 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
+				setLineState((prev) => ({
+					...prev,
+					pendingLine: selectedStation.line ?? null,
+				}));
+				// 現在の駅の路線情報を選択した路線に合わせて更新
+				const updatedStation = getStationWithMatchingLine(
+					station,
+					selectedStation.line ?? null,
+				);
+				setStationState((prev) => ({
+					...prev,
+					pendingStation: updatedStation,
+					station: updatedStation,
+				}));
+				const stationsByLineIdRes = await fetchStationsByLineId({
+					variables: {
+						lineId: selectedStation.line.id,
+					},
+				});
+				const stations = stationsByLineIdRes.data?.lineStations ?? [];
+				setStationState((prev) => ({
+					...prev,
+					pendingStations: stations,
+				}));
+				return;
+			}
 
-      // 先に選択される列車種別を決定
-      const localTrainType =
-        findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
+			// 先に選択される列車種別を決定
+			const localTrainType =
+				findLocalType(fetchedTrainTypes) ?? fetchedTrainTypes[0];
 
-      if (!localTrainType?.groupId) {
-        return;
-      }
+			if (!localTrainType?.groupId) {
+				return;
+			}
 
-      // 選択された列車種別のみを使って路線を決定
-      const newCurrentStation = computeCurrentStationInRoutes(
-        station,
-        newPendingLine,
-        [localTrainType]
-      );
-      if (newCurrentStation) {
-        setStationState((prev) => {
-          const isSamePendingStation =
-            prev.pendingStation?.groupId === newCurrentStation.groupId;
-          const isSameStationLine =
-            prev.station?.line?.id === newCurrentStation.line?.id;
+			// 選択された列車種別のみを使って路線を決定
+			const newCurrentStation = computeCurrentStationInRoutes(
+				station,
+				newPendingLine,
+				[localTrainType],
+			);
+			if (newCurrentStation) {
+				setStationState((prev) => {
+					const isSamePendingStation =
+						prev.pendingStation?.groupId === newCurrentStation.groupId;
+					const isSameStationLine =
+						prev.station?.line?.id === newCurrentStation.line?.id;
 
-          if (isSamePendingStation && isSameStationLine) {
-            return prev;
-          }
-          return {
-            ...prev,
-            pendingStation: isSamePendingStation
-              ? prev.pendingStation
-              : newCurrentStation,
-            // stationのlineも列車種別とマッチする路線に更新
-            station: prev.station
-              ? { ...prev.station, line: newCurrentStation.line }
-              : prev.station,
-          };
-        });
-        // pendingLineを現在の駅にマッチする路線に更新
-        if (newCurrentStation.line) {
-          setLineState((prev) => ({
-            ...prev,
-            pendingLine: newCurrentStation.line ?? null,
-          }));
-        }
-      }
+					if (isSamePendingStation && isSameStationLine) {
+						return prev;
+					}
+					return {
+						...prev,
+						pendingStation: isSamePendingStation
+							? prev.pendingStation
+							: newCurrentStation,
+						// stationのlineも列車種別とマッチする路線に更新
+						station: prev.station
+							? { ...prev.station, line: newCurrentStation.line }
+							: prev.station,
+					};
+				});
+				// pendingLineを現在の駅にマッチする路線に更新
+				if (newCurrentStation.line) {
+					setLineState((prev) => ({
+						...prev,
+						pendingLine: newCurrentStation.line ?? null,
+					}));
+				}
+			}
 
-      const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
-        variables: { lineGroupId: localTrainType.groupId },
-      });
-      const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations: stations,
-      }));
-      setNavigationState((prev) => ({
-        ...prev,
-        fetchedTrainTypes,
-        pendingTrainType: localTrainType,
-      }));
-    },
-    [
-      station,
-      fetchStationsByLineId,
-      fetchStationsByLineGroupId,
-      fetchRouteTypes,
-      fetchConnectedRoutes,
-      setNavigationState,
-      setStationState,
-      setLineState,
-    ]
-  );
+			const stationsByLineGroupIdRes = await fetchStationsByLineGroupId({
+				variables: { lineGroupId: localTrainType.groupId },
+			});
+			const stations = stationsByLineGroupIdRes.data?.lineGroupStations ?? [];
+			setStationState((prev) => ({
+				...prev,
+				pendingStations: stations,
+			}));
+			setNavigationState((prev) => ({
+				...prev,
+				fetchedTrainTypes,
+				pendingTrainType: localTrainType,
+			}));
+		},
+		[
+			station,
+			fetchStationsByLineId,
+			fetchStationsByLineGroupId,
+			fetchRouteTypes,
+			fetchConnectedRoutes,
+			setNavigationState,
+			setStationState,
+			setLineState,
+		],
+	);
 
-  const handleTrainTypeSelected = useCallback(
-    async (trainType: TrainType) => {
-      if (!trainType.groupId) return;
+	const handleTrainTypeSelected = useCallback(
+		async (trainType: TrainType) => {
+			if (!trainType.groupId) return;
 
-      setSelectBoundModalVisible(true);
+			setSelectBoundModalVisible(true);
 
-      setNavigationState((prev) => ({
-        ...prev,
-        pendingTrainType: trainType,
-      }));
+			setNavigationState((prev) => ({
+				...prev,
+				pendingTrainType: trainType,
+			}));
 
-      const connectedStations = connectedRouteStationsRef.current.get(
-        trainType.groupId
-      );
-      if (connectedStations) {
-        const newCurrentStation = computeCurrentStationInRoutes(
-          station,
-          pendingLine,
-          [trainType]
-        );
-        setStationState((prev) => ({
-          ...prev,
-          pendingStation: newCurrentStation,
-          station:
-            prev.station && newCurrentStation?.line
-              ? { ...prev.station, line: newCurrentStation.line }
-              : prev.station,
-          pendingStations: connectedStations,
-        }));
-        if (newCurrentStation?.line) {
-          setLineState((prev) => ({
-            ...prev,
-            pendingLine: newCurrentStation.line,
-          }));
-        }
-        return;
-      }
+			const connectedStations = connectedRouteStationsRef.current.get(
+				trainType.groupId,
+			);
+			if (connectedStations) {
+				const newCurrentStation = computeCurrentStationInRoutes(
+					station,
+					pendingLine,
+					[trainType],
+				);
+				setStationState((prev) => ({
+					...prev,
+					pendingStation: newCurrentStation,
+					station:
+						prev.station && newCurrentStation?.line
+							? { ...prev.station, line: newCurrentStation.line }
+							: prev.station,
+					pendingStations: connectedStations,
+				}));
+				if (newCurrentStation?.line) {
+					setLineState((prev) => ({
+						...prev,
+						pendingLine: newCurrentStation.line,
+					}));
+				}
+				return;
+			}
 
-      // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
-      queryClient.removeQueries({
-        queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
-          lineGroupId: trainType.groupId,
-        }),
-      });
+			// キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
+			queryClient.removeQueries({
+				queryKey: graphqlQueryKey(GET_LINE_GROUP_STATIONS, {
+					lineGroupId: trainType.groupId,
+				}),
+			});
 
-      const pendingStationsData = await fetchStationsByLineGroupId({
-        variables: {
-          lineGroupId: trainType.groupId,
-        },
-      });
-      const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
-      setStationState((prev) => ({
-        ...prev,
-        pendingStations,
-      }));
-    },
-    [
-      fetchStationsByLineGroupId,
-      station,
-      pendingLine,
-      setStationState,
-      setNavigationState,
-      setLineState,
-      queryClient,
-    ]
-  );
+			const pendingStationsData = await fetchStationsByLineGroupId({
+				variables: {
+					lineGroupId: trainType.groupId,
+				},
+			});
+			const pendingStations = pendingStationsData.data?.lineGroupStations ?? [];
+			setStationState((prev) => ({
+				...prev,
+				pendingStations,
+			}));
+		},
+		[
+			fetchStationsByLineGroupId,
+			station,
+			pendingLine,
+			setStationState,
+			setNavigationState,
+			setLineState,
+			queryClient,
+		],
+	);
 
-  const currentStationInRoutes = useMemo<Station | null>(
-    () =>
-      computeCurrentStationInRoutes(
-        station,
-        pendingLine,
-        routeTypesData?.routeTypes?.trainTypes ?? []
-      ),
-    [station, pendingLine, routeTypesData?.routeTypes]
-  );
+	const currentStationInRoutes = useMemo<Station | null>(
+		() =>
+			computeCurrentStationInRoutes(
+				station,
+				pendingLine,
+				routeTypesData?.routeTypes?.trainTypes ?? [],
+			),
+		[station, pendingLine, routeTypesData?.routeTypes],
+	);
 
-  const trainTypeModalLine = useMemo(() => {
-    const currentLine = currentStationInRoutes?.line;
-    const currentStationLines = station?.lines ?? [];
+	const trainTypeModalLine = useMemo(() => {
+		const currentLine = currentStationInRoutes?.line;
+		const currentStationLines = station?.lines ?? [];
 
-    if (
-      currentLine &&
-      currentStationLines.some(
-        (stationLine) => stationLine.id === currentLine.id
-      )
-    ) {
-      return currentLine;
-    }
+		if (
+			currentLine &&
+			currentStationLines.some(
+				(stationLine) => stationLine.id === currentLine.id,
+			)
+		) {
+			return currentLine;
+		}
 
-    return station?.line ?? currentStationLines[0] ?? null;
-  }, [currentStationInRoutes?.line, station?.line, station?.lines]);
+		return station?.line ?? currentStationLines[0] ?? null;
+	}, [currentStationInRoutes?.line, station?.line, station?.lines]);
 
-  const handleCloseSelectBoundModal = useCallback(() => {
-    setSelectBoundModalVisible(false);
-  }, []);
+	const handleCloseSelectBoundModal = useCallback(() => {
+		setSelectBoundModalVisible(false);
+	}, []);
 
-  const handleSelectBoundModalCloseAnimationEnd = useCallback(() => {
-    setSelectedDestination(null);
-  }, []);
+	const handleSelectBoundModalCloseAnimationEnd = useCallback(() => {
+		setSelectedDestination(null);
+	}, []);
 
-  const handleBoundSelected = useCallback(() => {
-    setSelectBoundModalVisible(false);
-    setTrainTypeListModalVisible(false);
-  }, []);
+	const handleBoundSelected = useCallback(() => {
+		setSelectBoundModalVisible(false);
+		setTrainTypeListModalVisible(false);
+	}, []);
 
-  const handleCloseTrainTypeListModal = useCallback(() => {
-    setTrainTypeListModalVisible(false);
-  }, []);
+	const handleCloseTrainTypeListModal = useCallback(() => {
+		setTrainTypeListModalVisible(false);
+	}, []);
 
-  const modalLoading =
-    fetchRouteTypesLoading ||
-    fetchConnectedRoutesLoading ||
-    fetchStationsByLineIdLoading ||
-    fetchStationsByLineGroupIdLoading;
+	const modalLoading =
+		fetchRouteTypesLoading ||
+		fetchConnectedRoutesLoading ||
+		fetchStationsByLineIdLoading ||
+		fetchStationsByLineGroupIdLoading;
 
-  const modalError =
-    fetchRouteTypesError ??
-    fetchConnectedRoutesError ??
-    fetchStationsByLineIdError ??
-    fetchStationsByLineGroupIdError ??
-    null;
+	const modalError =
+		fetchRouteTypesError ??
+		fetchConnectedRoutesError ??
+		fetchStationsByLineIdError ??
+		fetchStationsByLineGroupIdError ??
+		null;
 
-  return {
-    handleDestinationSelected,
-    handleTrainTypeSelected,
-    selectBoundModalVisible,
-    trainTypeListModalVisible,
-    selectedDestination,
-    wantedDestination,
-    trainTypeModalLine,
-    fetchRouteTypesLoading,
-    modalLoading,
-    modalError,
-    handleCloseSelectBoundModal,
-    handleSelectBoundModalCloseAnimationEnd,
-    handleBoundSelected,
-    handleCloseTrainTypeListModal,
-  };
+	return {
+		handleDestinationSelected,
+		handleTrainTypeSelected,
+		selectBoundModalVisible,
+		trainTypeListModalVisible,
+		selectedDestination,
+		wantedDestination,
+		trainTypeModalLine,
+		fetchRouteTypesLoading,
+		modalLoading,
+		modalError,
+		handleCloseSelectBoundModal,
+		handleSelectBoundModalCloseAnimationEnd,
+		handleBoundSelected,
+		handleCloseTrainTypeListModal,
+	};
 };

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -212,7 +212,9 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
 
         connectedRouteStationsRef.current = new Map(
           connectedRoutes.flatMap((route) =>
-            route.id && route.stops ? [[route.id, route.stops]] : []
+            route.id && route.stops
+              ? ([[route.id, route.stops]] as [number, Station[]][])
+              : []
           )
         );
 

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -439,6 +439,62 @@ export const TRAIN_TYPE_ROUTE_FRAGMENT = gql`
   }
 `;
 
+// Fragment for routes that connect multiple train-type groups
+export const CONNECTED_ROUTE_STATION_FRAGMENT = gql`
+  ${LINE_IN_STATION_FRAGMENT}
+  ${STATION_NUMBER_FRAGMENT}
+  ${TRAIN_TYPE_NESTED_FRAGMENT}
+  fragment ConnectedRouteStationFields on StationNested {
+    id
+    groupId
+    name
+    nameKatakana
+    nameRoman
+    nameChinese
+    nameKorean
+    nameTtsSegments {
+      ...TtsSegmentFields
+    }
+    threeLetterCode
+    latitude
+    longitude
+    prefectureId
+    hasTrainTypes
+    stopCondition
+    stationNumbers {
+      ...StationNumberFields
+    }
+    line {
+      ...LineInStationFields
+    }
+    lines {
+      ...LineInStationFields
+    }
+    trainType {
+      ...TrainTypeNestedFields
+    }
+  }
+`;
+
+// Query for routes that require multiple connected train types
+export const GET_CONNECTED_ROUTES = gql`
+  ${CONNECTED_ROUTE_STATION_FRAGMENT}
+  query GetConnectedRoutes(
+    $fromStationGroupId: Int!
+    $toStationGroupId: Int!
+  ) {
+    connectedRoutes(
+      fromStationGroupId: $fromStationGroupId
+      toStationGroupId: $toStationGroupId
+    ) {
+      id
+      stops {
+        ...ConnectedRouteStationFields
+      }
+    }
+  }
+`;
+
 // Query for getting route types (lightweight)
 export const GET_ROUTE_TYPES_LIGHT = gql`
   ${TRAIN_TYPE_ROUTE_FRAGMENT}

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -1,6 +1,6 @@
 // graphql-tag は Apollo の gql と同実装で、入れ子フラグメントの
 // 重複定義を自動でまとめてくれる(単純な文字列結合だと重複定義エラーになる)
-import gql from 'graphql-tag';
+import gql from "graphql-tag";
 
 // Fragment definitions for reusability
 export const COMPANY_FRAGMENT = gql`

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -1,6 +1,6 @@
 // graphql-tag は Apollo の gql と同実装で、入れ子フラグメントの
 // 重複定義を自動でまとめてくれる(単純な文字列結合だと重複定義エラーになる)
-import gql from "graphql-tag";
+import gql from 'graphql-tag';
 
 // Fragment definitions for reusability
 export const COMPANY_FRAGMENT = gql`

--- a/src/utils/routeSearch.test.ts
+++ b/src/utils/routeSearch.test.ts
@@ -1,413 +1,413 @@
-import type { Line, Station, TrainType } from "~/@types/graphql";
+import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
-	buildConnectedRouteTrainType,
-	computeCurrentStationInRoutes,
-	getStationWithMatchingLine,
-} from "./routeSearch";
+  buildConnectedRouteTrainType,
+  computeCurrentStationInRoutes,
+  getStationWithMatchingLine,
+} from './routeSearch';
 
 // テスト用のモックデータ
 const createMockLine = (id: number, name: string): Line =>
-	({
-		__typename: "Line",
-		id,
-		name,
-		nameShort: name,
-		nameRoman: name,
-	}) as unknown as Line;
+  ({
+    __typename: 'Line',
+    id,
+    name,
+    nameShort: name,
+    nameRoman: name,
+  }) as unknown as Line;
 
 const createMockStation = (
-	id: number,
-	name: string,
-	line: Line | null,
-	lines: Line[] = [],
+  id: number,
+  name: string,
+  line: Line | null,
+  lines: Line[] = []
 ): Station =>
-	({
-		__typename: "Station",
-		id,
-		groupId: id,
-		name,
-		nameRoman: name,
-		line,
-		lines,
-	}) as unknown as Station;
+  ({
+    __typename: 'Station',
+    id,
+    groupId: id,
+    name,
+    nameRoman: name,
+    line,
+    lines,
+  }) as unknown as Station;
 
 const createMockTrainType = (
-	id: number,
-	name: string,
-	line: Line,
-	lines: Line[] = [],
+  id: number,
+  name: string,
+  line: Line,
+  lines: Line[] = []
 ): TrainType =>
-	({
-		__typename: "TrainType",
-		id,
-		groupId: id,
-		name,
-		nameRoman: name,
-		line,
-		lines,
-	}) as unknown as TrainType;
+  ({
+    __typename: 'TrainType',
+    id,
+    groupId: id,
+    name,
+    nameRoman: name,
+    line,
+    lines,
+  }) as unknown as TrainType;
 
 afterEach(() => jest.clearAllMocks());
 
-describe("computeCurrentStationInRoutes", () => {
-	describe("列車種別がある場合", () => {
-		it("列車種別の路線とstationの路線の共通路線を返す", () => {
-			// 池袋駅: 西武池袋線、東武東上線、副都心線
-			const seibuLine = createMockLine(1, "西武池袋線");
-			const tobuLine = createMockLine(2, "東武東上線");
-			const fukutoshinLine = createMockLine(3, "副都心線");
+describe('computeCurrentStationInRoutes', () => {
+  describe('列車種別がある場合', () => {
+    it('列車種別の路線とstationの路線の共通路線を返す', () => {
+      // 池袋駅: 西武池袋線、東武東上線、副都心線
+      const seibuLine = createMockLine(1, '西武池袋線');
+      const tobuLine = createMockLine(2, '東武東上線');
+      const fukutoshinLine = createMockLine(3, '副都心線');
 
-			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
-				seibuLine,
-				tobuLine,
-				fukutoshinLine,
-			]);
+      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
+        seibuLine,
+        tobuLine,
+        fukutoshinLine,
+      ]);
 
-			// 元町・中華街方面への列車種別（西武線経由）
-			const trainType = createMockTrainType(1, "急行", seibuLine, [
-				seibuLine,
-				fukutoshinLine,
-			]);
+      // 元町・中華街方面への列車種別（西武線経由）
+      const trainType = createMockTrainType(1, '急行', seibuLine, [
+        seibuLine,
+        fukutoshinLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(
-				ikebukuroStation,
-				fukutoshinLine, // 選択した行き先の路線
-				[trainType],
-			);
+      const result = computeCurrentStationInRoutes(
+        ikebukuroStation,
+        fukutoshinLine, // 選択した行き先の路線
+        [trainType]
+      );
 
-			// 西武池袋線が選択されるべき（列車種別に含まれている）
-			expect(result?.line?.id).toBe(seibuLine.id);
-		});
+      // 西武池袋線が選択されるべき（列車種別に含まれている）
+      expect(result?.line?.id).toBe(seibuLine.id);
+    });
 
-		it("東武線経由の列車種別の場合は東武線が選択される", () => {
-			const seibuLine = createMockLine(1, "西武池袋線");
-			const tobuLine = createMockLine(2, "東武東上線");
-			const fukutoshinLine = createMockLine(3, "副都心線");
+    it('東武線経由の列車種別の場合は東武線が選択される', () => {
+      const seibuLine = createMockLine(1, '西武池袋線');
+      const tobuLine = createMockLine(2, '東武東上線');
+      const fukutoshinLine = createMockLine(3, '副都心線');
 
-			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
-				seibuLine,
-				tobuLine,
-				fukutoshinLine,
-			]);
+      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
+        seibuLine,
+        tobuLine,
+        fukutoshinLine,
+      ]);
 
-			// 東武線経由の列車種別
-			const trainType = createMockTrainType(2, "急行", tobuLine, [
-				tobuLine,
-				fukutoshinLine,
-			]);
+      // 東武線経由の列車種別
+      const trainType = createMockTrainType(2, '急行', tobuLine, [
+        tobuLine,
+        fukutoshinLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(
-				ikebukuroStation,
-				fukutoshinLine,
-				[trainType],
-			);
+      const result = computeCurrentStationInRoutes(
+        ikebukuroStation,
+        fukutoshinLine,
+        [trainType]
+      );
 
-			// 東武東上線が選択されるべき
-			expect(result?.line?.id).toBe(tobuLine.id);
-		});
+      // 東武東上線が選択されるべき
+      expect(result?.line?.id).toBe(tobuLine.id);
+    });
 
-		it("共通路線がない場合、pendingLineと同じ路線があればそれを使用", () => {
-			const seibuLine = createMockLine(1, "西武池袋線");
-			const unrelatedLine = createMockLine(99, "関係ない路線");
+    it('共通路線がない場合、pendingLineと同じ路線があればそれを使用', () => {
+      const seibuLine = createMockLine(1, '西武池袋線');
+      const unrelatedLine = createMockLine(99, '関係ない路線');
 
-			const station = createMockStation(100, "テスト駅", seibuLine, [
-				seibuLine,
-			]);
+      const station = createMockStation(100, 'テスト駅', seibuLine, [
+        seibuLine,
+      ]);
 
-			// stationの路線と無関係な列車種別
-			const trainType = createMockTrainType(1, "普通", unrelatedLine, [
-				unrelatedLine,
-			]);
+      // stationの路線と無関係な列車種別
+      const trainType = createMockTrainType(1, '普通', unrelatedLine, [
+        unrelatedLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(station, seibuLine, [
-				trainType,
-			]);
+      const result = computeCurrentStationInRoutes(station, seibuLine, [
+        trainType,
+      ]);
 
-			// pendingLineと同じ西武池袋線がフォールバックとして使用される
-			expect(result?.line?.id).toBe(seibuLine.id);
-		});
+      // pendingLineと同じ西武池袋線がフォールバックとして使用される
+      expect(result?.line?.id).toBe(seibuLine.id);
+    });
 
-		it("共通路線もフォールバック路線もない場合、pendingLineをそのまま使用", () => {
-			const seibuLine = createMockLine(1, "西武池袋線");
-			const tobuLine = createMockLine(2, "東武東上線");
-			const unrelatedLine = createMockLine(99, "関係ない路線");
+    it('共通路線もフォールバック路線もない場合、pendingLineをそのまま使用', () => {
+      const seibuLine = createMockLine(1, '西武池袋線');
+      const tobuLine = createMockLine(2, '東武東上線');
+      const unrelatedLine = createMockLine(99, '関係ない路線');
 
-			const station = createMockStation(100, "テスト駅", seibuLine, [
-				seibuLine,
-			]);
+      const station = createMockStation(100, 'テスト駅', seibuLine, [
+        seibuLine,
+      ]);
 
-			const trainType = createMockTrainType(1, "普通", unrelatedLine, [
-				unrelatedLine,
-			]);
+      const trainType = createMockTrainType(1, '普通', unrelatedLine, [
+        unrelatedLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(station, tobuLine, [
-				trainType,
-			]);
+      const result = computeCurrentStationInRoutes(station, tobuLine, [
+        trainType,
+      ]);
 
-			// tobuLine（pendingLine）がそのまま使用される
-			expect(result?.line?.id).toBe(tobuLine.id);
-		});
-	});
+      // tobuLine（pendingLine）がそのまま使用される
+      expect(result?.line?.id).toBe(tobuLine.id);
+    });
+  });
 
-	describe("エッジケース", () => {
-		it("stationがnullの場合はnullを返す", () => {
-			const line = createMockLine(1, "テスト路線");
-			const trainType = createMockTrainType(1, "普通", line, [line]);
+  describe('エッジケース', () => {
+    it('stationがnullの場合はnullを返す', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const trainType = createMockTrainType(1, '普通', line, [line]);
 
-			const result = computeCurrentStationInRoutes(null, line, [trainType]);
+      const result = computeCurrentStationInRoutes(null, line, [trainType]);
 
-			expect(result).toBeNull();
-		});
+      expect(result).toBeNull();
+    });
 
-		it("pendingLineがnullの場合はnullを返す", () => {
-			const line = createMockLine(1, "テスト路線");
-			const station = createMockStation(100, "テスト駅", line, [line]);
-			const trainType = createMockTrainType(1, "普通", line, [line]);
+    it('pendingLineがnullの場合はnullを返す', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const station = createMockStation(100, 'テスト駅', line, [line]);
+      const trainType = createMockTrainType(1, '普通', line, [line]);
 
-			const result = computeCurrentStationInRoutes(station, null, [trainType]);
+      const result = computeCurrentStationInRoutes(station, null, [trainType]);
 
-			expect(result).toBeNull();
-		});
+      expect(result).toBeNull();
+    });
 
-		it("trainTypesが空の場合、フォールバックロジックが動作する", () => {
-			const line = createMockLine(1, "テスト路線");
-			const station = createMockStation(100, "テスト駅", line, [line]);
+    it('trainTypesが空の場合、フォールバックロジックが動作する', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const station = createMockStation(100, 'テスト駅', line, [line]);
 
-			const result = computeCurrentStationInRoutes(station, line, []);
+      const result = computeCurrentStationInRoutes(station, line, []);
 
-			// stationにpendingLineと同じ路線があるのでそれを使用
-			expect(result?.line?.id).toBe(line.id);
-		});
-	});
+      // stationにpendingLineと同じ路線があるのでそれを使用
+      expect(result?.line?.id).toBe(line.id);
+    });
+  });
 });
 
-describe("computeCurrentStationInRoutes - 実際のユースケース", () => {
-	describe("新宿→高崎のような異なる路線間の検索", () => {
-		it("出発駅と行き先駅の路線が完全に異なる場合、pendingLineをそのまま使用", () => {
-			// 新宿駅: 中央線、山手線、小田急線など
-			const chuoLine = createMockLine(1, "中央線");
-			const yamanoteLine = createMockLine(2, "山手線");
-			const odakyuLine = createMockLine(3, "小田急線");
+describe('computeCurrentStationInRoutes - 実際のユースケース', () => {
+  describe('新宿→高崎のような異なる路線間の検索', () => {
+    it('出発駅と行き先駅の路線が完全に異なる場合、pendingLineをそのまま使用', () => {
+      // 新宿駅: 中央線、山手線、小田急線など
+      const chuoLine = createMockLine(1, '中央線');
+      const yamanoteLine = createMockLine(2, '山手線');
+      const odakyuLine = createMockLine(3, '小田急線');
 
-			// 高崎線（新宿駅には存在しない）
-			const takasakiLine = createMockLine(10, "高崎線");
+      // 高崎線（新宿駅には存在しない）
+      const takasakiLine = createMockLine(10, '高崎線');
 
-			const shinjukuStation = createMockStation(100, "新宿", chuoLine, [
-				chuoLine,
-				yamanoteLine,
-				odakyuLine,
-			]);
+      const shinjukuStation = createMockStation(100, '新宿', chuoLine, [
+        chuoLine,
+        yamanoteLine,
+        odakyuLine,
+      ]);
 
-			// 高崎線の普通列車種別（新宿駅の路線とは共通なし）
-			const trainType = createMockTrainType(1, "普通", takasakiLine, [
-				takasakiLine,
-			]);
+      // 高崎線の普通列車種別（新宿駅の路線とは共通なし）
+      const trainType = createMockTrainType(1, '普通', takasakiLine, [
+        takasakiLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(
-				shinjukuStation,
-				takasakiLine,
-				[trainType],
-			);
+      const result = computeCurrentStationInRoutes(
+        shinjukuStation,
+        takasakiLine,
+        [trainType]
+      );
 
-			// 共通路線がないので、pendingLine（高崎線）がそのまま使用される
-			expect(result?.line?.id).toBe(takasakiLine.id);
-		});
+      // 共通路線がないので、pendingLine（高崎線）がそのまま使用される
+      expect(result?.line?.id).toBe(takasakiLine.id);
+    });
 
-		it("湘南新宿ラインのように複数路線を経由する場合、共通路線が選択される", () => {
-			// 新宿駅に湘南新宿ラインがある場合
-			const chuoLine = createMockLine(1, "中央線");
-			const shonanShinjukuLine = createMockLine(5, "湘南新宿ライン");
-			const takasakiLine = createMockLine(10, "高崎線");
+    it('湘南新宿ラインのように複数路線を経由する場合、共通路線が選択される', () => {
+      // 新宿駅に湘南新宿ラインがある場合
+      const chuoLine = createMockLine(1, '中央線');
+      const shonanShinjukuLine = createMockLine(5, '湘南新宿ライン');
+      const takasakiLine = createMockLine(10, '高崎線');
 
-			const shinjukuStation = createMockStation(100, "新宿", chuoLine, [
-				chuoLine,
-				shonanShinjukuLine,
-			]);
+      const shinjukuStation = createMockStation(100, '新宿', chuoLine, [
+        chuoLine,
+        shonanShinjukuLine,
+      ]);
 
-			// 湘南新宿ライン経由の列車種別
-			const trainType = createMockTrainType(1, "快速", shonanShinjukuLine, [
-				shonanShinjukuLine,
-				takasakiLine,
-			]);
+      // 湘南新宿ライン経由の列車種別
+      const trainType = createMockTrainType(1, '快速', shonanShinjukuLine, [
+        shonanShinjukuLine,
+        takasakiLine,
+      ]);
 
-			const result = computeCurrentStationInRoutes(
-				shinjukuStation,
-				takasakiLine,
-				[trainType],
-			);
+      const result = computeCurrentStationInRoutes(
+        shinjukuStation,
+        takasakiLine,
+        [trainType]
+      );
 
-			// 湘南新宿ラインが共通路線として選択される
-			expect(result?.line?.id).toBe(shonanShinjukuLine.id);
-		});
-	});
+      // 湘南新宿ラインが共通路線として選択される
+      expect(result?.line?.id).toBe(shonanShinjukuLine.id);
+    });
+  });
 
-	describe("station.linesが空またはundefinedの場合", () => {
-		it("station.linesが空配列の場合、pendingLineを使用", () => {
-			const line = createMockLine(1, "テスト路線");
-			const station = createMockStation(100, "テスト駅", line, []);
-			const trainType = createMockTrainType(1, "普通", line, [line]);
+  describe('station.linesが空またはundefinedの場合', () => {
+    it('station.linesが空配列の場合、pendingLineを使用', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const station = createMockStation(100, 'テスト駅', line, []);
+      const trainType = createMockTrainType(1, '普通', line, [line]);
 
-			const result = computeCurrentStationInRoutes(station, line, [trainType]);
+      const result = computeCurrentStationInRoutes(station, line, [trainType]);
 
-			expect(result?.line?.id).toBe(line.id);
-		});
+      expect(result?.line?.id).toBe(line.id);
+    });
 
-		it("station.linesがundefinedの場合、pendingLineを使用", () => {
-			const line = createMockLine(1, "テスト路線");
-			const station = {
-				__typename: "Station",
-				id: 100,
-				groupId: 100,
-				name: "テスト駅",
-				nameRoman: "Test",
-				line,
-				lines: undefined,
-			} as unknown as Station;
-			const trainType = createMockTrainType(1, "普通", line, [line]);
+    it('station.linesがundefinedの場合、pendingLineを使用', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const station = {
+        __typename: 'Station',
+        id: 100,
+        groupId: 100,
+        name: 'テスト駅',
+        nameRoman: 'Test',
+        line,
+        lines: undefined,
+      } as unknown as Station;
+      const trainType = createMockTrainType(1, '普通', line, [line]);
 
-			const result = computeCurrentStationInRoutes(station, line, [trainType]);
+      const result = computeCurrentStationInRoutes(station, line, [trainType]);
 
-			expect(result?.line?.id).toBe(line.id);
-		});
-	});
+      expect(result?.line?.id).toBe(line.id);
+    });
+  });
 
-	describe("複数の列車種別がある場合", () => {
-		it("最初に見つかった共通路線を選択する", () => {
-			const seibuLine = createMockLine(1, "西武池袋線");
-			const tobuLine = createMockLine(2, "東武東上線");
-			const fukutoshinLine = createMockLine(3, "副都心線");
+  describe('複数の列車種別がある場合', () => {
+    it('最初に見つかった共通路線を選択する', () => {
+      const seibuLine = createMockLine(1, '西武池袋線');
+      const tobuLine = createMockLine(2, '東武東上線');
+      const fukutoshinLine = createMockLine(3, '副都心線');
 
-			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
-				seibuLine,
-				tobuLine,
-				fukutoshinLine,
-			]);
+      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
+        seibuLine,
+        tobuLine,
+        fukutoshinLine,
+      ]);
 
-			// 複数の列車種別（西武経由と東武経由）
-			const trainType1 = createMockTrainType(1, "急行（西武経由）", seibuLine, [
-				seibuLine,
-				fukutoshinLine,
-			]);
-			const trainType2 = createMockTrainType(2, "急行（東武経由）", tobuLine, [
-				tobuLine,
-				fukutoshinLine,
-			]);
+      // 複数の列車種別（西武経由と東武経由）
+      const trainType1 = createMockTrainType(1, '急行（西武経由）', seibuLine, [
+        seibuLine,
+        fukutoshinLine,
+      ]);
+      const trainType2 = createMockTrainType(2, '急行（東武経由）', tobuLine, [
+        tobuLine,
+        fukutoshinLine,
+      ]);
 
-			// 西武線経由の列車種別のみを渡した場合
-			const result = computeCurrentStationInRoutes(
-				ikebukuroStation,
-				fukutoshinLine,
-				[trainType1],
-			);
+      // 西武線経由の列車種別のみを渡した場合
+      const result = computeCurrentStationInRoutes(
+        ikebukuroStation,
+        fukutoshinLine,
+        [trainType1]
+      );
 
-			expect(result?.line?.id).toBe(seibuLine.id);
+      expect(result?.line?.id).toBe(seibuLine.id);
 
-			// 東武線経由の列車種別のみを渡した場合
-			const result2 = computeCurrentStationInRoutes(
-				ikebukuroStation,
-				fukutoshinLine,
-				[trainType2],
-			);
+      // 東武線経由の列車種別のみを渡した場合
+      const result2 = computeCurrentStationInRoutes(
+        ikebukuroStation,
+        fukutoshinLine,
+        [trainType2]
+      );
 
-			expect(result2?.line?.id).toBe(tobuLine.id);
-		});
-	});
+      expect(result2?.line?.id).toBe(tobuLine.id);
+    });
+  });
 });
 
-describe("getStationWithMatchingLine", () => {
-	describe("列車種別が存在しない場合の処理", () => {
-		it("選択した路線と一致する路線を持つ駅を返す", () => {
-			// 佐世保駅: 佐世保線、松浦鉄道
-			const saseboLine = createMockLine(1, "佐世保線");
-			const matsuuraLine = createMockLine(2, "松浦鉄道");
+describe('getStationWithMatchingLine', () => {
+  describe('列車種別が存在しない場合の処理', () => {
+    it('選択した路線と一致する路線を持つ駅を返す', () => {
+      // 佐世保駅: 佐世保線、松浦鉄道
+      const saseboLine = createMockLine(1, '佐世保線');
+      const matsuuraLine = createMockLine(2, '松浦鉄道');
 
-			const saseboStation = createMockStation(100, "佐世保", saseboLine, [
-				saseboLine,
-				matsuuraLine,
-			]);
+      const saseboStation = createMockStation(100, '佐世保', saseboLine, [
+        saseboLine,
+        matsuuraLine,
+      ]);
 
-			// たびら平戸口駅の路線（松浦鉄道）を選択
-			const result = getStationWithMatchingLine(saseboStation, matsuuraLine);
+      // たびら平戸口駅の路線（松浦鉄道）を選択
+      const result = getStationWithMatchingLine(saseboStation, matsuuraLine);
 
-			// 佐世保駅の路線が松浦鉄道に更新される
-			expect(result?.line?.id).toBe(matsuuraLine.id);
-		});
+      // 佐世保駅の路線が松浦鉄道に更新される
+      expect(result?.line?.id).toBe(matsuuraLine.id);
+    });
 
-		it("一致する路線がない場合は元の駅をそのまま返す", () => {
-			const saseboLine = createMockLine(1, "佐世保線");
-			const unrelatedLine = createMockLine(99, "関係ない路線");
+    it('一致する路線がない場合は元の駅をそのまま返す', () => {
+      const saseboLine = createMockLine(1, '佐世保線');
+      const unrelatedLine = createMockLine(99, '関係ない路線');
 
-			const saseboStation = createMockStation(100, "佐世保", saseboLine, [
-				saseboLine,
-			]);
+      const saseboStation = createMockStation(100, '佐世保', saseboLine, [
+        saseboLine,
+      ]);
 
-			const result = getStationWithMatchingLine(saseboStation, unrelatedLine);
+      const result = getStationWithMatchingLine(saseboStation, unrelatedLine);
 
-			// 元の佐世保線のまま
-			expect(result?.line?.id).toBe(saseboLine.id);
-		});
-	});
+      // 元の佐世保線のまま
+      expect(result?.line?.id).toBe(saseboLine.id);
+    });
+  });
 
-	describe("エッジケース", () => {
-		it("stationがnullの場合はnullを返す", () => {
-			const line = createMockLine(1, "テスト路線");
+  describe('エッジケース', () => {
+    it('stationがnullの場合はnullを返す', () => {
+      const line = createMockLine(1, 'テスト路線');
 
-			const result = getStationWithMatchingLine(null, line);
+      const result = getStationWithMatchingLine(null, line);
 
-			expect(result).toBeNull();
-		});
+      expect(result).toBeNull();
+    });
 
-		it("selectedLineがnullの場合はnullを返す", () => {
-			const line = createMockLine(1, "テスト路線");
-			const station = createMockStation(100, "テスト駅", line, [line]);
+    it('selectedLineがnullの場合はnullを返す', () => {
+      const line = createMockLine(1, 'テスト路線');
+      const station = createMockStation(100, 'テスト駅', line, [line]);
 
-			const result = getStationWithMatchingLine(station, null);
+      const result = getStationWithMatchingLine(station, null);
 
-			expect(result).toBeNull();
-		});
-	});
+      expect(result).toBeNull();
+    });
+  });
 });
 
-describe("buildConnectedRouteTrainType", () => {
-	it("複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する", () => {
-		const firstLine = createMockLine(1, "1路線目");
-		const secondLine = createMockLine(2, "2路線目");
-		const firstType = createMockTrainType(10, "普通", firstLine, [firstLine]);
-		const secondType = createMockTrainType(20, "快速", secondLine, [
-			secondLine,
-		]);
-		const firstStop = {
-			...createMockStation(100, "出発駅", firstLine, [firstLine]),
-			trainType: firstType,
-		} as Station;
-		const secondStop = {
-			...createMockStation(200, "到着駅", secondLine, [secondLine]),
-			trainType: secondType,
-		} as Station;
+describe('buildConnectedRouteTrainType', () => {
+  it('複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する', () => {
+    const firstLine = createMockLine(1, '1路線目');
+    const secondLine = createMockLine(2, '2路線目');
+    const firstType = createMockTrainType(10, '普通', firstLine, [firstLine]);
+    const secondType = createMockTrainType(20, '快速', secondLine, [
+      secondLine,
+    ]);
+    const firstStop = {
+      ...createMockStation(100, '出発駅', firstLine, [firstLine]),
+      trainType: firstType,
+    } as Station;
+    const secondStop = {
+      ...createMockStation(200, '到着駅', secondLine, [secondLine]),
+      trainType: secondType,
+    } as Station;
 
-		const result = buildConnectedRouteTrainType({
-			id: 9000,
-			stops: [firstStop, secondStop],
-		});
+    const result = buildConnectedRouteTrainType({
+      id: 9000,
+      stops: [firstStop, secondStop],
+    });
 
-		expect(result?.id).toBe(9000);
-		expect(result?.groupId).toBe(9000);
-		expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
-		expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
-			"普通",
-			"快速",
-		]);
-	});
+    expect(result?.id).toBe(9000);
+    expect(result?.groupId).toBe(9000);
+    expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
+    expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
+      '普通',
+      '快速',
+    ]);
+  });
 
-	it("経路IDまたは種別情報がない経路は選択肢にしない", () => {
-		const line = createMockLine(1, "テスト路線");
-		const station = createMockStation(100, "テスト駅", line, [line]);
+  it('経路IDまたは種別情報がない経路は選択肢にしない', () => {
+    const line = createMockLine(1, 'テスト路線');
+    const station = createMockStation(100, 'テスト駅', line, [line]);
 
-		expect(
-			buildConnectedRouteTrainType({ id: null, stops: [station] }),
-		).toBeNull();
-		expect(
-			buildConnectedRouteTrainType({ id: 9000, stops: [station] }),
-		).toBeNull();
-	});
+    expect(
+      buildConnectedRouteTrainType({ id: null, stops: [station] })
+    ).toBeNull();
+    expect(
+      buildConnectedRouteTrainType({ id: 9000, stops: [station] })
+    ).toBeNull();
+  });
 });

--- a/src/utils/routeSearch.test.ts
+++ b/src/utils/routeSearch.test.ts
@@ -1,414 +1,413 @@
-import type { Line, Station, TrainType } from '~/@types/graphql';
+import type { Line, Station, TrainType } from "~/@types/graphql";
 import {
-  buildConnectedRouteTrainType,
-  computeCurrentStationInRoutes,
-  getStationWithMatchingLine,
-} from './routeSearch';
+	buildConnectedRouteTrainType,
+	computeCurrentStationInRoutes,
+	getStationWithMatchingLine,
+} from "./routeSearch";
 
 // テスト用のモックデータ
 const createMockLine = (id: number, name: string): Line =>
-  ({
-    __typename: 'Line',
-    id,
-    name,
-    nameShort: name,
-    nameRoman: name,
-  }) as unknown as Line;
+	({
+		__typename: "Line",
+		id,
+		name,
+		nameShort: name,
+		nameRoman: name,
+	}) as unknown as Line;
 
 const createMockStation = (
-  id: number,
-  name: string,
-  line: Line | null,
-  lines: Line[] = []
+	id: number,
+	name: string,
+	line: Line | null,
+	lines: Line[] = [],
 ): Station =>
-  ({
-    __typename: 'Station',
-    id,
-    groupId: id,
-    name,
-    nameRoman: name,
-    line,
-    lines,
-  }) as unknown as Station;
+	({
+		__typename: "Station",
+		id,
+		groupId: id,
+		name,
+		nameRoman: name,
+		line,
+		lines,
+	}) as unknown as Station;
 
 const createMockTrainType = (
-  id: number,
-  name: string,
-  line: Line,
-  lines: Line[] = []
+	id: number,
+	name: string,
+	line: Line,
+	lines: Line[] = [],
 ): TrainType =>
-  ({
-    __typename: 'TrainType',
-    id,
-    groupId: id,
-    name,
-    nameRoman: name,
-    line,
-    lines,
-  }) as unknown as TrainType;
+	({
+		__typename: "TrainType",
+		id,
+		groupId: id,
+		name,
+		nameRoman: name,
+		line,
+		lines,
+	}) as unknown as TrainType;
 
 afterEach(() => jest.clearAllMocks());
 
-describe('computeCurrentStationInRoutes', () => {
-  describe('列車種別がある場合', () => {
-    it('列車種別の路線とstationの路線の共通路線を返す', () => {
-      // 池袋駅: 西武池袋線、東武東上線、副都心線
-      const seibuLine = createMockLine(1, '西武池袋線');
-      const tobuLine = createMockLine(2, '東武東上線');
-      const fukutoshinLine = createMockLine(3, '副都心線');
+describe("computeCurrentStationInRoutes", () => {
+	describe("列車種別がある場合", () => {
+		it("列車種別の路線とstationの路線の共通路線を返す", () => {
+			// 池袋駅: 西武池袋線、東武東上線、副都心線
+			const seibuLine = createMockLine(1, "西武池袋線");
+			const tobuLine = createMockLine(2, "東武東上線");
+			const fukutoshinLine = createMockLine(3, "副都心線");
 
-      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
-        seibuLine,
-        tobuLine,
-        fukutoshinLine,
-      ]);
+			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
+				seibuLine,
+				tobuLine,
+				fukutoshinLine,
+			]);
 
-      // 元町・中華街方面への列車種別（西武線経由）
-      const trainType = createMockTrainType(1, '急行', seibuLine, [
-        seibuLine,
-        fukutoshinLine,
-      ]);
+			// 元町・中華街方面への列車種別（西武線経由）
+			const trainType = createMockTrainType(1, "急行", seibuLine, [
+				seibuLine,
+				fukutoshinLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(
-        ikebukuroStation,
-        fukutoshinLine, // 選択した行き先の路線
-        [trainType]
-      );
+			const result = computeCurrentStationInRoutes(
+				ikebukuroStation,
+				fukutoshinLine, // 選択した行き先の路線
+				[trainType],
+			);
 
-      // 西武池袋線が選択されるべき（列車種別に含まれている）
-      expect(result?.line?.id).toBe(seibuLine.id);
-    });
+			// 西武池袋線が選択されるべき（列車種別に含まれている）
+			expect(result?.line?.id).toBe(seibuLine.id);
+		});
 
-    it('東武線経由の列車種別の場合は東武線が選択される', () => {
-      const seibuLine = createMockLine(1, '西武池袋線');
-      const tobuLine = createMockLine(2, '東武東上線');
-      const fukutoshinLine = createMockLine(3, '副都心線');
+		it("東武線経由の列車種別の場合は東武線が選択される", () => {
+			const seibuLine = createMockLine(1, "西武池袋線");
+			const tobuLine = createMockLine(2, "東武東上線");
+			const fukutoshinLine = createMockLine(3, "副都心線");
 
-      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
-        seibuLine,
-        tobuLine,
-        fukutoshinLine,
-      ]);
+			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
+				seibuLine,
+				tobuLine,
+				fukutoshinLine,
+			]);
 
-      // 東武線経由の列車種別
-      const trainType = createMockTrainType(2, '急行', tobuLine, [
-        tobuLine,
-        fukutoshinLine,
-      ]);
+			// 東武線経由の列車種別
+			const trainType = createMockTrainType(2, "急行", tobuLine, [
+				tobuLine,
+				fukutoshinLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(
-        ikebukuroStation,
-        fukutoshinLine,
-        [trainType]
-      );
+			const result = computeCurrentStationInRoutes(
+				ikebukuroStation,
+				fukutoshinLine,
+				[trainType],
+			);
 
-      // 東武東上線が選択されるべき
-      expect(result?.line?.id).toBe(tobuLine.id);
-    });
+			// 東武東上線が選択されるべき
+			expect(result?.line?.id).toBe(tobuLine.id);
+		});
 
-    it('共通路線がない場合、pendingLineと同じ路線があればそれを使用', () => {
-      const seibuLine = createMockLine(1, '西武池袋線');
-      const unrelatedLine = createMockLine(99, '関係ない路線');
+		it("共通路線がない場合、pendingLineと同じ路線があればそれを使用", () => {
+			const seibuLine = createMockLine(1, "西武池袋線");
+			const unrelatedLine = createMockLine(99, "関係ない路線");
 
-      const station = createMockStation(100, 'テスト駅', seibuLine, [
-        seibuLine,
-      ]);
+			const station = createMockStation(100, "テスト駅", seibuLine, [
+				seibuLine,
+			]);
 
-      // stationの路線と無関係な列車種別
-      const trainType = createMockTrainType(1, '普通', unrelatedLine, [
-        unrelatedLine,
-      ]);
+			// stationの路線と無関係な列車種別
+			const trainType = createMockTrainType(1, "普通", unrelatedLine, [
+				unrelatedLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(station, seibuLine, [
-        trainType,
-      ]);
+			const result = computeCurrentStationInRoutes(station, seibuLine, [
+				trainType,
+			]);
 
-      // pendingLineと同じ西武池袋線がフォールバックとして使用される
-      expect(result?.line?.id).toBe(seibuLine.id);
-    });
+			// pendingLineと同じ西武池袋線がフォールバックとして使用される
+			expect(result?.line?.id).toBe(seibuLine.id);
+		});
 
-    it('共通路線もフォールバック路線もない場合、pendingLineをそのまま使用', () => {
-      const seibuLine = createMockLine(1, '西武池袋線');
-      const tobuLine = createMockLine(2, '東武東上線');
-      const unrelatedLine = createMockLine(99, '関係ない路線');
+		it("共通路線もフォールバック路線もない場合、pendingLineをそのまま使用", () => {
+			const seibuLine = createMockLine(1, "西武池袋線");
+			const tobuLine = createMockLine(2, "東武東上線");
+			const unrelatedLine = createMockLine(99, "関係ない路線");
 
-      const station = createMockStation(100, 'テスト駅', seibuLine, [
-        seibuLine,
-      ]);
+			const station = createMockStation(100, "テスト駅", seibuLine, [
+				seibuLine,
+			]);
 
-      const trainType = createMockTrainType(1, '普通', unrelatedLine, [
-        unrelatedLine,
-      ]);
+			const trainType = createMockTrainType(1, "普通", unrelatedLine, [
+				unrelatedLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(station, tobuLine, [
-        trainType,
-      ]);
+			const result = computeCurrentStationInRoutes(station, tobuLine, [
+				trainType,
+			]);
 
-      // tobuLine（pendingLine）がそのまま使用される
-      expect(result?.line?.id).toBe(tobuLine.id);
-    });
-  });
+			// tobuLine（pendingLine）がそのまま使用される
+			expect(result?.line?.id).toBe(tobuLine.id);
+		});
+	});
 
-  describe('エッジケース', () => {
-    it('stationがnullの場合はnullを返す', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const trainType = createMockTrainType(1, '普通', line, [line]);
+	describe("エッジケース", () => {
+		it("stationがnullの場合はnullを返す", () => {
+			const line = createMockLine(1, "テスト路線");
+			const trainType = createMockTrainType(1, "普通", line, [line]);
 
-      const result = computeCurrentStationInRoutes(null, line, [trainType]);
+			const result = computeCurrentStationInRoutes(null, line, [trainType]);
 
-      expect(result).toBeNull();
-    });
+			expect(result).toBeNull();
+		});
 
-    it('pendingLineがnullの場合はnullを返す', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const station = createMockStation(100, 'テスト駅', line, [line]);
-      const trainType = createMockTrainType(1, '普通', line, [line]);
+		it("pendingLineがnullの場合はnullを返す", () => {
+			const line = createMockLine(1, "テスト路線");
+			const station = createMockStation(100, "テスト駅", line, [line]);
+			const trainType = createMockTrainType(1, "普通", line, [line]);
 
-      const result = computeCurrentStationInRoutes(station, null, [trainType]);
+			const result = computeCurrentStationInRoutes(station, null, [trainType]);
 
-      expect(result).toBeNull();
-    });
+			expect(result).toBeNull();
+		});
 
-    it('trainTypesが空の場合、フォールバックロジックが動作する', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const station = createMockStation(100, 'テスト駅', line, [line]);
+		it("trainTypesが空の場合、フォールバックロジックが動作する", () => {
+			const line = createMockLine(1, "テスト路線");
+			const station = createMockStation(100, "テスト駅", line, [line]);
 
-      const result = computeCurrentStationInRoutes(station, line, []);
+			const result = computeCurrentStationInRoutes(station, line, []);
 
-      // stationにpendingLineと同じ路線があるのでそれを使用
-      expect(result?.line?.id).toBe(line.id);
-    });
-  });
+			// stationにpendingLineと同じ路線があるのでそれを使用
+			expect(result?.line?.id).toBe(line.id);
+		});
+	});
 });
 
-describe('computeCurrentStationInRoutes - 実際のユースケース', () => {
-  describe('新宿→高崎のような異なる路線間の検索', () => {
-    it('出発駅と行き先駅の路線が完全に異なる場合、pendingLineをそのまま使用', () => {
-      // 新宿駅: 中央線、山手線、小田急線など
-      const chuoLine = createMockLine(1, '中央線');
-      const yamanoteLine = createMockLine(2, '山手線');
-      const odakyuLine = createMockLine(3, '小田急線');
+describe("computeCurrentStationInRoutes - 実際のユースケース", () => {
+	describe("新宿→高崎のような異なる路線間の検索", () => {
+		it("出発駅と行き先駅の路線が完全に異なる場合、pendingLineをそのまま使用", () => {
+			// 新宿駅: 中央線、山手線、小田急線など
+			const chuoLine = createMockLine(1, "中央線");
+			const yamanoteLine = createMockLine(2, "山手線");
+			const odakyuLine = createMockLine(3, "小田急線");
 
-      // 高崎線（新宿駅には存在しない）
-      const takasakiLine = createMockLine(10, '高崎線');
+			// 高崎線（新宿駅には存在しない）
+			const takasakiLine = createMockLine(10, "高崎線");
 
-      const shinjukuStation = createMockStation(100, '新宿', chuoLine, [
-        chuoLine,
-        yamanoteLine,
-        odakyuLine,
-      ]);
+			const shinjukuStation = createMockStation(100, "新宿", chuoLine, [
+				chuoLine,
+				yamanoteLine,
+				odakyuLine,
+			]);
 
-      // 高崎線の普通列車種別（新宿駅の路線とは共通なし）
-      const trainType = createMockTrainType(1, '普通', takasakiLine, [
-        takasakiLine,
-      ]);
+			// 高崎線の普通列車種別（新宿駅の路線とは共通なし）
+			const trainType = createMockTrainType(1, "普通", takasakiLine, [
+				takasakiLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(
-        shinjukuStation,
-        takasakiLine,
-        [trainType]
-      );
+			const result = computeCurrentStationInRoutes(
+				shinjukuStation,
+				takasakiLine,
+				[trainType],
+			);
 
-      // 共通路線がないので、pendingLine（高崎線）がそのまま使用される
-      expect(result?.line?.id).toBe(takasakiLine.id);
-    });
+			// 共通路線がないので、pendingLine（高崎線）がそのまま使用される
+			expect(result?.line?.id).toBe(takasakiLine.id);
+		});
 
-    it('湘南新宿ラインのように複数路線を経由する場合、共通路線が選択される', () => {
-      // 新宿駅に湘南新宿ラインがある場合
-      const chuoLine = createMockLine(1, '中央線');
-      const shonanShinjukuLine = createMockLine(5, '湘南新宿ライン');
-      const takasakiLine = createMockLine(10, '高崎線');
+		it("湘南新宿ラインのように複数路線を経由する場合、共通路線が選択される", () => {
+			// 新宿駅に湘南新宿ラインがある場合
+			const chuoLine = createMockLine(1, "中央線");
+			const shonanShinjukuLine = createMockLine(5, "湘南新宿ライン");
+			const takasakiLine = createMockLine(10, "高崎線");
 
-      const shinjukuStation = createMockStation(100, '新宿', chuoLine, [
-        chuoLine,
-        shonanShinjukuLine,
-      ]);
+			const shinjukuStation = createMockStation(100, "新宿", chuoLine, [
+				chuoLine,
+				shonanShinjukuLine,
+			]);
 
-      // 湘南新宿ライン経由の列車種別
-      const trainType = createMockTrainType(1, '快速', shonanShinjukuLine, [
-        shonanShinjukuLine,
-        takasakiLine,
-      ]);
+			// 湘南新宿ライン経由の列車種別
+			const trainType = createMockTrainType(1, "快速", shonanShinjukuLine, [
+				shonanShinjukuLine,
+				takasakiLine,
+			]);
 
-      const result = computeCurrentStationInRoutes(
-        shinjukuStation,
-        takasakiLine,
-        [trainType]
-      );
+			const result = computeCurrentStationInRoutes(
+				shinjukuStation,
+				takasakiLine,
+				[trainType],
+			);
 
-      // 湘南新宿ラインが共通路線として選択される
-      expect(result?.line?.id).toBe(shonanShinjukuLine.id);
-    });
-  });
+			// 湘南新宿ラインが共通路線として選択される
+			expect(result?.line?.id).toBe(shonanShinjukuLine.id);
+		});
+	});
 
-  describe('station.linesが空またはundefinedの場合', () => {
-    it('station.linesが空配列の場合、pendingLineを使用', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const station = createMockStation(100, 'テスト駅', line, []);
-      const trainType = createMockTrainType(1, '普通', line, [line]);
+	describe("station.linesが空またはundefinedの場合", () => {
+		it("station.linesが空配列の場合、pendingLineを使用", () => {
+			const line = createMockLine(1, "テスト路線");
+			const station = createMockStation(100, "テスト駅", line, []);
+			const trainType = createMockTrainType(1, "普通", line, [line]);
 
-      const result = computeCurrentStationInRoutes(station, line, [trainType]);
+			const result = computeCurrentStationInRoutes(station, line, [trainType]);
 
-      expect(result?.line?.id).toBe(line.id);
-    });
+			expect(result?.line?.id).toBe(line.id);
+		});
 
-    it('station.linesがundefinedの場合、pendingLineを使用', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const station = {
-        __typename: 'Station',
-        id: 100,
-        groupId: 100,
-        name: 'テスト駅',
-        nameRoman: 'Test',
-        line,
-        lines: undefined,
-      } as unknown as Station;
-      const trainType = createMockTrainType(1, '普通', line, [line]);
+		it("station.linesがundefinedの場合、pendingLineを使用", () => {
+			const line = createMockLine(1, "テスト路線");
+			const station = {
+				__typename: "Station",
+				id: 100,
+				groupId: 100,
+				name: "テスト駅",
+				nameRoman: "Test",
+				line,
+				lines: undefined,
+			} as unknown as Station;
+			const trainType = createMockTrainType(1, "普通", line, [line]);
 
-      const result = computeCurrentStationInRoutes(station, line, [trainType]);
+			const result = computeCurrentStationInRoutes(station, line, [trainType]);
 
-      expect(result?.line?.id).toBe(line.id);
-    });
-  });
+			expect(result?.line?.id).toBe(line.id);
+		});
+	});
 
-  describe('複数の列車種別がある場合', () => {
-    it('最初に見つかった共通路線を選択する', () => {
-      const seibuLine = createMockLine(1, '西武池袋線');
-      const tobuLine = createMockLine(2, '東武東上線');
-      const fukutoshinLine = createMockLine(3, '副都心線');
+	describe("複数の列車種別がある場合", () => {
+		it("最初に見つかった共通路線を選択する", () => {
+			const seibuLine = createMockLine(1, "西武池袋線");
+			const tobuLine = createMockLine(2, "東武東上線");
+			const fukutoshinLine = createMockLine(3, "副都心線");
 
-      const ikebukuroStation = createMockStation(100, '池袋', seibuLine, [
-        seibuLine,
-        tobuLine,
-        fukutoshinLine,
-      ]);
+			const ikebukuroStation = createMockStation(100, "池袋", seibuLine, [
+				seibuLine,
+				tobuLine,
+				fukutoshinLine,
+			]);
 
-      // 複数の列車種別（西武経由と東武経由）
-      const trainType1 = createMockTrainType(1, '急行（西武経由）', seibuLine, [
-        seibuLine,
-        fukutoshinLine,
-      ]);
-      const trainType2 = createMockTrainType(2, '急行（東武経由）', tobuLine, [
-        tobuLine,
-        fukutoshinLine,
-      ]);
+			// 複数の列車種別（西武経由と東武経由）
+			const trainType1 = createMockTrainType(1, "急行（西武経由）", seibuLine, [
+				seibuLine,
+				fukutoshinLine,
+			]);
+			const trainType2 = createMockTrainType(2, "急行（東武経由）", tobuLine, [
+				tobuLine,
+				fukutoshinLine,
+			]);
 
-      // 西武線経由の列車種別のみを渡した場合
-      const result = computeCurrentStationInRoutes(
-        ikebukuroStation,
-        fukutoshinLine,
-        [trainType1]
-      );
+			// 西武線経由の列車種別のみを渡した場合
+			const result = computeCurrentStationInRoutes(
+				ikebukuroStation,
+				fukutoshinLine,
+				[trainType1],
+			);
 
-      expect(result?.line?.id).toBe(seibuLine.id);
+			expect(result?.line?.id).toBe(seibuLine.id);
 
-      // 東武線経由の列車種別のみを渡した場合
-      const result2 = computeCurrentStationInRoutes(
-        ikebukuroStation,
-        fukutoshinLine,
-        [trainType2]
-      );
+			// 東武線経由の列車種別のみを渡した場合
+			const result2 = computeCurrentStationInRoutes(
+				ikebukuroStation,
+				fukutoshinLine,
+				[trainType2],
+			);
 
-      expect(result2?.line?.id).toBe(tobuLine.id);
-    });
-  });
+			expect(result2?.line?.id).toBe(tobuLine.id);
+		});
+	});
 });
 
-describe('getStationWithMatchingLine', () => {
-  describe('列車種別が存在しない場合の処理', () => {
-    it('選択した路線と一致する路線を持つ駅を返す', () => {
-      // 佐世保駅: 佐世保線、松浦鉄道
-      const saseboLine = createMockLine(1, '佐世保線');
-      const matsuuraLine = createMockLine(2, '松浦鉄道');
+describe("getStationWithMatchingLine", () => {
+	describe("列車種別が存在しない場合の処理", () => {
+		it("選択した路線と一致する路線を持つ駅を返す", () => {
+			// 佐世保駅: 佐世保線、松浦鉄道
+			const saseboLine = createMockLine(1, "佐世保線");
+			const matsuuraLine = createMockLine(2, "松浦鉄道");
 
-      const saseboStation = createMockStation(100, '佐世保', saseboLine, [
-        saseboLine,
-        matsuuraLine,
-      ]);
+			const saseboStation = createMockStation(100, "佐世保", saseboLine, [
+				saseboLine,
+				matsuuraLine,
+			]);
 
-      // たびら平戸口駅の路線（松浦鉄道）を選択
-      const result = getStationWithMatchingLine(saseboStation, matsuuraLine);
+			// たびら平戸口駅の路線（松浦鉄道）を選択
+			const result = getStationWithMatchingLine(saseboStation, matsuuraLine);
 
-      // 佐世保駅の路線が松浦鉄道に更新される
-      expect(result?.line?.id).toBe(matsuuraLine.id);
-    });
+			// 佐世保駅の路線が松浦鉄道に更新される
+			expect(result?.line?.id).toBe(matsuuraLine.id);
+		});
 
-    it('一致する路線がない場合は元の駅をそのまま返す', () => {
-      const saseboLine = createMockLine(1, '佐世保線');
-      const unrelatedLine = createMockLine(99, '関係ない路線');
+		it("一致する路線がない場合は元の駅をそのまま返す", () => {
+			const saseboLine = createMockLine(1, "佐世保線");
+			const unrelatedLine = createMockLine(99, "関係ない路線");
 
-      const saseboStation = createMockStation(100, '佐世保', saseboLine, [
-        saseboLine,
-      ]);
+			const saseboStation = createMockStation(100, "佐世保", saseboLine, [
+				saseboLine,
+			]);
 
-      const result = getStationWithMatchingLine(saseboStation, unrelatedLine);
+			const result = getStationWithMatchingLine(saseboStation, unrelatedLine);
 
-      // 元の佐世保線のまま
-      expect(result?.line?.id).toBe(saseboLine.id);
-    });
-  });
+			// 元の佐世保線のまま
+			expect(result?.line?.id).toBe(saseboLine.id);
+		});
+	});
 
-  describe('エッジケース', () => {
-    it('stationがnullの場合はnullを返す', () => {
-      const line = createMockLine(1, 'テスト路線');
+	describe("エッジケース", () => {
+		it("stationがnullの場合はnullを返す", () => {
+			const line = createMockLine(1, "テスト路線");
 
-      const result = getStationWithMatchingLine(null, line);
+			const result = getStationWithMatchingLine(null, line);
 
-      expect(result).toBeNull();
-    });
+			expect(result).toBeNull();
+		});
 
-    it('selectedLineがnullの場合はnullを返す', () => {
-      const line = createMockLine(1, 'テスト路線');
-      const station = createMockStation(100, 'テスト駅', line, [line]);
+		it("selectedLineがnullの場合はnullを返す", () => {
+			const line = createMockLine(1, "テスト路線");
+			const station = createMockStation(100, "テスト駅", line, [line]);
 
-      const result = getStationWithMatchingLine(station, null);
+			const result = getStationWithMatchingLine(station, null);
 
-      expect(result).toBeNull();
-    });
-  });
+			expect(result).toBeNull();
+		});
+	});
 });
 
+describe("buildConnectedRouteTrainType", () => {
+	it("複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する", () => {
+		const firstLine = createMockLine(1, "1路線目");
+		const secondLine = createMockLine(2, "2路線目");
+		const firstType = createMockTrainType(10, "普通", firstLine, [firstLine]);
+		const secondType = createMockTrainType(20, "快速", secondLine, [
+			secondLine,
+		]);
+		const firstStop = {
+			...createMockStation(100, "出発駅", firstLine, [firstLine]),
+			trainType: firstType,
+		} as Station;
+		const secondStop = {
+			...createMockStation(200, "到着駅", secondLine, [secondLine]),
+			trainType: secondType,
+		} as Station;
 
-describe('buildConnectedRouteTrainType', () => {
-  it('複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する', () => {
-    const firstLine = createMockLine(1, '1路線目');
-    const secondLine = createMockLine(2, '2路線目');
-    const firstType = createMockTrainType(10, '普通', firstLine, [firstLine]);
-    const secondType = createMockTrainType(20, '快速', secondLine, [
-      secondLine,
-    ]);
-    const firstStop = {
-      ...createMockStation(100, '出発駅', firstLine, [firstLine]),
-      trainType: firstType,
-    } as Station;
-    const secondStop = {
-      ...createMockStation(200, '到着駅', secondLine, [secondLine]),
-      trainType: secondType,
-    } as Station;
+		const result = buildConnectedRouteTrainType({
+			id: 9000,
+			stops: [firstStop, secondStop],
+		});
 
-    const result = buildConnectedRouteTrainType({
-      id: 9000,
-      stops: [firstStop, secondStop],
-    });
+		expect(result?.id).toBe(9000);
+		expect(result?.groupId).toBe(9000);
+		expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
+		expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
+			"普通",
+			"快速",
+		]);
+	});
 
-    expect(result?.id).toBe(9000);
-    expect(result?.groupId).toBe(9000);
-    expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
-    expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
-      '普通',
-      '快速',
-    ]);
-  });
+	it("経路IDまたは種別情報がない経路は選択肢にしない", () => {
+		const line = createMockLine(1, "テスト路線");
+		const station = createMockStation(100, "テスト駅", line, [line]);
 
-  it('経路IDまたは種別情報がない経路は選択肢にしない', () => {
-    const line = createMockLine(1, 'テスト路線');
-    const station = createMockStation(100, 'テスト駅', line, [line]);
-
-    expect(
-      buildConnectedRouteTrainType({ id: null, stops: [station] })
-    ).toBeNull();
-    expect(
-      buildConnectedRouteTrainType({ id: 9000, stops: [station] })
-    ).toBeNull();
-  });
+		expect(
+			buildConnectedRouteTrainType({ id: null, stops: [station] }),
+		).toBeNull();
+		expect(
+			buildConnectedRouteTrainType({ id: 9000, stops: [station] }),
+		).toBeNull();
+	});
 });

--- a/src/utils/routeSearch.test.ts
+++ b/src/utils/routeSearch.test.ts
@@ -1,5 +1,6 @@
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
+  buildConnectedRouteTrainType,
   computeCurrentStationInRoutes,
   getStationWithMatchingLine,
 } from './routeSearch';
@@ -364,5 +365,50 @@ describe('getStationWithMatchingLine', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+
+describe('buildConnectedRouteTrainType', () => {
+  it('複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する', () => {
+    const firstLine = createMockLine(1, '1路線目');
+    const secondLine = createMockLine(2, '2路線目');
+    const firstType = createMockTrainType(10, '普通', firstLine, [firstLine]);
+    const secondType = createMockTrainType(20, '快速', secondLine, [
+      secondLine,
+    ]);
+    const firstStop = {
+      ...createMockStation(100, '出発駅', firstLine, [firstLine]),
+      trainType: firstType,
+    } as Station;
+    const secondStop = {
+      ...createMockStation(200, '到着駅', secondLine, [secondLine]),
+      trainType: secondType,
+    } as Station;
+
+    const result = buildConnectedRouteTrainType({
+      id: 9000,
+      stops: [firstStop, secondStop],
+    });
+
+    expect(result?.id).toBe(9000);
+    expect(result?.groupId).toBe(9000);
+    expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
+    expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
+      '普通',
+      '快速',
+    ]);
+  });
+
+  it('経路IDまたは種別情報がない経路は選択肢にしない', () => {
+    const line = createMockLine(1, 'テスト路線');
+    const station = createMockStation(100, 'テスト駅', line, [line]);
+
+    expect(
+      buildConnectedRouteTrainType({ id: null, stops: [station] })
+    ).toBeNull();
+    expect(
+      buildConnectedRouteTrainType({ id: 9000, stops: [station] })
+    ).toBeNull();
   });
 });

--- a/src/utils/routeSearch.ts
+++ b/src/utils/routeSearch.ts
@@ -1,4 +1,4 @@
-import type { Line, Station, TrainType } from "~/@types/graphql";
+import type { Line, Station, TrainType } from '~/@types/graphql';
 
 /**
  * 列車種別に基づいて、現在の駅の路線を決定する
@@ -8,44 +8,44 @@ import type { Line, Station, TrainType } from "~/@types/graphql";
  * @returns 路線情報が更新された駅、または null
  */
 export const computeCurrentStationInRoutes = (
-	station: Station | null,
-	pendingLine: Line | null,
-	trainTypes: TrainType[],
+  station: Station | null,
+  pendingLine: Line | null,
+  trainTypes: TrainType[]
 ): Station | null => {
-	if (!station || !pendingLine) return null;
+  if (!station || !pendingLine) return null;
 
-	const currentIds = new Set(
-		(station.lines ?? []).map((l) => l?.id).filter(Boolean),
-	);
+  const currentIds = new Set(
+    (station.lines ?? []).map((l) => l?.id).filter(Boolean)
+  );
 
-	// 列車種別に関連する路線IDを収集
-	const routeLineIdSet = new Set(
-		trainTypes
-			.flatMap((tt: TrainType) => [
-				tt.line?.id,
-				...(tt.lines ?? []).map((l) => l.id),
-			])
-			.filter(Boolean),
-	);
+  // 列車種別に関連する路線IDを収集
+  const routeLineIdSet = new Set(
+    trainTypes
+      .flatMap((tt: TrainType) => [
+        tt.line?.id,
+        ...(tt.lines ?? []).map((l) => l.id),
+      ])
+      .filter(Boolean)
+  );
 
-	// 列車種別の路線とstationの路線の共通路線を探す
-	const commonIds = [...currentIds].filter((id) => routeLineIdSet.has(id));
-	const commonLine = (station.lines ?? []).find((l) =>
-		commonIds.includes(l.id),
-	);
+  // 列車種別の路線とstationの路線の共通路線を探す
+  const commonIds = [...currentIds].filter((id) => routeLineIdSet.has(id));
+  const commonLine = (station.lines ?? []).find((l) =>
+    commonIds.includes(l.id)
+  );
 
-	if (commonLine) {
-		return { ...station, line: commonLine } as Station;
-	}
+  if (commonLine) {
+    return { ...station, line: commonLine } as Station;
+  }
 
-	// 共通路線がない場合、stationにpendingLineと同じ路線があればそれを使用
-	const fallbackLine = station.lines?.find((l) => l.id === pendingLine.id);
+  // 共通路線がない場合、stationにpendingLineと同じ路線があればそれを使用
+  const fallbackLine = station.lines?.find((l) => l.id === pendingLine.id);
 
-	if (fallbackLine) {
-		return { ...station, line: fallbackLine } as Station;
-	}
+  if (fallbackLine) {
+    return { ...station, line: fallbackLine } as Station;
+  }
 
-	return { ...station, line: pendingLine } as Station;
+  return { ...station, line: pendingLine } as Station;
 };
 
 /**
@@ -55,23 +55,23 @@ export const computeCurrentStationInRoutes = (
  * @returns 一致する路線を持つ駅
  */
 export const getStationWithMatchingLine = (
-	station: Station | null,
-	selectedLine: Line | null,
+  station: Station | null,
+  selectedLine: Line | null
 ): Station | null => {
-	if (!station || !selectedLine) return null;
+  if (!station || !selectedLine) return null;
 
-	const matchingLine = station.lines?.find((l) => l.id === selectedLine.id);
+  const matchingLine = station.lines?.find((l) => l.id === selectedLine.id);
 
-	if (matchingLine) {
-		return { ...station, line: matchingLine } as Station;
-	}
+  if (matchingLine) {
+    return { ...station, line: matchingLine } as Station;
+  }
 
-	return station;
+  return station;
 };
 
 export type ConnectedRoute = {
-	id: number | null;
-	stops: Station[] | null;
+  id: number | null;
+  stops: Station[] | null;
 };
 
 /**
@@ -80,33 +80,33 @@ export type ConnectedRoute = {
  * 各区間の路線・種別は stops から復元する。
  */
 export const buildConnectedRouteTrainType = (
-	route: ConnectedRoute,
+  route: ConnectedRoute
 ): TrainType | null => {
-	if (!route.id) return null;
+  if (!route.id) return null;
 
-	const stops = route.stops ?? [];
-	const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
-	if (!baseTrainType) return null;
+  const stops = route.stops ?? [];
+  const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
+  if (!baseTrainType) return null;
 
-	const seenLineIds = new Set<number>();
-	const lines = stops.flatMap((stop) => {
-		const line = stop.line;
-		if (!line?.id || seenLineIds.has(line.id)) return [];
+  const seenLineIds = new Set<number>();
+  const lines = stops.flatMap((stop) => {
+    const line = stop.line;
+    if (!line?.id || seenLineIds.has(line.id)) return [];
 
-		seenLineIds.add(line.id);
-		return [
-			{
-				...line,
-				trainType: stop.trainType ?? line.trainType,
-			} as Line,
-		];
-	});
+    seenLineIds.add(line.id);
+    return [
+      {
+        ...line,
+        trainType: stop.trainType ?? line.trainType,
+      } as Line,
+    ];
+  });
 
-	return {
-		...baseTrainType,
-		id: route.id,
-		groupId: route.id,
-		line: lines[0] ?? baseTrainType.line,
-		lines,
-	} as unknown as TrainType;
+  return {
+    ...baseTrainType,
+    id: route.id,
+    groupId: route.id,
+    line: lines[0] ?? baseTrainType.line,
+    lines,
+  } as unknown as TrainType;
 };

--- a/src/utils/routeSearch.ts
+++ b/src/utils/routeSearch.ts
@@ -1,4 +1,4 @@
-import type { Line, Station, TrainType } from '~/@types/graphql';
+import type { Line, Station, TrainType } from "~/@types/graphql";
 
 /**
  * 列車種別に基づいて、現在の駅の路線を決定する
@@ -8,44 +8,44 @@ import type { Line, Station, TrainType } from '~/@types/graphql';
  * @returns 路線情報が更新された駅、または null
  */
 export const computeCurrentStationInRoutes = (
-  station: Station | null,
-  pendingLine: Line | null,
-  trainTypes: TrainType[]
+	station: Station | null,
+	pendingLine: Line | null,
+	trainTypes: TrainType[],
 ): Station | null => {
-  if (!station || !pendingLine) return null;
+	if (!station || !pendingLine) return null;
 
-  const currentIds = new Set(
-    (station.lines ?? []).map((l) => l?.id).filter(Boolean)
-  );
+	const currentIds = new Set(
+		(station.lines ?? []).map((l) => l?.id).filter(Boolean),
+	);
 
-  // 列車種別に関連する路線IDを収集
-  const routeLineIdSet = new Set(
-    trainTypes
-      .flatMap((tt: TrainType) => [
-        tt.line?.id,
-        ...(tt.lines ?? []).map((l) => l.id),
-      ])
-      .filter(Boolean)
-  );
+	// 列車種別に関連する路線IDを収集
+	const routeLineIdSet = new Set(
+		trainTypes
+			.flatMap((tt: TrainType) => [
+				tt.line?.id,
+				...(tt.lines ?? []).map((l) => l.id),
+			])
+			.filter(Boolean),
+	);
 
-  // 列車種別の路線とstationの路線の共通路線を探す
-  const commonIds = [...currentIds].filter((id) => routeLineIdSet.has(id));
-  const commonLine = (station.lines ?? []).find((l) =>
-    commonIds.includes(l.id)
-  );
+	// 列車種別の路線とstationの路線の共通路線を探す
+	const commonIds = [...currentIds].filter((id) => routeLineIdSet.has(id));
+	const commonLine = (station.lines ?? []).find((l) =>
+		commonIds.includes(l.id),
+	);
 
-  if (commonLine) {
-    return { ...station, line: commonLine } as Station;
-  }
+	if (commonLine) {
+		return { ...station, line: commonLine } as Station;
+	}
 
-  // 共通路線がない場合、stationにpendingLineと同じ路線があればそれを使用
-  const fallbackLine = station.lines?.find((l) => l.id === pendingLine.id);
+	// 共通路線がない場合、stationにpendingLineと同じ路線があればそれを使用
+	const fallbackLine = station.lines?.find((l) => l.id === pendingLine.id);
 
-  if (fallbackLine) {
-    return { ...station, line: fallbackLine } as Station;
-  }
+	if (fallbackLine) {
+		return { ...station, line: fallbackLine } as Station;
+	}
 
-  return { ...station, line: pendingLine } as Station;
+	return { ...station, line: pendingLine } as Station;
 };
 
 /**
@@ -55,24 +55,23 @@ export const computeCurrentStationInRoutes = (
  * @returns 一致する路線を持つ駅
  */
 export const getStationWithMatchingLine = (
-  station: Station | null,
-  selectedLine: Line | null
+	station: Station | null,
+	selectedLine: Line | null,
 ): Station | null => {
-  if (!station || !selectedLine) return null;
+	if (!station || !selectedLine) return null;
 
-  const matchingLine = station.lines?.find((l) => l.id === selectedLine.id);
+	const matchingLine = station.lines?.find((l) => l.id === selectedLine.id);
 
-  if (matchingLine) {
-    return { ...station, line: matchingLine } as Station;
-  }
+	if (matchingLine) {
+		return { ...station, line: matchingLine } as Station;
+	}
 
-  return station;
+	return station;
 };
 
-
 export type ConnectedRoute = {
-  id: number | null;
-  stops: Station[] | null;
+	id: number | null;
+	stops: Station[] | null;
 };
 
 /**
@@ -81,33 +80,33 @@ export type ConnectedRoute = {
  * 各区間の路線・種別は stops から復元する。
  */
 export const buildConnectedRouteTrainType = (
-  route: ConnectedRoute
+	route: ConnectedRoute,
 ): TrainType | null => {
-  if (!route.id) return null;
+	if (!route.id) return null;
 
-  const stops = route.stops ?? [];
-  const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
-  if (!baseTrainType) return null;
+	const stops = route.stops ?? [];
+	const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
+	if (!baseTrainType) return null;
 
-  const seenLineIds = new Set<number>();
-  const lines = stops.flatMap((stop) => {
-    const line = stop.line;
-    if (!line?.id || seenLineIds.has(line.id)) return [];
+	const seenLineIds = new Set<number>();
+	const lines = stops.flatMap((stop) => {
+		const line = stop.line;
+		if (!line?.id || seenLineIds.has(line.id)) return [];
 
-    seenLineIds.add(line.id);
-    return [
-      {
-        ...line,
-        trainType: stop.trainType ?? line.trainType,
-      } as Line,
-    ];
-  });
+		seenLineIds.add(line.id);
+		return [
+			{
+				...line,
+				trainType: stop.trainType ?? line.trainType,
+			} as Line,
+		];
+	});
 
-  return {
-    ...baseTrainType,
-    id: route.id,
-    groupId: route.id,
-    line: lines[0] ?? baseTrainType.line,
-    lines,
-  } as unknown as TrainType;
+	return {
+		...baseTrainType,
+		id: route.id,
+		groupId: route.id,
+		line: lines[0] ?? baseTrainType.line,
+		lines,
+	} as unknown as TrainType;
 };

--- a/src/utils/routeSearch.ts
+++ b/src/utils/routeSearch.ts
@@ -68,3 +68,46 @@ export const getStationWithMatchingLine = (
 
   return station;
 };
+
+
+export type ConnectedRoute = {
+  id: number | null;
+  stops: Station[] | null;
+};
+
+/**
+ * ConnectedRoutes の各経路を既存の列車種別選択UIで扱える形へ変換する。
+ * 経路IDは StationAPI が経路全体へ付与した仮想 lineGroupId であり、
+ * 各区間の路線・種別は stops から復元する。
+ */
+export const buildConnectedRouteTrainType = (
+  route: ConnectedRoute
+): TrainType | null => {
+  if (!route.id) return null;
+
+  const stops = route.stops ?? [];
+  const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
+  if (!baseTrainType) return null;
+
+  const seenLineIds = new Set<number>();
+  const lines = stops.flatMap((stop) => {
+    const line = stop.line;
+    if (!line?.id || seenLineIds.has(line.id)) return [];
+
+    seenLineIds.add(line.id);
+    return [
+      {
+        ...line,
+        trainType: stop.trainType ?? line.trainType,
+      } as Line,
+    ];
+  });
+
+  return {
+    ...baseTrainType,
+    id: route.id,
+    groupId: route.id,
+    line: lines[0] ?? baseTrainType.line,
+    lines,
+  } as unknown as TrainType;
+};


### PR DESCRIPTION
## 変更内容

- 通常の `routeTypes` で単一種別の経路が見つからない場合のみ `connectedRoutes` を問い合わせる
- ConnectedRoutes の各経路を既存の列車種別選択UIで扱える候補へ変換する
- StationAPI が付与する仮想 `lineGroupId` と経路内の駅列を保持し、初期候補および候補切替時にその駅列を直接使用する
- ConnectedRoutes も空の場合は、従来の「選択路線をそのまま使う」フォールバックへ戻す

## 背景

現在の経路検索は `routeTypes` の単一種別だけを前提としているため、途中で種別が変わる経路を構築できませんでした。単一種別で完結しない場合に限って ConnectedRoutes を使い、複数種別を一つの経路として扱います。

## 影響

単一種別で到達できる既存経路の挙動は変わりません。単一種別が見つからなかった検索のみ追加のAPI呼び出しが発生します。

## 検証

- ConnectedRoutes の仮想 `lineGroupId`、区間路線、区間種別を既存の列車種別モデルへ変換する単体テストを追加
- GitHub Actions の結果を確認予定
