### PR TITLE
ウィジェットの路線色バーの太さをナンバリングサークルの線幅に揃える

### DIFF
--- a/android/app/src/main/res/drawable/widget_line_bar.xml
+++ b/android/app/src/main/res/drawable/widget_line_bar.xml
@@ -2,6 +2,6 @@
 <!-- 路線色はRemoteViews#setInt("setColorFilter")で着色するため、ここでは白で描く -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners android:radius="2dp" />
+    <corners android:radius="@dimen/widget_line_bar_corner_radius" />
     <solid android:color="#FFFFFFFF" />
 </shape>

--- a/android/app/src/main/res/drawable/widget_numbering_circle.xml
+++ b/android/app/src/main/res/drawable/widget_numbering_circle.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   iOS版のナンバリングサークル(Circle().strokeBorder)相当。路線色はsetColorFilterで着色する。
-  線幅はiOS側(直径の約1/7)に合わせている
+  線幅はiOS側(直径の約1/7)に合わせており、路線色バーとも共通のdimenを使う
 -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid android:color="@android:color/transparent" />
     <stroke
-        android:width="7dp"
+        android:width="@dimen/widget_line_stroke_width"
         android:color="#FFFFFFFF" />
 </shape>

--- a/android/app/src/main/res/layout/widget_ride_rectangular.xml
+++ b/android/app/src/main/res/layout/widget_ride_rectangular.xml
@@ -9,9 +9,10 @@
     android:orientation="horizontal"
     android:padding="12dp">
 
+    <!-- 太さは右端のナンバリングサークルの線幅と揃える -->
     <ImageView
         android:id="@+id/widget_line_bar"
-        android:layout_width="4dp"
+        android:layout_width="@dimen/widget_line_stroke_width"
         android:layout_height="match_parent"
         android:layout_marginEnd="10dp"
         android:contentDescription="@null"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,4 +1,10 @@
 <resources>
   <!-- ホーム画面ウィジェットの角丸。Android 12以降はvalues-v31でシステム既定値へ差し替える -->
   <dimen name="widget_corner_radius">16dp</dimen>
+  <!--
+    ナンバリングサークルの線幅と、路線色バーの太さの共通値。
+    iOS版に合わせてサークルの直径(48dp)の約1/7としており、
+    同じレイアウトに並ぶバーの太さもこの値に揃える
+  -->
+  <dimen name="widget_line_stroke_width">7dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -7,4 +7,10 @@
     同じレイアウトに並ぶバーの太さもこの値に揃える
   -->
   <dimen name="widget_line_stroke_width">7dp</dimen>
+  <!--
+    路線色バーの角丸。太くする前(幅4dp・角丸2dp)と同じく端が半円になるよう、バーの太さの半分にする。
+    widget_line_barはこれより細いインラインレイアウトでも使い回すが、
+    GradientDrawableが角丸を短辺の半分までに丸めるため、そちらの見た目は従来どおり変わらない
+  -->
+  <dimen name="widget_line_bar_corner_radius">3.5dp</dimen>
 </resources>

--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -14,11 +14,19 @@ import WidgetKit
 // watchOSのaccessoryRectangular・iOSのロック画面ウィジェット・Androidのホーム画面ウィジェットと
 // 同じ体裁(路線色のナンバリングサークルとバー + 路線名 + 方面)を踏襲する。
 
