### PR TITLE
ロック画面最下部に置けるiOS 18向け円形コントロールを追加

### DIFF
--- a/ios/Localizable/en.lproj/Localizable.strings
+++ b/ios/Localizable/en.lproj/Localizable.strings
@@ -24,3 +24,5 @@
 "destinationNotSet" = "Destination not set";
 "lineNotSet" = "No route selected";
 "lastUpdated" = "Last updated";
+"openApp" = "Open TrainLCD";
+"controlDescription" = "Opens TrainLCD from the Lock Screen or Control Center.";

--- a/ios/Localizable/ja.lproj/Localizable.strings
+++ b/ios/Localizable/ja.lproj/Localizable.strings
@@ -24,3 +24,5 @@
 "destinationNotSet" = "方面が未設定です";
 "lineNotSet" = "路線が未設定です";
 "lastUpdated" = "最終更新";
+"openApp" = "TrainLCDを開く";
+"controlDescription" = "ロック画面やコントロールセンターからTrainLCDを開きます。";

--- a/ios/Modules/LiveActivity/LiveActivityModule.swift
+++ b/ios/Modules/LiveActivity/LiveActivityModule.swift
@@ -8,6 +8,8 @@ class LiveActivityModule: NSObject {
   var sessionActivity: Activity<RideSessionAttributes>?
 
   private let lockScreenWidgetKind = "LockScreenWidget"
+  // RideSessionActivity側のLockScreenControl.kindと一致させること
+  private let lockScreenControlKind = "me.tinykitten.trainlcd.LockScreenControl"
 
   private var appGroupID: String {
     Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
@@ -40,7 +42,15 @@ class LiveActivityModule: NSObject {
       defaults.set(value, forKey: key)
     }
     defaults.set(true, forKey: "loaded")
+    reloadLockScreenSurfaces()
+  }
+
+  // ロック画面ウィジェットとロック画面コントロールは同じApp Groupを参照するため常に同時に更新する
+  private func reloadLockScreenSurfaces() {
     WidgetCenter.shared.reloadTimelines(ofKind: lockScreenWidgetKind)
+    if #available(iOS 18.0, *) {
+      ControlCenter.shared.reloadControls(ofKind: lockScreenControlKind)
+    }
   }
 
   private func clearLockScreenWidgetState() {
@@ -49,7 +59,7 @@ class LiveActivityModule: NSObject {
       return
     }
     defaults.set(false, forKey: "loaded")
-    WidgetCenter.shared.reloadTimelines(ofKind: lockScreenWidgetKind)
+    reloadLockScreenSurfaces()
   }
 
   func getStatus(_ dic: NSDictionary?) -> RideSessionAttributes.RideSessionStatus? {

--- a/ios/RideSessionActivity/LockScreenControl.swift
+++ b/ios/RideSessionActivity/LockScreenControl.swift
@@ -1,0 +1,107 @@
+//
+//  LockScreenControl.swift
+//  RideSessionActivity
+//
+//  Created by Tsubasa SEKIGUCHI on 2026/08/06.
+//  Copyright © 2026 Facebook. All rights reserved.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+// ロック画面最下部（懐中電灯・カメラと同じ列）とコントロールセンターに置ける円形コントロール。
+// iOS 18で追加されたControlWidgetを利用するため、旧OSではWidgetBundleから除外される。
+
+// ロック画面ウィジェットと同じApp Groupの値をコントロール表示用に整形する
+@available(iOS 18.0, *)
+struct LockScreenControlValue: Sendable {
+  // 未乗車時やApp Groupが空のときに使うTrainLCDのブランドカラー
+  private static let fallbackLineColor = "277BC0"
+
+  let loaded: Bool
+  let lineName: String
+  let lineColor: String
+  let boundFor: String
+
+  init(entry: LockScreenEntry) {
+    loaded = entry.loaded
+    lineName = entry.lineName
+    lineColor = entry.lineColor
+    boundFor = entry.boundFor
+  }
+
+  // コントロールセンターでのタイトル。未乗車時は路線名の代わりにアプリ名を出す
+  var title: String {
+    loaded ? lineName : "TrainLCD"
+  }
+
+  var subtitle: String {
+    boundFor
+  }
+
+  var symbolName: String {
+    loaded ? "tram.fill" : "tram"
+  }
+
+  // Color(hex:)は空文字を渡すとほぼ透明になるため、必ず既定色へフォールバックする
+  var tint: Color {
+    Color(hex: lineColor.isEmpty ? Self.fallbackLineColor : lineColor)
+  }
+}
+
+@available(iOS 18.0, *)
+struct LockScreenControlProvider: ControlValueProvider {
+  var previewValue: LockScreenControlValue {
+    LockScreenControlValue(entry: .notLoaded)
+  }
+
+  func currentValue() async throws -> LockScreenControlValue {
+    LockScreenControlValue(entry: .current())
+  }
+}
+
+// コントロールのタップでTrainLCD本体を開く。openAppWhenRunにより
+// Canary/Prodそれぞれの親アプリが起動するのでURLスキームの出し分けは不要
+@available(iOS 18.0, *)
+struct OpenTrainLCDIntent: AppIntent {
+  // 文字列リソースが引けない場合でもキー名が露出しないようdefaultValueを添える
+  static var title: LocalizedStringResource {
+    LocalizedStringResource("openApp", defaultValue: "Open TrainLCD")
+  }
+  static let openAppWhenRun = true
+
+  func perform() async throws -> some IntentResult {
+    .result()
+  }
+}
+
+@available(iOS 18.0, *)
+struct LockScreenControl: ControlWidget {
+  // LiveActivityModule側のreloadControls(ofKind:)と一致させること
+  static let kind = "me.tinykitten.trainlcd.LockScreenControl"
+
+  var body: some ControlWidgetConfiguration {
+    StaticControlConfiguration(
+      kind: Self.kind,
+      provider: LockScreenControlProvider()
+    ) { value in
+      ControlWidgetButton(action: OpenTrainLCDIntent()) {
+        Label {
+          Text(value.title)
+        } icon: {
+          Image(systemName: value.symbolName)
+        }
+        Text(value.subtitle)
+      }
+      .tint(value.tint)
+    }
+    .displayName("TrainLCD")
+    .description(
+      LocalizedStringResource(
+        "controlDescription",
+        defaultValue: "Opens TrainLCD from the Lock Screen or Control Center."
+      )
+    )
+  }
+}

--- a/ios/RideSessionActivity/LockScreenWidget.swift
+++ b/ios/RideSessionActivity/LockScreenWidget.swift
@@ -9,12 +9,17 @@
 import SwiftUI
 import WidgetKit
 
-// ライブアクティビティとロック画面ウィジェットを同一Extensionで配信するためのバンドル
+// ライブアクティビティ・ロック画面ウィジェット・ロック画面コントロールを
+// 同一Extensionで配信するためのバンドル
 @main
 struct RideSessionWidgetBundle: WidgetBundle {
   var body: some Widget {
     RideSessionWidget()
     LockScreenWidget()
+    // ControlWidgetはiOS 18以降のみ。Extensionのデプロイターゲットは16.1のため条件付きで追加する
+    if #available(iOS 18.0, *) {
+      LockScreenControl()
+    }
   }
 }
 
