### PR TITLE
ロック画面コントロールを長押ししてもアプリが開かない問題を修正

### DIFF
--- a/ios/RideSessionActivity/LockScreenControl.swift
+++ b/ios/RideSessionActivity/LockScreenControl.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2026 Facebook. All rights reserved.
 //
 
-import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -61,21 +60,7 @@ struct LockScreenControlProvider: ControlValueProvider {
   }
 }
 
-// コントロールのタップでTrainLCD本体を開く。openAppWhenRunにより
-// Canary/Prodそれぞれの親アプリが起動するのでURLスキームの出し分けは不要
-@available(iOS 18.0, *)
-struct OpenTrainLCDIntent: AppIntent {
-  // 文字列リソースが引けない場合でもキー名が露出しないようdefaultValueを添える
-  static var title: LocalizedStringResource {
-    LocalizedStringResource("openApp", defaultValue: "Open TrainLCD")
-  }
-  static let openAppWhenRun = true
-
-  func perform() async throws -> some IntentResult {
-    .result()
-  }
-}
-
+// タップ時に実行するOpenTrainLCDIntentはアプリ本体とも共有するためOpenTrainLCDIntent.swiftに置く
 @available(iOS 18.0, *)
 struct LockScreenControl: ControlWidget {
   // LiveActivityModule側のreloadControls(ofKind:)と一致させること

--- a/ios/RideSessionActivity/OpenTrainLCDIntent.swift
+++ b/ios/RideSessionActivity/OpenTrainLCDIntent.swift
@@ -12,12 +12,17 @@ import Foundation
 // ロック画面コントロールのタップでTrainLCD本体を開くインテント。
 //
 // NOTE: このファイルはアプリ本体（Canary/Prod）とRideSessionActivity Extensionの
-// 両方のターゲットに所属させること。コントロールから起動されるAppIntentがExtension側にしか
-// 存在しないと、システムがアプリ側でインテントを実行できず長押ししても何も起きない。
+// 両方のターゲットに所属させること。openAppWhenRunを立てたAppIntentはExtensionプロセスでは
+// 実行できず、システムはアプリ側の定義を使って実行する。アプリ側に定義が無いと実行先が
+// 見つからず、コントロールを長押ししても何も起きない。
 //
-// NOTE: openAppWhenRunだけではコントロール経由の起動が失敗する既知の不具合があるため、
-// OpenURLIntentによるディープリンクも併せて返す。ユニバーサルリンクはiOS 18.0で
-// ブラウザが開いてしまう不具合があったため、登録済みのカスタムURLスキームを使う。
+// NOTE: openAppWhenRunはiOS 26でsupportedModes(.foreground(.immediate))へ置き換えられたが、
+// supportedModes自体がiOS 26以降のAPIで、本コントロールはiOS 18以降を対象とするため移行できない。
+// supportedModesを宣言しない場合の既定実装がopenAppWhenRunの値を引き継ぐ。
+//
+// NOTE: OpenURLIntentによるディープリンク併用は見送っている。OpenURLIntentはUniversal Linkを
+// 前提としたAPIで、本アプリはassociated-domainsを設定していない（applinksを持つのはApp Clipのみ）ため、
+// trainlcd://のようなカスタムスキームを渡しても確実な起動経路にならない。
 @available(iOS 18.0, *)
 struct OpenTrainLCDIntent: AppIntent {
   // 文字列リソースが引けない場合でもキー名が露出しないようdefaultValueを添える
@@ -26,18 +31,7 @@ struct OpenTrainLCDIntent: AppIntent {
   }
   static let openAppWhenRun = true
 
-  func perform() async throws -> some IntentResult & OpensIntent {
-    .result(opensIntent: OpenURLIntent(Self.deepLinkURL))
-  }
-
-  // Canary/Prodで登録済みのURLスキームを出し分ける。スキーム名はアプリ・Extension双方の
-  // Info.plistのCURRENT_SCHEME_NAMEから解決する
-  private static var deepLinkURL: URL {
-    let schemeName =
-      Bundle.main.object(forInfoDictionaryKey: "CURRENT_SCHEME_NAME") as? String
-    let urlString =
-      schemeName == "CanaryTrainLCD" ? "trainlcd-canary://" : "trainlcd://"
-    // 固定文字列のためURL化は必ず成功する
-    return URL(string: urlString)!
+  func perform() async throws -> some IntentResult {
+    .result()
   }
 }

--- a/ios/RideSessionActivity/OpenTrainLCDIntent.swift
+++ b/ios/RideSessionActivity/OpenTrainLCDIntent.swift
@@ -1,0 +1,43 @@
+//
+//  OpenTrainLCDIntent.swift
+//  TrainLCD
+//
+//  Created by Tsubasa SEKIGUCHI on 2026/08/06.
+//  Copyright © 2026 Facebook. All rights reserved.
+//
+
+import AppIntents
+import Foundation
+
+// ロック画面コントロールのタップでTrainLCD本体を開くインテント。
+//
+// NOTE: このファイルはアプリ本体（Canary/Prod）とRideSessionActivity Extensionの
+// 両方のターゲットに所属させること。コントロールから起動されるAppIntentがExtension側にしか
+// 存在しないと、システムがアプリ側でインテントを実行できず長押ししても何も起きない。
+//
+// NOTE: openAppWhenRunだけではコントロール経由の起動が失敗する既知の不具合があるため、
+// OpenURLIntentによるディープリンクも併せて返す。ユニバーサルリンクはiOS 18.0で
+// ブラウザが開いてしまう不具合があったため、登録済みのカスタムURLスキームを使う。
+@available(iOS 18.0, *)
+struct OpenTrainLCDIntent: AppIntent {
+  // 文字列リソースが引けない場合でもキー名が露出しないようdefaultValueを添える
+  static var title: LocalizedStringResource {
+    LocalizedStringResource("openApp", defaultValue: "Open TrainLCD")
+  }
+  static let openAppWhenRun = true
+
+  func perform() async throws -> some IntentResult & OpensIntent {
+    .result(opensIntent: OpenURLIntent(Self.deepLinkURL))
+  }
+
+  // Canary/Prodで登録済みのURLスキームを出し分ける。スキーム名はアプリ・Extension双方の
+  // Info.plistのCURRENT_SCHEME_NAMEから解決する
+  private static var deepLinkURL: URL {
+    let schemeName =
+      Bundle.main.object(forInfoDictionaryKey: "CURRENT_SCHEME_NAME") as? String
+    let urlString =
+      schemeName == "CanaryTrainLCD" ? "trainlcd-canary://" : "trainlcd://"
+    // 固定文字列のためURL化は必ず成功する
+    return URL(string: urlString)!
+  }
+}

--- a/ios/RideSessionActivity/Schemes/Dev/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Dev/Info.plist
@@ -8,6 +8,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CURRENT_SCHEME_NAME</key>
+	<string>CanaryTrainLCD</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/RideSessionActivity/Schemes/Prod/Info.plist
+++ b/ios/RideSessionActivity/Schemes/Prod/Info.plist
@@ -8,6 +8,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CURRENT_SCHEME_NAME</key>
+	<string>ProdTrainLCD</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -53,6 +53,10 @@
 		94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
 		94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
 		94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
+		94D3F4662E40A00300000001 /* OpenTrainLCDIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */; };
+		94D3F4672E40A00300000002 /* OpenTrainLCDIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */; };
+		94D3F4682E40A00300000003 /* OpenTrainLCDIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */; };
+		94D3F4692E40A00300000004 /* OpenTrainLCDIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */; };
 		942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EAA025890E8500E02655 /* ColorExtension.swift */; };
 		942CB60B2A32AAB4008339D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDE128D3025900D68287 /* SwiftUI.framework */; };
 		942CB60C2A32AAB4008339D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDDF28D3025900D68287 /* WidgetKit.framework */; };
