### PR TITLE
iOS/watchOS版ウィジェットと同じ体裁のホーム画面ウィジェットをAndroidに追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,5 +45,16 @@
       android:name="expo.modules.location.services.LocationTaskService"
       android:exported="false"
       android:foregroundServiceType="location" />
+    <receiver
+      android:name=".RideWidgetProvider"
+      android:label="@string/app_name"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/ride_widget_info"/>
+    </receiver>
   </application>
 </manifest>

--- a/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
@@ -1,0 +1,174 @@
+package me.tinykitten.trainlcd
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import android.widget.RemoteViews
+
+/**
+ * ホーム画面ウィジェット。
+ *
+ * iOS/watchOS版のウィジェット(LockScreenWidget / WatchWidget)と同じ情報・体裁を踏襲し、
+ * ウィジェットのサイズに応じて円形(accessoryCircular相当)、1行(accessoryInline相当)、
+ * 横長(accessoryRectangular相当)の3レイアウトを出し分ける。
+ */
+class RideWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        appWidgetIds.forEach { updateWidget(context, appWidgetManager, it) }
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle?
+    ) {
+        // リサイズでレイアウトの出し分けが変わるため再描画する
+        updateWidget(context, appWidgetManager, appWidgetId)
+    }
+
+    companion object {
+        // iOSのaccessoryCircular/accessoryInline/accessoryRectangularに対応する閾値(dp)
+        private const val CIRCULAR_MAX_WIDTH_DP = 110
+        private const val INLINE_MAX_HEIGHT_DP = 70
+
+        /** アプリ側から表示内容を更新する際のエントリポイント */
+        fun updateAll(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+            val ids = appWidgetManager.getAppWidgetIds(
+                ComponentName(context.applicationContext, RideWidgetProvider::class.java)
+            )
+            ids.forEach { updateWidget(context, appWidgetManager, it) }
+        }
+
+        private fun updateWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val options: Bundle? = appWidgetManager.getAppWidgetOptions(appWidgetId)
+            val minWidthDp = options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 0) ?: 0
+            val minHeightDp = options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0) ?: 0
+
+            appWidgetManager.updateAppWidget(
+                appWidgetId,
+                buildRemoteViews(
+                    context,
+                    WidgetStateStore.load(context),
+                    minWidthDp,
+                    minHeightDp
+                )
+            )
+        }
+
+        private fun buildRemoteViews(
+            context: Context,
+            state: WidgetState,
+            minWidthDp: Int,
+            minHeightDp: Int
+        ): RemoteViews {
+            val lineName = if (state.loaded && state.lineName.isNotEmpty()) {
+                state.lineName
+            } else {
+                context.getString(R.string.widget_line_not_set)
+            }
+            val boundFor = if (state.loaded && state.boundStationName.isNotEmpty()) {
+                state.boundStationName
+            } else {
+                context.getString(R.string.widget_destination_not_set)
+            }
+            // iOS版と同様に、路線記号が無い路線では路線名の先頭1文字で代替する
+            val lineSymbol = when {
+                !state.loaded -> "?"
+                state.lineSymbol.isNotEmpty() -> state.lineSymbol
+                lineName.isNotEmpty() -> lineName.take(1)
+                else -> "?"
+            }
+            val lineColor = WidgetStateStore.parseColor(
+                if (state.loaded) state.lineColor else WidgetStateStore.PLACEHOLDER_LINE_COLOR,
+                WidgetStateStore.parseColor(WidgetStateStore.PLACEHOLDER_LINE_COLOR, 0)
+            )
+
+            val views = when {
+                // サイズ未取得(0)のときは既定の横長レイアウトにフォールバックする
+                minWidthDp in 1 until CIRCULAR_MAX_WIDTH_DP ->
+                    circularViews(context, lineSymbol, lineColor)
+                minHeightDp in 1..INLINE_MAX_HEIGHT_DP ->
+                    inlineViews(context, state.loaded, lineName, lineColor)
+                else -> rectangularViews(context, lineName, boundFor, lineColor)
+            }
+
+            views.setContentDescription(
+                R.id.widget_root,
+                if (state.loaded) {
+                    "${context.getString(R.string.widget_riding_on, lineName)} / $boundFor"
+                } else {
+                    context.getString(R.string.app_name)
+                }
+            )
+            createContentIntent(context)?.let {
+                views.setOnClickPendingIntent(R.id.widget_root, it)
+            }
+
+            return views
+        }
+
+        private fun circularViews(
+            context: Context,
+            lineSymbol: String,
+            lineColor: Int
+        ): RemoteViews =
+            RemoteViews(context.packageName, R.layout.widget_ride_circular).apply {
+                setInt(R.id.widget_numbering_circle, "setColorFilter", lineColor)
+                setTextViewText(R.id.widget_line_symbol, lineSymbol)
+            }
+
+        private fun inlineViews(
+            context: Context,
+            loaded: Boolean,
+            lineName: String,
+            lineColor: Int
+        ): RemoteViews =
+            RemoteViews(context.packageName, R.layout.widget_ride_inline).apply {
+                setInt(R.id.widget_line_bar, "setColorFilter", lineColor)
+                setTextViewText(
+                    R.id.widget_inline_text,
+                    if (loaded) {
+                        context.getString(R.string.widget_riding_on, lineName)
+                    } else {
+                        context.getString(R.string.app_name)
+                    }
+                )
+            }
+
+        private fun rectangularViews(
+            context: Context,
+            lineName: String,
+            boundFor: String,
+            lineColor: Int
+        ): RemoteViews =
+            RemoteViews(context.packageName, R.layout.widget_ride_rectangular).apply {
+                setInt(R.id.widget_line_bar, "setColorFilter", lineColor)
+                setTextViewText(R.id.widget_line_name, lineName)
+                setTextViewText(R.id.widget_bound_for, boundFor)
+            }
+
+        private fun createContentIntent(context: Context): PendingIntent? {
+            val intent = context.packageManager
+                .getLaunchIntentForPackage(context.packageName) ?: return null
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/me/tinykitten/trainlcd/TrainLCDPackage.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/TrainLCDPackage.kt
@@ -21,6 +21,7 @@ class TrainLCDPackage : ReactPackage {
     IgnoreBatteryOptimizationsModule(reactContext),
     GnssModule(reactContext),
     LiveUpdateModule(reactContext),
-    PictureInPictureModule(reactContext)
+    PictureInPictureModule(reactContext),
+    WidgetModule(reactContext)
   ).toMutableList()
 }