@@ -36,28 +41,9 @@ struct LockScreenEntry: TimelineEntry {
       boundFor: String(localized: "destinationNotSet")
     )
   }
-}
 
-struct LockScreenProvider: TimelineProvider {
-  func placeholder(in context: Context) -> LockScreenEntry {
-    .notLoaded
-  }
-
-  func getSnapshot(
-    in context: Context, completion: @escaping (LockScreenEntry) -> Void
-  ) {
-    completion(loadEntry())
-  }
-
-  func getTimeline(
-    in context: Context, completion: @escaping (Timeline<LockScreenEntry>) -> Void
-  ) {
-    // 表示内容はアプリ側がApp Groupへ書き込んだ時点のWidgetCenter経由リロードでのみ変わるため、
-    // 時刻ベースの再生成は行わない
-    completion(Timeline(entries: [loadEntry()], policy: .never))
-  }
-
-  private func loadEntry() -> LockScreenEntry {
+  // ロック画面ウィジェットとロック画面コントロールで共通のApp Group読み出し
+  static func current() -> LockScreenEntry {
     let appGroupID =
       Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
       ?? "group.me.tinykitten.trainlcd"
@@ -79,6 +65,26 @@ struct LockScreenProvider: TimelineProvider {
       lineSymbol: lineSymbol.isEmpty ? String(lineName.prefix(1)) : lineSymbol,
       boundFor: defaults.string(forKey: "boundStationName") ?? ""
     )
+  }
+}
+
+struct LockScreenProvider: TimelineProvider {
+  func placeholder(in context: Context) -> LockScreenEntry {
+    .notLoaded
+  }
+
+  func getSnapshot(
+    in context: Context, completion: @escaping (LockScreenEntry) -> Void
+  ) {
+    completion(.current())
+  }
+
+  func getTimeline(
+    in context: Context, completion: @escaping (Timeline<LockScreenEntry>) -> Void
+  ) {
+    // 表示内容はアプリ側がApp Groupへ書き込んだ時点のWidgetCenter経由リロードでのみ変わるため、
+    // 時刻ベースの再生成は行わない
+    completion(Timeline(entries: [.current()], policy: .never))
   }
 }
 

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B9CDE428D3025900D68287 /* RideSessionActivity.swift */; };
 		94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
 		94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
