### PR TITLE
経路検索画面のウォークスルーにAIチャットバナー紹介を追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -301,6 +301,8 @@
   "routeSearchWalkthroughDescription1": "On this screen, you can search for a destination station and find a route.",
   "routeSearchWalkthroughTitle2": "Enter Station Name",
   "routeSearchWalkthroughDescription2": "Enter the name of your destination station here and tap the search button to see the available options.",
+  "routeSearchWalkthroughAgentTitle": "Ask AI Where to Go",
+  "routeSearchWalkthroughAgentDescription": "If you do not know the station name, open the AI chat from this banner. Share what you want to do or how you feel to get destination ideas.",
   "routeSearchWalkthroughTitle3": "Select a Route",
   "routeSearchWalkthroughDescription3": "Tap a destination from the search results to see the route to that station. Routes are color-coded by line, so you can choose the line you want to take.",
   "settingsWalkthroughTitle1": "Welcome to Settings",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -302,6 +302,8 @@
   "routeSearchWalkthroughDescription1": "この画面では、目的地の駅を検索して経路を見つけることができます。",
   "routeSearchWalkthroughTitle2": "駅名を入力",
   "routeSearchWalkthroughDescription2": "ここに目的地の駅名を入力して検索ボタンをタップすると、候補が表示されます。",
+  "routeSearchWalkthroughAgentTitle": "AIに行き先を相談",
+  "routeSearchWalkthroughAgentDescription": "駅名がわからないときは、このバナーからAIチャットを開けます。希望や気分を伝えて、行き先の候補を相談してみましょう。",
   "routeSearchWalkthroughTitle3": "経路を選択",
   "routeSearchWalkthroughDescription3": "検索結果から目的地をタップすると、その駅までの経路が表示されます。路線ごとに色分けされているので、乗りたい路線を選んでください。",
   "settingsWalkthroughTitle1": "設定画面へようこそ",

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -30,6 +30,7 @@ export type WalkthroughStepId =
   | 'customize'
   | 'routeSearchIntro'
   | 'routeSearchBar'
+  | 'routeSearchAgentBanner'
   | 'routeSearchResults'
   | 'settingsWelcome'
   | 'settingsTheme'

