### PR TITLE
路線切替モーダルに切替先の路線記号を表示

### DIFF
--- a/src/components/CommonDialogModal.test.tsx
+++ b/src/components/CommonDialogModal.test.tsx
@@ -11,6 +11,14 @@ jest.mock('@gorhom/portal', () => ({
   Portal: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children, ...props }: { children?: React.ReactNode }) => {
+    const React = require('react');
+    const { View } = require('react-native');
+    return React.createElement(View, props, children);
+  },
+}));
+
 describe('CommonDialogModal', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -66,5 +74,43 @@ describe('CommonDialogModal', () => {
 
     fireEvent.press(getByText('次回以降表示しない'));
     expect(onCheckboxChange).toHaveBeenCalledWith(true);
+  });
+
+  it('路線記号画像がある場合は絵文字の代わりに表示する', () => {
+    const { getByTestId, queryByText } = render(
+      <CommonDialogModal
+        visible
+        emoji="ℹ️"
+        lineSymbol={{ image: 101, color: '#c1a470' }}
+        title="路線を切り替えますか？"
+        description="確認してください"
+        confirmButtonText="OK"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(getByTestId('common-dialog-line-symbol-image')).toBeTruthy();
+    expect(queryByText('ℹ️')).toBeNull();
+  });
+
+  it('路線記号画像がない場合はラインカラーのグラデーションを表示する', () => {
+    const { getByTestId, queryByText } = render(
+      <CommonDialogModal
+        visible
+        emoji="ℹ️"
+        lineSymbol={{ color: '#c1a470' }}
+        title="路線を切り替えますか？"
+        description="確認してください"
+        confirmButtonText="OK"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(
+      getByTestId('common-dialog-line-symbol-fallback').props.colors
+    ).toEqual(['#c1a470', '#d0bb94']);
+    expect(queryByText('ℹ️')).toBeNull();
   });
 });

--- a/src/components/CommonDialogModal.tsx
+++ b/src/components/CommonDialogModal.tsx
@@ -1,7 +1,11 @@
+import { Image } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useAtomValue } from 'jotai';
+import { lighten } from 'polished';
 import type React from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
+import type { DialogOptions } from '~/utils/dialogPresentation';
 import { RFValue } from '~/utils/rfValue';
 import {
   DialogModalLayout,
@@ -17,6 +21,14 @@ const styles = StyleSheet.create({
     textAlignVertical: 'center',
     includeFontPadding: false,
   },
+  lineSymbol: {
+    width: '100%',
+    height: '100%',
+  },
+  lineSymbolFallback: {
+    flex: 1,
+    width: '100%',
+  },
 });
 
 export type CommonDialogModalProps = Omit<
@@ -24,22 +36,47 @@ export type CommonDialogModalProps = Omit<
   'isLEDTheme' | 'leading' | 'leadingStyle'
 > & {
   emoji: string;
+  lineSymbol?: DialogOptions['lineSymbol'];
 };
 
 // 汎用ダイアログ用の公開コンポーネント。
