### PR TITLE
commitとpush前の検証ルールをAGENTS.mdに追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,17 @@ This handbook defines how automation agents collaborate safely and effectively o
 5. **Validate:** run only the necessary commands (`npm run lint`, `npm test`, `npm run typecheck`, etc.) and capture summarized output.
 6. **Document & Handoff:** update READMEs or docs when behavior changes, summarize modifications, list executed commands, and attach artifacts (logs, screenshots) before opening PRs.
 
+### Commit and push gate
+
+- **Do not commit or push unvalidated code on your own initiative.** Before
+  every commit or push that contains code changes, run both `npm run lint` and
+  the relevant unit tests, and confirm that both commands succeed. Run
+  `npm test` when the relevant test scope cannot be narrowed with confidence.
+- If either lint or unit tests fail, do not commit or push. Fix the failure and
+  rerun the checks, or stop and report the blocker to the repository owner.
+- Do not treat CI after a push as a substitute for local validation before the
+  commit or push.
+
 ## Repository Map
 
 - `src/`: Expo React Native app code.


### PR DESCRIPTION
## 概要

コード変更を検証せずにcommitまたはpushすることを禁止するルールを`AGENTS.md`へ明記します。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- コード変更を含むcommitまたはpushの前に、`npm run lint`と関連ユニットテストの成功確認を必須化します。
- 関連テストを確実に絞れない場合は`npm test`の実行を必須化します。
- lintまたはテストが失敗した場合はcommit・pushせず、修正して再実行するか、ブロッカーとして報告するよう明記します。
- push後のCIを事前のローカル検証の代替にしてはならないことを明記します。

## テスト

ドキュメントのみの変更のため、アプリのlint・ユニットテスト・型チェックは対象外です。

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

実行した確認:

- `git diff --check`: 通過
- `markdownlint-cli2@0.19.0`（既存文書のMD013・MD036を除外）: 0エラー
- 除外なしの比較では変更前後とも57エラーで、今回の追記による新規違反がないことを確認

## 関連Issue

なし

## スクリーンショット（任意）

ドキュメントのみの変更のため、スクリーンショットはありません。