@@ -409,6 +413,7 @@
 		94B9CDE428D3025900D68287 /* RideSessionActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionActivity.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		94D3F45F2E40A00100000000 /* LockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWidget.swift; sourceTree = "<group>"; };
 		94D3F4622E40A00200000000 /* LockScreenControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenControl.swift; sourceTree = "<group>"; };
+		94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTrainLCDIntent.swift; sourceTree = "<group>"; };
 		94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = RideSessionActivity.intentdefinition; sourceTree = "<group>"; };
 		94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionAttributes.swift; sourceTree = "<group>"; };
 		94BFA3B7258F0FF3001D95E4 /* StationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListView.swift; sourceTree = "<group>"; };
@@ -831,6 +836,7 @@
 				94B9CDE428D3025900D68287 /* RideSessionActivity.swift */,
 				94D3F45F2E40A00100000000 /* LockScreenWidget.swift */,
 				94D3F4622E40A00200000000 /* LockScreenControl.swift */,
+				94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */,
 				94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */,
 				94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */,
 				94000A592AD73E8900B5A11C /* Assets.xcassets */,
@@ -2186,6 +2192,7 @@
 				94C1658529B99E0A007329A6 /* SensitiveNotificationModule.swift in Sources */,
 				94C1658F29B9A349007329A6 /* LiveActivityModule.swift in Sources */,
 				944C2C3628DAC55A0004DA72 /* RideSessionAttributes.swift in Sources */,
