### PR TITLE
AIエージェントを本番ビルドで有効化

### DIFF
--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -734,8 +734,7 @@ Expo SDK 更新時はこのパッチの要否を再確認する。
    追加。
 2. アプリ側は `REMOTE_CONFIG_KEYS` にキー追加 → フォールバック定数
    （`false`）→ ゲッター → `useAIAgentFeatureEnabled` フック。
-3. PoC 期間中はさらに `isDevApp`（dev/canary ビルド）でもゲートし、
-   本番ビルドには一切露出しない。
+3. 本番を含む全ビルドで Remote Config の値だけを表示条件とする。
 4. 障害・コスト超過時は KV の値を `false` にするだけで全クライアントから
    機能が消える（`FxTTS` と同じキルスイッチ構造）。
 
@@ -860,10 +859,11 @@ LangChain を使わず、検証プラットフォームとして LangSmith を�
 | --- | --- | --- |
 | Phase 0（PoC） | dev ビルド | 本設計の実装 + モデル比較検証 + 実測 |
 | Phase 1 | canary | プロンプト調整後に開放し指標評価 |
-| Phase 2 | production | フラグ本番化・`isDevApp` ゲート除去 |
+| Phase 2 | production | フラグ本番化（完了） |
 
 - Phase 0 では `ai_agent_enabled` を dev 環境 KV のみ `true` にする。
 - Phase 1 の評価指標はコスト・謝絶率・提案採択率。
+- Phase 2 では `isDevApp` ゲートを除去し、本番環境 KV で公開を制御する。
 - Phase 2 で WANT 要件（経路検索）の着手可否を判断する。
 
 ## 開発プロセス（#6473 実装備考より）

--- a/docs/spec/ai-agent/ui.md
+++ b/docs/spec/ai-agent/ui.md
@@ -53,8 +53,8 @@ Figma デザインは人力ではなく Figma MCP で本書を入力として起
 ## エントリポイント
 
 表示条件はすべて共通: `useAIAgentFeatureEnabled()`（Remote Config
-`ai_agent_enabled`）かつ PoC 期間中は `isDevApp`。フラグ off 時は
-エントリポイント自体を描画しない（architecture.md のエラー表参照）。
+`ai_agent_enabled`）。フラグ off 時はエントリポイント自体を描画しない
+（architecture.md のエラー表参照）。
 
 ### 案 A: RouteSearchScreen の検索バー直下バナー（推奨）
 

--- a/src/hooks/useAIAgentFeatureEnabled.test.tsx
+++ b/src/hooks/useAIAgentFeatureEnabled.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react-native';
+import { useAIAgentFeatureEnabled } from './useAIAgentFeatureEnabled';
+
+const mockIsAIAgentFeatureEnabled = jest.fn<boolean, []>();
+
+jest.mock('~/lib/remoteConfig', () => ({
+  isAIAgentFeatureEnabled: () => mockIsAIAgentFeatureEnabled(),
+  subscribeRemoteConfig: () => () => undefined,
+}));
+
+describe('useAIAgentFeatureEnabled', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([true, false])(
+    'Remote Config が %s の場合はその値を返す',
+    (enabled) => {
+      mockIsAIAgentFeatureEnabled.mockReturnValue(enabled);
+
+      const { result } = renderHook(() => useAIAgentFeatureEnabled());
+
+      expect(result.current).toBe(enabled);
+    }
+  );
+});

--- a/src/hooks/useAIAgentFeatureEnabled.ts
+++ b/src/hooks/useAIAgentFeatureEnabled.ts
@@ -3,17 +3,9 @@ import {
   isAIAgentFeatureEnabled,
   subscribeRemoteConfig,
 } from '~/lib/remoteConfig';
-import { isDevApp } from '~/utils/isDevApp';
 
 // AIエージェント機能キルスイッチ(ai_agent_enabled)のリアクティブ版。
 // setupRemoteConfig は起動時に非同期で完了するため、同期読みだけではコールドスタート時の
 // キャッシュ更新に追従できない。useTTSFeatureEnabled と同じくキャッシュ更新を購読する。
-// PoC 期間中は本番ビルドへ一切露出させないため isDevApp との AND でゲートする
-// (Phase 2 で本番開放する際にこの条件を外す)。
-export const useAIAgentFeatureEnabled = (): boolean => {
-  const remoteEnabled = useSyncExternalStore(
-    subscribeRemoteConfig,
-    isAIAgentFeatureEnabled
-  );
-  return isDevApp && remoteEnabled;
-};
+export const useAIAgentFeatureEnabled = (): boolean =>
+  useSyncExternalStore(subscribeRemoteConfig, isAIAgentFeatureEnabled);


### PR DESCRIPTION
## 概要

AIエージェントの表示条件から開発ビルド判定を除去し、本番ビルドでも Remote Config によって公開できるようにします。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useAIAgentFeatureEnabled` から `isDevApp` ゲートを除去
- 全ビルドで `ai_agent_enabled` の値だけを表示条件として使用
- Remote Config の true / false をそのまま返すことを確認するテストを追加
- UI・アーキテクチャ仕様書を本番開放後の状態に更新

Remote Config が未設定または取得できない場合は、既存のフォールバック値 `false` により引き続き非表示になります。そのため、公開範囲は本番環境の Remote Config で即時に制御できます。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加で `git diff --check` と `npm test -- --runInBand src/hooks/useAIAgentFeatureEnabled.test.tsx` が通ることを確認しました。

## 関連Issue

なし

## スクリーンショット（任意）

Argent MCP がこのセッションでは利用できなかったため、端末でのスクリーンショットは未取得です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Remote Config の設定により、本番環境でも AI エージェントの表示を制御できるようになりました。
  * 設定が有効な場合にのみ、AI エージェントのエントリポイントが表示されます。

* **テスト**
  * AI エージェントの表示設定が正しく反映されることを確認するテストを追加しました。

* **ドキュメント**
  * AI エージェントの段階的リリース計画を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->