### PR TITLE
watchOS向けウィジェットと同等のロック画面ウィジェットをiOSに追加

### DIFF
--- a/ios/CanaryTrainLCD.entitlements
+++ b/ios/CanaryTrainLCD.entitlements
@@ -4,6 +4,10 @@
   <dict>
     <key>aps-environment</key>
     <string>development</string>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.me.tinykitten.trainlcd.dev</string>
+    </array>
     <key>com.apple.developer.associated-appclip-app-identifiers</key>
     <array>
       <string>$(AppIdentifierPrefix)me.tinykitten.trainlcd.dev.Clip</string>

--- a/ios/Modules/LiveActivity/LiveActivityModule.swift
+++ b/ios/Modules/LiveActivity/LiveActivityModule.swift
@@ -1,11 +1,57 @@
 import Foundation
 import ActivityKit
+import WidgetKit
 
 @available(iOS 16.1, *)
 @objc(LiveActivityModule)
 class LiveActivityModule: NSObject {
   var sessionActivity: Activity<RideSessionAttributes>?
-  
+
+  private let lockScreenWidgetKind = "LockScreenWidget"
+
+  private var appGroupID: String {
+    Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
+      ?? "group.me.tinykitten.trainlcd"
+  }
+
+  // 直近にウィジェットへ書き込んだ内容。差分がない更新でのUserDefaults書き込みと
+  // reloadTimelines呼び出し(WidgetKitのリロードバジェット消費)を避ける
+  private var lastWidgetState: [String: String]?
+
+  // ロック画面ウィジェットが参照するApp Groupへ乗車中の路線情報を書き込む
+  private func syncLockScreenWidgetState(_ dic: NSDictionary?) {
+    guard let dic = dic else {
+      return
+    }
+    let state = [
+      "lineColor": dic["lineColor"] as? String ?? "",
+      "lineName": dic["lineName"] as? String ?? "",
+      "lineSymbol": dic["lineSymbol"] as? String ?? "",
+      "boundStationName": dic["boundStationName"] as? String ?? "",
+    ]
+    if state == lastWidgetState {
+      return
+    }
+    lastWidgetState = state
+    guard let defaults = UserDefaults(suiteName: appGroupID) else {
+      return
+    }
+    for (key, value) in state {
+      defaults.set(value, forKey: key)
+    }
+    defaults.set(true, forKey: "loaded")
+    WidgetCenter.shared.reloadTimelines(ofKind: lockScreenWidgetKind)
+  }
+
+  private func clearLockScreenWidgetState() {
+    lastWidgetState = nil
+    guard let defaults = UserDefaults(suiteName: appGroupID) else {
+      return
+    }
+    defaults.set(false, forKey: "loaded")
+    WidgetCenter.shared.reloadTimelines(ofKind: lockScreenWidgetKind)
+  }
+
   func getStatus(_ dic: NSDictionary?) -> RideSessionAttributes.RideSessionStatus? {
     guard let state = dic else {
       return nil
@@ -37,10 +83,12 @@ class LiveActivityModule: NSObject {
     }
     
     let activityAttributes = RideSessionAttributes()
-    
+
     guard let initialContentState = getStatus(dic) else {
       return
     }
+
+    syncLockScreenWidgetState(dic)
     
     do {
       let finalContentState = getStatus(dic)
@@ -79,6 +127,9 @@ class LiveActivityModule: NSObject {
     guard let nextContentState = getStatus(dic) else {
       return
     }
+
+    syncLockScreenWidgetState(dic)
+
     Task {
       await sessionActivity?.update(using: nextContentState)
     }
@@ -90,6 +141,8 @@ class LiveActivityModule: NSObject {
       return
     }
     
+    clearLockScreenWidgetState()
+
     let finalContentState = getStatus(dic)
     Task {
       for activity in Activity<RideSessionAttributes>.activities {

--- a/ios/ProdTrainLCD.entitlements
+++ b/ios/ProdTrainLCD.entitlements
@@ -4,6 +4,10 @@
   <dict>
     <key>aps-environment</key>
     <string>development</string>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.me.tinykitten.trainlcd</string>
+    </array>
     <key>com.apple.developer.associated-appclip-app-identifiers</key>
     <array>
       <string>$(AppIdentifierPrefix)me.tinykitten.trainlcd.Clip</string>

--- a/ios/RideSessionActivity/CanaryRideSessionActivity.entitlements
+++ b/ios/RideSessionActivity/CanaryRideSessionActivity.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.me.tinykitten.trainlcd.dev</string>
+	</array>
+</dict>
 </plist>

--- a/ios/RideSessionActivity/LockScreenWidget.swift
+++ b/ios/RideSessionActivity/LockScreenWidget.swift
@@ -1,0 +1,205 @@
+//
+//  LockScreenWidget.swift
+//  RideSessionActivity
+//
+//  Created by Tsubasa SEKIGUCHI on 2026/08/06.
+//  Copyright © 2026 Facebook. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// ライブアクティビティとロック画面ウィジェットを同一Extensionで配信するためのバンドル
+@main
+struct RideSessionWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    RideSessionWidget()
+    LockScreenWidget()
+  }
+}
+
+struct LockScreenEntry: TimelineEntry {
+  let date: Date
+  let loaded: Bool
+  let lineColor: String
+  let lineName: String
+  let lineSymbol: String
+  let boundFor: String
+
+  static var notLoaded: LockScreenEntry {
+    LockScreenEntry(
+      date: Date(),
+      loaded: false,
+      lineColor: "277BC0",
+      lineName: String(localized: "lineNotSet"),
+      lineSymbol: "?",
+      boundFor: String(localized: "destinationNotSet")
+    )
+  }
+}
+
+struct LockScreenProvider: TimelineProvider {
+  func placeholder(in context: Context) -> LockScreenEntry {
+    .notLoaded
+  }
+
+  func getSnapshot(
+    in context: Context, completion: @escaping (LockScreenEntry) -> Void
+  ) {
+    completion(loadEntry())
+  }
+
+  func getTimeline(
+    in context: Context, completion: @escaping (Timeline<LockScreenEntry>) -> Void
+  ) {
+    // 表示内容はアプリ側がApp Groupへ書き込んだ時点のWidgetCenter経由リロードでのみ変わるため、
+    // 時刻ベースの再生成は行わない
+    completion(Timeline(entries: [loadEntry()], policy: .never))
+  }
+
+  private func loadEntry() -> LockScreenEntry {
+    let appGroupID =
+      Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
+      ?? "group.me.tinykitten.trainlcd"
+
+    guard let defaults = UserDefaults(suiteName: appGroupID),
+      defaults.bool(forKey: "loaded")
+    else {
+      return .notLoaded
+    }
+
+    let lineName = defaults.string(forKey: "lineName") ?? ""
+    let lineSymbol = defaults.string(forKey: "lineSymbol") ?? ""
+
+    return LockScreenEntry(
+      date: Date(),
+      loaded: true,
+      lineColor: defaults.string(forKey: "lineColor") ?? "",
+      lineName: lineName,
+      lineSymbol: lineSymbol.isEmpty ? String(lineName.prefix(1)) : lineSymbol,
+      boundFor: defaults.string(forKey: "boundStationName") ?? ""
+    )
+  }
+}
+
+struct LockScreenNumberingCircle: View {
+  let lineColor: String
+  let lineSymbol: String
+
+  var body: some View {
+    ZStack {
+      AccessoryWidgetBackground()
+      Circle()
+        .stroke(Color(hex: lineColor), lineWidth: 6)
+        .widgetAccentable()
+      Text(lineSymbol)
+        .font(.system(.body, design: .rounded))
+        .fontWeight(.bold)
+        .minimumScaleFactor(0.5)
+        .padding(12)
+    }
+  }
+}
+
+struct LockScreenWidgetEntryView: View {
+  let entry: LockScreenEntry
+
+  @Environment(\.widgetFamily) var family
+
+  var body: some View {
+    switch family {
+    case .accessoryCircular:
+      circularView
+    case .accessoryRectangular:
+      rectangularView
+    case .accessoryInline:
+      inlineView
+    default:
+      EmptyView()
+    }
+  }
+
+  var circularView: some View {
+    LockScreenNumberingCircle(
+      lineColor: entry.lineColor,
+      lineSymbol: entry.lineSymbol
+    )
+  }
+
+  var rectangularView: some View {
+    HStack(spacing: 8) {
+      RoundedRectangle(cornerRadius: 2)
+        .fill(Color(hex: entry.lineColor))
+        .frame(width: 4)
+        .widgetAccentable()
+      VStack(alignment: .leading, spacing: 2) {
+        Text(entry.lineName)
+          .font(.headline)
+          .fontWeight(.bold)
+          .widgetAccentable()
+        Text(entry.boundFor)
+          .font(.caption)
+      }
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  var inlineView: some View {
+    Text(
+      entry.loaded
+        ? String(format: String(localized: "ridingOn"), entry.lineName)
+        : "TrainLCD"
+    )
+  }
+}
+
+extension View {
+  // containerBackgroundはiOS 17以降必須だが、Extensionのデプロイターゲットが16.1のため互換ラップする
+  @ViewBuilder
+  fileprivate func lockScreenContainerBackground() -> some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      containerBackground(.fill.tertiary, for: .widget)
+    } else {
+      self
+    }
+  }
+}
+
+struct LockScreenWidget: Widget {
+  let kind: String = "LockScreenWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: LockScreenProvider()) { entry in
+      LockScreenWidgetEntryView(entry: entry)
+        .lockScreenContainerBackground()
+    }
+    .configurationDisplayName("TrainLCD")
+    .description("TrainLCD")
+    .supportedFamilies(
+      [
+        .accessoryCircular,
+        .accessoryRectangular,
+        .accessoryInline,
+      ]
+    )
+  }
+}
+
+struct LockScreenWidget_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      LockScreenWidgetEntryView(
+        entry: LockScreenEntry(
+          date: .now,
+          loaded: true,
+          lineColor: "80C241",
+          lineName: "山手線",
+          lineSymbol: "JY",
+          boundFor: "新宿・渋谷方面"
+        )
+      )
+      .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+    }
+  }
+}

