### PR TITLE
Androidのライブアップデートが呼ばれなくなっていた問題を修正

### DIFF
--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -29,7 +29,7 @@ import DevOverlay from '~/components/DevOverlay';
 import { FxTTS } from '~/components/FxTTS';
 import Header from '~/components/Header';
 import { SelectBoundModal } from '~/components/SelectBoundModal';
-import { STORAGE_KEYS } from '~/constants';
+import { IS_LIVE_UPDATE_ELIGIBLE_PLATFORM, STORAGE_KEYS } from '~/constants';
 import {
   useAndroidPictureInPicture,
   useConsoleTelemetry,
@@ -174,9 +174,12 @@ const FxUpdateLiveActivitiesInner: React.FC = () => {
   useUpdateLiveActivities();
   return null;
 };
-// LiveActivities は iOS 専用。Android では activityState の派生計算自体を止める。
+// LiveActivities は iOS 専用、Android のライブアップデートは Android 16(API 36) 以降専用。
+// どちらの通知先も持たない端末では activityState の派生計算自体を止める。
 const FxUpdateLiveActivities: React.FC = () => {
-  return Platform.OS === 'ios' ? <FxUpdateLiveActivitiesInner /> : null;
+  return Platform.OS === 'ios' || IS_LIVE_UPDATE_ELIGIBLE_PLATFORM ? (
+    <FxUpdateLiveActivitiesInner />
+  ) : null;
 };
 const FxAndroidPictureInPicture: React.FC = () => {
   useAndroidPictureInPicture();


### PR DESCRIPTION
## 概要

Android 16（API 36）以降で表示されるライブアップデート通知（`Notification.ProgressStyle`）が、実際には一度も呼び出されていない状態になっていたため修正します。

`LiveUpdateModule` を叩く `startLiveUpdate` / `updateLiveUpdate` / `stopLiveUpdate` の唯一の呼び出し元は `useUpdateLiveActivities` ですが、#6422（高頻度 atom 購読の隔離）で同フックが `FxUpdateLiveActivities` へ移された際に `Platform.OS === 'ios'` のゲートが付き、Android ではマウントされなくなっていました。

- 2026-07-04 #6350: `useUpdateLiveActivities` に `startLiveUpdate` 系を追加。当時はフックが Main 画面の本体から無条件に呼ばれていたため Android でも動作
- 2026-07-16 #6422: フックを iOS 限定マウントへ変更 → 以降 Android では未実行

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `FxUpdateLiveActivities` のマウント条件を `Platform.OS === 'ios' || IS_LIVE_UPDATE_ELIGIBLE_PLATFORM` に変更

ライブアップデートは駅名・接近・停車・進捗など毎秒変化する項目を必要とするため、ウィジェット同期のような低頻度の部分購読では代替できず、`activityState` の派生計算を回す必要があります。そのため、#6422 が避けたコストを無条件に戻さないよう、実際に通知先を持つ **iOS と Android 16 以降** に限ってマウントする条件としています（Android 15 以下では従来どおり派生計算ごと止まります）。

## テスト

<!-- どのようにテストしたかを記述してください -->

`npm run lint` / `npm test`（208 suites・2195 tests passed）/ `npm run typecheck` をローカルで実行し、いずれも成功しています。

プラットフォーム分岐 1 行の変更で、既存フックの入出力は変えていないためユニットテストの追加はしていません。実機での動作確認（Android 16 端末で乗車中に進捗通知が出ること、Android 15 以下で従来どおり何も出ないこと）をお願いします。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

作業環境に実機がないため未取得です。

> [!NOTE]
> #6577（Android ウィジェットの修正）も `src/screens/Main.tsx` の近い行を変更しています。どちらか一方をマージした後にコンフリクトが出る可能性がありますが、内容は独立しているため解決は単純です（必要なら私の方で解消します）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XHQB1iKjHbZLmPDKysVpnt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * Live Activitiesの更新処理が、iOSおよび対応するAndroidプラットフォームで利用可能になりました。
  * 対象外の端末では、関連する更新コンポーネントが表示されなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->