+		94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
+		94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
 		942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EAA025890E8500E02655 /* ColorExtension.swift */; };
 		942CB60B2A32AAB4008339D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDE128D3025900D68287 /* SwiftUI.framework */; };
 		942CB60C2A32AAB4008339D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDDF28D3025900D68287 /* WidgetKit.framework */; };
@@ -406,6 +408,7 @@
 		94B9CDE128D3025900D68287 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		94B9CDE428D3025900D68287 /* RideSessionActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionActivity.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		94D3F45F2E40A00100000000 /* LockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWidget.swift; sourceTree = "<group>"; };
+		94D3F4622E40A00200000000 /* LockScreenControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenControl.swift; sourceTree = "<group>"; };
 		94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = RideSessionActivity.intentdefinition; sourceTree = "<group>"; };
 		94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionAttributes.swift; sourceTree = "<group>"; };
 		94BFA3B7258F0FF3001D95E4 /* StationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListView.swift; sourceTree = "<group>"; };
@@ -827,6 +830,7 @@
 				942CB64A2A32BA12008339D2 /* Info.plist */,
 				94B9CDE428D3025900D68287 /* RideSessionActivity.swift */,
 				94D3F45F2E40A00100000000 /* LockScreenWidget.swift */,
+				94D3F4622E40A00200000000 /* LockScreenControl.swift */,
 				94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */,
 				94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */,
 				94000A592AD73E8900B5A11C /* Assets.xcassets */,
@@ -2234,6 +2238,7 @@
 				942CB6072A32AAB4008339D2 /* RideSessionActivity.intentdefinition in Sources */,
 				942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */,
 				94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */,
+				94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */,
 				942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */,
 				94E6881C2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);
@@ -2267,6 +2272,7 @@
 				94B9CDEA28D3025A00D68287 /* RideSessionActivity.intentdefinition in Sources */,
 				94B9CDE528D3025900D68287 /* RideSessionActivity.swift in Sources */,
 				94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */,
+				94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */,
 				944C2C4F28DADC380004DA72 /* ColorExtension.swift in Sources */,
 				94E6881B2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);


### PR DESCRIPTION
## 概要

ロック画面の最下部（懐中電灯・カメラと同じ列）とコントロールセンターに配置できる丸いコントロールを、iOS 18 の `ControlWidget` として追加する。