--- a/ios/RideSessionActivity/ProdRideSessionActivity.entitlements
+++ b/ios/RideSessionActivity/ProdRideSessionActivity.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.me.tinykitten.trainlcd</string>
+	</array>
+</dict>
 </plist>

--- a/ios/RideSessionActivity/RideSessionActivity.swift
+++ b/ios/RideSessionActivity/RideSessionActivity.swift
@@ -101,7 +101,7 @@ func getRunningStateText(
   return ""
 }
 
-@main
+// エントリポイントはLockScreenWidget.swiftのRideSessionWidgetBundle
 struct RideSessionWidget: Widget {
   var body: some WidgetConfiguration {
     ActivityConfiguration(for: RideSessionAttributes.self) { context in

--- a/ios/RideSessionActivity/Schemes/Dev/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Dev/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>

--- a/ios/RideSessionActivity/Schemes/Prod/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Prod/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		942CB6062A32AAB4008339D2 /* RideSessionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */; };
 		942CB6072A32AAB4008339D2 /* RideSessionActivity.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */; };
 		942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B9CDE428D3025900D68287 /* RideSessionActivity.swift */; };
+		94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
+		94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
 		942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EAA025890E8500E02655 /* ColorExtension.swift */; };
 		942CB60B2A32AAB4008339D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDE128D3025900D68287 /* SwiftUI.framework */; };
 		942CB60C2A32AAB4008339D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDDF28D3025900D68287 /* WidgetKit.framework */; };
