### PR TITLE
ホーム画面ウィジェットの路線記号の枠線と文字を太くして視認性を改善

### DIFF
--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -22,13 +22,16 @@ struct HomeScreenNumberingCircle: View {
 
   var body: some View {
     ZStack {
+      // strokeBorderは線を内側に描くのでdiameterがそのまま外径になる。
+      // 中央揃えのstrokeだと線幅の半分がframeの外にはみ出し、線を太くしたぶんだけ
+      // レイアウトと実際の見た目がずれるため使わない
       Circle()
-        .stroke(Color(hex: lineColor), lineWidth: diameter / 10)
+        .strokeBorder(Color(hex: lineColor), lineWidth: diameter / 7)
       Text(lineSymbol)
-        .font(.system(size: diameter * 0.4, weight: .bold, design: .rounded))
+        .font(.system(size: diameter * 0.4, weight: .heavy, design: .rounded))
         .minimumScaleFactor(0.5)
         .lineLimit(1)
-        .padding(diameter * 0.18)
+        .padding(diameter * 0.2)
     }
     .frame(width: diameter, height: diameter)
   }
@@ -92,7 +95,7 @@ struct HomeScreenWidgetEntryView: View {
         HomeScreenNumberingCircle(
           lineColor: entry.displayLineColor,
           lineSymbol: entry.lineSymbol,
-          diameter: 44
+          diameter: 48
         )
         Spacer(minLength: 0)
       }
@@ -122,7 +125,7 @@ struct HomeScreenWidgetEntryView: View {
       HomeScreenNumberingCircle(
         lineColor: entry.displayLineColor,
         lineSymbol: entry.lineSymbol,
-        diameter: 56
+        diameter: 60
       )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)


### PR DESCRIPTION
## 概要

iOS ホーム画面ウィジェット（`systemSmall` / `systemMedium`）のナンバリングサークルについて「枠線と文字が細すぎる」という指摘を受けたため、線幅と文字ウェイトを引き上げました。

指摘時のスクリーンショットを実測したところ、外径 約162px に対し枠線 約15px（@3x = 外径約55pt / 枠線約5pt）で、枠線が直径の約 1/11 しかありませんでした。アプリ内の `NumberingIconRound` は 72pt に対し 8pt（1/9）、`SMALL` / `MEDIUM` サイズでは 1/5 なので、ウィジェットだけが明確に細い状態でした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `HomeScreenNumberingCircle` の枠線を `Circle().stroke(lineWidth: diameter / 10)` から `Circle().strokeBorder(lineWidth: diameter / 7)` に変更
  - `stroke` はパス中央揃えで線幅の半分が `frame` の外へはみ出すため、太くするほどレイアウト上の寸法と見た目がずれます。`strokeBorder` は線を内側に描くので `diameter` がそのまま外径になります
- 路線記号の文字ウェイトを `.bold` から `.heavy` に変更
- 文字のパディングを `diameter * 0.18` から `diameter * 0.2` に変更し、太くなった枠線との間隔を確保
- `strokeBorder` 化で見かけの外径が縮むぶんを直径で補正（`systemSmall` 44 → 48 / `systemMedium` 56 → 60）
  - 従来の見た目の外径（約48.4 / 約61.6）を維持しつつ、`diameter * 0.4` 連動の文字サイズも 17.6 → 19.2pt / 22.4 → 24pt に上がります

変更対象は `ios/RideSessionActivity/HomeScreenWidget.swift` の 1 ファイルのみです。ロック画面ウィジェット（`LockScreenWidget.swift`）、watchOS（`WatchWidget.swift`）、Android（`widget_numbering_circle.xml`）は今回のスコープ外で未変更です。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（208 suites / 2195 tests passed）
- [x] `npm run typecheck` が通ること

上記 3 点はいずれもローカルで成功していますが、**変更が Swift のみのため、これらのチェックは今回の差分をカバーしていません**。また作業環境に Xcode / iOS シミュレータが無いため、**シミュレータ・実機での表示確認は未実施**です。太さの調整が必要な場合は `diameter / 7` の分母で加減できます（1/8 でやや控えめ、1/6 でさらに太め）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

UI 変更ですが、上記のとおりビルド環境が無いため変更後のスクリーンショットは未取得です。レビュー時に実機での確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_016YPp2NkWQiVs5WALPKjwGP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ホーム画面ウィジェットの番号表示を見やすく調整しました。
  * 番号の文字を太くし、円線や余白のバランスを改善しました。
  * 小サイズ・中サイズの番号表示を拡大し、視認性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->