--- a/android/app/src/main/java/me/tinykitten/trainlcd/WidgetModule.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/WidgetModule.kt
@@ -1,0 +1,47 @@
+package me.tinykitten.trainlcd
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+
+private fun ReadableMap.optString(key: String, default: String = ""): String =
+    if (hasKey(key) && !isNull(key)) getString(key) ?: default else default
+
+/**
+ * ホーム画面ウィジェットの表示内容をJS側から更新するモジュール。
+ *
+ * iOS版はLiveActivityModuleがライブアクティビティ更新のついでにウィジェット用の
+ * App Groupへ書き込んでいるが、Android版のライブアップデート(LiveUpdateModule)は
+ * Android 16以降専用のため、ウィジェットの更新経路は独立させている。
+ */
+class WidgetModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName() = "WidgetModule"
+
+    @ReactMethod
+    fun updateWidget(state: ReadableMap?) {
+        if (state == null) {
+            return
+        }
+
+        val changed = WidgetStateStore.save(
+            reactApplicationContext,
+            lineName = state.optString("lineName"),
+            lineColor = state.optString("lineColor"),
+            lineSymbol = state.optString("lineSymbol"),
+            boundStationName = state.optString("boundStationName")
+        )
+        if (changed) {
+            RideWidgetProvider.updateAll(reactApplicationContext)
+        }
+    }
+
+    @ReactMethod
+    fun clearWidget() {
+        if (WidgetStateStore.clear(reactApplicationContext)) {
+            RideWidgetProvider.updateAll(reactApplicationContext)
+        }
+    }
+}