@@ -403,6 +405,7 @@
 		94B9CDDF28D3025900D68287 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		94B9CDE128D3025900D68287 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		94B9CDE428D3025900D68287 /* RideSessionActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionActivity.swift; sourceTree = "<group>"; wrapsLines = 0; };
+		94D3F45F2E40A00100000000 /* LockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWidget.swift; sourceTree = "<group>"; };
 		94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = RideSessionActivity.intentdefinition; sourceTree = "<group>"; };
 		94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionAttributes.swift; sourceTree = "<group>"; };
 		94BFA3B7258F0FF3001D95E4 /* StationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListView.swift; sourceTree = "<group>"; };
@@ -823,6 +826,7 @@
 				942CB6492A32BA0A008339D2 /* Info.plist */,
 				942CB64A2A32BA12008339D2 /* Info.plist */,
 				94B9CDE428D3025900D68287 /* RideSessionActivity.swift */,
+				94D3F45F2E40A00100000000 /* LockScreenWidget.swift */,
 				94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */,
 				94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */,
 				94000A592AD73E8900B5A11C /* Assets.xcassets */,
@@ -2229,6 +2233,7 @@
 				942CB6062A32AAB4008339D2 /* RideSessionAttributes.swift in Sources */,
 				942CB6072A32AAB4008339D2 /* RideSessionActivity.intentdefinition in Sources */,
 				942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */,
