### PR TITLE
韓国語の列車種別名が空欄になる問題を修正

### DIFF
--- a/src/components/TrainTypeBox.test.tsx
+++ b/src/components/TrainTypeBox.test.tsx
@@ -1,8 +1,32 @@
 import { render } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
 import React from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import type { TrainType } from '~/@types/graphql';
 import { FONTS } from '../constants';
 import { APP_THEME } from '../models/Theme';
-import { resolveTrainTypeFontFamily } from './TrainTypeBox';
+import { headerStateAtom } from '../store/atoms/navigation';
+import { themeAtom } from '../store/atoms/theme';
+import tuningState from '../store/atoms/tuning';
+import TrainTypeBox, { resolveTrainTypeFontFamily } from './TrainTypeBox';
+
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+
+jest.mock('../hooks', () => ({
+  useCurrentLine: jest.fn(() => null),
+  useLandscapeWindowDimensions: jest.fn(() => ({ width: 800, height: 400 })),
+  useLazyPrevious: jest.requireActual('../hooks/useLazyPrevious')
+    .useLazyPrevious,
+  useNextTrainType: jest.fn(() => null),
+  usePrevious: jest.requireActual('../hooks/usePrevious').usePrevious,
+}));
+
+jest.mock('../translation', () => ({
+  translate: jest.fn((key) => key),
+}));
 
 // Create a minimal component that tests the specific crash fix
 const TestSplitFunction = ({
@@ -137,5 +161,71 @@ describe('TrainTypeBox font family', () => {
     expect(resolveTrainTypeFontFamily(APP_THEME.TOKYO_METRO, 'JA')).toBe(
       FONTS.RobotoBold
     );
+  });
+
+  it('LEDテーマでは韓国語以外にドットフォントを使用する', () => {
+    expect(resolveTrainTypeFontFamily(APP_THEME.LED, 'JA')).toBe(
+      FONTS.JFDotJiskan24h
+    );
+  });
+
+  it('LEDテーマでも韓国語はOSフォントへフォールバックする', () => {
+    expect(resolveTrainTypeFontFamily(APP_THEME.LED, 'KO')).toBeUndefined();
+  });
+});
+
+describe('TrainTypeBox language transition', () => {
+  const trainType: TrainType = {
+    __typename: 'TrainType',
+    id: 1,
+    typeId: 1,
+    groupId: 1,
+    name: '快速',
+    nameKatakana: 'カイソク',
+    nameRoman: 'Rapid',
+    nameIpa: null,
+    nameRomanIpa: null,
+    nameTtsSegments: null,
+    nameChinese: '快速',
+    nameKorean: '쾌속',
+    color: '#f00',
+    direction: null,
+    kind: null,
+    line: null,
+    lines: null,
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('KOからJAへのフェード中は旧ハングルにOSフォント設定を維持する', () => {
+    let headerState = 'CURRENT_KO';
+    (useAtomValue as jest.Mock).mockImplementation((atom: unknown) => {
+      if (atom === headerStateAtom) return headerState;
+      if (atom === themeAtom) return APP_THEME.TOKYO_METRO;
+      if (atom === tuningState) return { headerTransitionDelay: 1000 };
+      return undefined;
+    });
+    jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation(() => ({ start: jest.fn() }) as never);
+
+    const { getByText, rerender } = render(
+      <TrainTypeBox trainType={trainType} />
+    );
+    headerState = 'CURRENT_JA';
+    rerender(<TrainTypeBox trainType={{ ...trainType }} />);
+
+    const previousKoreanStyle = StyleSheet.flatten(
+      getByText('쾌속').props.style
+    );
+    const currentJapaneseStyle = StyleSheet.flatten(
+      getByText('快速').props.style
+    );
+
+    expect(previousKoreanStyle.fontFamily).toBeUndefined();
+    expect(previousKoreanStyle.fontWeight).toBe('bold');
+    expect(currentJapaneseStyle.fontFamily).toBe(FONTS.RobotoBold);
   });
 });

--- a/src/components/TrainTypeBox.test.tsx
+++ b/src/components/TrainTypeBox.test.tsx
@@ -1,5 +1,8 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
+import { FONTS } from '../constants';
+import { APP_THEME } from '../models/Theme';
+import { resolveTrainTypeFontFamily } from './TrainTypeBox';
 
 // Create a minimal component that tests the specific crash fix
 const TestSplitFunction = ({
@@ -120,5 +123,19 @@ describe('TrainTypeBox crash fix', () => {
       // Render again with same value
       render(<TestInfiniteLoopFix trainTypeName="Test" />);
     }).not.toThrow();
+  });
+});
+
+describe('TrainTypeBox font family', () => {
+  it('韓国語ではハングル対応のOSフォントへフォールバックする', () => {
+    expect(resolveTrainTypeFontFamily(APP_THEME.TOKYO_METRO, 'KO')).toBe(
+      undefined
+    );
+  });
+
+  it('韓国語以外では通常テーマ用フォントを維持する', () => {
+    expect(resolveTrainTypeFontFamily(APP_THEME.TOKYO_METRO, 'JA')).toBe(
+      FONTS.RobotoBold
+    );
   });
 });

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -24,7 +24,7 @@ import {
   usePrevious,
 } from '../hooks';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
