### PR TITLE
今後表示しない操作をチェックボックス化してダイアログの見切れを防止

### DIFF
--- a/src/components/CommonDialogModal.test.tsx
+++ b/src/components/CommonDialogModal.test.tsx
@@ -42,4 +42,29 @@ describe('CommonDialogModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
+
+  it('今後表示しない設定をアクションではなくチェックボックスで表示する', () => {
+    const onCheckboxChange = jest.fn();
+    const { getByRole, getByText } = render(
+      <CommonDialogModal
+        visible
+        emoji="ℹ️"
+        title="動作保証外"
+        description="地下鉄線内は電波が入りづらいため、動作保証外となります。"
+        checkboxText="次回以降表示しない"
+        checkboxChecked={false}
+        onCheckboxChange={onCheckboxChange}
+        confirmButtonText="OK"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(getByRole('checkbox').props.accessibilityState).toEqual({
+      checked: false,
+    });
+
+    fireEvent.press(getByText('次回以降表示しない'));
+    expect(onCheckboxChange).toHaveBeenCalledWith(true);
+  });
 });

--- a/src/components/CommonDialogPresenter.test.tsx
+++ b/src/components/CommonDialogPresenter.test.tsx
@@ -55,4 +55,37 @@ describe('CommonDialogPresenter', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(queryByText('確認')).toBeNull();
   });