時計下のウィジェット枠に置く `accessoryCircular` は #6561 で対応済みのため、本 PR ではその下段にあたる「コントロール」領域を新たに埋める。タップすると TrainLCD 本体が起動し、乗車中は路線カラーと路線名が反映される。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/RideSessionActivity/LockScreenControl.swift`（新規）
  - `StaticControlConfiguration` + `ControlValueProvider` 構成の `ControlWidget` を追加。ロック画面最下部とコントロールセンターの双方に配置できる
  - タップ時は `openAppWhenRun` を立てた `OpenTrainLCDIntent` を実行。Extension の親アプリが起動するため Canary / Prod で URL スキームを出し分ける必要がない
  - 乗車中は `tram.fill` + 路線名 + 方面、未乗車時は `tram` + `TrainLCD` を表示
  - コントロールの tint に路線カラーを適用。`Color(hex:)` は空文字を渡すとほぼ透明になるため、ブランドカラー `277BC0` へフォールバックする
- `ios/RideSessionActivity/LockScreenWidget.swift`
  - App Group の読み出しを `LockScreenEntry.current()` へ切り出し、ロック画面ウィジェットとコントロールで共通化（`LockScreenProvider` 内の `loadEntry()` を置き換え）
  - `WidgetBundle` へ `if #available(iOS 18.0, *)` 付きで `LockScreenControl()` を追加。Extension のデプロイターゲットは 16.1 のまま
- `ios/Modules/LiveActivity/LiveActivityModule.swift`
  - `reloadLockScreenSurfaces()` を追加し、`WidgetCenter.reloadTimelines(ofKind:)` と `ControlCenter.shared.reloadControls(ofKind:)` を必ず同時に呼ぶよう集約。乗車開始・終了の両経路から利用する
- `ios/Localizable/{en,ja}.lproj/Localizable.strings`
  - コントロール名・説明用に `openApp` / `controlDescription` を追加
- `ios/TrainLCD.xcodeproj/project.pbxproj`
  - Canary / Prod 両方の `RideSessionActivity` ターゲットへ新規ファイルを登録

### 回帰リスクと緩和策

- **既存ロック画面ウィジェットへの影響**: `loadEntry()` を `LockScreenEntry.current()` へ移設した箇所は処理内容を変えていない純粋な移動で、`getSnapshot` / `getTimeline` の呼び出し結果は従来どおり。
- **iOS 17 以前での表示**: `ControlWidget` は iOS 18 以降のみ。`WidgetBundle` 内で `if #available` により除外しているため、旧 OS では従来のライブアクティビティとロック画面ウィジェットのみが配信される。なお `WidgetBundle` 内の `#available` は Xcode 16.1 beta 3 で修正済みの既知不具合があったが、CI は `macos-26`（Xcode 26）のため影響しない。
- **リロードバジェット**: コントロールのリロードは既存の `syncLockScreenWidgetState` の差分ガード（`lastWidgetState` 比較）の内側で発火するため、更新頻度は現状のウィジェットと同じ。

## テスト

ローカルで以下を実行し、すべて成功することを確認した。

- `npm run lint`: 613 ファイル検査、指摘なし
- `npm test`: 207 suites / 2192 tests すべて成功
- `npm run typecheck`: エラーなし

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

**未検証事項（レビュー時にご確認ください）**

- 今回の変更は Swift のみで、JS 側のテスト対象コードは変更していない（上記 3 コマンドは回帰確認のために実行）。
- 作業環境が Linux コンテナのため **Xcode でのビルド確認は未実施**。利用 API は WWDC24 "Extend your app's controls across the system" のサンプルと照合済み（`ControlValueProvider` の `previewValue` / `currentValue()`、`ControlWidgetTemplate.tint(_:)`、`ControlCenter.shared.reloadControls(ofKind:)`、`.displayName` / `.description`）だが、実ビルドと実機配置の確認をお願いしたい。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

macOS / シミュレータのない環境での作業のため未添付。ロック画面下部のコントロール追加 UI と、乗車中の路線カラー反映の実機確認をお願いしたい（例: iPhone 15 Pro / iOS 18 以降）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez1jjea88ehoXQa6yKYh3x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOS 18以降、ロック画面やコントロールセンターからTrainLCDを起動できる円形コントロールを追加しました。
  * 乗車中は路線名・行き先・路線カラーを表示し、未乗車時は標準表示に切り替わります。
  * コントロールのタップでTrainLCDをすばやく開けます。

* **改善**
  * 乗車状態の変更やリセット時に、ロック画面の表示が自動的に更新されるようになりました。
  * 日本語・英語の表示と操作説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->