-import { APP_THEME } from '../models/Theme';
+import { APP_THEME, type AppTheme } from '../models/Theme';
 import { headerStateAtom } from '../store/atoms/navigation';
 import { themeAtom } from '../store/atoms/theme';
 import tuningState from '../store/atoms/tuning';
@@ -41,6 +41,18 @@ type Props = {
   nextTrainTypeColor?: string;
   darkenColor?: boolean;
   fontSizeScale?: number;
+};
+
+export const resolveTrainTypeFontFamily = (
+  theme: AppTheme,
+  headerLangState: HeaderLangState
+): string | undefined => {
+  // バンドル済みのRoboto/JF Dotはいずれもハングルを収録していないため、
+  // 韓国語ではOSのフォールバックフォントを使用する。
+  if (headerLangState === 'KO') {
+    return undefined;
+  }
+  return theme === APP_THEME.LED ? FONTS.JFDotJiskan24h : FONTS.RobotoBold;
 };
 
 const styles = StyleSheet.create({
@@ -189,10 +201,9 @@ const TrainTypeBox: React.FC<Props> = ({
   const prevLetterSpacing = usePrevious(letterSpacing);
   const animatedTextBaseStyle = useMemo(
     () => ({
-      fontFamily:
-        theme === APP_THEME.LED ? FONTS.JFDotJiskan24h : FONTS.RobotoBold,
+      fontFamily: resolveTrainTypeFontFamily(theme, headerLangState),
     }),
-    [theme]
+    [headerLangState, theme]
   );
 
   const prevTrainTypeName = useLazyPrevious(trainTypeName, fadeOutFinished);
@@ -333,7 +344,10 @@ const TrainTypeBox: React.FC<Props> = ({
               [
                 styles.text,
                 animatedTextBaseStyle,
-                theme === APP_THEME.LED && { fontWeight: 'normal' as const },
+                theme === APP_THEME.LED &&
+                  headerLangState !== 'KO' && {
+                    fontWeight: 'normal' as const,
+                  },
                 {
                   letterSpacing,
                   marginLeft,
@@ -353,7 +367,8 @@ const TrainTypeBox: React.FC<Props> = ({
           style={[
             styles.text,
             animatedTextBaseStyle,
-            theme === APP_THEME.LED && { fontWeight: 'normal' as const },
+            theme === APP_THEME.LED &&
+              headerLangState !== 'KO' && { fontWeight: 'normal' as const },
             textBottomAnimatedStyles,
             {
               letterSpacing: prevLetterSpacing,

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -202,11 +202,27 @@ const TrainTypeBox: React.FC<Props> = ({
   const animatedTextBaseStyle = useMemo(
     () => ({
       fontFamily: resolveTrainTypeFontFamily(theme, headerLangState),
+      fontWeight:
+        theme === APP_THEME.LED && headerLangState !== 'KO'
+          ? ('normal' as const)
+          : ('bold' as const),
     }),
     [headerLangState, theme]
   );
 
-  const prevTrainTypeName = useLazyPrevious(trainTypeName, fadeOutFinished);
+  const trainTypeDisplayState = useMemo(
+    () => ({
+      name: trainTypeName,
+      headerLangState,
+      textStyle: animatedTextBaseStyle,
+    }),
+    [animatedTextBaseStyle, headerLangState, trainTypeName]
+  );
+  const prevTrainTypeDisplayState = useLazyPrevious(
+    trainTypeDisplayState,
+    fadeOutFinished
+  );
+  const prevTrainTypeName = prevTrainTypeDisplayState.name;
 
   const handleFinish = useCallback((finished: boolean | undefined) => {
     if (finished) {
@@ -229,19 +245,24 @@ const TrainTypeBox: React.FC<Props> = ({
     });
   }, [handleFinish, headerTransitionDelay, textOpacityAnim]);
 
-  // 電車種別が変更されたときのみfadeOutFinishedをリセット
-  // biome-ignore lint/correctness/useExhaustiveDependencies: prevTrainTypeNameの変更時にもアニメーション状態をリセットする必要がある
+  // 表示内容または表示設定が変更されたときのみfadeOutFinishedをリセット
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 前回表示状態の変更時にもアニメーション状態をリセットする必要がある
   useEffect(() => {
     setFadeOutFinished(false);
-  }, [trainTypeName, prevTrainTypeName]);
+  }, [trainTypeDisplayState, prevTrainTypeDisplayState]);
 
   useEffect(() => {
-    if (prevTrainTypeName !== trainTypeName) {
+    if (prevTrainTypeDisplayState !== trainTypeDisplayState) {
       updateOpacity();
     } else {
       resetValue();
     }
-  }, [prevTrainTypeName, resetValue, trainTypeName, updateOpacity]);
+  }, [
+    prevTrainTypeDisplayState,
+    resetValue,
+    trainTypeDisplayState,
+    updateOpacity,
+  ]);
 
   const textTopAnimatedStyles = useMemo(
     () => ({
@@ -344,10 +365,6 @@ const TrainTypeBox: React.FC<Props> = ({
               [
                 styles.text,
                 animatedTextBaseStyle,
-                theme === APP_THEME.LED &&
-                  headerLangState !== 'KO' && {
-                    fontWeight: 'normal' as const,
-                  },
                 {
                   letterSpacing,
                   marginLeft,
@@ -366,9 +383,7 @@ const TrainTypeBox: React.FC<Props> = ({
         <RNAnimated.Text
           style={[
             styles.text,
-            animatedTextBaseStyle,
-            theme === APP_THEME.LED &&
-              headerLangState !== 'KO' && { fontWeight: 'normal' as const },
+            prevTrainTypeDisplayState.textStyle,
             textBottomAnimatedStyles,
             {
               letterSpacing: prevLetterSpacing,


### PR DESCRIPTION
## 概要

韓国語の列車種別名が空欄になる問題を修正します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 通常テーマで指定していたバンドル版 Roboto にハングルのグリフが含まれないことが原因でした。
- ヘッダー言語が韓国語の場合はカスタムフォントを指定せず、OSのハングル対応システムフォントへフォールバックします。
- フェード中の旧種別名には、旧言語と同じフォントファミリー・ウェイトを維持します。
- KOからJAへの切替中と、フォント解決のLEDテーマ分岐を含む回帰テストを追加しました。
- 影響範囲は `TrainTypeBox` の言語切替表示に限定されます。新旧テキストの表示設定を同じ更新単位で保持し、切替完了後に更新します。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行したテスト:

- `npm test -- --runInBand src/components/TrainTypeBox.test.tsx`（12件成功）
- `npm test -- --runInBand`（202スイート、2176件成功）
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- Android実機 T12_ROW で `TrainTypeBox` に韓国語種別名「쾌속」が表示されることを確認

## 関連Issue

なし

## スクリーンショット（任意）

Android実機 T12_ROW で韓国語種別名「쾌속」の表示を確認済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 韓国語表示時にOSのフォールバックフォントを使用するようになり、文字がより自然に表示されます。
  * LEDテーマでも、韓国語の文字に適したフォント表示に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
