### PR TITLE
watchOS・ロック画面ウィジェットと同じ体裁のホーム画面ウィジェットをiOSに追加

### DIFF
--- a/ios/Localizable/en.lproj/Localizable.strings
+++ b/ios/Localizable/en.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "lastUpdated" = "Last updated";
 "openApp" = "Open TrainLCD";
 "controlDescription" = "Opens TrainLCD from the Lock Screen or Control Center.";
+"widgetDescription" = "Shows the line and destination for your current ride";

--- a/ios/Localizable/ja.lproj/Localizable.strings
+++ b/ios/Localizable/ja.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "lastUpdated" = "最終更新";
 "openApp" = "TrainLCDを開く";
 "controlDescription" = "ロック画面やコントロールセンターからTrainLCDを開きます。";
+"widgetDescription" = "乗車中の路線と方面を表示します";

--- a/ios/Modules/LiveActivity/LiveActivityModule.swift
+++ b/ios/Modules/LiveActivity/LiveActivityModule.swift
@@ -8,6 +8,8 @@ class LiveActivityModule: NSObject {
   var sessionActivity: Activity<RideSessionAttributes>?
 
   private let lockScreenWidgetKind = "LockScreenWidget"
+  // RideSessionActivity側のHomeScreenWidget.kindと一致させること
+  private let homeScreenWidgetKind = "HomeScreenWidget"
   // RideSessionActivity側のLockScreenControl.kindと一致させること
   private let lockScreenControlKind = "me.tinykitten.trainlcd.LockScreenControl"
 
@@ -20,8 +22,8 @@ class LiveActivityModule: NSObject {
   // reloadTimelines呼び出し(WidgetKitのリロードバジェット消費)を避ける
   private var lastWidgetState: [String: String]?
 
-  // ロック画面ウィジェットが参照するApp Groupへ乗車中の路線情報を書き込む
-  private func syncLockScreenWidgetState(_ dic: NSDictionary?) {
+  // ロック画面/ホーム画面ウィジェットが参照するApp Groupへ乗車中の路線情報を書き込む
+  private func syncWidgetState(_ dic: NSDictionary?) {
     guard let dic = dic else {
       return
     }
@@ -42,24 +44,25 @@ class LiveActivityModule: NSObject {
       defaults.set(value, forKey: key)
     }
     defaults.set(true, forKey: "loaded")
-    reloadLockScreenSurfaces()
+    reloadWidgetSurfaces()
   }
 
-  // ロック画面ウィジェットとロック画面コントロールは同じApp Groupを参照するため常に同時に更新する
-  private func reloadLockScreenSurfaces() {
+  // ロック画面/ホーム画面ウィジェットとロック画面コントロールは同じApp Groupを参照するため常に同時に更新する
+  private func reloadWidgetSurfaces() {
     WidgetCenter.shared.reloadTimelines(ofKind: lockScreenWidgetKind)
+    WidgetCenter.shared.reloadTimelines(ofKind: homeScreenWidgetKind)
     if #available(iOS 18.0, *) {
       ControlCenter.shared.reloadControls(ofKind: lockScreenControlKind)
     }
   }
 
-  private func clearLockScreenWidgetState() {
+  private func clearWidgetState() {
     lastWidgetState = nil
     guard let defaults = UserDefaults(suiteName: appGroupID) else {
       return
     }
     defaults.set(false, forKey: "loaded")
-    reloadLockScreenSurfaces()
+    reloadWidgetSurfaces()
   }
 
   func getStatus(_ dic: NSDictionary?) -> RideSessionAttributes.RideSessionStatus? {
@@ -98,7 +101,7 @@ class LiveActivityModule: NSObject {
       return
     }
 
-    syncLockScreenWidgetState(dic)
+    syncWidgetState(dic)
     
     do {
       let finalContentState = getStatus(dic)
@@ -138,7 +141,7 @@ class LiveActivityModule: NSObject {
       return
     }
 
-    syncLockScreenWidgetState(dic)
+    syncWidgetState(dic)
 
     Task {
       await sessionActivity?.update(using: nextContentState)
@@ -151,7 +154,7 @@ class LiveActivityModule: NSObject {
       return
     }
     
-    clearLockScreenWidgetState()
+    clearWidgetState()
 
     let finalContentState = getStatus(dic)
     Task {

--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -90,7 +90,7 @@ struct HomeScreenWidgetEntryView: View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(spacing: 0) {
         HomeScreenNumberingCircle(
-          lineColor: entry.lineColor,
+          lineColor: entry.displayLineColor,
           lineSymbol: entry.lineSymbol,
           diameter: 44
         )
@@ -109,7 +109,7 @@ struct HomeScreenWidgetEntryView: View {
   // アプリ名とナンバリングサークルを足した構成
   var mediumView: some View {
     HStack(spacing: 12) {
-      HomeScreenLineBar(lineColor: entry.lineColor)
+      HomeScreenLineBar(lineColor: entry.displayLineColor)
       VStack(alignment: .leading, spacing: 4) {
         brandLabel
         lineNameText
@@ -120,7 +120,7 @@ struct HomeScreenWidgetEntryView: View {
       }
       Spacer(minLength: 0)
       HomeScreenNumberingCircle(
-        lineColor: entry.lineColor,
+        lineColor: entry.displayLineColor,
         lineSymbol: entry.lineSymbol,
         diameter: 56
       )

--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -1,0 +1,185 @@
+//
+//  HomeScreenWidget.swift
+//  RideSessionActivity
+//
+//  Created by Tsubasa SEKIGUCHI on 2026/08/06.
+//  Copyright © 2026 Facebook. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// ホーム画面(systemSmall / systemMedium)に置けるウィジェット。
+// 表示データはロック画面ウィジェットと同じApp Group(LockScreenEntry)を共有し、
+// watchOSのaccessoryRectangular・iOSのロック画面ウィジェット・Androidのホーム画面ウィジェットと
+// 同じ体裁(路線色のナンバリングサークルとバー + 路線名 + 方面)を踏襲する。
+
+// watchOS/ロック画面のNumberingCircle相当。ホーム画面はサイズが可変なので直径を受け取る
+struct HomeScreenNumberingCircle: View {
+  let lineColor: String
+  let lineSymbol: String
+  let diameter: CGFloat
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(Color(hex: lineColor), lineWidth: diameter / 10)
+      Text(lineSymbol)
+        .font(.system(size: diameter * 0.4, weight: .bold, design: .rounded))
+        .minimumScaleFactor(0.5)
+        .lineLimit(1)
+        .padding(diameter * 0.18)
+    }
+    .frame(width: diameter, height: diameter)
+  }
+}
+
+// accessoryRectangular / Androidのwidget_line_barと同じ路線色のバー
+struct HomeScreenLineBar: View {
+  let lineColor: String
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: 2)
+      .fill(Color(hex: lineColor))
+      .frame(width: 4)
+  }
+}
+
+struct HomeScreenWidgetEntryView: View {
+  let entry: LockScreenEntry
+
+  @Environment(\.widgetFamily) var family
+
+  var body: some View {
+    switch family {
+    case .systemSmall:
+      smallView
+    case .systemMedium:
+      mediumView
+    default:
+      EmptyView()
+    }
+  }
+
+  // ロック画面コントロールと同じtramシンボルでアプリの表示を揃える
+  private var brandLabel: some View {
+    HStack(spacing: 4) {
+      Image(systemName: entry.loaded ? "tram.fill" : "tram")
+      Text("TrainLCD")
+    }
+    .font(.caption2)
+    .fontWeight(.bold)
+    .foregroundStyle(.secondary)
+  }
+
+  private var lineNameText: some View {
+    Text(entry.lineName)
+      .lineLimit(2)
+      .minimumScaleFactor(0.7)
+  }
+
+  private var boundForText: some View {
+    Text(entry.boundFor)
+      .foregroundStyle(.secondary)
+      .lineLimit(2)
+      .minimumScaleFactor(0.8)
+  }
+
+  // 正方形なのでaccessoryCircular相当のサークルを上に置き、その下に路線名と方面を積む
+  var smallView: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 0) {
+        HomeScreenNumberingCircle(
+          lineColor: entry.lineColor,
+          lineSymbol: entry.lineSymbol,
+          diameter: 44
+        )
+        Spacer(minLength: 0)
+      }
+      Spacer(minLength: 8)
+      lineNameText
+        .font(.headline)
+      boundForText
+        .font(.caption)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+  }
+
+  // accessoryRectangularと同じ「バー + 路線名 + 方面」に、余白のあるホーム画面向けとして
+  // アプリ名とナンバリングサークルを足した構成
+  var mediumView: some View {
+    HStack(spacing: 12) {
+      HomeScreenLineBar(lineColor: entry.lineColor)
+      VStack(alignment: .leading, spacing: 4) {
+        brandLabel
+        lineNameText
+          .font(.title3)
+          .fontWeight(.bold)
+        boundForText
+          .font(.subheadline)
+      }
+      Spacer(minLength: 0)
+      HomeScreenNumberingCircle(
+        lineColor: entry.lineColor,
+        lineSymbol: entry.lineSymbol,
+        diameter: 56
+      )
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+  }
+}
+
+extension View {
+  // containerBackgroundはiOS 17以降必須だが、Extensionのデプロイターゲットが16.1のため互換ラップする。
+  // iOS 16にはコンテンツマージンが無く端まで描画されてしまうので、その場合のみ自前で余白を付ける
+  @ViewBuilder
+  fileprivate func homeScreenContainerBackground() -> some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      containerBackground(.fill.tertiary, for: .widget)
+    } else {
+      padding()
+    }
+  }
+}
+
+struct HomeScreenWidget: Widget {
+  // LiveActivityModule側のreloadTimelines(ofKind:)と一致させること
+  let kind: String = "HomeScreenWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: LockScreenProvider()) { entry in
+      HomeScreenWidgetEntryView(entry: entry)
+        .homeScreenContainerBackground()
+    }
+    .configurationDisplayName("TrainLCD")
+    .description(String(localized: "widgetDescription"))
+    .supportedFamilies(
+      [
+        .systemSmall,
+        .systemMedium,
+      ]
+    )
+  }
+}
+
+struct HomeScreenWidget_Previews: PreviewProvider {
+  private static var entry: LockScreenEntry {
+    LockScreenEntry(
+      date: .now,
+      loaded: true,
+      lineColor: "80C241",
+      lineName: "山手線",
+      lineSymbol: "JY",
+      boundFor: "新宿・渋谷方面"
+    )
+  }
+
+  static var previews: some View {
+    Group {
+      HomeScreenWidgetEntryView(entry: entry)
+        .previewContext(WidgetPreviewContext(family: .systemSmall))
+      HomeScreenWidgetEntryView(entry: entry)
+        .previewContext(WidgetPreviewContext(family: .systemMedium))
+    }
+  }
+}

--- a/ios/RideSessionActivity/LockScreenControl.swift
+++ b/ios/RideSessionActivity/LockScreenControl.swift
@@ -15,9 +15,6 @@ import WidgetKit
 // ロック画面ウィジェットと同じApp Groupの値をコントロール表示用に整形する
 @available(iOS 18.0, *)
 struct LockScreenControlValue: Sendable {
-  // 未乗車時やApp Groupが空のときに使うTrainLCDのブランドカラー
-  private static let fallbackLineColor = "277BC0"
-
   let loaded: Bool
   let lineName: String
   let lineColor: String
@@ -45,7 +42,7 @@ struct LockScreenControlValue: Sendable {
 
   // Color(hex:)は空文字を渡すとほぼ透明になるため、必ず既定色へフォールバックする
   var tint: Color {
-    Color(hex: lineColor.isEmpty ? Self.fallbackLineColor : lineColor)
+    Color(hex: lineColor.isEmpty ? LockScreenEntry.fallbackLineColor : lineColor)
   }
 }
 

--- a/ios/RideSessionActivity/LockScreenWidget.swift
+++ b/ios/RideSessionActivity/LockScreenWidget.swift
@@ -9,13 +9,14 @@
 import SwiftUI
 import WidgetKit
 
-// ライブアクティビティ・ロック画面ウィジェット・ロック画面コントロールを
-// 同一Extensionで配信するためのバンドル
+// ライブアクティビティ・ロック画面ウィジェット・ホーム画面ウィジェット・
+// ロック画面コントロールを同一Extensionで配信するためのバンドル
 @main
 struct RideSessionWidgetBundle: WidgetBundle {
   var body: some Widget {
     RideSessionWidget()
     LockScreenWidget()
+    HomeScreenWidget()
     // ControlWidgetはiOS 18以降のみ。Extensionのデプロイターゲットは16.1のため条件付きで追加する
     if #available(iOS 18.0, *) {
       LockScreenControl()
@@ -42,7 +43,7 @@ struct LockScreenEntry: TimelineEntry {
     )
   }
 
-  // ロック画面ウィジェットとロック画面コントロールで共通のApp Group読み出し
+  // ロック画面ウィジェット・ホーム画面ウィジェット・ロック画面コントロールで共通のApp Group読み出し
   static func current() -> LockScreenEntry {
     let appGroupID =
       Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
@@ -83,7 +84,7 @@ struct LockScreenProvider: TimelineProvider {
     in context: Context, completion: @escaping (Timeline<LockScreenEntry>) -> Void
   ) {
     // 表示内容はアプリ側がApp Groupへ書き込んだ時点のWidgetCenter経由リロードでのみ変わるため、
-    // 時刻ベースの再生成は行わない
+    // 時刻ベースの再生成は行わない。ホーム画面ウィジェットもこのProviderを共有する
     completion(Timeline(entries: [.current()], policy: .never))
   }
 }

--- a/ios/RideSessionActivity/LockScreenWidget.swift
+++ b/ios/RideSessionActivity/LockScreenWidget.swift
@@ -25,6 +25,9 @@ struct RideSessionWidgetBundle: WidgetBundle {
 }
 
 struct LockScreenEntry: TimelineEntry {
+  // 未乗車時やApp GroupのlineColorが空のときに使うTrainLCDのブランドカラー
+  static let fallbackLineColor = "277BC0"
+
   let date: Date
   let loaded: Bool
   let lineColor: String
@@ -32,11 +35,16 @@ struct LockScreenEntry: TimelineEntry {
   let lineSymbol: String
   let boundFor: String
 
+  // Color(hex:)は空文字を渡すとほぼ透明になるため、描画に使う路線色は必ずここを経由する
+  var displayLineColor: String {
+    lineColor.isEmpty ? Self.fallbackLineColor : lineColor
+  }
+
   static var notLoaded: LockScreenEntry {
     LockScreenEntry(
       date: Date(),
       loaded: false,
-      lineColor: "277BC0",
+      lineColor: fallbackLineColor,
       lineName: String(localized: "lineNotSet"),
       lineSymbol: "?",
       boundFor: String(localized: "destinationNotSet")
@@ -128,7 +136,7 @@ struct LockScreenWidgetEntryView: View {
 
   var circularView: some View {
     LockScreenNumberingCircle(
-      lineColor: entry.lineColor,
+      lineColor: entry.displayLineColor,
       lineSymbol: entry.lineSymbol
     )
   }
@@ -136,7 +144,7 @@ struct LockScreenWidgetEntryView: View {
   var rectangularView: some View {
     HStack(spacing: 8) {
       RoundedRectangle(cornerRadius: 2)
-        .fill(Color(hex: entry.lineColor))
+        .fill(Color(hex: entry.displayLineColor))
         .frame(width: 4)
         .widgetAccentable()
       VStack(alignment: .leading, spacing: 2) {

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F45F2E40A00100000000 /* LockScreenWidget.swift */; };
 		94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
 		94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4622E40A00200000000 /* LockScreenControl.swift */; };
+		94D3F4662E40A00300000001 /* HomeScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* HomeScreenWidget.swift */; };
+		94D3F4672E40A00300000002 /* HomeScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* HomeScreenWidget.swift */; };
 		942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EAA025890E8500E02655 /* ColorExtension.swift */; };
 		942CB60B2A32AAB4008339D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDE128D3025900D68287 /* SwiftUI.framework */; };
 		942CB60C2A32AAB4008339D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDDF28D3025900D68287 /* WidgetKit.framework */; };
@@ -409,6 +411,7 @@
 		94B9CDE428D3025900D68287 /* RideSessionActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionActivity.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		94D3F45F2E40A00100000000 /* LockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWidget.swift; sourceTree = "<group>"; };
 		94D3F4622E40A00200000000 /* LockScreenControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenControl.swift; sourceTree = "<group>"; };
+		94D3F4652E40A00300000000 /* HomeScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenWidget.swift; sourceTree = "<group>"; };
 		94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = RideSessionActivity.intentdefinition; sourceTree = "<group>"; };
 		94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionAttributes.swift; sourceTree = "<group>"; };
 		94BFA3B7258F0FF3001D95E4 /* StationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListView.swift; sourceTree = "<group>"; };
@@ -830,6 +833,7 @@
 				942CB64A2A32BA12008339D2 /* Info.plist */,
 				94B9CDE428D3025900D68287 /* RideSessionActivity.swift */,
 				94D3F45F2E40A00100000000 /* LockScreenWidget.swift */,
+				94D3F4652E40A00300000000 /* HomeScreenWidget.swift */,
 				94D3F4622E40A00200000000 /* LockScreenControl.swift */,
 				94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */,
 				94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */,
@@ -2238,6 +2242,7 @@
 				942CB6072A32AAB4008339D2 /* RideSessionActivity.intentdefinition in Sources */,
 				942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */,
 				94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */,
+				94D3F4672E40A00300000002 /* HomeScreenWidget.swift in Sources */,
 				94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */,
 				942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */,
 				94E6881C2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,
@@ -2272,6 +2277,7 @@
 				94B9CDEA28D3025A00D68287 /* RideSessionActivity.intentdefinition in Sources */,
 				94B9CDE528D3025900D68287 /* RideSessionActivity.swift in Sources */,
 				94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */,
+				94D3F4662E40A00300000001 /* HomeScreenWidget.swift in Sources */,
 				94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */,
 				944C2C4F28DADC380004DA72 /* ColorExtension.swift in Sources */,
 				94E6881B2C99B27200FAF1F2 /* WidgetConfigurationExtension.swift in Sources */,


### PR DESCRIPTION
## 概要

iOSのホーム画面に置けるウィジェットを追加しました。デザインとレイアウトは既存のwatchOSウィジェット（`accessoryRectangular` / `accessoryCircular`）とiOSのロック画面ウィジェット、およびAndroidのホーム画面ウィジェット（#6569）の体裁を踏襲しています。

新規ターゲットは作らず、既存の `RideSessionActivity` Extension（ライブアクティビティ・ロック画面ウィジェット・ロック画面コントロールを配信中）の `WidgetBundle` に足す形にしたため、署名・entitlements・App Group の設定はそのまま流用できます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/RideSessionActivity/HomeScreenWidget.swift` を追加し、`systemSmall` / `systemMedium` に対応
  - `systemSmall`: 左上に路線色のナンバリングサークル（`accessoryCircular` 相当。路線記号が無い路線は路線名の先頭1文字で代替）、その下に路線名と方面
  - `systemMedium`: `accessoryRectangular` と同じ「路線色バー + 路線名 + 方面」に、tramシンボル付きのアプリ名とナンバリングサークルを追加
  - 背景はニュートラル（`.fill.tertiary`）＋路線色をアクセントに使う構成とし、ロック画面ウィジェット・Android版と揃えた
  - Extensionのデプロイターゲットが16.1のため、`containerBackground` は既存の互換ラップと同じ方式で `@available` 分岐し、コンテンツマージンの無いiOS 16では自前で余白を付ける
- 表示データはロック画面ウィジェットと同じ `LockScreenEntry` / `LockScreenProvider`（App Group）を共有。新しい同期経路は増やしていないためJS側の変更は無し
- `LiveActivityModule` がApp Groupへ書き込む際、ホーム画面ウィジェットのtimelineも併せてリロードするよう変更（差分がある時だけ書き込む既存のリロードバジェット節約はそのまま維持）
  - あわせて `syncLockScreenWidgetState` → `syncWidgetState` など、ロック画面専用ではなくなったprivateメソッド名を実態に合わせて改名
- ウィジェットギャラリー用の説明文を ja/en の `Localizable.strings` に `widgetDescription` として追加（文言はAndroid版の `widget_description` と統一）
- `project.pbxproj` にProd / Canary両RideSessionActivity Extensionのソースとして登録

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

### リグレッションリスクと補足

- 既存のロック画面ウィジェット・ロック画面コントロール・ライブアクティビティのコードパスは、`WidgetCenter.reloadTimelines` の対象kindが1つ増える以外は変更していません。App Groupに書き込むキーも従来どおりで、追加・変更はありません。
- 実行環境にXcode / Swiftツールチェーンが無いため、**ネイティブビルドとシミュレータ上での表示確認は未実施**です。レイアウトは既存ウィジェットと同じAPI・記法に揃えていますが、実機での見え方の最終確認をお願いします。
- `origin/dev` の #6572（`OpenTrainLCDIntent.swift` 追加）と `project.pbxproj` のオブジェクトIDが偶然衝突していたため、devをマージのうえ本PR側のIDを採番し直しています（重複IDが残っていないことは確認済み）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01JjtU2f2caqGzJMk9SriShh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOSのホーム画面に、乗車中の路線や方面を表示するSmall・Mediumウィジェットを追加しました。
  * 乗車開始・更新・終了時に、ホーム画面ウィジェットの表示内容が自動更新されます。
  * 英語・日本語のウィジェット説明文に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->