--- a/android/app/src/main/java/me/tinykitten/trainlcd/WidgetStateStore.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/WidgetStateStore.kt
@@ -1,0 +1,100 @@
+package me.tinykitten.trainlcd
+
+import android.content.Context
+import android.graphics.Color
+
+/**
+ * ホーム画面ウィジェットが表示する乗車中の路線情報。
+ * iOS版がApp GroupのUserDefaultsへ書き込んでいる内容(LiveActivityModule.syncLockScreenWidgetState)と対になる。
+ */
+data class WidgetState(
+    val loaded: Boolean,
+    val lineName: String,
+    val lineColor: String,
+    val lineSymbol: String,
+    val boundStationName: String
+)
+
+/**
+ * ウィジェットの表示内容をSharedPreferencesへ永続化する。
+ * アプリのプロセスが落ちていてもAppWidgetProviderから読めるようにするため、
+ * メモリではなく端末ストレージへ保存する。
+ */
+object WidgetStateStore {
+    private const val PREFS_NAME = "me.tinykitten.trainlcd.widget"
+    private const val KEY_LOADED = "loaded"
+    private const val KEY_LINE_NAME = "lineName"
+    private const val KEY_LINE_COLOR = "lineColor"
+    private const val KEY_LINE_SYMBOL = "lineSymbol"
+    private const val KEY_BOUND_STATION_NAME = "boundStationName"
+
+    /** 未乗車時にiOS版が使っているプレースホルダー色に合わせる */
+    const val PLACEHOLDER_LINE_COLOR = "#277BC0"
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * 乗車情報を保存する。内容に差分がある場合のみtrueを返し、
+     * 変化のない更新でウィジェット再描画のブロードキャストを投げないようにする。
+     */
+    fun save(
+        context: Context,
+        lineName: String,
+        lineColor: String,
+        lineSymbol: String,
+        boundStationName: String
+    ): Boolean {
+        val prefs = prefs(context)
+        val unchanged = prefs.getBoolean(KEY_LOADED, false) &&
+            prefs.getString(KEY_LINE_NAME, "") == lineName &&
+            prefs.getString(KEY_LINE_COLOR, "") == lineColor &&
+            prefs.getString(KEY_LINE_SYMBOL, "") == lineSymbol &&
+            prefs.getString(KEY_BOUND_STATION_NAME, "") == boundStationName
+        if (unchanged) {
+            return false
+        }
+
+        prefs.edit()
+            .putBoolean(KEY_LOADED, true)
+            .putString(KEY_LINE_NAME, lineName)
+            .putString(KEY_LINE_COLOR, lineColor)
+            .putString(KEY_LINE_SYMBOL, lineSymbol)
+            .putString(KEY_BOUND_STATION_NAME, boundStationName)
+            .apply()
+        return true
+    }
+
+    /** 降車時に未乗車表示へ戻す。既に未乗車ならfalseを返す */
+    fun clear(context: Context): Boolean {
+        val prefs = prefs(context)
+        if (!prefs.getBoolean(KEY_LOADED, false)) {
+            return false
+        }
+        prefs.edit().putBoolean(KEY_LOADED, false).apply()
+        return true
+    }
+
+    fun load(context: Context): WidgetState {
+        val prefs = prefs(context)
+        return WidgetState(
+            loaded = prefs.getBoolean(KEY_LOADED, false),
+            lineName = prefs.getString(KEY_LINE_NAME, "").orEmpty(),
+            lineColor = prefs.getString(KEY_LINE_COLOR, "").orEmpty(),
+            lineSymbol = prefs.getString(KEY_LINE_SYMBOL, "").orEmpty(),
+            boundStationName = prefs.getString(KEY_BOUND_STATION_NAME, "").orEmpty()
+        )
+    }
+
+    /** 路線色は`#RRGGBB`と`RRGGBB`の双方が渡り得るため、どちらでも解釈できるようにする */
+    fun parseColor(hex: String, fallback: Int): Int {
+        if (hex.isEmpty()) {
+            return fallback
+        }
+        return try {
+            Color.parseColor(if (hex.startsWith("#")) hex else "#$hex")
+        } catch (_: IllegalArgumentException) {
+            fallback
+        }
+    }
+}

--- a/android/app/src/main/res/drawable/widget_background.xml
+++ b/android/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/widget_corner_radius" />
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_background_circle.xml
+++ b/android/app/src/main/res/drawable/widget_background_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_line_bar.xml
+++ b/android/app/src/main/res/drawable/widget_line_bar.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 路線色はRemoteViews#setInt("setColorFilter")で着色するため、ここでは白で描く -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="#FFFFFFFF" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_numbering_circle.xml
+++ b/android/app/src/main/res/drawable/widget_numbering_circle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- iOS版のナンバリングサークル(Circle().stroke)相当。路線色はsetColorFilterで着色する -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@android:color/transparent" />
+    <stroke
+        android:width="5dp"
+        android:color="#FFFFFFFF" />
+</shape>

