### PR TITLE
経路検索で複数種別のConnectedRoutesを利用

### DIFF
--- a/src/hooks/useDestinationSelection.test.tsx
+++ b/src/hooks/useDestinationSelection.test.tsx
@@ -1,0 +1,305 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import type { Line, Station, TrainType } from '~/@types/graphql';
+import {
+  GET_CONNECTED_ROUTES,
+  GET_LINE_GROUP_STATIONS,
+  GET_LINE_STATIONS,
+  GET_ROUTE_TYPES_LIGHT,
+} from '~/lib/graphql/queries';
+import { pendingLineAtom } from '~/store/atoms/line';
+import {
+  fetchedTrainTypesAtom,
+  pendingTrainTypeAtom,
+} from '~/store/atoms/navigation';
+import {
+  pendingStationAtom,
+  pendingStationsAtom,
+  stationAtom,
+} from '~/store/atoms/station';
+import { createLine, createStation } from '~/utils/test/factories';
+import { useDestinationSelection } from './useDestinationSelection';
+import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
+
+jest.mock('./useLazyGraphQLQuery', () => ({
+  useLazyGraphQLQuery: jest.fn(),
+}));
+
+type HookResult = ReturnType<typeof useDestinationSelection> | null;
+
+const HookBridge: React.FC<{ onReady: (value: HookResult) => void }> = ({
+  onReady,
+}) => {
+  onReady(useDestinationSelection());
+  return null;
+};
+
+const idleQueryState = {
+  data: undefined,
+  loading: false,
+  error: undefined,
+  called: false,
+};
+
+describe('useDestinationSelection', () => {
+  const mockUseLazyGraphQLQuery = useLazyGraphQLQuery as jest.MockedFunction<
+    typeof useLazyGraphQLQuery
+  >;
+  const fetchRouteTypes = jest.fn();
+  const fetchConnectedRoutes = jest.fn();
+  const fetchStationsByLineId = jest.fn();
+  const fetchStationsByLineGroupId = jest.fn();
+
+  const firstLine = createLine(10);
+  const secondLine = createLine(20);
+  const currentStation = createStation(100, {
+    groupId: 100,
+    line: firstLine,
+    lines: [firstLine, secondLine],
+  });
+  const destination = createStation(200, {
+    groupId: 200,
+    line: secondLine,
+    lines: [secondLine],
+  });
+
+  const createTrainType = (
+    id: number,
+    groupId: number,
+    line: Line,
+    name = '普通'
+  ) =>
+    ({
+      __typename: 'TrainType',
+      id,
+      groupId,
+      name,
+      nameRoman: 'Local',
+      line,
+      lines: [line],
+    }) as TrainType;
+
+  const createConnectedStops = (
+    routeId: number,
+    line: Line,
+    offset: number
+  ): Station[] => {
+    const trainType = createTrainType(routeId, routeId, line);
+    return [
+      {
+        ...createStation(100 + offset, {
+          groupId: 100,
+          line,
+          lines: [line],
+        }),
+        trainType,
+      } as Station,
+      {
+        ...createStation(200 + offset, {
+          groupId: 200,
+          line: secondLine,
+          lines: [secondLine],
+        }),
+        trainType: createTrainType(routeId + 1, routeId, secondLine, '快速'),
+      } as Station,
+    ];
+  };
+
+  const setupLazyQueries = () => {
+    mockUseLazyGraphQLQuery.mockImplementation((document) => {
+      if (document === GET_ROUTE_TYPES_LIGHT) {
+        return [fetchRouteTypes, idleQueryState];
+      }
+      if (document === GET_CONNECTED_ROUTES) {
+        return [fetchConnectedRoutes, idleQueryState];
+      }
+      if (document === GET_LINE_STATIONS) {
+        return [fetchStationsByLineId, idleQueryState];
+      }
+      if (document === GET_LINE_GROUP_STATIONS) {
+        return [fetchStationsByLineGroupId, idleQueryState];
+      }
+      throw new Error('unknown query');
+    });
+  };
+
+  const renderHook = () => {
+    const store = createStore();
+    store.set(stationAtom, currentStation);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: Number.POSITIVE_INFINITY,
+        },
+      },
+    });
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <HookBridge
+            onReady={(value) => {
+              hookRef.current = value;
+            }}
+          />
+        </QueryClientProvider>
+      </Provider>
+    );
+    return { hookRef, store };
+  };
+
+  beforeEach(() => {
+    setupLazyQueries();
+    fetchStationsByLineId.mockResolvedValue({
+      data: { lineStations: [currentStation, destination] },
+      error: undefined,
+    });
+    fetchStationsByLineGroupId.mockResolvedValue({
+      data: { lineGroupStations: [currentStation, destination] },
+      error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('単一種別がある場合はConnectedRoutesを実行しない', async () => {
+    const trainType = createTrainType(1, 1000, firstLine);
+    fetchRouteTypes.mockResolvedValue({
+      data: {
+        routeTypes: { nextPageToken: null, trainTypes: [trainType] },
+      },
+      error: undefined,
+    });
+    const { hookRef } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+
+    expect(fetchConnectedRoutes).not.toHaveBeenCalled();
+    expect(fetchStationsByLineGroupId).toHaveBeenCalledWith({
+      variables: { lineGroupId: 1000 },
+    });
+  });
+
+  it('単一種別が空の場合は接続経路の駅列と仮想lineGroupIdを設定する', async () => {
+    const stops = createConnectedStops(9000, firstLine, 0);
+    fetchRouteTypes.mockResolvedValue({
+      data: { routeTypes: { nextPageToken: null, trainTypes: [] } },
+      error: undefined,
+    });
+    fetchConnectedRoutes.mockResolvedValue({
+      data: { connectedRoutes: [{ id: 9000, stops }] },
+      error: undefined,
+    });
+    const { hookRef, store } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+
+    expect(store.get(pendingStationsAtom)).toEqual(stops);
+    expect(store.get(pendingTrainTypeAtom)?.groupId).toBe(9000);
+    expect(store.get(fetchedTrainTypesAtom)).toHaveLength(1);
+    expect(store.get(pendingStationAtom)?.groupId).toBe(100);
+  });
+
+  it('ConnectedRoutesが空の場合は既存の路線フォールバックを維持する', async () => {
+    fetchRouteTypes.mockResolvedValue({
+      data: { routeTypes: { nextPageToken: null, trainTypes: [] } },
+      error: undefined,
+    });
+    fetchConnectedRoutes.mockResolvedValue({
+      data: { connectedRoutes: [] },
+      error: undefined,
+    });
+    const { hookRef, store } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+
+    expect(fetchStationsByLineId).toHaveBeenCalledWith({
+      variables: { lineId: secondLine.id },
+    });
+    expect(store.get(pendingLineAtom)?.id).toBe(secondLine.id);
+    expect(store.get(pendingStationsAtom)).toEqual([
+      currentStation,
+      destination,
+    ]);
+  });
+
+  it('仮想候補への切替時は保持済み駅列を使う', async () => {
+    const firstStops = createConnectedStops(9000, firstLine, 0);
+    const secondStops = createConnectedStops(9001, secondLine, 10);
+    fetchRouteTypes.mockResolvedValue({
+      data: { routeTypes: { nextPageToken: null, trainTypes: [] } },
+      error: undefined,
+    });
+    fetchConnectedRoutes.mockResolvedValue({
+      data: {
+        connectedRoutes: [
+          { id: 9000, stops: firstStops },
+          { id: 9001, stops: secondStops },
+        ],
+      },
+      error: undefined,
+    });
+    const { hookRef, store } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+    const secondCandidate = store
+      .get(fetchedTrainTypesAtom)
+      .find((trainType) => trainType.groupId === 9001);
+    expect(secondCandidate).toBeDefined();
+
+    await act(async () => {
+      if (secondCandidate) {
+        await hookRef.current?.handleTrainTypeSelected(secondCandidate);
+      }
+    });
+
+    expect(store.get(pendingStationsAtom)).toEqual(secondStops);
+    expect(fetchStationsByLineGroupId).not.toHaveBeenCalled();
+  });
+
+  it('単一種別取得の失敗時はConnectedRoutesへ進まない', async () => {
+    fetchRouteTypes.mockResolvedValue({
+      data: undefined,
+      error: new Error('route types failed'),
+    });
+    const { hookRef } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+
+    expect(fetchConnectedRoutes).not.toHaveBeenCalled();
+    expect(fetchStationsByLineId).not.toHaveBeenCalled();
+  });
+
+  it('ConnectedRoutes取得の失敗時は路線フォールバックへ進まない', async () => {
+    fetchRouteTypes.mockResolvedValue({
+      data: { routeTypes: { nextPageToken: null, trainTypes: [] } },
+      error: undefined,
+    });
+    fetchConnectedRoutes.mockResolvedValue({
+      data: undefined,
+      error: new Error('connected routes failed'),
+    });
+    const { hookRef } = renderHook();
+
+    await act(async () => {
+      await hookRef.current?.handleDestinationSelected(destination);
+    });
+
+    expect(fetchStationsByLineId).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDestinationSelection.test.tsx
+++ b/src/hooks/useDestinationSelection.test.tsx
@@ -27,6 +27,13 @@ jest.mock('./useLazyGraphQLQuery', () => ({
   useLazyGraphQLQuery: jest.fn(),
 }));
 
+jest.mock('~/lib/gql', () => ({
+  graphqlQueryKey: jest.fn((document: unknown, variables?: object) => [
+    document,
+    variables ?? null,
+  ]),
+}));
+
 type HookResult = ReturnType<typeof useDestinationSelection> | null;
 
 const HookBridge: React.FC<{ onReady: (value: HookResult) => void }> = ({

--- a/src/hooks/useDestinationSelection.test.tsx
+++ b/src/hooks/useDestinationSelection.test.tsx
@@ -44,9 +44,7 @@ const idleQueryState = {
 };
 
 describe('useDestinationSelection', () => {
-  const mockUseLazyGraphQLQuery = useLazyGraphQLQuery as jest.MockedFunction<
-    typeof useLazyGraphQLQuery
-  >;
+  const mockUseLazyGraphQLQuery = useLazyGraphQLQuery as unknown as jest.Mock;
   const fetchRouteTypes = jest.fn();
   const fetchConnectedRoutes = jest.fn();
   const fetchStationsByLineId = jest.fn();
@@ -54,15 +52,23 @@ describe('useDestinationSelection', () => {
 
   const firstLine = createLine(10);
   const secondLine = createLine(20);
+  const firstNestedLine = {
+    ...firstLine,
+    __typename: 'LineNested' as const,
+  } as NonNullable<Station['line']>;
+  const secondNestedLine = {
+    ...secondLine,
+    __typename: 'LineNested' as const,
+  } as NonNullable<Station['line']>;
   const currentStation = createStation(100, {
     groupId: 100,
-    line: firstLine,
-    lines: [firstLine, secondLine],
+    line: firstNestedLine,
+    lines: [firstNestedLine, secondNestedLine],
   });
   const destination = createStation(200, {
     groupId: 200,
-    line: secondLine,
-    lines: [secondLine],
+    line: secondNestedLine,
+    lines: [secondNestedLine],
   });
 
   const createTrainType = (
@@ -79,7 +85,7 @@ describe('useDestinationSelection', () => {
       nameRoman: 'Local',
       line,
       lines: [line],
-    }) as TrainType;
+    }) as unknown as TrainType;
 
   const createConnectedStops = (
     routeId: number,
@@ -91,16 +97,16 @@ describe('useDestinationSelection', () => {
       {
         ...createStation(100 + offset, {
           groupId: 100,
-          line,
-          lines: [line],
+          line: { ...line, __typename: 'LineNested' },
+          lines: [{ ...line, __typename: 'LineNested' }],
         }),
         trainType,
       } as Station,
       {
         ...createStation(200 + offset, {
           groupId: 200,
-          line: secondLine,
-          lines: [secondLine],
+          line: secondNestedLine,
+          lines: [secondNestedLine],
         }),
         trainType: createTrainType(routeId + 1, routeId, secondLine, '快速'),
       } as Station,
@@ -108,7 +114,7 @@ describe('useDestinationSelection', () => {
   };
 
   const setupLazyQueries = () => {
-    mockUseLazyGraphQLQuery.mockImplementation((document) => {
+    mockUseLazyGraphQLQuery.mockImplementation((document: unknown) => {
       if (document === GET_ROUTE_TYPES_LIGHT) {
         return [fetchRouteTypes, idleQueryState];
       }

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -191,6 +191,10 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         },
       });
 
+      if (result.error) {
+        return;
+      }
+
       const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
 
       if (!fetchedTrainTypes.length) {
@@ -200,6 +204,10 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
             toStationGroupId: selectedStation.groupId,
           },
         });
+        if (connectedRoutesResult.error) {
+          return;
+        }
+
         const connectedRoutes =
           connectedRoutesResult.data?.connectedRoutes ?? [];
         const connectedTrainTypes = connectedRoutes
@@ -238,7 +246,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
           if (newCurrentStation?.line) {
             setLineState((prev) => ({
               ...prev,
-              pendingLine: newCurrentStation.line,
+              pendingLine: newCurrentStation.line as Line,
             }));
           }
           setNavigationState((prev) => ({
@@ -382,7 +390,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         if (newCurrentStation?.line) {
           setLineState((prev) => ({
             ...prev,
-            pendingLine: newCurrentStation.line,
+            pendingLine: newCurrentStation.line as Line,
           }));
         }
         return;

--- a/src/hooks/useDestinationSelection.ts
+++ b/src/hooks/useDestinationSelection.ts
@@ -1,9 +1,10 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import { graphqlQueryKey } from '~/lib/gql';
 import {
+  GET_CONNECTED_ROUTES,
   GET_LINE_GROUP_STATIONS,
   GET_LINE_STATIONS,
   GET_ROUTE_TYPES_LIGHT,
@@ -15,6 +16,8 @@ import stationState, {
   wantedDestinationAtom,
 } from '~/store/atoms/station';
 import {
+  buildConnectedRouteTrainType,
+  type ConnectedRoute,
   computeCurrentStationInRoutes,
   getStationWithMatchingLine,
 } from '~/utils/routeSearch';
@@ -34,6 +37,15 @@ type GetRouteTypesVariables = {
   pageSize?: number;
   pageToken?: string;
   viaLineId?: number;
+};
+
+type GetConnectedRoutesData = {
+  connectedRoutes: ConnectedRoute[];
+};
+
+type GetConnectedRoutesVariables = {
+  fromStationGroupId: number;
+  toStationGroupId: number;
 };
 
 type GetLineStationsData = {
@@ -97,6 +109,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
   const setLineState = useSetAtom(lineState);
 
   const queryClient = useQueryClient();
+  const connectedRouteStationsRef = useRef(new Map<number, Station[]>());
 
   const [
     fetchRouteTypes,
@@ -107,6 +120,13 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     },
   ] = useLazyGraphQLQuery<GetRouteTypesData, GetRouteTypesVariables>(
     GET_ROUTE_TYPES_LIGHT
+  );
+
+  const [
+    fetchConnectedRoutes,
+    { loading: fetchConnectedRoutesLoading, error: fetchConnectedRoutesError },
+  ] = useLazyGraphQLQuery<GetConnectedRoutesData, GetConnectedRoutesVariables>(
+    GET_CONNECTED_ROUTES
   );
 
   const [
@@ -134,6 +154,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     async (selectedStation: Station) => {
       setSelectBoundModalVisible(true);
       setSelectedDestination(selectedStation);
+      connectedRouteStationsRef.current.clear();
 
       const newPendingLine = selectedStation.line ?? null;
 
@@ -172,11 +193,66 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
 
       const fetchedTrainTypes = result.data?.routeTypes.trainTypes ?? [];
 
-      if (!fetchedTrainTypes?.length) {
+      if (!fetchedTrainTypes.length) {
+        const connectedRoutesResult = await fetchConnectedRoutes({
+          variables: {
+            fromStationGroupId: station.groupId,
+            toStationGroupId: selectedStation.groupId,
+          },
+        });
+        const connectedRoutes =
+          connectedRoutesResult.data?.connectedRoutes ?? [];
+        const connectedTrainTypes = connectedRoutes
+          .map(buildConnectedRouteTrainType)
+          .filter((trainType): trainType is TrainType => !!trainType);
+
+        connectedRouteStationsRef.current = new Map(
+          connectedRoutes.flatMap((route) =>
+            route.id && route.stops
+              ? ([[route.id, route.stops]] as [number, Station[]][])
+              : []
+          )
+        );
+
+        const connectedTrainType =
+          findLocalType(connectedTrainTypes) ?? connectedTrainTypes[0];
+        if (connectedTrainType?.groupId) {
+          const connectedStations =
+            connectedRouteStationsRef.current.get(connectedTrainType.groupId) ??
+            [];
+          const newCurrentStation = computeCurrentStationInRoutes(
+            station,
+            newPendingLine,
+            [connectedTrainType]
+          );
+
+          setStationState((prev) => ({
+            ...prev,
+            pendingStation: newCurrentStation,
+            station:
+              prev.station && newCurrentStation?.line
+                ? { ...prev.station, line: newCurrentStation.line }
+                : prev.station,
+            pendingStations: connectedStations,
+          }));
+          if (newCurrentStation?.line) {
+            setLineState((prev) => ({
+              ...prev,
+              pendingLine: newCurrentStation.line,
+            }));
+          }
+          setNavigationState((prev) => ({
+            ...prev,
+            fetchedTrainTypes: connectedTrainTypes,
+            pendingTrainType: connectedTrainType,
+          }));
+          return;
+        }
+
         if (!selectedStation.line?.id) {
           return;
         }
-        // 列車種別が存在しない場合は選択した行き先駅の路線を使用
+        // 単一種別・接続経路のどちらも存在しない場合は選択した行き先駅の路線を使用
         setLineState((prev) => ({
           ...prev,
           pendingLine: selectedStation.line ?? null,
@@ -267,6 +343,7 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
       fetchStationsByLineId,
       fetchStationsByLineGroupId,
       fetchRouteTypes,
+      fetchConnectedRoutes,
       setNavigationState,
       setStationState,
       setLineState,
@@ -283,6 +360,33 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
         ...prev,
         pendingTrainType: trainType,
       }));
+
+      const connectedStations = connectedRouteStationsRef.current.get(
+        trainType.groupId
+      );
+      if (connectedStations) {
+        const newCurrentStation = computeCurrentStationInRoutes(
+          station,
+          pendingLine,
+          [trainType]
+        );
+        setStationState((prev) => ({
+          ...prev,
+          pendingStation: newCurrentStation,
+          station:
+            prev.station && newCurrentStation?.line
+              ? { ...prev.station, line: newCurrentStation.line }
+              : prev.station,
+          pendingStations: connectedStations,
+        }));
+        if (newCurrentStation?.line) {
+          setLineState((prev) => ({
+            ...prev,
+            pendingLine: newCurrentStation.line,
+          }));
+        }
+        return;
+      }
 
       // キャッシュ済みでも常に最新の駅一覧を取得したいので該当キーを破棄する
       queryClient.removeQueries({
@@ -304,8 +408,11 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
     },
     [
       fetchStationsByLineGroupId,
+      station,
+      pendingLine,
       setStationState,
       setNavigationState,
+      setLineState,
       queryClient,
     ]
   );
@@ -355,11 +462,13 @@ export const useDestinationSelection = (): UseDestinationSelectionResult => {
 
   const modalLoading =
     fetchRouteTypesLoading ||
+    fetchConnectedRoutesLoading ||
     fetchStationsByLineIdLoading ||
     fetchStationsByLineGroupIdLoading;
 
   const modalError =
     fetchRouteTypesError ??
+    fetchConnectedRoutesError ??
     fetchStationsByLineIdError ??
     fetchStationsByLineGroupIdError ??
     null;

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -479,7 +479,7 @@ export const CONNECTED_ROUTE_STATION_FRAGMENT = gql`
 // Query for routes that require multiple connected train types
 export const GET_CONNECTED_ROUTES = gql`
   ${CONNECTED_ROUTE_STATION_FRAGMENT}
-  query GetConnectedRoutes(
+  query GetConnectedRoutesQuery(
     $fromStationGroupId: Int!
     $toStationGroupId: Int!
   ) {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -439,6 +439,62 @@ export const TRAIN_TYPE_ROUTE_FRAGMENT = gql`
   }
 `;
 
+// Fragment for routes that connect multiple train-type groups
+export const CONNECTED_ROUTE_STATION_FRAGMENT = gql`
+  ${LINE_IN_STATION_FRAGMENT}
+  ${STATION_NUMBER_FRAGMENT}
+  ${TRAIN_TYPE_NESTED_FRAGMENT}
+  fragment ConnectedRouteStationFields on StationNested {
+    id
+    groupId
+    name
+    nameKatakana
+    nameRoman
+    nameChinese
+    nameKorean
+    nameTtsSegments {
+      ...TtsSegmentFields
+    }
+    threeLetterCode
+    latitude
+    longitude
+    prefectureId
+    hasTrainTypes
+    stopCondition
+    stationNumbers {
+      ...StationNumberFields
+    }
+    line {
+      ...LineInStationFields
+    }
+    lines {
+      ...LineInStationFields
+    }
+    trainType {
+      ...TrainTypeNestedFields
+    }
+  }
+`;
+
+// Query for routes that require multiple connected train types
+export const GET_CONNECTED_ROUTES = gql`
+  ${CONNECTED_ROUTE_STATION_FRAGMENT}
+  query GetConnectedRoutes(
+    $fromStationGroupId: Int!
+    $toStationGroupId: Int!
+  ) {
+    connectedRoutes(
+      fromStationGroupId: $fromStationGroupId
+      toStationGroupId: $toStationGroupId
+    ) {
+      id
+      stops {
+        ...ConnectedRouteStationFields
+      }
+    }
+  }
+`;
+
 // Query for getting route types (lightweight)
 export const GET_ROUTE_TYPES_LIGHT = gql`
   ${TRAIN_TYPE_ROUTE_FRAGMENT}

--- a/src/utils/routeSearch.test.ts
+++ b/src/utils/routeSearch.test.ts
@@ -1,5 +1,6 @@
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
+  buildConnectedRouteTrainType,
   computeCurrentStationInRoutes,
   getStationWithMatchingLine,
 } from './routeSearch';
@@ -364,5 +365,49 @@ describe('getStationWithMatchingLine', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('buildConnectedRouteTrainType', () => {
+  it('複数種別の経路を仮想lineGroupIdを持つ一つの選択肢へ変換する', () => {
+    const firstLine = createMockLine(1, '1路線目');
+    const secondLine = createMockLine(2, '2路線目');
+    const firstType = createMockTrainType(10, '普通', firstLine, [firstLine]);
+    const secondType = createMockTrainType(20, '快速', secondLine, [
+      secondLine,
+    ]);
+    const firstStop = {
+      ...createMockStation(100, '出発駅', firstLine, [firstLine]),
+      trainType: firstType,
+    } as Station;
+    const secondStop = {
+      ...createMockStation(200, '到着駅', secondLine, [secondLine]),
+      trainType: secondType,
+    } as Station;
+
+    const result = buildConnectedRouteTrainType({
+      id: 9000,
+      stops: [firstStop, secondStop],
+    });
+
+    expect(result?.id).toBe(9000);
+    expect(result?.groupId).toBe(9000);
+    expect(result?.lines?.map((line) => line.id)).toEqual([1, 2]);
+    expect(result?.lines?.map((line) => line.trainType?.name)).toEqual([
+      '普通',
+      '快速',
+    ]);
+  });
+
+  it('経路IDまたは種別情報がない経路は選択肢にしない', () => {
+    const line = createMockLine(1, 'テスト路線');
+    const station = createMockStation(100, 'テスト駅', line, [line]);
+
+    expect(
+      buildConnectedRouteTrainType({ id: null, stops: [station] })
+    ).toBeNull();
+    expect(
+      buildConnectedRouteTrainType({ id: 9000, stops: [station] })
+    ).toBeNull();
   });
 });

--- a/src/utils/routeSearch.ts
+++ b/src/utils/routeSearch.ts
@@ -68,3 +68,45 @@ export const getStationWithMatchingLine = (
 
   return station;
 };
+
+export type ConnectedRoute = {
+  id: number | null;
+  stops: Station[] | null;
+};
+
+/**
+ * ConnectedRoutes の各経路を既存の列車種別選択UIで扱える形へ変換する。
+ * 経路IDは StationAPI が経路全体へ付与した仮想 lineGroupId であり、
+ * 各区間の路線・種別は stops から復元する。
+ */
+export const buildConnectedRouteTrainType = (
+  route: ConnectedRoute
+): TrainType | null => {
+  if (!route.id) return null;
+
+  const stops = route.stops ?? [];
+  const baseTrainType = stops.find((stop) => stop.trainType)?.trainType;
+  if (!baseTrainType) return null;
+
+  const seenLineIds = new Set<number>();
+  const lines = stops.flatMap((stop) => {
+    const line = stop.line;
+    if (!line?.id || seenLineIds.has(line.id)) return [];
+
+    seenLineIds.add(line.id);
+    return [
+      {
+        ...line,
+        trainType: stop.trainType ?? line.trainType,
+      } as Line,
+    ];
+  });
+
+  return {
+    ...baseTrainType,
+    id: route.id,
+    groupId: route.id,
+    line: lines[0] ?? baseTrainType.line,
+    lines,
+  } as unknown as TrainType;
+};


### PR DESCRIPTION
## 概要

単一の列車種別だけでは到達できない経路を、ConnectedRoutesで検索できるようにします。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `routeTypes` で単一種別の経路が見つからない場合のみ `connectedRoutes` を問い合わせます。
- ConnectedRoutesの各経路を既存の列車種別選択UIで扱える候補へ変換します。
- StationAPIが付与する仮想 `lineGroupId` と駅列を保持し、初期候補と候補切替時に使用します。
- ConnectedRoutesも空の場合は、従来の選択路線フォールバックを維持します。
- 単一種別で到達できる既存経路には追加のAPI呼び出しは発生しません。
- `routeTypes` または `connectedRoutes` の取得失敗時は、経路なしとして次のフォールバックへ進まずエラー状態を維持します。
- GraphQL操作名を `GetConnectedRoutesQuery` へ変更しました。
- 回帰リスクは複数種別経路の状態構築です。仮想 `lineGroupId`、区間路線、区間種別の変換テストに加え、取得条件・状態更新・候補切替・取得失敗を検証するフック統合テストを追加して軽減します。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

Node.js 22.23.2 / npm 10.9.9で以下を確認しました。

- `npm run lint`: 605ファイルすべて通過
- `npm test -- --runInBand`: 202スイート、2,177テストすべて通過
- `npm run typecheck`: 通過
- `npm test -- --runInBand src/hooks/useDestinationSelection.test.tsx`: ConnectedRoutes選択フローの6テストすべて通過

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数の列車種別をまたぐ接続経路を取得し、1つの選択肢として表示できるようになりました。
  * 接続経路に含まれる駅や路線情報を、列車種別の選択・表示に反映します。
  * 接続経路の読み込み中やエラー発生時も、適切に状態を表示します。

* **品質改善**
  * 経路情報や列車種別が不足している場合、不完全な選択肢を表示しないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->