### PR TITLE
Canary PRのレビュー待ち不要ルールを明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 - Pull requests must follow `.github/pull_request_template.md`; do not add or remove sections from the template without maintainer approval.
 - Open pull requests as ready for review by default; use Draft only when the user explicitly requests it.
 - Pull requests must be assigned to `@TinyKitten`.
+- Canary promotion PRs from `dev` to `canary` contain changes that have already passed review before reaching `dev`. Do not request or wait for an additional human or CodeRabbit review on the Canary PR itself. Once required CI succeeds and the PR is mergeable, the Canary PR may be merged without review approval.
 - Pull requests must include:
   - Purpose and summary of key changes.
   - Regression risk assessment and mitigation.


### PR DESCRIPTION
## 概要

Canary PR は `dev` に入るまでにレビュー済みの変更だけを昇格するため、Canary PR 自体では追加レビューを待たない運用を `AGENTS.md` に明文化します。
ドキュメントのみの変更で、アプリの実行挙動への影響はありません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `dev` → `canary` の Canary PR は既にレビュー済みの変更を対象とすることを明記
- Canary PR 自体では人間・CodeRabbit の追加レビューを要求・待機せず、必要なCI成功とmergeableを確認してマージできることを明記

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: コード変更なし。 `git diff --check` と差分レビューを実施。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