--- a/android/app/src/main/res/layout/widget_ride_circular.xml
+++ b/android/app/src/main/res/layout/widget_ride_circular.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- iOS/watchOSのaccessoryCircular(ナンバリングサークル)に相当するレイアウト -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background_circle"
+    android:padding="4dp">
+
+    <ImageView
+        android:id="@+id/widget_numbering_circle"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@null"
+        android:src="@drawable/widget_numbering_circle" />
+
+    <TextView
+        android:id="@+id/widget_line_symbol"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:textColor="@color/widget_text_primary"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+</FrameLayout>

--- a/android/app/src/main/res/layout/widget_ride_inline.xml
+++ b/android/app/src/main/res/layout/widget_ride_inline.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- iOS/watchOSのaccessoryInline(1行表示)に相当するレイアウト -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="10dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="10dp"
+    android:paddingBottom="8dp">
+
+    <ImageView
+        android:id="@+id/widget_line_bar"
+        android:layout_width="4dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="8dp"
+        android:contentDescription="@null"
+        android:scaleType="fitXY"
+        android:src="@drawable/widget_line_bar" />
+
+    <TextView
+        android:id="@+id/widget_inline_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="@color/widget_text_primary"
+        android:textSize="13sp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_ride_rectangular.xml
+++ b/android/app/src/main/res/layout/widget_ride_rectangular.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- iOS/watchOSのaccessoryRectangularに相当するレイアウト -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:padding="12dp">
+
+    <ImageView
+        android:id="@+id/widget_line_bar"
+        android:layout_width="4dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="8dp"
+        android:contentDescription="@null"
+        android:scaleType="fitXY"
+        android:src="@drawable/widget_line_bar" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/widget_line_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/widget_bound_for"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="12sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -5,4 +5,8 @@
   <string name="live_update_passing">Passing through %1$s</string>
   <string name="live_update_approaching">Now approaching: %1$s</string>
   <string name="live_update_next">Next: %1$s</string>
+  <string name="widget_description">Shows the line and destination you are riding</string>
+  <string name="widget_line_not_set">No route selected</string>
+  <string name="widget_destination_not_set">Destination not set</string>
+  <string name="widget_riding_on">Riding on %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -5,7 +5,7 @@
   <string name="live_update_passing">Passing through %1$s</string>
   <string name="live_update_approaching">Now approaching: %1$s</string>
   <string name="live_update_next">Next: %1$s</string>
-  <string name="widget_description">Shows the line and destination you are riding</string>
+  <string name="widget_description">Shows the line and destination for your current ride</string>
   <string name="widget_line_not_set">No route selected</string>
   <string name="widget_destination_not_set">Destination not set</string>
   <string name="widget_riding_on">Riding on %1$s</string>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,1 +1,6 @@
-<resources/>
+<resources>
+  <!-- ホーム画面ウィジェット(ダークテーマ) -->
+  <color name="widget_background">#F21F1F1F</color>
+  <color name="widget_text_primary">#FFFFFFFF</color>
+  <color name="widget_text_secondary">#B3FFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values-v31/dimens.xml
+++ b/android/app/src/main/res/values-v31/dimens.xml
@@ -1,0 +1,4 @@
+<resources>
+  <!-- Android 12以降はランチャーのウィジェット角丸に合わせる -->
+  <dimen name="widget_corner_radius">@android:dimen/system_app_widget_background_radius</dimen>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -3,4 +3,8 @@
   <color name="iconBackground">#EEEEEE</color>
   <color name="colorPrimary">#023c69</color>
   <color name="colorPrimaryDark">#fff</color>
+  <!-- ホーム画面ウィジェット(ライトテーマ) -->
+  <color name="widget_background">#F2FFFFFF</color>
+  <color name="widget_text_primary">#FF1F1F1F</color>
+  <color name="widget_text_secondary">#B31F1F1F</color>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<resources>
+  <!-- ホーム画面ウィジェットの角丸。Android 12以降はvalues-v31でシステム既定値へ差し替える -->
+  <dimen name="widget_corner_radius">16dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,10 @@
   <string name="live_update_passing">%1$sを通過中</string>
   <string name="live_update_approaching">まもなく%1$s</string>
   <string name="live_update_next">次は%1$s</string>
