### PR TITLE
iOSビルド番号を従来のリポジトリ管理へ戻す

### DIFF
--- a/.github/workflows/build_ios_canary.yml
+++ b/.github/workflows/build_ios_canary.yml
@@ -168,7 +168,6 @@ jobs:
           EXPERIMENTAL_TELEMETRY_TOKEN: "${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}"
           API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          PROJECT_VERSION: "${{ github.run_number }}.${{ github.run_attempt }}"
         run: |
           xcodebuild \
             -workspace ios/TrainLCD.xcworkspace \
@@ -180,7 +179,6 @@ jobs:
             -authenticationKeyPath "$API_KEY_PATH" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID" \
-            CURRENT_PROJECT_VERSION="$PROJECT_VERSION" \
             archive
 
       - name: Upload to TestFlight

--- a/.github/workflows/build_ios_production.yml
+++ b/.github/workflows/build_ios_production.yml
@@ -168,7 +168,6 @@ jobs:
           EXPERIMENTAL_TELEMETRY_TOKEN: "${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}"
           API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          PROJECT_VERSION: "${{ github.run_number }}.${{ github.run_attempt }}"
         run: |
           xcodebuild \
             -workspace ios/TrainLCD.xcworkspace \
@@ -180,7 +179,6 @@ jobs:
             -authenticationKeyPath "$API_KEY_PATH" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID" \
-            CURRENT_PROJECT_VERSION="$PROJECT_VERSION" \
             archive
 
       - name: Upload to TestFlight

--- a/docs/ios-build-workflows.md
+++ b/docs/ios-build-workflows.md
@@ -5,6 +5,11 @@ optionally upload them to TestFlight. A push to `canary` or `master` uploads the
 corresponding build automatically. A manual run defaults to an archive-only
 dry-run.
 
+Both workflows preserve the iOS build number committed to
+`ios/TrainLCD.xcodeproj/project.pbxproj`. The version bump workflow updates that
+value together with `app.config.ts`; build workflows must not replace it with a
+GitHub Actions run number.
+
 ## Prerequisites
 
 - A GitHub-hosted `macos-26` runner with Node.js 22 and CocoaPods available.
@@ -33,10 +38,10 @@ Configure these GitHub Actions secrets:
 | `APP_STORE_CONNECT_API_ISSUER_ID` | App Store Connect API issuer ID |
 | `APP_STORE_CONNECT_API_KEY_ID` | App Store Connect API key ID |
 | `APP_STORE_CONNECT_API_PRIVATE_KEY_BASE64` | Base64-encoded API private key |
-| `IOS_DEVELOPMENT_CERTIFICATE_BASE64` | Base64-encoded development PKCS #12 certificate and private key |
-| `IOS_DEVELOPMENT_CERTIFICATE_PASSWORD` | Development PKCS #12 certificate password |
-| `IOS_DISTRIBUTION_CERTIFICATE_BASE64` | Base64-encoded distribution PKCS #12 certificate and private key |
-| `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD` | Distribution PKCS #12 certificate password |
+| `IOS_DEVELOPMENT_CERTIFICATE_BASE64` | Base64 development PKCS #12 |
+| `IOS_DEVELOPMENT_CERTIFICATE_PASSWORD` | Development PKCS #12 password |
+| `IOS_DISTRIBUTION_CERTIFICATE_BASE64` | Base64 distribution PKCS #12 |
+| `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD` | Distribution PKCS #12 password |
 
 The workflow exposes application endpoint and telemetry values as environment
 variables. App Store Connect credentials, certificate data, and the Fonts SSH


### PR DESCRIPTION
## 概要

GitHub ActionsのiOSビルド番号を、従来どおりリポジトリで管理する値へ戻します。Actionsの実行回数と再実行回数を組み合わせた独自採番により、Production成果物のビルド番号が `3.2` になる問題を修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- iOS Canary / Production workflowから `github.run_number` と `github.run_attempt` による採番を削除しました。
- `xcodebuild` に渡していた `CURRENT_PROJECT_VERSION` の上書きを削除しました。
- `app.config.ts` とXcodeプロジェクトをiOSビルド番号の管理元とする仕様をドキュメントへ明記しました。
- Androidは従来どおりGradleの `versionCode` を使用しており、変更していません。

回帰リスクは、同一ビルド番号の成果物をTestFlightへ再アップロードすると拒否される可能性がある点です。リリース前のversion bump workflowでビルド番号を更新し、リポジトリ管理値を正として運用します。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- iOS Canary / Production workflowのYAML構文解析: 成功
- iOSビルド番号の同期確認とActions上書きの不在確認: 成功
- `npx --yes markdownlint-cli2 docs/ios-build-workflows.md`: 成功
- `npm run lint`: 成功（605 files）
- `npm test -- --runInBand --silent`: 成功（202 suites、2171 tests）
- `npm run typecheck`: 成功
- `git diff --check`: 成功

ローカル検証はNode.js 24.19.0で実行しました。macOS runner上でのarchiveとTestFlightアップロードは未実行です。

## 関連Issue

なし

## スクリーンショット（任意）

UI変更なし