+				94D3F4662E40A00300000001 /* OpenTrainLCDIntent.swift in Sources */,
 				94C1658629B99E0A007329A6 /* SensitiveNotificationModuleBridge.m in Sources */,
 				94C1658029B99DEB007329A6 /* LiveActivityModuleBridge.m in Sources */,
 				9DB892EB978E1EA030B325CF /* ExpoModulesProvider.swift in Sources */,
@@ -2200,6 +2207,7 @@
 				942CB5B92A32AA96008339D2 /* SensitiveNotificationModule.swift in Sources */,
 				942CB5BC2A32AA96008339D2 /* LiveActivityModule.swift in Sources */,
 				942CB5BD2A32AA96008339D2 /* RideSessionAttributes.swift in Sources */,
+				94D3F4672E40A00300000002 /* OpenTrainLCDIntent.swift in Sources */,
 				942CB5BF2A32AA96008339D2 /* SensitiveNotificationModuleBridge.m in Sources */,
 				942CB5C02A32AA96008339D2 /* LiveActivityModuleBridge.m in Sources */,
 				F4B63ECCFF1E13D682E1521B /* ExpoModulesProvider.swift in Sources */,
@@ -2239,6 +2247,7 @@
 				942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */,
 				94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */,
 				94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */,
+				94D3F4692E40A00300000004 /* OpenTrainLCDIntent.swift in Sources */,
 				942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */,
 				94E6881C2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);
@@ -2273,6 +2282,7 @@
 				94B9CDE528D3025900D68287 /* RideSessionActivity.swift in Sources */,
 				94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */,
 				94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */,
+				94D3F4682E40A00300000003 /* OpenTrainLCDIntent.swift in Sources */,
 				944C2C4F28DADC380004DA72 /* ColorExtension.swift in Sources */,
 				94E6881B2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
 			);


### PR DESCRIPTION
## 概要

#6568 で追加したロック画面コントロールを長押ししても TrainLCD が起動しない不具合を修正する。

ロック画面下部のコントロールは懐中電灯・カメラと同様に「触れたまま押し込む → 拡大したら離す」で発動するため、長押しが正しい起動操作である。つまり操作方法の問題ではなく、コントロールに紐づけた `AppIntent` が実行されていなかった。