+  <string name="widget_description">乗車中の路線と方面を表示します</string>
+  <string name="widget_line_not_set">路線が未設定です</string>
+  <string name="widget_destination_not_set">方面が未設定です</string>
+  <string name="widget_riding_on">%1$sに乗車中</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/android/app/src/main/res/xml/ride_widget_info.xml
+++ b/android/app/src/main/res/xml/ride_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/widget_ride_rectangular"
+    android:minHeight="40dp"
+    android:minResizeHeight="40dp"
+    android:minResizeWidth="40dp"
+    android:minWidth="110dp"
+    android:previewLayout="@layout/widget_ride_rectangular"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="1"
+    android:targetCellWidth="2"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -19,6 +19,10 @@ import {
   updateLiveUpdate,
 } from '../utils/native/android/liveUpdateModule';
 import {
+  clearWidget,
+  updateWidget,
+} from '../utils/native/android/widgetModule';
+import {
   startLiveActivity,
   stopLiveActivity,
   updateLiveActivity,
@@ -289,6 +293,8 @@ export const useUpdateLiveActivities = (): void => {
     if (selectedBound && !started) {
       startLiveActivity(activityState);
       startLiveUpdate(activityState);
+      // Androidのホーム画面ウィジェット。ライブアップデートはAndroid 16以降専用のため別経路で更新する
+      updateWidget(activityState);
       setStarted(true);
     }
   }, [activityState, selectedBound, started]);
@@ -297,6 +303,7 @@ export const useUpdateLiveActivities = (): void => {
     return () => {
       stopLiveActivity();
       stopLiveUpdate();
+      clearWidget();
       setStarted(false);
     };
   }, []);
@@ -305,6 +312,7 @@ export const useUpdateLiveActivities = (): void => {
     if (started) {
       updateLiveActivity(activityState);
       updateLiveUpdate(activityState);
+      updateWidget(activityState);
     }
   }, [activityState, started]);
 };