+				94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */,
 				942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */,
 				94E6881C2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);
@@ -2261,6 +2266,7 @@
 				94B9CDF528D3027500D68287 /* RideSessionAttributes.swift in Sources */,
 				94B9CDEA28D3025A00D68287 /* RideSessionActivity.intentdefinition in Sources */,
 				94B9CDE528D3025900D68287 /* RideSessionActivity.swift in Sources */,
+				94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */,
 				944C2C4F28DADC380004DA72 /* ColorExtension.swift in Sources */,
 				94E6881B2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);
@@ -2404,6 +2410,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd;
 				CODE_SIGN_ENTITLEMENTS = ProdTrainLCD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2443,6 +2450,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd;
 				CODE_SIGN_ENTITLEMENTS = ProdTrainLCD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2687,6 +2695,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd.dev;
 				CODE_SIGN_ENTITLEMENTS = CanaryTrainLCD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2726,6 +2735,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd.dev;
 				CODE_SIGN_ENTITLEMENTS = CanaryTrainLCD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2937,6 +2947,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd.dev;
 				CODE_SIGN_ENTITLEMENTS = RideSessionActivity/CanaryRideSessionActivity.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2987,6 +2998,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd.dev;
 				CODE_SIGN_ENTITLEMENTS = RideSessionActivity/CanaryRideSessionActivity.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -3253,6 +3265,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd;
 				CODE_SIGN_ENTITLEMENTS = RideSessionActivity/ProdRideSessionActivity.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -3303,6 +3316,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				APP_GROUP_ID = group.me.tinykitten.trainlcd;
 				CODE_SIGN_ENTITLEMENTS = RideSessionActivity/ProdRideSessionActivity.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ja_JP</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ja_JP</string>
 	<key>CFBundleDisplayName</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12187,9 +12187,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12209,9 +12206,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12233,9 +12227,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12255,9 +12246,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12187,6 +12187,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12206,6 +12209,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12227,6 +12233,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12246,6 +12255,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -32,6 +32,7 @@ import { useIsNextLastStop } from './useIsNextLastStop';
 import { useIsPassing } from './useIsPassing';
 import { useLoopLine } from './useLoopLine';
 import { useNextStation } from './useNextStation';