+// systemMediumのナンバリングサークルの直径。左のバーの太さもこの値から導出する
+private let mediumCircleDiameter: CGFloat = 60
+
 // watchOS/ロック画面のNumberingCircle相当。ホーム画面はサイズが可変なので直径を受け取る
 struct HomeScreenNumberingCircle: View {
   let lineColor: String
   let lineSymbol: String
   let diameter: CGFloat
+
+  // 円の線幅は直径の約1/7。同じ画面に並ぶ路線色バーの太さもこれに揃える
+  static func strokeWidth(for diameter: CGFloat) -> CGFloat {
+    diameter / 7
+  }
 
   var body: some View {
     ZStack {
@@ -26,7 +34,7 @@ struct HomeScreenNumberingCircle: View {
       // 中央揃えのstrokeだと線幅の半分がframeの外にはみ出し、線を太くしたぶんだけ
       // レイアウトと実際の見た目がずれるため使わない
       Circle()
-        .strokeBorder(Color(hex: lineColor), lineWidth: diameter / 7)
+        .strokeBorder(Color(hex: lineColor), lineWidth: Self.strokeWidth(for: diameter))
       Text(lineSymbol)
         .font(.system(size: diameter * 0.4, weight: .heavy, design: .rounded))
         .minimumScaleFactor(0.5)
@@ -37,14 +45,16 @@ struct HomeScreenNumberingCircle: View {
   }
 }
 
-// accessoryRectangular / Androidのwidget_line_barと同じ路線色のバー
+// accessoryRectangular / Androidのwidget_line_barと同じ路線色のバー。
+// 太さは並んで表示されるナンバリングサークルの線幅と揃える
 struct HomeScreenLineBar: View {
   let lineColor: String
+  let width: CGFloat
 
   var body: some View {
     RoundedRectangle(cornerRadius: 2)
       .fill(Color(hex: lineColor))
-      .frame(width: 4)
+      .frame(width: width)
   }
 }
 
@@ -112,7 +122,10 @@ struct HomeScreenWidgetEntryView: View {
   // アプリ名とナンバリングサークルを足した構成
   var mediumView: some View {
     HStack(spacing: 12) {
-      HomeScreenLineBar(lineColor: entry.displayLineColor)
+      HomeScreenLineBar(
+        lineColor: entry.displayLineColor,
+        width: HomeScreenNumberingCircle.strokeWidth(for: mediumCircleDiameter)
+      )
       VStack(alignment: .leading, spacing: 4) {
         brandLabel
         lineNameText
@@ -125,7 +138,7 @@ struct HomeScreenWidgetEntryView: View {
       HomeScreenNumberingCircle(
         lineColor: entry.displayLineColor,
         lineSymbol: entry.lineSymbol,
-        diameter: 60
+        diameter: mediumCircleDiameter
       )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)

--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -52,7 +52,9 @@ struct HomeScreenLineBar: View {
   let width: CGFloat
 
   var body: some View {
-    RoundedRectangle(cornerRadius: 2)
+    // 角丸は幅の半分。太くする前(幅4pt・角丸2pt)と同じく端が半円になる丸みを保つため、
+    // 固定値ではなく幅から導出する
+    RoundedRectangle(cornerRadius: width / 2)
       .fill(Color(hex: lineColor))
       .frame(width: width)
   }


### PR DESCRIPTION
## 概要

ホーム画面ウィジェット（iOS systemMedium / Android rectangular）で、左端の路線色バーが右端のナンバリングサークルの線幅より細く、同じ路線色の要素どうしで太さがちぐはぐに見えていた。バーの太さをサークルの線幅と同一にして見た目を揃える。あわせて、太くしたことで相対的に角が立って見えないよう、角丸も従来と同じ「幅の半分（端が半円）」の水準を保つ。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- iOS: `HomeScreenNumberingCircle` のサークル線幅（直径の 1/7）を `strokeWidth(for:)` として切り出し、サークルと `HomeScreenLineBar` の両方がこの単一の定義を参照するようにした
- iOS: systemMedium の直径リテラル `60` を `mediumCircleDiameter` 定数へ集約。バー幅は `4pt` → `60 / 7 ≒ 8.57pt`
- iOS: `HomeScreenLineBar` の角丸を固定値 `2pt` から `width / 2` へ変更（≒ `4.29pt`）。太くする前と同じく端が半円になる丸みを保つ
- Android: サークル線幅とバー太さの共通値として `@dimen/widget_line_stroke_width` (7dp) を `dimens.xml` に追加
- Android: `widget_numbering_circle.xml` の `<stroke android:width>` と `widget_ride_rectangular.xml` の `widget_line_bar` の `layout_width` を、ともに新しい dimen 参照へ置き換え。バー幅は `4dp` → `7dp`
- Android: バーの角丸として `@dimen/widget_line_bar_corner_radius` (3.5dp = 太さの半分) を追加し、`widget_line_bar.xml` の `<corners android:radius>` を `2dp` から置き換え

値をコピーして揃えるのではなく、サークル側の定義を単一のソースにしているため、今後サークルのサイズを変更してもバーが追従する。

同じ画面に参照元となるサークルが存在しない以下は太さの変更対象外とした:

- Android `widget_ride_inline.xml`（1 行表示、バーのみ）
- iOS ロック画面 `accessoryRectangular`（`LockScreenWidget.swift`）
- watchOS `accessoryRectangular`（`WatchWidget.swift`）

### 回帰リスクと緩和策

- リスクは低〜中。変更は寸法のみで、データ取得・更新経路・色の適用ロジック（`setColorFilter` / `Color(hex:)`）には触れていない。
- 横並びレイアウトでバーが iOS で約 4.6pt、Android で 3dp ぶん太くなるため、路線名・方面テキストに割ける横幅がそのぶん減る。いずれのテキストも `lineLimit(2)` / `maxLines="2"` と `minimumScaleFactor` / `ellipsize` を持つため折り返しや縮小で吸収される想定。
- Android の `widget_line_bar.xml` は太さを変えていないインラインレイアウト（幅 4dp）と共用のため、角丸 3.5dp がそちらにも及ぶ。ただし `GradientDrawable` は角丸を短辺の半分（この場合 2dp）に丸めるため、インライン側の描画結果は変更前と同一。
- `@dimen/widget_line_stroke_width` と `@dimen/widget_line_bar_corner_radius` はいずれも新規追加のため既存リソースとの衝突はない。`values-v31` 等でのオーバーライドも設けていない。
- 影響範囲は上記レイアウトに限定され、他のウィジェットファミリー（circular / small / ロック画面 / watchOS）の描画は変更前と同一。

## テスト

ローカルで実行したコマンド:

- `npm run lint` → Checked 617 files、エラーなし
- `npm test` → 209 suites / 2199 tests すべて成功
- `npm run typecheck` → エラーなし

なお、変更はネイティブ（Swift / Android リソース）のみのため上記 JS 側チェックは回帰確認の意味合いで実行している。Xcode / Android SDK を持たない環境で作業したため、**ネイティブビルドと実機・シミュレータでの表示確認は未実施**。レビュー前に実機での見た目確認をお願いしたい。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
