### PR TITLE
テーマプレビューの白枠から影を削除

### DIFF
--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -48,9 +48,6 @@ const styles = StyleSheet.create({
     lineHeight: RFValue(16),
     marginBottom: 16,
   },
-  previewContainer: {
-    boxShadow: '0px 0px 8px rgba(51, 51, 51, 0.25)',
-  },
   previewImageWrap: {
     width: '100%',
     aspectRatio: 16 / 9,
@@ -144,12 +141,7 @@ export const ThemeConfirmModal: React.FC<Props> = ({
             ? translate('themeDescriptionAuto')
             : (themeInfo?.description ?? '')}
         </Typography>
-        <View
-          style={[
-            styles.previewContainer,
-            { borderRadius: isLEDTheme ? 0 : 16 },
-          ]}
-        >
+        <View style={{ borderRadius: isLEDTheme ? 0 : 16 }}>
           <View
             style={[
               styles.previewImageWrap,


### PR DESCRIPTION
## 概要

テーマ設定の確認モーダルで、プレビュー画像の白枠に表示されていた不要な影を削除します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ThemeConfirmModal`のプレビュー外枠から`boxShadow`を削除しました。
- 白い境界線、角丸、余白などの既存レイアウトは維持します。
- 影専用だったスタイル定義を削除しました。
- 回帰リスクはプレビュー外枠の描画に限定されます。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

最新`dev`（`0e0246dd3`）から作成した作業ツリーで確認しました。

- `npm run lint`: 606ファイルすべて通過
- `npm test -- --runInBand --silent`: 203スイート、2,179テストすべて通過
- `npm run typecheck`: 通過
- `git diff --check`: 通過

## 関連Issue

なし

## スクリーンショット（任意）

依頼時に添付されたiPhoneの変更前スクリーンショットで対象箇所を確認しました。変更後スクリーンショットは未取得です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - テーマ確認モーダルのプレビュー領域の外側コンテナに適用されていたスタイルを整理しました。
  - プレビュー画像のレイアウトと角丸表示は、これまでどおり維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->