--- a/src/utils/native/android/widgetModule.test.ts
+++ b/src/utils/native/android/widgetModule.test.ts
@@ -1,0 +1,53 @@
+import { NativeModules, Platform } from 'react-native';
+
+const updateWidgetSpy = jest.fn();
+const clearWidgetSpy = jest.fn();
+
+// widgetModuleはimport時にNativeModulesを分割代入するため、読み込み前にモジュールを差し込む
+(NativeModules as unknown as Record<string, unknown>).WidgetModule = {
+  updateWidget: updateWidgetSpy,
+  clearWidget: clearWidgetSpy,
+};
+
+const { clearWidget, updateWidget } =
+  require('./widgetModule') as typeof import('./widgetModule');
+
+// jest-expo の既定 Platform.OS は 'ios'。テストごとに切り替えてafterEachで元へ戻す。
+const originalPlatformOS = Platform.OS;
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+};
+
+const state = {
+  lineName: '山手線',
+  lineColor: '#80C241',
+  lineSymbol: 'JY',
+  boundStationName: '新宿・渋谷方面',
+};
+
+afterEach(() => {
+  setPlatformOS(originalPlatformOS);
+  jest.clearAllMocks();
+});
+
+describe('widgetModule', () => {
+  it('Androidではネイティブモジュールへ乗車情報をそのまま渡す', () => {
+    setPlatformOS('android');
+    updateWidget(state);
+    expect(updateWidgetSpy).toHaveBeenCalledWith(state);
+  });
+
+  it('Androidでは降車時にウィジェットの表示内容をクリアする', () => {
+    setPlatformOS('android');
+    clearWidget();
+    expect(clearWidgetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Android以外ではネイティブモジュールを呼ばない', () => {
+    setPlatformOS('ios');
+    updateWidget(state);
+    clearWidget();
+    expect(updateWidgetSpy).not.toHaveBeenCalled();
+    expect(clearWidgetSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/native/android/widgetModule.ts
+++ b/src/utils/native/android/widgetModule.ts
@@ -1,0 +1,30 @@
+import { NativeModules, Platform } from 'react-native';
+
+const { WidgetModule } = NativeModules;
+
+/**
+ * ホーム画面ウィジェットへ渡す乗車情報。
+ * iOSのロック画面ウィジェットがApp Groupから読む項目と揃えている。
+ */
+export type WidgetState = {
+  lineName: string;
+  lineColor: string;
+  lineSymbol: string;
+  boundStationName: string;
+};
+
+export const updateWidget = (state: WidgetState) => {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+
+  WidgetModule?.updateWidget?.(state);
+};
+
+export const clearWidget = () => {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+
+  WidgetModule?.clearWidget?.();
+};


### PR DESCRIPTION
## 概要

iOS のロック画面ウィジェット（`LockScreenWidget`）と watchOS のコンプリケーション（`WatchWidget`）に相当するホーム画面ウィジェットを Android に追加しました。表示内容・レイアウトは iOS/watchOS 版を踏襲し、ウィジェットのサイズに応じて iOS の 3 つの accessory family 相当のレイアウトを出し分けます。

| レイアウト | iOS/watchOS 相当 | 表示内容 |
| ---- | ---- | ---- |
| `widget_ride_circular` | `accessoryCircular` | 路線色でストロークした円 + 路線記号 |
| `widget_ride_inline` | `accessoryInline` | 路線色バー + 「○○線に乗車中」 |
| `widget_ride_rectangular` | `accessoryRectangular` | 角丸の路線色バー + 路線名（太字） + 方面 |

未乗車時のプレースホルダー（`路線が未設定です` / `方面が未設定です` / 記号 `?` / 色 `#277BC0`）と、路線記号を持たない路線で路線名の先頭 1 文字を代替表示する挙動も iOS 版に合わせています。

データ経路は iOS と異なります。iOS は `LiveActivityModule` がライブアクティビティ更新のついでに App Group の `UserDefaults` へ書き込んでいますが、Android のライブアップデート（`LiveUpdateModule`）は Android 16 (API 36) 以降専用のため、それより前の OS でもウィジェットが動くよう更新経路を独立させています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `RideWidgetProvider`: `AppWidgetProvider` 実装。`onUpdate` / `onAppWidgetOptionsChanged` でウィジェットの実サイズ（`OPTION_APPWIDGET_MIN_WIDTH` / `MIN_HEIGHT`）を見て円形・1 行・横長のレイアウトを選択し、タップでアプリを起動する `PendingIntent` と `contentDescription` を設定
- `WidgetStateStore`: 表示内容を SharedPreferences へ保存。アプリのプロセスが落ちていても `AppWidgetProvider` から読めるようにするため。差分がある場合のみ保存＋再描画を行い、無変化の更新でブロードキャストを投げない（iOS 版の `lastWidgetState` と同じ考え方）
- `WidgetModule`: JS から表示内容を更新する React Native ブリッジ。`TrainLCDPackage` へ登録
- レイアウト 3 種・drawable 4 種を追加。背景と文字色は `values` / `values-night` でライト/ダーク両対応、角丸は Android 12 以降でランチャー既定値（`system_app_widget_background_radius`）へ追従
- `AndroidManifest.xml` に `RideWidgetProvider` の receiver と `@xml/ride_widget_info` を追加
- 文言（`widget_description` / `widget_line_not_set` / `widget_destination_not_set` / `widget_riding_on`）を日本語（`values`）・英語（`values-en`）で追加。iOS の `Localizable.strings` と同一文言
- `src/utils/native/android/widgetModule.ts`: ネイティブモジュールのラッパー（Android 以外では no-op）と、その単体テストを追加
- `useUpdateLiveActivities`: 乗車開始時・更新時に `updateWidget`、降車時に `clearWidget` を呼ぶよう追加

## テスト

`npm run lint` / `npm test` / `npm run typecheck` をローカルで実行し、いずれも成功しています（`npm test`: 208 suites / 2195 tests passed）。

加えて、Android SDK 36 + JDK 17 を用意して `./gradlew :app:compileDevDebugKotlin` を実行し BUILD SUCCESSFUL を確認しました。`processDevDebugResources` を通過しているため、追加したレイアウト・drawable・manifest の receiver 定義もリソース処理レベルで検証済みです。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

作業環境にエミュレータ／実機がないため未取得です。マージ前に実機（例: Pixel 8）で 1x1・2x1・4x1 の各サイズとライト/ダークテーマの見た目確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XHQB1iKjHbZLmPDKysVpnt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Androidのホーム画面に、乗車中の路線・路線記号・行き先を表示するウィジェットを追加しました。
  * ウィジェットのサイズに応じて表示レイアウトを自動調整します。
  * ライブ表示の開始・更新・終了に合わせて、ウィジェットの内容を自動更新・消去します。
  * ウィジェットからアプリを起動できます。
  * ライトテーマとダークテーマ、アクセシビリティに対応しました。

* **テスト**
  * Androidでのウィジェット更新・消去、およびAndroid以外での動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->