+import { useNumbering } from './useNumbering';
 import { useStationNumberIndexFunc } from './useStationNumberIndexFunc';
 
 /**
@@ -73,6 +74,8 @@ export const useUpdateLiveActivities = (): void => {
   const { directionalStops } = useBounds(stations);
   const isNextLastStop = useIsNextLastStop();
   const getStationNumberIndex = useStationNumberIndexFunc();
+  // iOSロック画面ウィジェットのナンバリングサークル表示用
+  const [currentNumbering] = useNumbering();
   const trainType = useCurrentTrainType();
   const {
     isLoopLine: isFullLoopLine,
@@ -256,6 +259,7 @@ export const useUpdateLiveActivities = (): void => {
       isNextLastStop,
       lineColor,
       lineName,
+      lineSymbol: currentNumbering?.lineSymbol ?? '',
       passingStationName,
       passingStationNumber,
       progress,
@@ -264,6 +268,7 @@ export const useUpdateLiveActivities = (): void => {
       approaching,
       boundStationName,
       boundStationNumber,
+      currentNumbering?.lineSymbol,
       isLoopLine,
       isNextLastStop,
       lineColor,

--- a/src/utils/native/ios/liveActivityModule.ts
+++ b/src/utils/native/ios/liveActivityModule.ts
@@ -12,6 +12,7 @@ type LiveActivityWidgetState = {
   stopped: boolean;
   lineName: string;
   lineColor: string;
+  lineSymbol: string;
   passingStationName: string;
   passingStationNumber: string;
   progress: number;


### PR DESCRIPTION
## 概要

watchOS向けウィジェット（`WatchWidget`）と同等の表示内容を、iOSのロック画面ウィジェット（WidgetKitのaccessoryファミリー）として新規に追加します。乗車中の路線・方面を、Live Activityとは別にロック画面へ常設表示できるようにします。

watchOS版はWatch側のApp Group `UserDefaults` を参照しているためそのままでは移植できません。そこで同じデータキー（`lineColor` / `lineName` / `lineSymbol` / `boundStationName` / `loaded`）をiPhone側のApp Groupへ書き込む経路を新設し、ウィジェットのビュー実装はwatchOS版のデザインを踏襲しました。

配信は既存のLive Activity用Extension（`RideSessionActivityExtension`）に同居させ、新規Extensionターゲットは追加していません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/RideSessionActivity/LockScreenWidget.swift` を新規追加。`accessoryCircular`（ナンバリングサークル）/ `accessoryRectangular`（路線名＋方面）/ `accessoryInline`（「〜に乗車中」）の3ファミリーに対応（watchOS専用の `accessoryCorner` は対象外）
- Live ActivityとロックスクリーンWidgetを同一Extensionで配信するため `RideSessionWidgetBundle`（`WidgetBundle`）をエントリポイント化し、`RideSessionActivity.swift` の `@main` を移動
- `LiveActivityModule.swift` にApp Groupへの状態同期を追加。Live Activityの開始・更新時に路線情報を書き込んで `WidgetCenter` でタイムラインをリロードし、終了時に `loaded=false` へクリア
- 同期処理は直前の書き込み内容と差分がない場合はスキップし、`UserDefaults` 書き込みとWidgetKitのリロードバジェット消費を抑制
- `useUpdateLiveActivities` にナンバリングサークル表示用の `lineSymbol`（`useNumbering` 由来）を追加し、`liveActivityModule.ts` の型にも反映
- 本体アプリ（Prod / Canary）と `RideSessionActivity` Extension（Prod / Canary）のentitlementsにApp Group（`group.me.tinykitten.trainlcd` / `.dev`）を追加
- 上記4ターゲットのDebug / Release全構成に `APP_GROUP_ID` ビルド設定を追加し、各Info.plistへ `APP_GROUP_ID` キーを配線（watch側と同じ方式）

### レビュー時の注意

- Extensionのデプロイターゲットが16.1のため、`containerBackground` はiOS 17以降でのみ適用されるようバージョン分岐しています
- 本体アプリのApp IDs（`me.tinykitten.trainlcd` / `.dev` と各 `.ridesessionactivity`）にApp Groups capabilityの追加が必要です。自動署名のためXcodeが処理しますが、初回ビルド時にDeveloper Portal側の更新が走ります
- ロック画面ウィジェットの仕様上、色はロック画面のティントにより単色化されます。乗車情報のリアルタイム表示は引き続きLive Activityが担い、本ウィジェットは「選択中の路線・方面」の常設表示という位置づけです

## テスト

Linux環境で実行したため、Swift側のビルド確認はCIおよびローカルのXcodeビルドに委ねています。JS/TS側は下記コマンドがすべて成功することを確認済みです（`npm test` は207スイート・2192件すべてパス）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

作業環境にXcodeがなくシミュレータを起動できないため未添付です。ロック画面ウィジェットの実機・シミュレータでの見た目確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFBheCcZCtASN6YwuDNyeZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ロック画面ウィジェットに乗車中の路線情報を表示できるようになりました。
  - 円形・矩形・インラインなど、複数の表示形式に対応しました。
  - ライブアクティビティに路線記号が表示されるようになりました。
- **改善**
  - 乗車情報の開始・更新・終了に合わせて、ウィジェットの表示が自動的に同期・消去されます。
  - 情報に変更がない場合は不要な更新を抑制し、表示の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->