### PR TITLE
Androidホーム画面ウィジェットが更新されず未乗車表示のままになる問題を修正

### DIFF
--- a/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
@@ -11,9 +11,10 @@ import android.widget.RemoteViews
 /**
  * ホーム画面ウィジェット。
  *
- * iOS/watchOS版のウィジェット(LockScreenWidget / WatchWidget)と同じ情報・体裁を踏襲し、
- * ウィジェットのサイズに応じて円形(accessoryCircular相当)、1行(accessoryInline相当)、
- * 横長(accessoryRectangular相当)の3レイアウトを出し分ける。
+ * iOS/watchOS版のウィジェット(HomeScreenWidget / LockScreenWidget / WatchWidget)と同じ情報・体裁を
+ * 踏襲し、ウィジェットのサイズに応じて4つのレイアウトを出し分ける。
+ * 正方形はiOSのsystemSmall、横長はsystemMedium、置ける情報が減る極小サイズは
+ * accessoryCircular / accessoryInlineに相当する。
  */
 class RideWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(
@@ -35,9 +36,10 @@ class RideWidgetProvider : AppWidgetProvider() {
     }
 
     companion object {
-        // iOSのaccessoryCircular/accessoryInline/accessoryRectangularに対応する閾値(dp)
+        // レイアウト出し分けの閾値(dp)
         private const val CIRCULAR_MAX_WIDTH_DP = 110
-        private const val INLINE_MAX_HEIGHT_DP = 70
+        private const val INLINE_MAX_HEIGHT_DP = 60
+        private const val SMALL_MIN_HEIGHT_DP = 110
 
         /** アプリ側から表示内容を更新する際のエントリポイント */
         fun updateAll(context: Context) {
@@ -86,11 +88,12 @@ class RideWidgetProvider : AppWidgetProvider() {
             }
             // iOS版と同様に、路線記号が無い路線では路線名の先頭1文字で代替する
             val lineSymbol = when {
-                !state.loaded -> "?"
+                !state.loaded -> context.getString(R.string.widget_line_symbol_placeholder)
                 state.lineSymbol.isNotEmpty() -> state.lineSymbol
                 lineName.isNotEmpty() -> lineName.take(1)
-                else -> "?"
+                else -> context.getString(R.string.widget_line_symbol_placeholder)
             }
+            // 未乗車時と路線色が空のときはiOS版と同じブランドカラーへフォールバックする
             val lineColor = WidgetStateStore.parseColor(
                 if (state.loaded) state.lineColor else WidgetStateStore.PLACEHOLDER_LINE_COLOR,
                 WidgetStateStore.parseColor(WidgetStateStore.PLACEHOLDER_LINE_COLOR, 0)
@@ -101,23 +104,23 @@ class RideWidgetProvider : AppWidgetProvider() {
                 minWidthDp in 1 until CIRCULAR_MAX_WIDTH_DP ->
                     circularViews(context, lineSymbol, lineColor)
                 minHeightDp in 1..INLINE_MAX_HEIGHT_DP ->
-                    inlineViews(context, state.loaded, lineName, lineColor)
-                else -> rectangularViews(context, lineName, boundFor, lineColor)
+                    inlineViews(context, lineName, lineColor)
+                minHeightDp >= SMALL_MIN_HEIGHT_DP ->
+                    smallViews(context, lineName, boundFor, lineSymbol, lineColor)
+                else -> rectangularViews(context, lineName, boundFor, lineSymbol, lineColor)
             }
 
-            views.setContentDescription(
-                R.id.widget_root,
-                if (state.loaded) {
-                    "${context.getString(R.string.widget_riding_on, lineName)} / $boundFor"
-                } else {
-                    context.getString(R.string.app_name)
-                }
-            )
+            views.setContentDescription(R.id.widget_root, "$lineName / $boundFor")
             createContentIntent(context)?.let {
                 views.setOnClickPendingIntent(R.id.widget_root, it)
             }
 
             return views
+        }
+
+        private fun RemoteViews.applyNumberingCircle(lineSymbol: String, lineColor: Int) {
+            setInt(R.id.widget_numbering_circle, "setColorFilter", lineColor)
+            setTextViewText(R.id.widget_line_symbol, lineSymbol)
         }
 
         private fun circularViews(
@@ -126,35 +129,41 @@ class RideWidgetProvider : AppWidgetProvider() {
             lineColor: Int
         ): RemoteViews =
             RemoteViews(context.packageName, R.layout.widget_ride_circular).apply {
-                setInt(R.id.widget_numbering_circle, "setColorFilter", lineColor)
-                setTextViewText(R.id.widget_line_symbol, lineSymbol)
+                applyNumberingCircle(lineSymbol, lineColor)
             }
 
         private fun inlineViews(
             context: Context,
-            loaded: Boolean,
             lineName: String,
             lineColor: Int
         ): RemoteViews =
             RemoteViews(context.packageName, R.layout.widget_ride_inline).apply {
                 setInt(R.id.widget_line_bar, "setColorFilter", lineColor)
-                setTextViewText(
-                    R.id.widget_inline_text,
-                    if (loaded) {
-                        context.getString(R.string.widget_riding_on, lineName)
-                    } else {
-                        context.getString(R.string.app_name)
-                    }
-                )
+                setTextViewText(R.id.widget_inline_text, lineName)
+            }
+
+        private fun smallViews(
+            context: Context,
+            lineName: String,
+            boundFor: String,
+            lineSymbol: String,
+            lineColor: Int
+        ): RemoteViews =
+            RemoteViews(context.packageName, R.layout.widget_ride_small).apply {
+                applyNumberingCircle(lineSymbol, lineColor)
+                setTextViewText(R.id.widget_line_name, lineName)
+                setTextViewText(R.id.widget_bound_for, boundFor)
             }
 
         private fun rectangularViews(
             context: Context,
             lineName: String,
             boundFor: String,
+            lineSymbol: String,
             lineColor: Int
         ): RemoteViews =
             RemoteViews(context.packageName, R.layout.widget_ride_rectangular).apply {
+                applyNumberingCircle(lineSymbol, lineColor)
                 setInt(R.id.widget_line_bar, "setColorFilter", lineColor)
                 setTextViewText(R.id.widget_line_name, lineName)
                 setTextViewText(R.id.widget_bound_for, boundFor)

--- a/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/RideWidgetProvider.kt
@@ -105,7 +105,8 @@ class RideWidgetProvider : AppWidgetProvider() {
                     circularViews(context, lineSymbol, lineColor)
                 minHeightDp in 1..INLINE_MAX_HEIGHT_DP ->
                     inlineViews(context, lineName, lineColor)
-                minHeightDp >= SMALL_MIN_HEIGHT_DP ->
+                // 4x2のような横長は高さが足りていても横長レイアウトを使う
+                minHeightDp >= SMALL_MIN_HEIGHT_DP && minWidthDp <= minHeightDp ->
                     smallViews(context, lineName, boundFor, lineSymbol, lineColor)
                 else -> rectangularViews(context, lineName, boundFor, lineSymbol, lineColor)
             }

--- a/android/app/src/main/res/drawable/widget_numbering_circle.xml
+++ b/android/app/src/main/res/drawable/widget_numbering_circle.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- iOS版のナンバリングサークル(Circle().stroke)相当。路線色はsetColorFilterで着色する -->
+<!--
+  iOS版のナンバリングサークル(Circle().strokeBorder)相当。路線色はsetColorFilterで着色する。
+  線幅はiOS側(直径の約1/7)に合わせている
+-->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid android:color="@android:color/transparent" />
     <stroke
-        android:width="5dp"
+        android:width="7dp"
         android:color="#FFFFFFFF" />
 </shape>

--- a/android/app/src/main/res/layout/widget_ride_circular.xml
+++ b/android/app/src/main/res/layout/widget_ride_circular.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- iOS/watchOSのaccessoryCircular(ナンバリングサークル)に相当するレイアウト -->
+<!-- 1セル幅で文字が入らないサイズ向け。watchOS/ロック画面のaccessoryCircular相当 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
@@ -23,6 +23,7 @@
         android:maxLines="1"
         android:paddingStart="10dp"
         android:paddingEnd="10dp"
+        android:text="@string/widget_line_symbol_placeholder"
         android:textColor="@color/widget_text_primary"
         android:textSize="18sp"
         android:textStyle="bold" />

--- a/android/app/src/main/res/layout/widget_ride_inline.xml
+++ b/android/app/src/main/res/layout/widget_ride_inline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- iOS/watchOSのaccessoryInline(1行表示)に相当するレイアウト -->
+<!-- 1行しか入らない高さ向け。watchOS/ロック画面のaccessoryInline相当 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
@@ -28,6 +28,7 @@
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
+        android:text="@string/widget_line_not_set"
         android:textColor="@color/widget_text_primary"
         android:textSize="13sp"
         android:textStyle="bold" />

--- a/android/app/src/main/res/layout/widget_ride_rectangular.xml
+++ b/android/app/src/main/res/layout/widget_ride_rectangular.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- iOS/watchOSのaccessoryRectangularに相当するレイアウト -->
+<!-- iOSのホーム画面ウィジェット(systemMedium)、watchOSのaccessoryRectangularに相当するレイアウト -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
@@ -13,7 +13,7 @@
         android:id="@+id/widget_line_bar"
         android:layout_width="4dp"
         android:layout_height="match_parent"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="10dp"
         android:contentDescription="@null"
         android:scaleType="fitXY"
         android:src="@drawable/widget_line_bar" />
@@ -24,14 +24,39 @@
         android:layout_weight="1"
         android:orientation="vertical">
 
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="12dp"
+                android:layout_height="12dp"
+                android:layout_marginEnd="4dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_notification_live_update"
+                android:tint="@color/widget_text_secondary" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_brand"
+                android:textColor="@color/widget_text_secondary"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
         <TextView
             android:id="@+id/widget_line_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
             android:ellipsize="end"
             android:maxLines="2"
+            android:text="@string/widget_line_not_set"
             android:textColor="@color/widget_text_primary"
-            android:textSize="15sp"
+            android:textSize="17sp"
             android:textStyle="bold" />
 
         <TextView
@@ -41,7 +66,35 @@
             android:layout_marginTop="2dp"
             android:ellipsize="end"
             android:maxLines="2"
+            android:text="@string/widget_destination_not_set"
             android:textColor="@color/widget_text_secondary"
-            android:textSize="12sp" />
+            android:textSize="13sp" />
     </LinearLayout>
+
+    <FrameLayout
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="10dp">
+
+        <ImageView
+            android:id="@+id/widget_numbering_circle"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            android:src="@drawable/widget_numbering_circle" />
+
+        <TextView
+            android:id="@+id/widget_line_symbol"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingStart="9dp"
+            android:paddingEnd="9dp"
+            android:text="@string/widget_line_symbol_placeholder"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+    </FrameLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_ride_small.xml
+++ b/android/app/src/main/res/layout/widget_ride_small.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- iOSのホーム画面ウィジェット(systemSmall)に相当するレイアウト -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <FrameLayout
+        android:layout_width="48dp"
+        android:layout_height="48dp">
+
+        <ImageView
+            android:id="@+id/widget_numbering_circle"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            android:src="@drawable/widget_numbering_circle" />
+
+        <TextView
+            android:id="@+id/widget_line_symbol"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingStart="9dp"
+            android:paddingEnd="9dp"
+            android:text="@string/widget_line_symbol_placeholder"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/widget_line_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:text="@string/widget_line_not_set"
+        android:textColor="@color/widget_text_primary"
+        android:textSize="15sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widget_bound_for"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:text="@string/widget_destination_not_set"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="12sp" />
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
   <string name="live_update_passing">%1$sを通過中</string>
   <string name="live_update_approaching">まもなく%1$s</string>
   <string name="live_update_next">次は%1$s</string>
+  <string name="widget_brand" translatable="false">TrainLCD</string>
+  <string name="widget_line_symbol_placeholder" translatable="false">?</string>
   <string name="widget_description">乗車中の路線と方面を表示します</string>
   <string name="widget_line_not_set">路線が未設定です</string>
   <string name="widget_destination_not_set">方面が未設定です</string>

--- a/android/app/src/main/res/xml/ride_widget_info.xml
+++ b/android/app/src/main/res/xml/ride_widget_info.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/widget_description"
-    android:initialLayout="@layout/widget_ride_rectangular"
-    android:minHeight="40dp"
+    android:initialLayout="@layout/widget_ride_small"
+    android:minHeight="110dp"
     android:minResizeHeight="40dp"
     android:minResizeWidth="40dp"
     android:minWidth="110dp"
-    android:previewLayout="@layout/widget_ride_rectangular"
+    android:previewLayout="@layout/widget_ride_small"
     android:resizeMode="horizontal|vertical"
-    android:targetCellHeight="1"
+    android:targetCellHeight="2"
     android:targetCellWidth="2"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -92,6 +92,7 @@ export { useTypeWillChange } from './useTypeWillChange';
 export { useUnderMaintenance } from './useUnderMaintenance';
 export { useUpdateBottomState } from './useUpdateBottomState';
 export { useUpdateLiveActivities } from './useUpdateLiveActivities';
+export { useUpdateWidget } from './useUpdateWidget';
 export { useValueRef } from './useValueRef';
 export { useWalkthroughCompleted } from './useWalkthroughCompleted';
 export { useWarningInfo } from './useWarningInfo';

--- a/src/hooks/useUpdateLiveActivities.ts
+++ b/src/hooks/useUpdateLiveActivities.ts
@@ -19,10 +19,6 @@ import {
   updateLiveUpdate,
 } from '../utils/native/android/liveUpdateModule';
 import {
-  clearWidget,
-  updateWidget,
-} from '../utils/native/android/widgetModule';
-import {
   startLiveActivity,
   stopLiveActivity,
   updateLiveActivity,
@@ -293,8 +289,6 @@ export const useUpdateLiveActivities = (): void => {
     if (selectedBound && !started) {
       startLiveActivity(activityState);
       startLiveUpdate(activityState);
-      // Androidのホーム画面ウィジェット。ライブアップデートはAndroid 16以降専用のため別経路で更新する
-      updateWidget(activityState);
       setStarted(true);
     }
   }, [activityState, selectedBound, started]);
@@ -303,7 +297,6 @@ export const useUpdateLiveActivities = (): void => {
     return () => {
       stopLiveActivity();
       stopLiveUpdate();
-      clearWidget();
       setStarted(false);
     };
   }, []);
@@ -312,7 +305,6 @@ export const useUpdateLiveActivities = (): void => {
     if (started) {
       updateLiveActivity(activityState);
       updateLiveUpdate(activityState);
-      updateWidget(activityState);
     }
   }, [activityState, started]);
 };

--- a/src/hooks/useUpdateWidget.test.tsx
+++ b/src/hooks/useUpdateWidget.test.tsx
@@ -1,0 +1,112 @@
+import { render } from '@testing-library/react-native';
+import type React from 'react';
+import type { Line, Station } from '~/@types/graphql';
+
+// フックの依存を制御するためモジュールをモックする
+jest.mock('jotai', () => ({
+  __esModule: true,
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+jest.mock('./useBounds', () => ({ useBounds: jest.fn() }));
+jest.mock('./useCurrentLine', () => ({ useCurrentLine: jest.fn() }));
+jest.mock('./useNumbering', () => ({ useNumbering: jest.fn() }));
+// jest-expo の既定ロケールは英語のため、日本語表記の組み立てを確認できるよう固定する
+jest.mock('../translation', () => ({
+  __esModule: true,
+  ...jest.requireActual('../translation'),
+  isJapanese: true,
+}));
+jest.mock('../utils/native/android/widgetModule', () => ({
+  updateWidget: jest.fn(),
+  clearWidget: jest.fn(),
+}));
+
+import { useAtomValue } from 'jotai';
+import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
+import {
+  clearWidget,
+  updateWidget,
+} from '../utils/native/android/widgetModule';
+import { useBounds } from './useBounds';
+import { useCurrentLine } from './useCurrentLine';
+import { useNumbering } from './useNumbering';
+import { useUpdateWidget } from './useUpdateWidget';
+
+const makeStation = (name: string): Station =>
+  ({ name, nameRoman: name }) as Station;
+
+const setAtomValues = ({
+  selectedBound = null,
+  stations = [],
+}: {
+  selectedBound?: unknown;
+  stations?: Station[];
+}) => {
+  (useAtomValue as jest.Mock).mockImplementation((atom: unknown) => {
+    if (atom === selectedBoundAtom) return selectedBound;
+    if (atom === stationsAtom) return stations;
+    return undefined;
+  });
+};
+
+const TestComponent: React.FC = () => {
+  useUpdateWidget();
+  return null;
+};
+
+describe('useUpdateWidget フック', () => {
+  beforeEach(() => {
+    (useCurrentLine as jest.Mock).mockReturnValue({
+      nameShort: '山手線',
+      nameRoman: 'Yamanote Line',
+      color: '#80C241',
+    } as Line);
+    (useNumbering as jest.Mock).mockReturnValue([
+      { lineSymbol: 'JY' },
+      undefined,
+    ]);
+    (useBounds as jest.Mock).mockReturnValue({
+      bounds: [[], []],
+      directionalStops: [makeStation('新宿'), makeStation('渋谷')],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('行先選択済みならウィジェットへ路線情報を送る', () => {
+    setAtomValues({ selectedBound: makeStation('大崎') });
+
+    render(<TestComponent />);
+
+    expect(updateWidget).toHaveBeenCalledWith({
+      lineName: '山手線',
+      lineColor: '#80C241',
+      lineSymbol: 'JY',
+      boundStationName: '新宿・渋谷方面',
+    });
+  });
+
+  it('行先未選択のうちはウィジェットを更新しない', () => {
+    setAtomValues({ selectedBound: null });
+
+    render(<TestComponent />);
+
+    expect(updateWidget).not.toHaveBeenCalled();
+  });
+
+  it('アンマウント(降車)でウィジェットを未乗車表示へ戻す', () => {
+    setAtomValues({ selectedBound: makeStation('大崎') });
+
+    // StrictModeの二重マウントで解除が先に走り得るため、アンマウント前後の差分で見る
+    const { unmount } = render(<TestComponent />);
+    const callsBeforeUnmount = (clearWidget as jest.Mock).mock.calls.length;
+
+    unmount();
+    expect((clearWidget as jest.Mock).mock.calls.length).toBe(
+      callsBeforeUnmount + 1
+    );
+  });
+});

--- a/src/hooks/useUpdateWidget.test.tsx
+++ b/src/hooks/useUpdateWidget.test.tsx
@@ -97,6 +97,20 @@ describe('useUpdateWidget フック', () => {
     expect(updateWidget).not.toHaveBeenCalled();
   });
 
+  it('行先が解除されたらマウントされたままでもウィジェットを消去する', () => {
+    setAtomValues({ selectedBound: makeStation('大崎') });
+
+    const { rerender } = render(<TestComponent />);
+    const callsBeforeReset = (clearWidget as jest.Mock).mock.calls.length;
+
+    setAtomValues({ selectedBound: null });
+    rerender(<TestComponent />);
+
+    expect((clearWidget as jest.Mock).mock.calls.length).toBeGreaterThan(
+      callsBeforeReset
+    );
+  });
+
   it('アンマウント(降車)でウィジェットを未乗車表示へ戻す', () => {
     setAtomValues({ selectedBound: makeStation('大崎') });
 

--- a/src/hooks/useUpdateWidget.ts
+++ b/src/hooks/useUpdateWidget.ts
@@ -1,0 +1,62 @@
+import { useAtomValue } from 'jotai';
+import { useEffect, useMemo } from 'react';
+import { getLocalizedLineName } from '~/utils/line';
+import { selectedBoundAtom, stationsAtom } from '../store/atoms/station';
+import { isJapanese } from '../translation';
+import {
+  clearWidget,
+  updateWidget,
+} from '../utils/native/android/widgetModule';
+import { useBounds } from './useBounds';
+import { useCurrentLine } from './useCurrentLine';
+import { useNumbering } from './useNumbering';
+
+/**
+ * Androidのホーム画面ウィジェットへ乗車中の路線情報を同期する。
+ *
+ * iOSはライブアクティビティの更新ついでにウィジェット用のApp Groupへ書き込んでいるが、
+ * Android側の同等フック(useUpdateLiveActivities)はiOSでしかマウントされないため、
+ * ウィジェットが必要とする低頻度の項目だけを購読する専用フックとして分離している。
+ * 駅の到着・通過など毎秒変化する状態は購読しない。
+ */
+export const useUpdateWidget = (): void => {
+  const selectedBound = useAtomValue(selectedBoundAtom);
+  const stations = useAtomValue(stationsAtom);
+  const currentLine = useCurrentLine();
+  const [currentNumbering] = useNumbering();
+  const { directionalStops } = useBounds(stations);
+
+  // iOS側のウィジェットが受け取る文字列と同じ組み立て方に揃える
+  const boundStationName = useMemo(() => {
+    const names = directionalStops
+      .map((s) => (isJapanese ? s.name : s.nameRoman))
+      .join(isJapanese ? '・' : '/');
+
+    return isJapanese ? `${names}方面` : names;
+  }, [directionalStops]);
+
+  const widgetState = useMemo(
+    () => ({
+      lineName: getLocalizedLineName(currentLine, isJapanese),
+      lineColor: currentLine?.color ?? '',
+      lineSymbol: currentNumbering?.lineSymbol ?? '',
+      boundStationName,
+    }),
+    [boundStationName, currentLine, currentNumbering?.lineSymbol]
+  );
+
+  useEffect(() => {
+    if (!selectedBound) {
+      return;
+    }
+
+    updateWidget(widgetState);
+  }, [selectedBound, widgetState]);
+
+  // 降車(画面のアンマウント)でウィジェットを未乗車表示へ戻す
+  useEffect(() => {
+    return () => {
+      clearWidget();
+    };
+  }, []);
+};

--- a/src/hooks/useUpdateWidget.ts
+++ b/src/hooks/useUpdateWidget.ts
@@ -46,7 +46,9 @@ export const useUpdateWidget = (): void => {
   );
 
   useEffect(() => {
+    // 行先が解除されたらマウントされたままでも未乗車表示へ戻す
     if (!selectedBound) {
+      clearWidget();
       return;
     }
 

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -56,6 +56,7 @@ import {
   useTypeWillChange,
   useUpdateBottomState,
   useUpdateLiveActivities,
+  useUpdateWidget,
 } from '~/hooks';
 import {
   GET_LINE_GROUP_STATIONS,
@@ -178,6 +179,12 @@ const FxUpdateLiveActivitiesInner: React.FC = () => {
 const FxUpdateLiveActivities: React.FC = () => {
   return Platform.OS === 'ios' ? <FxUpdateLiveActivitiesInner /> : null;
 };
+// Androidのホーム画面ウィジェット。LiveActivitiesがiOS専用でマウントされないため、
+// ウィジェットに必要な低頻度の項目だけを見る専用フックを別ホストで動かす
+const FxUpdateWidget: React.FC = () => {
+  useUpdateWidget();
+  return null;
+};
 const FxAndroidPictureInPicture: React.FC = () => {
   useAndroidPictureInPicture();
   return null;
@@ -199,6 +206,7 @@ const MainScreenEffects: React.FC = () => {
       <FxStartBackgroundLocationUpdates />
       <FxTTS />
       <FxUpdateLiveActivities />
+      {Platform.OS === 'android' && <FxUpdateWidget />}
       {Platform.OS === 'android' && <FxAndroidPictureInPicture />}
     </>
   );


### PR DESCRIPTION
## 概要

Android のホーム画面ウィジェットが、乗車中でも常に未乗車表示（dev 版ではアプリ名の `TrainLCD Canary`）のままになる問題を修正します。

原因は、ウィジェットへの同期を呼んでいた `useUpdateLiveActivities` が iOS でしかマウントされていないことでした（`src/screens/Main.tsx` の `FxUpdateLiveActivities` が `Platform.OS === 'ios'` でゲートされている。#6422 の再レンダー最適化で導入）。そのため Android では `updateWidget` が一度も呼ばれず、ウィジェットは初期状態のままでした。

加えて、未乗車時の 1 行レイアウトが `@string/app_name` を表示していたため、`TrainLCD Canary` という文字列だけが見える状態になっていました。ウィジェット選択画面のプレビューも、レイアウトに既定文言がなく空欄でした。

> [!NOTE]
> 同じゲートにより Android 16 のライブアップデート通知（`startLiveUpdate` / `updateLiveUpdate`）も現状呼ばれていません。ウィジェットとは独立した挙動変更になるため本 PR では触れていません。復活させるべきかは別途ご判断ください。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

**データ経路の修正**

- `useUpdateWidget` を新設。ウィジェットが必要とする低頻度の項目（路線名・路線色・路線記号・方面）だけを購読し、到着・通過など毎秒変化する状態は購読しないため、#6422 で避けた位置更新ごとの派生計算コストは持ち込まない
- `MainScreenEffects` に `FxUpdateWidget` を追加し、Android でのみマウント（レンダーレス副作用ホスト 1 つにつき 1 フックの規約に従う）
- iOS 専用の `useUpdateLiveActivities` から、呼ばれることのなかった `updateWidget` / `clearWidget` の呼び出しを削除
- `useUpdateWidget` の単体テストを追加（行先選択時に送信する / 未選択では送らない / アンマウント（降車）で消去する）

**表示の修正**

- 未乗車時にアプリ名を出すのをやめ、`路線が未設定です` / `方面が未設定です` のプレースホルダーに統一
- iOS に追加された `HomeScreenWidget`（#6573 / #6576）に体裁を合わせ、正方形サイズ向けレイアウト（ナンバリングサークル + 路線名 + 方面、systemSmall 相当）を追加。横長は「路線色バー + TrainLCD + 路線名 + 方面 + ナンバリングサークル」（systemMedium 相当）に更新
- ナンバリングサークルの線幅を iOS 側（直径の約 1/7）に合わせて 5dp → 7dp へ変更
- 各レイアウトに既定文言を設定し、ウィジェット選択画面のプレビューが空欄にならないように修正。既定サイズを 2x2（`targetCellWidth` / `targetCellHeight`）へ変更

## テスト

`npm run lint` / `npm test`（209 suites・2198 tests passed）/ `npm run typecheck` をローカルで実行し、いずれも成功しています。あわせて Android SDK 36 + JDK 17 で `./gradlew :app:compileDevDebugKotlin` を実行し BUILD SUCCESSFUL を確認しました（`processDevDebugResources` を通過しているため、追加・変更したレイアウトとリソースも検証済みです）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

作業環境にエミュレータ／実機がないため未取得です。canary ビルドで、乗車後にウィジェットへ路線名・方面・路線記号が反映されること、および未乗車時にプレースホルダーが表示されることの確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XHQB1iKjHbZLmPDKysVpnt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Androidホーム画面ウィジェットが、極小・小型・横長・正方形の4サイズに対応しました。
  * 路線名、行き先、路線記号をサイズに応じて見やすく表示します。
  * 選択中の乗車情報を自動反映し、乗車情報が解除されるとウィジェットもリセットされます。

* **改善**
  * 路線記号や行き先が未設定の場合に、適切なプレースホルダーを表示します。
  * ウィジェットの初期表示とプレビューを小型レイアウトに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->