--- a/src/hooks/useRouteSearchWalkthrough.test.tsx
+++ b/src/hooks/useRouteSearchWalkthrough.test.tsx
@@ -4,6 +4,14 @@ import { useRouteSearchWalkthrough } from '~/hooks/useRouteSearchWalkthrough';
 import { storage } from '~/lib/storage';
 
 describe('useRouteSearchWalkthrough', () => {
+  beforeEach(() => {
+    storage.remove(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('AIエージェント有効時はバナー紹介を検索バーと検索結果の間に表示する', () => {
     const { result } = renderHook(() => useRouteSearchWalkthrough(true));
 

--- a/src/hooks/useRouteSearchWalkthrough.test.tsx
+++ b/src/hooks/useRouteSearchWalkthrough.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { STORAGE_KEYS } from '~/constants/storage';
+import { useRouteSearchWalkthrough } from '~/hooks/useRouteSearchWalkthrough';
+import { storage } from '~/lib/storage';
+
+describe('useRouteSearchWalkthrough', () => {
+  it('AIエージェント有効時はバナー紹介を検索バーと検索結果の間に表示する', () => {
+    const { result } = renderHook(() => useRouteSearchWalkthrough(true));
+
+    expect(result.current.totalSteps).toBe(4);
+
+    act(() => result.current.nextStep());
+    expect(result.current.currentStepId).toBe('routeSearchBar');
+
+    act(() => result.current.nextStep());
+    expect(result.current.currentStep).toMatchObject({
+      id: 'routeSearchAgentBanner',
+      titleKey: 'routeSearchWalkthroughAgentTitle',
+      descriptionKey: 'routeSearchWalkthroughAgentDescription',
+    });
+
+    act(() => result.current.nextStep());
+    expect(result.current.currentStepId).toBe('routeSearchResults');
+  });
+
+  it('AIエージェント無効時はバナー紹介を省略する', () => {
+    const { result } = renderHook(() => useRouteSearchWalkthrough(false));
+
+    expect(result.current.totalSteps).toBe(3);
+
+    act(() => result.current.goToStep(2));
+    expect(result.current.currentStepId).toBe('routeSearchResults');
+  });
+
+  it('AIエージェント有効時の最終ステップで完了状態を保存する', () => {
+    const { result } = renderHook(() => useRouteSearchWalkthrough(true));
+
+    act(() => result.current.goToStep(3));
+    act(() => result.current.nextStep());
+
+    expect(
+      storage.getString(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED)
+    ).toBe('true');
+    expect(result.current.isWalkthroughCompleted).toBe(true);
+    expect(result.current.isWalkthroughActive).toBe(false);
+  });
+});

--- a/src/hooks/useRouteSearchWalkthrough.ts
+++ b/src/hooks/useRouteSearchWalkthrough.ts
@@ -20,12 +20,23 @@ const ROUTE_SEARCH_WALKTHROUGH_STEPS: WalkthroughStep[] = [
     tooltipPosition: 'bottom',
   },
   {
+    id: 'routeSearchAgentBanner',
+    titleKey: 'routeSearchWalkthroughAgentTitle',
+    descriptionKey: 'routeSearchWalkthroughAgentDescription',
+    tooltipPosition: 'bottom',
+  },
+  {
     id: 'routeSearchResults',
     titleKey: 'routeSearchWalkthroughTitle3',
     descriptionKey: 'routeSearchWalkthroughDescription3',
     tooltipPosition: 'bottom',
   },
 ];
+
+const ROUTE_SEARCH_WALKTHROUGH_STEPS_WITHOUT_AI =
+  ROUTE_SEARCH_WALKTHROUGH_STEPS.filter(
+    (step) => step.id !== 'routeSearchAgentBanner'
+  );
 
 type UseRouteSearchWalkthroughResult = {
   isWalkthroughCompleted: boolean;
@@ -40,81 +51,89 @@ type UseRouteSearchWalkthroughResult = {
   setSpotlightArea: (area: WalkthroughStep['spotlightArea']) => void;
 };
 
-export const useRouteSearchWalkthrough =
-  (): UseRouteSearchWalkthroughResult => {
-    // MMKV は同期 API のため初回レンダー時に完了状態が確定する
-    const [isWalkthroughCompleted, setIsWalkthroughCompleted] = useState(
-      () =>
-        storage.getString(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED) ===
-        'true'
-    );
-    const [currentStepIndex, setCurrentStepIndex] = useState(0);
-    const [spotlightArea, setSpotlightAreaState] =
-      useState<WalkthroughStep['spotlightArea']>(undefined);
+export const useRouteSearchWalkthrough = (
+  includeAIAgentStep: boolean
+): UseRouteSearchWalkthroughResult => {
+  const walkthroughSteps = includeAIAgentStep
+    ? ROUTE_SEARCH_WALKTHROUGH_STEPS
+    : ROUTE_SEARCH_WALKTHROUGH_STEPS_WITHOUT_AI;
 
-    const completeWalkthrough = useCallback(async () => {
-      setIsWalkthroughCompleted(true);
-      try {
-        storage.set(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED, 'true');
-      } catch (error) {
-        // ストレージエラーは非ブロッキングとして扱う
-        console.error(
-          'Failed to save route search walkthrough completion status:',
-          error
-        );
-      }
-    }, []);
+  // MMKV は同期 API のため初回レンダー時に完了状態が確定する
+  const [isWalkthroughCompleted, setIsWalkthroughCompleted] = useState(
+    () =>
+      storage.getString(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED) ===
+      'true'
+  );
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [spotlightArea, setSpotlightAreaState] =
+    useState<WalkthroughStep['spotlightArea']>(undefined);
 
-    const nextStep = useCallback(() => {
-      if (currentStepIndex < ROUTE_SEARCH_WALKTHROUGH_STEPS.length - 1) {
-        setCurrentStepIndex((prev) => prev + 1);
-        setSpotlightAreaState(undefined);
-      } else {
-        completeWalkthrough();
-      }
-    }, [currentStepIndex, completeWalkthrough]);
+  const completeWalkthrough = useCallback(async () => {
+    setIsWalkthroughCompleted(true);
+    try {
+      storage.set(STORAGE_KEYS.ROUTE_SEARCH_WALKTHROUGH_COMPLETED, 'true');
+    } catch (error) {
+      // ストレージエラーは非ブロッキングとして扱う
+      console.error(
+        'Failed to save route search walkthrough completion status:',
+        error
+      );
+    }
+  }, []);
 
-    const goToStep = useCallback((index: number) => {
-      if (index >= 0 && index < ROUTE_SEARCH_WALKTHROUGH_STEPS.length) {
+  const nextStep = useCallback(() => {
+    if (currentStepIndex < walkthroughSteps.length - 1) {
+      setCurrentStepIndex((prev) => prev + 1);
+      setSpotlightAreaState(undefined);
+    } else {
+      completeWalkthrough();
+    }
+  }, [currentStepIndex, completeWalkthrough, walkthroughSteps.length]);
+
+  const goToStep = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < walkthroughSteps.length) {
         setCurrentStepIndex(index);
         setSpotlightAreaState(undefined);
       }
-    }, []);
+    },
+    [walkthroughSteps.length]
+  );
 
-    const skipWalkthrough = useCallback(async () => {
-      await completeWalkthrough();
-    }, [completeWalkthrough]);
+  const skipWalkthrough = useCallback(async () => {
+    await completeWalkthrough();
+  }, [completeWalkthrough]);
 
-    const setSpotlightArea = useCallback(
-      (area: WalkthroughStep['spotlightArea']) => {
-        setSpotlightAreaState(area);
-      },
-      []
-    );
+  const setSpotlightArea = useCallback(
+    (area: WalkthroughStep['spotlightArea']) => {
+      setSpotlightAreaState(area);
+    },
+    []
+  );
 
-    const isWalkthroughActive =
-      isWalkthroughCompleted === false &&
-      currentStepIndex < ROUTE_SEARCH_WALKTHROUGH_STEPS.length;
+  const isWalkthroughActive =
+    isWalkthroughCompleted === false &&
+    currentStepIndex < walkthroughSteps.length;
 
-    const currentStep = isWalkthroughActive
-      ? {
-          ...ROUTE_SEARCH_WALKTHROUGH_STEPS[currentStepIndex],
-          spotlightArea,
-        }
-      : null;
+  const currentStep = isWalkthroughActive
+    ? {
+        ...walkthroughSteps[currentStepIndex],
+        spotlightArea,
+      }
+    : null;
 
-    const currentStepId = currentStep?.id ?? null;
+  const currentStepId = currentStep?.id ?? null;
 
-    return {
-      isWalkthroughCompleted,
-      isWalkthroughActive,
-      currentStepIndex,
-      currentStepId,
-      currentStep,
-      totalSteps: ROUTE_SEARCH_WALKTHROUGH_STEPS.length,
-      nextStep,
-      goToStep,
-      skipWalkthrough,
-      setSpotlightArea,
-    };
+  return {
+    isWalkthroughCompleted,
+    isWalkthroughActive,
+    currentStepIndex,
+    currentStepId,
+    currentStep,
+    totalSteps: walkthroughSteps.length,
+    nextStep,
+    goToStep,
+    skipWalkthrough,
+    setSpotlightArea,
   };
+};

--- a/src/screens/RouteSearchScreen.tsx
+++ b/src/screens/RouteSearchScreen.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
   },
   // AI相談バナーは検索バーと検索結果見出しの間の余白(従来 marginBottom: 48)に置く。
   // バナー非表示時に従来と同じ余白を保つため、間隔は見出し側の marginTop で確保する。
-  agentEntryBanner: {
+  agentEntryBannerContainer: {
     marginTop: 16,
   },
   searchResultHeading: {
@@ -149,11 +149,18 @@ const RouteSearchScreen = () => {
     goToStep,
     skipWalkthrough,
     setSpotlightArea,
-  } = useRouteSearchWalkthrough();
+  } = useRouteSearchWalkthrough(aiAgentEnabled);
 
   const searchBarRef = useRef<View>(null);
+  const agentEntryBannerRef = useRef<View>(null);
   const searchResultsRef = useRef<View>(null);
   const [searchBarLayout, setSearchBarLayout] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
+  const [agentEntryBannerLayout, setAgentEntryBannerLayout] = useState<{
     x: number;
     y: number;
     width: number;
@@ -290,6 +297,16 @@ const RouteSearchScreen = () => {
     }
   }, []);
 
+  const measureAgentEntryBanner = useCallback(() => {
+    if (agentEntryBannerRef.current) {
+      agentEntryBannerRef.current.measureInWindow(
+        (x: number, y: number, width: number, height: number) => {
+          setAgentEntryBannerLayout({ x, y, width, height });
+        }
+      );
+    }
+  }, []);
+
   // ステップが変わった時にレイアウトを再計測
   useEffect(() => {
     if (currentStepId === 'routeSearchBar') {
@@ -300,6 +317,15 @@ const RouteSearchScreen = () => {
       return () => clearTimeout(timer);
     }
   }, [currentStepId, measureSearchBar]);
+
+  useEffect(() => {
+    if (currentStepId === 'routeSearchAgentBanner') {
+      const timer = setTimeout(() => {
+        measureAgentEntryBanner();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [currentStepId, measureAgentEntryBanner]);
 
   useEffect(() => {
     if (currentStepId === 'routeSearchResults') {
@@ -322,6 +348,18 @@ const RouteSearchScreen = () => {
       });
     }
   }, [currentStepId, searchBarLayout, setSpotlightArea]);
+
+  useEffect(() => {
+    if (currentStepId === 'routeSearchAgentBanner' && agentEntryBannerLayout) {
+      setSpotlightArea({
+        x: agentEntryBannerLayout.x,
+        y: agentEntryBannerLayout.y,
+        width: agentEntryBannerLayout.width,
+        height: agentEntryBannerLayout.height,
+        borderRadius: 8,
+      });
+    }
+  }, [currentStepId, agentEntryBannerLayout, setSpotlightArea]);
 
   useEffect(() => {
     if (currentStepId === 'routeSearchResults' && searchResultsLayout) {
@@ -355,7 +393,15 @@ const RouteSearchScreen = () => {
               <View ref={searchBarRef} onLayout={measureSearchBar}>
                 <SearchBar onSearch={handleSearch} />
               </View>
-              <AgentEntryBanner style={styles.agentEntryBanner} />
+              {aiAgentEnabled && (
+                <View
+                  ref={agentEntryBannerRef}
+                  onLayout={measureAgentEntryBanner}
+                  style={styles.agentEntryBannerContainer}
+                >
+                  <AgentEntryBanner />
+                </View>
+              )}
               <Heading
                 style={[
                   styles.searchResultHeading,


### PR DESCRIPTION
## 概要

経路検索画面のウォークスルーに、AIチャットバナーの紹介を追加します。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- AIエージェント機能が有効な場合のみ、検索バーと検索結果の間にAIチャットバナー紹介ステップを追加
- バナーの実測領域をスポットライトし、日本語・英語の案内文を追加
- AIエージェント機能が無効な場合は、従来の3ステップ構成を維持
- 有効・無効双方のステップ構成と完了状態の保存をテストで検証
- 回帰リスク: Remote Configの切り替えによりステップ数が変化する点。バナー表示と同じフラグを使用し、無効時の既存フローをテストすることで軽減

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（203スイート、2,179テスト）
- [x] `npm run typecheck` が通ること

## 関連Issue

なし

## スクリーンショット（任意）

未添付です。Android Medium_Phone AVDが2回とも起動直後に`SIGABRT`となり、破壊的なAVDワイプを避けたため端末キャプチャを取得できませんでした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ルート検索のウォークスルーに、AIへ目的地を相談できるバナー案内を追加しました。
  * AI機能の有効・無効に応じて、ウォークスルーのステップ数を自動調整します。
  * AI相談バナーをウォークスルーのスポットライト表示に対応しました。
* **改善**
  * 英語・日本語の案内タイトルと説明文を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->