**原因**: `OpenTrainLCDIntent` を `RideSessionActivity` Extension のターゲットにしか含めていなかった。`openAppWhenRun = true` の `AppIntent` は Extension プロセスでは実行されず、システムがアプリを起動してアプリ側の定義で `perform()` を走らせる。アプリ本体に定義が無いと実行先が見つからず無反応になる。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/RideSessionActivity/OpenTrainLCDIntent.swift`（新規）
  - `OpenTrainLCDIntent` を `LockScreenControl.swift` から切り出し、アプリ本体と共有できるようにした
  - `openAppWhenRun = true` による起動に一本化。`OpenURLIntent` によるディープリンク併用は行わない（後述）
- `ios/TrainLCD.xcodeproj/project.pbxproj`
  - 上記ファイルを **CanaryTrainLCD / ProdTrainLCD（アプリ本体）と CanaryRideSessionActivityExtension / ProdRideSessionActivityExtension（Extension）の 4 ターゲット全て**に登録。これが不具合の直接の修正にあたる
- `ios/RideSessionActivity/LockScreenControl.swift`
  - インテント定義の移設に伴い `import AppIntents` を削除（コントロール定義自体は変更なし）
- `ios/RideSessionActivity/Schemes/{Dev,Prod}/Info.plist`
  - `CURRENT_SCHEME_NAME` を追加。**既存の Canary 版ロック画面ウィジェットが `widgetURL` で Prod スキーム（`trainlcd://`）を開いてしまう潜在バグの修正**（`RideSessionActivity.swift` は `Bundle.main` からこのキーを読むが、Extension の Info.plist に存在しなかったため常に Prod 側へフォールバックしていた）

### レビュー反映（`000386a`）

初回実装では `openAppWhenRun` に加えて `OpenURLIntent` でカスタムスキーム（`trainlcd://` / `trainlcd-canary://`）も返していたが、`OpenURLIntent` は Universal Link 前提の API であり、カスタムスキームでは確実な起動経路にならない。本アプリの entitlements を確認したところ、**アプリ本体には `com.apple.developer.associated-domains` が未設定**（`applinks:` を持つのは App Clip のみ、しかも `appclips:` プレフィックス）で Universal Link を用意できないため、機能しないコードとして `OpenURLIntent` の併用を削除した。

Universal Link 経路が必要になるのは `openAppWhenRun` 単独での起動が実機で失敗した場合に限られ、その際は associated-domains + AASA の整備を含む別 PR で対応する。

### 回帰リスクと緩和策

- **アプリ本体への `AppIntents` 追加**: `OpenTrainLCDIntent` は `@available(iOS 18.0, *)` で全体をガードしているため、アプリのデプロイターゲット（15.1）を下回る環境では参照されない。AppIntents.framework は可用性情報に基づき自動で weak link される。
- **`openAppWhenRun` の非推奨化**: 後継の `supportedModes` / `IntentModes` は iOS 26.0 以降の API のため、iOS 18 を対象とする本コントロールでは採用できない（適合型より新しい可用性のメンバーでプロトコル要件を満たせない）。`supportedModes` を宣言しない場合の既定実装が `openAppWhenRun` を引き継ぐ後方互換設計に依存する。iOS 18 が最低対応から外れた時点で `.foreground(.immediate)` へ移行する。
- **Canary の URL スキーム変更**: これまで Canary 拡張のウィジェットは誤って `trainlcd://` を開いていたため、本 PR で `trainlcd-canary://` に変わる。Canary ビルドで意図した側のアプリが開くことの確認が必要。

## テスト

ローカルで以下を実行し、すべて成功することを確認した。

- `npm run lint`: 615 ファイル検査、指摘なし
- `npm test`: 208 suites / 2195 tests すべて成功
- `npm run typecheck`: エラーなし

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

**未検証事項（レビュー時にご確認ください）**

- 変更は Swift / pbxproj / Info.plist のみで、JS 側のテスト対象コードは変更していない（上記 3 コマンドは回帰確認のために実行）。
- 作業環境が Linux コンテナのため **Xcode でのビルド確認は未実施**。実機での以下の確認をお願いしたい。
  - ロック画面下部のコントロールを長押しして TrainLCD が起動すること
  - Canary ビルドで Canary アプリが（Prod ではなく）起動すること
  - コントロールセンターに配置したコントロールからも起動すること
  - Canary 版ロック画面ウィジェットのタップで Canary アプリが開くこと（`CURRENT_SCHEME_NAME` 追加による副次的な修正）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

macOS / シミュレータのない環境での作業のため未添付。動作確認時のロック画面からの起動フローの記録をいただけると助かります（例: iPhone 15 Pro / iOS 18 以降）。
