### PR TITLE
テーマ確認モーダルのレイアウトを改善

### DIFF
--- a/src/components/CustomModal.tablet.test.tsx
+++ b/src/components/CustomModal.tablet.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react-native';
+import type React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { CustomModal } from './CustomModal';
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('@gorhom/portal', () => ({
+  Portal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: true,
+}));
+
+describe('CustomModal - tablet', () => {
+  it('最大高さを90%に広げる', () => {
+    const { UNSAFE_root } = render(
+      <CustomModal visible={true}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    const modalContent = UNSAFE_root.findAll((node: typeof UNSAFE_root) => {
+      const style = StyleSheet.flatten(node.props.style);
+      return style?.maxWidth === 480;
+    })[0];
+
+    expect(modalContent).toBeDefined();
+    expect(StyleSheet.flatten(modalContent.props.style)?.maxHeight).toBe('90%');
+  });
+});

--- a/src/components/CustomModal.test.tsx
+++ b/src/components/CustomModal.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from '@testing-library/react-native';
 import type React from 'react';
-import { Animated, Text } from 'react-native';
+import { Animated, StyleSheet, Text } from 'react-native';
 import { CustomModal } from './CustomModal';
 
 // jotaiのモック
@@ -49,6 +49,22 @@ describe('CustomModal', () => {
 
     // CustomModal はレンダリングされる
     expect(getByTestId('modal')).toBeTruthy();
+  });
+
+  it('スマートフォンでは最大高さを75%に保つ', () => {
+    const { UNSAFE_root } = render(
+      <CustomModal visible={true}>
+        <Text>Test Content</Text>
+      </CustomModal>
+    );
+
+    const modalContent = UNSAFE_root.findAll((node: typeof UNSAFE_root) => {
+      const style = StyleSheet.flatten(node.props.style);
+      return style?.maxWidth === 400;
+    })[0];
+
+    expect(modalContent).toBeDefined();
+    expect(StyleSheet.flatten(modalContent.props.style)?.maxHeight).toBe('75%');
   });
 });
 

--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -209,7 +209,7 @@ const styles = StyleSheet.create({
   content: {
     width: '100%',
     maxWidth: isTablet ? 480 : 400,
-    maxHeight: '75%',
+    maxHeight: isTablet ? '90%' : '75%',
     overflow: 'hidden',
     backgroundColor: '#fff',
     boxShadow: '0px 6px 24px rgba(0, 0, 0, 0.18)',

--- a/src/components/ThemeConfirmModal.test.tsx
+++ b/src/components/ThemeConfirmModal.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react-native';
+import { Image } from 'expo-image';
+import type React from 'react';
+import { THEME_PREFERENCE } from '~/models/Theme';
+import { ThemeConfirmModal } from './ThemeConfirmModal';
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('@gorhom/portal', () => ({
+  Portal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+describe('ThemeConfirmModal', () => {
+  it('タイトルの位置を保ち、プレビュー画像を説明文より先に表示する', () => {
+    const { UNSAFE_getByType, UNSAFE_root, getByText } = render(
+      <ThemeConfirmModal
+        visible
+        themeId={THEME_PREFERENCE.TOKYO_METRO}
+        themeTitle="東京メトロ風"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    const renderedNodes = UNSAFE_root.findAll(() => true);
+    const themeTitle = getByText('東京メトロ風');
+    const previewImage = UNSAFE_getByType(Image);
+    const description = getByText('themeDescriptionTokyoMetro');
+
+    expect(renderedNodes.indexOf(themeTitle)).toBeLessThan(
+      renderedNodes.indexOf(previewImage)
+    );
+    expect(renderedNodes.indexOf(previewImage)).toBeLessThan(
+      renderedNodes.indexOf(description)
+    );
+  });
+});

--- a/src/components/ThemeConfirmModal.test.tsx
+++ b/src/components/ThemeConfirmModal.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react-native';
 import { Image } from 'expo-image';
 import type React from 'react';
+import { StyleSheet } from 'react-native';
 import { THEME_PREFERENCE } from '~/models/Theme';
 import { ThemeConfirmModal } from './ThemeConfirmModal';
 
@@ -44,5 +45,6 @@ describe('ThemeConfirmModal', () => {
     expect(renderedNodes.indexOf(previewImage)).toBeLessThan(
       renderedNodes.indexOf(description)
     );
+    expect(StyleSheet.flatten(description.props.style)?.marginBottom).toBe(24);
   });
 });

--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
   description: {
     fontSize: RFValue(12),
     lineHeight: RFValue(16),
-    marginBottom: 16,
+    marginBottom: 24,
   },
   previewImageWrap: {
     width: '100%',

--- a/src/components/ThemeConfirmModal.tsx
+++ b/src/components/ThemeConfirmModal.tsx
@@ -136,11 +136,6 @@ export const ThemeConfirmModal: React.FC<Props> = ({
           </View>
           <Typography style={styles.title}>{themeTitle}</Typography>
         </View>
-        <Typography style={styles.description}>
-          {isAuto
-            ? translate('themeDescriptionAuto')
-            : (themeInfo?.description ?? '')}
-        </Typography>
         <View style={{ borderRadius: isLEDTheme ? 0 : 16 }}>
           <View
             style={[
@@ -164,6 +159,11 @@ export const ThemeConfirmModal: React.FC<Props> = ({
             )}
           </View>
         </View>
+        <Typography style={styles.description}>
+          {isAuto
+            ? translate('themeDescriptionAuto')
+            : (themeInfo?.description ?? '')}
+        </Typography>
         <View style={styles.buttonsRow}>
           <Button
             style={styles.button}


### PR DESCRIPTION
## 概要

テーマ確認モーダルのコンテンツ順とタブレット表示領域、要素間隔を調整し、アクションボタンが見切れず読みやすいレイアウトにします。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- テーマタイトルの位置を維持したまま、プレビュー画像を説明文より前に表示
- 説明文とアクションボタンの間隔を 24 に拡張
- タブレットで `CustomModal` の最大高さを 75% から 90% に拡張
- スマートフォンの最大高さは 75% のまま維持
- 端末別の高さ、テーマ確認モーダルの表示順、説明文の余白を検証する回帰テストを追加
- 共通モーダルのタブレット表示に影響するため、スマートフォン用テストと Android タブレット実機確認で回帰リスクを軽減

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint`: 成功
- `npm test -- --runInBand`: 205 suites / 2182 tests 成功
- `npm run typecheck`: 成功
- push 前の関連テスト: 3 suites / 9 tests 成功

## 関連Issue

なし

## スクリーンショット（任意）

- Android タブレット T12_ROW（ランドスケープ）で説明文とボタンの間隔、および「キャンセル」「適用」ボタンが完全に表示されることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - タブレットで表示するモーダルの最大高さを90%に拡大し、より多くの内容を確認しやすくしました。
  - スマートフォンでは従来どおり最大高さ75%で表示されます。
  - テーマ確認モーダルのレイアウトを調整し、テーマ説明文をプレビュー画像の直後に配置しました。
  - テーマ説明文の下部余白を拡大し、各要素の間隔をより見やすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->