-// 共通レイアウトの左上要素だけを絵文字にし、現在のテーマを自動的に反映する。
+// 共通レイアウトの左上要素と現在のテーマだけを用途別に差し替える。
 export const CommonDialogModal: React.FC<CommonDialogModalProps> = ({
   emoji,
+  lineSymbol,
   ...props
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const lineSymbolBorderRadius = isLEDTheme ? 0 : 8;
+  const hasLineSymbolLeading =
+    lineSymbol?.image !== undefined || lineSymbol?.color !== undefined;
 
-  // アプリ用フォントではなくOSの絵文字フォントを使い、字形の欠けを防ぐ。
+  const leading =
+    lineSymbol?.image !== undefined ? (
+      <Image
+        source={lineSymbol.image}
+        style={styles.lineSymbol}
+        contentFit="contain"
+        testID="common-dialog-line-symbol-image"
+      />
+    ) : lineSymbol?.color ? (
+      <LinearGradient
+        colors={[lineSymbol.color, lighten(0.1, lineSymbol.color)]}
+        style={styles.lineSymbolFallback}
+        testID="common-dialog-line-symbol-fallback"
+      />
+    ) : (
+      <Text style={styles.emoji}>{emoji}</Text>
+    );
+
   return (
     <DialogModalLayout
       {...props}
       isLEDTheme={isLEDTheme}
-      leading={<Text style={styles.emoji}>{emoji}</Text>}
+      leading={leading}
+      leadingStyle={
+        hasLineSymbolLeading ? { borderRadius: lineSymbolBorderRadius } : null
+      }
     />
   );
 };

--- a/src/components/CommonDialogPresenter.tsx
+++ b/src/components/CommonDialogPresenter.tsx
@@ -62,6 +62,7 @@ export const CommonDialogPresenter: React.FC = () => {
         request.options.emoji ??
         (confirmButton?.style === 'destructive' ? '⚠️' : 'ℹ️')
       }
+      lineSymbol={request.options.lineSymbol}
       title={request.title}
       description={request.message ?? ''}
       checkboxText={checkboxButton?.text}

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -63,6 +63,7 @@ import {
   GET_STATION_TRAIN_TYPES_LIGHT,
 } from '~/lib/graphql/queries';
 import { storage } from '~/lib/storage';
+import { getLineSymbolImage } from '~/lineSymbolImage';
 import { APP_THEME } from '~/models/Theme';
 import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import lineState from '~/store/atoms/line';
@@ -685,21 +686,19 @@ const MainScreen: React.FC = () => {
         return;
       }
 
+      const targetLine = selectedStation.line;
+
       showDialog(
         translate('confirmChangeLineTitle', {
           lineName:
-            (isJapanese
-              ? selectedStation.line?.nameShort
-              : selectedStation.line?.nameRoman) ?? '',
+            (isJapanese ? targetLine?.nameShort : targetLine?.nameRoman) ?? '',
         }),
         translate('confirmChangeLineText', {
           currentLineName:
             (isJapanese ? currentLine?.nameShort : currentLine?.nameRoman) ??
             '',
           lineName:
-            (isJapanese
-              ? selectedStation.line?.nameShort
-              : selectedStation.line?.nameRoman) ?? '',
+            (isJapanese ? targetLine?.nameShort : targetLine?.nameRoman) ?? '',
         }),
         [
           {
@@ -712,7 +711,15 @@ const MainScreen: React.FC = () => {
               changeOperatingLine(selectedStation);
             },
           },
-        ]
+        ],
+        {
+          lineSymbol: targetLine
+            ? {
+                image: getLineSymbolImage(targetLine, false)?.signPath,
+                color: targetLine.color ?? undefined,
+              }
+            : undefined,
+        }
       );
     },
     [

--- a/src/utils/dialogPresentation.ts
+++ b/src/utils/dialogPresentation.ts
@@ -14,6 +14,10 @@ export type DialogButton = {
  */
 export type DialogOptions = {
   emoji?: string;
+  lineSymbol?: {
+    image?: number;
+    color?: string;
+  };
   cancelable?: boolean;
   onDismiss?: () => void;
 };


### PR DESCRIPTION
## 概要

路線切替確認モーダルの左上表示を、汎用の情報絵文字から切替先の路線記号へ変更します。路線記号画像がアプリに登録されていない路線では、切替先のラインカラーを使ったグラデーション正方形を表示します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 路線切替時に `getLineSymbolImage` から切替先の路線記号画像を取得してダイアログへ渡すよう変更
- 路線記号画像がない場合、テーマ確認モーダルと同じ配色ロジック（ラインカラーから10%明るくした色へのグラデーション）でフォールバック
- 路線記号画像／グラデーションを使わない既存ダイアログでは従来の絵文字表示を維持
- 路線記号画像あり／なしの双方をユニットテストで検証

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

全体テスト: 207 suites / 2192 tests passed。
commit前・push前にも関連13テストとlintを再実行済みです。

## 関連Issue

なし

## スクリーンショット（任意）

未添付（実機スクリーンショットを取得できる環境がないため）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 乗換駅などの確認ダイアログに、路線記号画像を表示できるようになりました。
  * 路線記号画像がない場合は、路線カラーのグラデーションで表示します。
  * 選択した路線名と路線記号がダイアログに正しく反映されます。
* **改善**
  * 路線記号が指定されていない場合は、従来どおり絵文字を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->