+
+  it('チェックした今後表示しない設定をOK押下後に反映する', () => {
+    const onSuppress = jest.fn();
+    const onConfirm = jest.fn();
+    const { getByRole, getByText } = render(<CommonDialogPresenter />);
+
+    act(() => {
+      showDialog('動作保証外', '確認してください', [
+        {
+          text: '次回以降表示しない',
+          style: 'checkbox',
+          onPress: onSuppress,
+        },
+        { text: 'OK', onPress: onConfirm },
+      ]);
+    });
+
+    fireEvent.press(getByText('次回以降表示しない'));
+    expect(getByRole('checkbox').props.accessibilityState).toEqual({
+      checked: true,
+    });
+
+    fireEvent.press(getByText('OK'));
+    expect(onSuppress).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(onSuppress).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/CommonDialogPresenter.tsx
+++ b/src/components/CommonDialogPresenter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useSyncExternalStore } from 'react';
+import React, { useEffect, useState, useSyncExternalStore } from 'react';
 import { BackHandler } from 'react-native';
 import {
   completePresentedDialogDismissal,
@@ -16,6 +16,7 @@ export const CommonDialogPresenter: React.FC = () => {
     getDialogPresentationSnapshot,
     getDialogPresentationSnapshot
   );
+  const [checkedRequestId, setCheckedRequestId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!request) {
@@ -39,16 +40,20 @@ export const CommonDialogPresenter: React.FC = () => {
     return null;
   }
 
-  // 従来のダイアログ呼び出しと同じボタン配列を、共通UIの最大2ボタンへ割り当てる。
-  // cancel 指定のボタンを左側、それ以外を右側の確定ボタンとして扱う。
+  // cancel は左側のボタン、checkbox は本文下、それ以外を右側の確定ボタンとして扱う。
   const cancelButtonIndex = request.buttons.findIndex(
     (button) => button.style === 'cancel'
   );
+  const checkboxButtonIndex = request.buttons.findIndex(
+    (button) => button.style === 'checkbox'
+  );
   const confirmButtonIndex = request.buttons.findIndex(
-    (button) => button.style !== 'cancel'
+    (button) => button.style !== 'cancel' && button.style !== 'checkbox'
   );
   const confirmButton = request.buttons[confirmButtonIndex];
   const cancelButton = request.buttons[cancelButtonIndex];
+  const checkboxButton = request.buttons[checkboxButtonIndex];
+  const checkboxChecked = checkedRequestId === request.id;
 
   return (
     <CommonDialogModal
@@ -59,13 +64,24 @@ export const CommonDialogPresenter: React.FC = () => {
       }
       title={request.title}
       description={request.message ?? ''}
+      checkboxText={checkboxButton?.text}
+      checkboxChecked={checkboxChecked}
+      onCheckboxChange={(checked) =>
+        setCheckedRequestId(checked ? request.id : null)
+      }
       cancelButtonText={cancelButton?.text}
       confirmButtonText={confirmButton?.text ?? 'OK'}
       confirmButtonDestructive={confirmButton?.style === 'destructive'}
       dismissOnBackdropPress={request.options.cancelable ?? true}
       onClose={() => dismissPresentedDialog(undefined, true)}
       onCancel={() => dismissPresentedDialog(cancelButtonIndex)}
-      onConfirm={() => dismissPresentedDialog(confirmButtonIndex)}
+      onConfirm={() =>
+        dismissPresentedDialog(
+          confirmButtonIndex,
+          false,
+          checkboxChecked ? checkboxButtonIndex : undefined
+        )
+      }
       // ボタン処理は閉じるアニメーションとの競合を避けるため、完了後に実行する。
       onCloseAnimationEnd={completePresentedDialogDismissal}
       testID="common-dialog-presenter"

--- a/src/components/DialogModalLayout.tsx
+++ b/src/components/DialogModalLayout.tsx
@@ -1,8 +1,10 @@
 import type React from 'react';
 import {
+  Pressable,
   ScrollView,
   type StyleProp,
   StyleSheet,
+  Text,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -42,6 +44,33 @@ const styles = StyleSheet.create({
     lineHeight: RFValue(16),
     marginBottom: 24,
   },
+  descriptionWithCheckbox: {
+    marginBottom: 16,
+  },
+  checkboxRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginBottom: 24,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderWidth: 2,
+    borderRadius: 4,
+    marginRight: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  checkboxMark: {
+    color: '#fff',
+    fontSize: 16,
+    lineHeight: 18,
+    fontWeight: 'bold',
+  },
+  checkboxText: {
+    fontSize: RFValue(12),
+  },
   buttonsRow: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
@@ -69,6 +98,9 @@ export type DialogModalLayoutProps = {
   leadingStyle?: StyleProp<ViewStyle>;
   title: React.ReactNode;
   description: React.ReactNode;
+  checkboxText?: React.ReactNode;
+  checkboxChecked?: boolean;
+  onCheckboxChange?: (checked: boolean) => void;
   cancelButtonText?: React.ReactNode;
   confirmButtonText: React.ReactNode;
   children?: React.ReactNode;
@@ -88,6 +120,9 @@ export const DialogModalLayout: React.FC<DialogModalLayoutProps> = ({
   leadingStyle,
   title,
   description,
+  checkboxText,
+  checkboxChecked = false,
+  onCheckboxChange,
   cancelButtonText,
   confirmButtonText,
   children,
@@ -118,7 +153,41 @@ export const DialogModalLayout: React.FC<DialogModalLayoutProps> = ({
         <Typography style={styles.title}>{title}</Typography>
       </View>
       {children}
-      <Typography style={styles.description}>{description}</Typography>
+      <Typography
+        style={[
+          styles.description,
+          checkboxText ? styles.descriptionWithCheckbox : undefined,
+        ]}
+      >
+        {description}
+      </Typography>
+      {checkboxText ? (
+        <Pressable
+          style={styles.checkboxRow}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: checkboxChecked }}
+          onPress={() => onCheckboxChange?.(!checkboxChecked)}
+        >
+          <View
+            style={[
+              styles.checkbox,
+              {
+                borderColor: isLEDTheme ? '#fff' : '#008ffe',
+                backgroundColor: checkboxChecked
+                  ? '#008ffe'
+                  : isLEDTheme
+                    ? LED_THEME_BG_COLOR
+                    : '#fff',
+              },
+            ]}
+          >
+            {checkboxChecked ? (
+              <Text style={styles.checkboxMark}>✓</Text>
+            ) : null}
+          </View>
+          <Typography style={styles.checkboxText}>{checkboxText}</Typography>
+        </Pressable>
+      ) : null}
       <View style={styles.buttonsRow}>
         {cancelButtonText ? (
           <Button

--- a/src/components/DialogModalLayout.tsx
+++ b/src/components/DialogModalLayout.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     overflow: 'hidden',
-    marginRight: 12,
+    marginRight: 4,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -387,7 +387,7 @@ const MainScreen: React.FC = () => {
           [
             {
               text: translate('doNotShowAgain'),
-              style: 'cancel',
+              style: 'checkbox',
               onPress: (): void => {
                 storage.set(STORAGE_KEYS.SUBWAY_ALERT_DISMISSED, 'true');
               },
@@ -420,7 +420,7 @@ const MainScreen: React.FC = () => {
         [
           {
             text: translate('doNotShowAgain'),
-            style: 'cancel',
+            style: 'checkbox',
             onPress: (): void => {
               storage.set(STORAGE_KEYS.HOLIDAY_ALERT_DISMISSED, 'true');
             },
@@ -449,7 +449,7 @@ const MainScreen: React.FC = () => {
         [
           {
             text: translate('doNotShowAgain'),
-            style: 'cancel',
+            style: 'checkbox',
             onPress: (): void => {
               storage.set(STORAGE_KEYS.WEEKDAY_ALERT_DISMISSED, 'true');
             },
@@ -476,7 +476,7 @@ const MainScreen: React.FC = () => {
         [
           {
             text: translate('doNotShowAgain'),
-            style: 'cancel',
+            style: 'checkbox',
             onPress: (): void => {
               storage.set(STORAGE_KEYS.PARTIALLY_PASS_ALERT_DISMISSED, 'true');
             },
@@ -560,7 +560,7 @@ const MainScreen: React.FC = () => {
           [
             {
               text: translate('doNotShowAgain'),
-              style: 'cancel',
+              style: 'checkbox',
               onPress: (): void => {
                 storage.set(
                   STORAGE_KEYS.ALWAYS_PERMISSION_NOT_GRANTED_WARNING_DISMISSED,
@@ -604,7 +604,7 @@ const MainScreen: React.FC = () => {
             [
               {
                 text: translate('doNotShowAgain'),
-                style: 'cancel',
+                style: 'checkbox',
                 onPress: (): void => {
                   storage.set(STORAGE_KEYS.DOZE_CONFIRMED, 'true');
                 },

--- a/src/screens/TTSSettings.tsx
+++ b/src/screens/TTSSettings.tsx
@@ -250,7 +250,7 @@ const TTSSettingsScreen: React.FC = () => {
           showDialog(translate('notice'), translate('ttsAlertText'), [
             {
               text: translate('doNotShowAgain'),
-              style: 'cancel',
+              style: 'checkbox',
               onPress: (): void => {
                 try {
                   storage.set(STORAGE_KEYS.TTS_NOTICE, 'true');
@@ -297,7 +297,7 @@ const TTSSettingsScreen: React.FC = () => {
           showDialog(translate('notice'), translate('bgTtsAlertText'), [
             {
               text: translate('doNotShowAgain'),
-              style: 'cancel',
+              style: 'checkbox',
               onPress: (): void => {
                 try {
                   storage.set(STORAGE_KEYS.BG_TTS_NOTICE, 'true');

--- a/src/utils/dialogPresentation.test.ts
+++ b/src/utils/dialogPresentation.test.ts
@@ -59,9 +59,26 @@ describe('dialogPresentation', () => {
     expect(() =>
       showDialog('invalid', undefined, [{ text: 'first' }, { text: 'second' }])
     ).toThrow(
-      'Dialog buttons must contain exactly one confirm button and at most one cancel button.'
+      'Dialog buttons must contain exactly one confirm button and at most one cancel button and checkbox.'
     );
     expect(getDialogPresentationSnapshot().request).toBeNull();
+  });
+
+  it('チェック済み操作と確定操作を閉じるアニメーション完了後に実行する', () => {
+    const onChecked = jest.fn();
+    const onConfirm = jest.fn();
+    showDialog('title', undefined, [
+      { text: '今後表示しない', style: 'checkbox', onPress: onChecked },
+      { text: 'OK', onPress: onConfirm },
+    ]);
+
+    dismissPresentedDialog(1, false, 0);
+    expect(onChecked).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    completePresentedDialogDismissal();
+    expect(onChecked).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
   it('コールバックから追加されたダイアログを既存キューの後に表示する', () => {

--- a/src/utils/dialogPresentation.ts
+++ b/src/utils/dialogPresentation.ts
@@ -1,10 +1,10 @@
 /**
- * ダイアログのボタン定義。
- * ボタン配列には確定操作を1個、必要な場合だけキャンセル操作を1個指定する。
+ * ダイアログの操作定義。
+ * 確定操作を1個、必要に応じてキャンセル操作とチェックボックスを1個ずつ指定する。
  */
 export type DialogButton = {
   text: string;
-  style?: 'default' | 'cancel' | 'destructive';
+  style?: 'default' | 'cancel' | 'destructive' | 'checkbox';
   onPress?: () => void | Promise<void>;
 };
 
@@ -47,6 +47,7 @@ let snapshot: DialogPresentationSnapshot = {
 // ボタンの処理はモーダルが画面から消えてから実行する。
 // 先に画面遷移などが走り、閉じるアニメーションと競合することを防ぐための一時保存。
 let pendingButtonIndex: number | undefined;
+let pendingCheckedButtonIndex: number | undefined;
 let dismissedByBackdrop = false;
 
 const emit = () => {
@@ -67,11 +68,20 @@ const normalizeButtons = (buttons?: DialogButton[]): DialogButton[] => {
   const cancelButtonCount = normalizedButtons.filter(
     (button) => button.style === 'cancel'
   ).length;
-  const confirmButtonCount = normalizedButtons.length - cancelButtonCount;
+  const checkboxButtonCount = normalizedButtons.filter(
+    (button) => button.style === 'checkbox'
+  ).length;
+  const confirmButtonCount = normalizedButtons.filter(
+    (button) => button.style !== 'cancel' && button.style !== 'checkbox'
+  ).length;
 
-  if (cancelButtonCount > 1 || confirmButtonCount !== 1) {
+  if (
+    cancelButtonCount > 1 ||
+    checkboxButtonCount > 1 ||
+    confirmButtonCount !== 1
+  ) {
     throw new Error(
-      'Dialog buttons must contain exactly one confirm button and at most one cancel button.'
+      'Dialog buttons must contain exactly one confirm button and at most one cancel button and checkbox.'
     );
   }
 
@@ -85,7 +95,7 @@ const enqueueDialog = (
   buttons?: DialogButton[],
   options?: DialogOptions
 ): boolean => {
-  // 2ボタン固定のUIで操作が黙って欠落しないよう、要求を受け取った時点で検証する。
+  // 共通UIで扱える操作だけになるよう、要求を受け取った時点で検証する。
   const normalizedButtons = normalizeButtons(buttons);
 
   // StrictMode で effect が再実行されても、同じ論理ダイアログは一つだけ表示する。
@@ -149,13 +159,15 @@ export const getDialogPresentationSnapshot = () => snapshot;
  */
 export const dismissPresentedDialog = (
   buttonIndex?: number,
-  byBackdrop = false
+  byBackdrop = false,
+  checkedButtonIndex?: number
 ) => {
   if (!snapshot.request || !snapshot.visible) {
     return;
   }
 
   pendingButtonIndex = buttonIndex;
+  pendingCheckedButtonIndex = checkedButtonIndex;
   dismissedByBackdrop = byBackdrop;
   snapshot = { ...snapshot, visible: false };
   emit();
@@ -171,8 +183,10 @@ export const completePresentedDialogDismissal = () => {
   }
 
   const buttonIndex = pendingButtonIndex;
+  const checkedButtonIndex = pendingCheckedButtonIndex;
   const shouldCallOnDismiss = dismissedByBackdrop;
   pendingButtonIndex = undefined;
+  pendingCheckedButtonIndex = undefined;
   dismissedByBackdrop = false;
 
   // 待機済みの要求を先に有効化し、コールバック内で追加された要求をその後ろへ並べる。
@@ -186,6 +200,9 @@ export const completePresentedDialogDismissal = () => {
   }
 
   // 表示状態の更新を先に通知してから、画面遷移などを含む処理を実行する。
+  if (checkedButtonIndex !== undefined) {
+    void completedRequest.buttons[checkedButtonIndex]?.onPress?.();
+  }
   if (buttonIndex !== undefined) {
     void completedRequest.buttons[buttonIndex]?.onPress?.();
   } else if (shouldCallOnDismiss) {
@@ -198,6 +215,7 @@ export const resetDialogPresentationForTests = () => {
   queuedRequests.splice(0);
   nextRequestId = 1;
   pendingButtonIndex = undefined;
+  pendingCheckedButtonIndex = undefined;
   dismissedByBackdrop = false;
   snapshot = { request: null, visible: false };
   emit();


### PR DESCRIPTION
## 概要

共通ダイアログの「今後表示しない」をアクションボタンではなくチェックボックスとして表示し、狭い画面でボタンがモーダル外へ見切れる問題を修正します。あわせて左上アイコンとタイトルの間隔を詰めます。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 共通ダイアログにチェックボックス操作を追加
- 「次回以降表示しない」を使用していた8箇所をチェックボックス表示へ移行
- チェックした状態で確定した場合だけ、閉じるアニメーション完了後に永続化処理を実行
- 共通ダイアログの左上アイコンとタイトルの間隔を12から4へ縮小
- 既存のキャンセルボタン・破壊的アクションの挙動は維持
- 原因は、長い「次回以降表示しない」とOKを横並びのアクションボタンとして配置し、狭い画面で必要幅がモーダル内幅を超えていたこと
- 回帰リスクはダイアログ操作の振り分けと共通ヘッダーの余白。チェックボックス・通常確定・キャンセルの各経路をユニットテストで確認

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

全Jest: 207 suites / 2190 tests passed。
最新の余白調整後に関連3 suites / 5 tests、lint、typecheckを再実行済み。

## 関連Issue

なし

## スクリーンショット（任意）

修正前の見切れはユーザー提供スクリーンショットで確認。修正後の実機スクリーンショットは未添付。