### PR TITLE
プリセットを一覧表示するホーム画面ウィジェットをiOS/Androidに追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,5 +67,10 @@
         android:name="android.appwidget.provider"
         android:resource="@xml/presets_widget_info"/>
     </receiver>
+    <!-- プリセットウィジェットの行を供給するアダプタ。BIND_REMOTEVIEWSはシステムのみが保持する -->
+    <service
+      android:name=".PresetsWidgetService"
+      android:exported="false"
+      android:permission="android.permission.BIND_REMOTEVIEWS"/>
   </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,5 +56,16 @@
         android:name="android.appwidget.provider"
         android:resource="@xml/ride_widget_info"/>
     </receiver>
+    <receiver
+      android:name=".PresetsWidgetProvider"
+      android:label="@string/widget_presets_title"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/presets_widget_info"/>
+    </receiver>
   </application>
 </manifest>

--- a/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
@@ -1,0 +1,207 @@
+package me.tinykitten.trainlcd
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.RemoteViews
+
+/**
+ * アプリ内で登録したプリセットを並べるホーム画面ウィジェット。
+ *
+ * 行をタップすると `trainlcd://?preset=<SavedRoute.id>` のディープリンクでアプリが起動し、
+ * 該当プリセットの行き先選択が開く(JS側のuseDeepLink)。
+ * iOS版(PresetsWidget.swift)と同じ体裁・同じディープリンクを踏襲する。
+ */
+class PresetsWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        appWidgetIds.forEach { updateWidget(context, appWidgetManager, it) }
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle?
+    ) {
+        // リサイズで表示できる行数が変わるため再描画する
+        updateWidget(context, appWidgetManager, appWidgetId)
+    }
+
+    companion object {
+        /** ヘッダーとルート要素の余白が占める高さ(dp) */
+        private const val CHROME_HEIGHT_DP = 44
+
+        /** 1行あたりの高さ(dp)。widget_presets_rowのサークル34dp + 上下パディング5dpずつ */
+        private const val ROW_HEIGHT_DP = 44
+
+        /** ウィジェットの高さが取得できないときに表示する行数 */
+        private const val FALLBACK_ROW_COUNT = 2
+
+        /** JS側のMAX_PRESETS_WIDGET_ITEMSと揃えた表示上限 */
+        private const val MAX_ROW_COUNT = 8
+
+        /** アプリ側から表示内容を更新する際のエントリポイント */
+        fun updateAll(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+            val ids = appWidgetManager.getAppWidgetIds(
+                ComponentName(context.applicationContext, PresetsWidgetProvider::class.java)
+            )
+            ids.forEach { updateWidget(context, appWidgetManager, it) }
+        }
+
+        private fun updateWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val options: Bundle? = appWidgetManager.getAppWidgetOptions(appWidgetId)
+            val minHeightDp = options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0) ?: 0
+
+            appWidgetManager.updateAppWidget(
+                appWidgetId,
+                buildRemoteViews(
+                    context,
+                    PresetsWidgetStore.load(context),
+                    resolveRowCount(minHeightDp)
+                )
+            )
+        }
+
+        private fun resolveRowCount(minHeightDp: Int): Int {
+            if (minHeightDp <= 0) {
+                return FALLBACK_ROW_COUNT
+            }
+            val available = minHeightDp - CHROME_HEIGHT_DP
+            return (available / ROW_HEIGHT_DP).coerceIn(1, MAX_ROW_COUNT)
+        }
+
+        private fun buildRemoteViews(
+            context: Context,
+            presets: List<PresetWidgetItem>,
+            rowCount: Int
+        ): RemoteViews {
+            val views = RemoteViews(context.packageName, R.layout.widget_presets)
+            // RemoteViewsは再利用されるため、addViewする前に必ず前回の行を消す
+            views.removeAllViews(R.id.widget_presets_list)
+
+            if (presets.isEmpty()) {
+                views.setViewVisibility(R.id.widget_presets_list, View.GONE)
+                views.setViewVisibility(R.id.widget_presets_empty, View.VISIBLE)
+                views.setContentDescription(
+                    R.id.widget_presets_root,
+                    context.getString(R.string.widget_presets_empty)
+                )
+                // プリセット未登録時はウィジェット全体をアプリ起動のタップ領域にする
+                createLaunchIntent(context)?.let {
+                    views.setOnClickPendingIntent(R.id.widget_presets_root, it)
+                }
+                return views
+            }
+
+            views.setViewVisibility(R.id.widget_presets_list, View.VISIBLE)
+            views.setViewVisibility(R.id.widget_presets_empty, View.GONE)
+
+            val visiblePresets = presets.take(rowCount)
+            visiblePresets.forEachIndexed { index, preset ->
+                views.addView(
+                    R.id.widget_presets_list,
+                    buildRowViews(context, preset, index)
+                )
+            }
+            views.setContentDescription(
+                R.id.widget_presets_root,
+                visiblePresets.joinToString(", ") { it.name }
+            )
+
+            return views
+        }
+
+        private fun buildRowViews(
+            context: Context,
+            preset: PresetWidgetItem,
+            index: Int
+        ): RemoteViews {
+            // iOS版と同様に、路線記号が無い路線ではプリセット名ではなく路線名の先頭1文字で代替する
+            val lineSymbol = when {
+                preset.lineSymbol.isNotEmpty() -> preset.lineSymbol
+                preset.lineName.isNotEmpty() -> preset.lineName.take(1)
+                else -> context.getString(R.string.widget_line_symbol_placeholder)
+            }
+            val lineColor = WidgetStateStore.parseColor(
+                preset.lineColor.ifEmpty { WidgetStateStore.PLACEHOLDER_LINE_COLOR },
+                WidgetStateStore.parseColor(WidgetStateStore.PLACEHOLDER_LINE_COLOR, 0)
+            )
+            // 駅名が未取得のプリセットでは路線名だけを出す
+            val route =
+                if (preset.fromStationName.isEmpty() || preset.toStationName.isEmpty()) {
+                    preset.lineName
+                } else {
+                    context.getString(
+                        R.string.widget_presets_route,
+                        preset.fromStationName,
+                        preset.toStationName
+                    )
+                }
+
+            return RemoteViews(context.packageName, R.layout.widget_presets_row).apply {
+                setInt(R.id.widget_preset_circle, "setColorFilter", lineColor)
+                setTextViewText(R.id.widget_preset_symbol, lineSymbol)
+                setTextViewText(R.id.widget_preset_name, preset.name)
+                setTextViewText(R.id.widget_preset_route, route)
+                setContentDescription(R.id.widget_preset_row, "${preset.name} / $route")
+                createPresetIntent(context, preset.id, index)?.let {
+                    setOnClickPendingIntent(R.id.widget_preset_row, it)
+                }
+            }
+        }
+
+        private fun createPresetIntent(
+            context: Context,
+            presetId: String,
+            index: Int
+        ): PendingIntent? {
+            val uri = Uri.Builder()
+                .scheme(context.getString(R.string.app_scheme))
+                .authority("")
+                .appendQueryParameter("preset", presetId)
+                .build()
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                // 他アプリが同じスキームを宣言していても自アプリへ確実に届くよう明示する
+                setPackage(context.packageName)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            if (intent.resolveActivity(context.packageManager) == null) {
+                return createLaunchIntent(context)
+            }
+            return PendingIntent.getActivity(
+                context,
+                // 行ごとにPendingIntentを作り分けるためrequestCodeを変える。
+                // 同じ値を使うとFLAG_UPDATE_CURRENTで全行が最後のURIに揃ってしまう
+                index + 1,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        private fun createLaunchIntent(context: Context): PendingIntent? {
+            val intent = context.packageManager
+                .getLaunchIntentForPackage(context.packageName) ?: return null
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
@@ -7,7 +7,9 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.util.SizeF
 import android.view.View
 import android.widget.RemoteViews
 
@@ -38,11 +40,18 @@ class PresetsWidgetProvider : AppWidgetProvider() {
     }
 
     companion object {
-        /** ヘッダーとルート要素の余白が占める高さ(dp) */
-        private const val CHROME_HEIGHT_DP = 44
+        /** ルート要素の上下パディング(10dpずつ)と行リストの上マージンが占める高さ(dp) */
+        private const val PADDING_HEIGHT_DP = 22
 
-        /** 1行あたりの高さ(dp)。widget_presets_rowのサークル34dp + 上下パディング5dpずつ */
-        private const val ROW_HEIGHT_DP = 44
+        /** ヘッダー(アイコン12dp + 11spのテキスト)が占める高さ(dp) */
+        private const val HEADER_HEIGHT_DP = 16
+
+        /**
+         * 1行あたりの高さ(dp)。
+         * widget_presets_rowの上下パディング3dpずつと、サークル(30dp)より高くなる
+         * テキスト2段(13sp + 11sp ≒ 33dp)から見積もっている。
+         */
+        private const val ROW_HEIGHT_DP = 39
 
         /** ウィジェットの高さが取得できないときに表示する行数 */
         private const val FALLBACK_ROW_COUNT = 2
@@ -65,32 +74,71 @@ class PresetsWidgetProvider : AppWidgetProvider() {
             appWidgetId: Int
         ) {
             val options: Bundle? = appWidgetManager.getAppWidgetOptions(appWidgetId)
-            val minHeightDp = options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0) ?: 0
 
             appWidgetManager.updateAppWidget(
                 appWidgetId,
-                buildRemoteViews(
-                    context,
-                    PresetsWidgetStore.load(context),
-                    resolveRowCount(minHeightDp)
-                )
+                buildResponsiveViews(context, PresetsWidgetStore.load(context), options)
             )
         }
 
-        private fun resolveRowCount(minHeightDp: Int): Int {
-            if (minHeightDp <= 0) {
+        /**
+         * ウィジェットの高さに応じた表示を組み立てる。
+         *
+         * Android 12以降はOPTION_APPWIDGET_SIZESで縦向き・横向きそれぞれの実寸が取れるため、
+         * サイズごとのRemoteViewsをまとめて渡してシステムに出し分けさせる。
+         * それ以前はOPTION_APPWIDGET_MAX_HEIGHT(縦向き時の高さ)を使う。
+         * OPTION_APPWIDGET_MIN_HEIGHTは横向き時の高さ、つまり取り得る中で最小の値なので、
+         * これを基準にすると縦向きで収まるはずの行まで落としてしまう。
+         */
+        private fun buildResponsiveViews(
+            context: Context,
+            presets: List<PresetWidgetItem>,
+            options: Bundle?
+        ): RemoteViews {
+            if (options != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                @Suppress("DEPRECATION")
+                val sizes = options.getParcelableArrayList<SizeF>(
+                    AppWidgetManager.OPTION_APPWIDGET_SIZES
+                )
+                if (!sizes.isNullOrEmpty()) {
+                    return RemoteViews(
+                        sizes.associateWith { size ->
+                            buildRemoteViews(context, presets, size.height.toInt())
+                        }
+                    )
+                }
+            }
+
+            val portraitHeightDp =
+                options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, 0) ?: 0
+            return buildRemoteViews(context, presets, portraitHeightDp)
+        }
+
+        /**
+         * 与えられた高さに収まる行数を返す。
+         * ヘッダー込みでは1行も置けない高さのときはヘッダーを諦めて1行を優先する。
+         */
+        private fun resolveRowCount(heightDp: Int, withHeader: Boolean): Int {
+            if (heightDp <= 0) {
                 return FALLBACK_ROW_COUNT
             }
-            val available = minHeightDp - CHROME_HEIGHT_DP
-            return (available / ROW_HEIGHT_DP).coerceIn(1, MAX_ROW_COUNT)
+            val chrome = PADDING_HEIGHT_DP + if (withHeader) HEADER_HEIGHT_DP else 0
+            return ((heightDp - chrome) / ROW_HEIGHT_DP).coerceIn(0, MAX_ROW_COUNT)
         }
 
         private fun buildRemoteViews(
             context: Context,
             presets: List<PresetWidgetItem>,
-            rowCount: Int
+            heightDp: Int
         ): RemoteViews {
+            val showHeader = resolveRowCount(heightDp, withHeader = true) > 0
+            val rowCount = resolveRowCount(heightDp, showHeader).coerceAtLeast(1)
+
             val views = RemoteViews(context.packageName, R.layout.widget_presets)
+            views.setViewVisibility(
+                R.id.widget_presets_header,
+                if (showHeader) View.VISIBLE else View.GONE
+            )
             // RemoteViewsは再利用されるため、addViewする前に必ず前回の行を消す
             views.removeAllViews(R.id.widget_presets_list)
 

--- a/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetProvider.kt
@@ -8,9 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
-import android.util.SizeF
-import android.view.View
 import android.widget.RemoteViews
 
 /**
@@ -19,6 +16,11 @@ import android.widget.RemoteViews
  * 行をタップすると `trainlcd://?preset=<SavedRoute.id>` のディープリンクでアプリが起動し、
  * 該当プリセットの行き先選択が開く(JS側のuseDeepLink)。
  * iOS版(PresetsWidget.swift)と同じ体裁・同じディープリンクを踏襲する。
+ *
+ * 行の供給はPresetsWidgetServiceに任せている。ウィジェットの高さから表示行数を
+ * 見積もる方式は端末やランチャー・画面の向きで実寸が変わるため必ずずれる。
+ * ListViewのアダプタにすれば「入るだけ表示して残りはスクロール」をシステムが担うので、
+ * ウィジェットを引き伸ばした分だけ素直に表示件数が増える。
  */
 class PresetsWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(
@@ -29,43 +31,19 @@ class PresetsWidgetProvider : AppWidgetProvider() {
         appWidgetIds.forEach { updateWidget(context, appWidgetManager, it) }
     }
 
-    override fun onAppWidgetOptionsChanged(
-        context: Context,
-        appWidgetManager: AppWidgetManager,
-        appWidgetId: Int,
-        newOptions: Bundle?
-    ) {
-        // リサイズで表示できる行数が変わるため再描画する
-        updateWidget(context, appWidgetManager, appWidgetId)
-    }
-
     companion object {
-        /** ルート要素の上下パディング(10dpずつ)と行リストの上マージンが占める高さ(dp) */
-        private const val PADDING_HEIGHT_DP = 22
-
-        /** ヘッダー(アイコン12dp + 11spのテキスト)が占める高さ(dp) */
-        private const val HEADER_HEIGHT_DP = 16
-
-        /**
-         * 1行あたりの高さ(dp)。
-         * widget_presets_rowの上下パディング3dpずつと、サークル(30dp)より高くなる
-         * テキスト2段(13sp + 11sp ≒ 33dp)から見積もっている。
-         */
-        private const val ROW_HEIGHT_DP = 39
-
-        /** ウィジェットの高さが取得できないときに表示する行数 */
-        private const val FALLBACK_ROW_COUNT = 2
-
-        /** JS側のMAX_PRESETS_WIDGET_ITEMSと揃えた表示上限 */
-        private const val MAX_ROW_COUNT = 8
-
         /** アプリ側から表示内容を更新する際のエントリポイント */
         fun updateAll(context: Context) {
             val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
             val ids = appWidgetManager.getAppWidgetIds(
                 ComponentName(context.applicationContext, PresetsWidgetProvider::class.java)
             )
+            if (ids.isEmpty()) {
+                return
+            }
             ids.forEach { updateWidget(context, appWidgetManager, it) }
+            // アダプタに再読み込みを促す。これが無いと保存済みの古い一覧が出たままになる
+            appWidgetManager.notifyAppWidgetViewDataChanged(ids, R.id.widget_presets_list)
         }
 
         private fun updateWidget(
@@ -73,172 +51,48 @@ class PresetsWidgetProvider : AppWidgetProvider() {
             appWidgetManager: AppWidgetManager,
             appWidgetId: Int
         ) {
-            val options: Bundle? = appWidgetManager.getAppWidgetOptions(appWidgetId)
-
-            appWidgetManager.updateAppWidget(
-                appWidgetId,
-                buildResponsiveViews(context, PresetsWidgetStore.load(context), options)
-            )
-        }
-
-        /**
-         * ウィジェットの高さに応じた表示を組み立てる。
-         *
-         * Android 12以降はOPTION_APPWIDGET_SIZESで縦向き・横向きそれぞれの実寸が取れるため、
-         * サイズごとのRemoteViewsをまとめて渡してシステムに出し分けさせる。
-         * それ以前はOPTION_APPWIDGET_MAX_HEIGHT(縦向き時の高さ)を使う。
-         * OPTION_APPWIDGET_MIN_HEIGHTは横向き時の高さ、つまり取り得る中で最小の値なので、
-         * これを基準にすると縦向きで収まるはずの行まで落としてしまう。
-         */
-        private fun buildResponsiveViews(
-            context: Context,
-            presets: List<PresetWidgetItem>,
-            options: Bundle?
-        ): RemoteViews {
-            if (options != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                @Suppress("DEPRECATION")
-                val sizes = options.getParcelableArrayList<SizeF>(
-                    AppWidgetManager.OPTION_APPWIDGET_SIZES
-                )
-                if (!sizes.isNullOrEmpty()) {
-                    return RemoteViews(
-                        sizes.associateWith { size ->
-                            buildRemoteViews(context, presets, size.height.toInt())
-                        }
-                    )
-                }
-            }
-
-            val portraitHeightDp =
-                options?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, 0) ?: 0
-            return buildRemoteViews(context, presets, portraitHeightDp)
-        }
-
-        /**
-         * 与えられた高さに収まる行数を返す。
-         * ヘッダー込みでは1行も置けない高さのときはヘッダーを諦めて1行を優先する。
-         */
-        private fun resolveRowCount(heightDp: Int, withHeader: Boolean): Int {
-            if (heightDp <= 0) {
-                return FALLBACK_ROW_COUNT
-            }
-            val chrome = PADDING_HEIGHT_DP + if (withHeader) HEADER_HEIGHT_DP else 0
-            return ((heightDp - chrome) / ROW_HEIGHT_DP).coerceIn(0, MAX_ROW_COUNT)
-        }
-
-        private fun buildRemoteViews(
-            context: Context,
-            presets: List<PresetWidgetItem>,
-            heightDp: Int
-        ): RemoteViews {
-            val showHeader = resolveRowCount(heightDp, withHeader = true) > 0
-            val rowCount = resolveRowCount(heightDp, showHeader).coerceAtLeast(1)
-
             val views = RemoteViews(context.packageName, R.layout.widget_presets)
-            views.setViewVisibility(
-                R.id.widget_presets_header,
-                if (showHeader) View.VISIBLE else View.GONE
-            )
-            // RemoteViewsは再利用されるため、addViewする前に必ず前回の行を消す
-            views.removeAllViews(R.id.widget_presets_list)
 
-            if (presets.isEmpty()) {
-                views.setViewVisibility(R.id.widget_presets_list, View.GONE)
-                views.setViewVisibility(R.id.widget_presets_empty, View.VISIBLE)
-                views.setContentDescription(
-                    R.id.widget_presets_root,
-                    context.getString(R.string.widget_presets_empty)
-                )
-                // プリセット未登録時はウィジェット全体をアプリ起動のタップ領域にする
-                createLaunchIntent(context)?.let {
-                    views.setOnClickPendingIntent(R.id.widget_presets_root, it)
-                }
-                return views
+            views.setRemoteAdapter(R.id.widget_presets_list, adapterIntent(context, appWidgetId))
+            // プリセットが0件のときだけ案内文へ差し替える
+            views.setEmptyView(R.id.widget_presets_list, R.id.widget_presets_empty)
+            views.setPendingIntentTemplate(
+                R.id.widget_presets_list,
+                presetIntentTemplate(context)
+            )
+            // 案内文はコレクション側のタップが効かないため、単体でアプリ起動を割り当てる
+            createLaunchIntent(context)?.let {
+                views.setOnClickPendingIntent(R.id.widget_presets_empty, it)
             }
 
-            views.setViewVisibility(R.id.widget_presets_list, View.VISIBLE)
-            views.setViewVisibility(R.id.widget_presets_empty, View.GONE)
-
-            val visiblePresets = presets.take(rowCount)
-            visiblePresets.forEachIndexed { index, preset ->
-                views.addView(
-                    R.id.widget_presets_list,
-                    buildRowViews(context, preset, index)
-                )
-            }
-            views.setContentDescription(
-                R.id.widget_presets_root,
-                visiblePresets.joinToString(", ") { it.name }
-            )
-
-            return views
+            appWidgetManager.updateAppWidget(appWidgetId, views)
         }
 
-        private fun buildRowViews(
-            context: Context,
-            preset: PresetWidgetItem,
-            index: Int
-        ): RemoteViews {
-            // iOS版と同様に、路線記号が無い路線ではプリセット名ではなく路線名の先頭1文字で代替する
-            val lineSymbol = when {
-                preset.lineSymbol.isNotEmpty() -> preset.lineSymbol
-                preset.lineName.isNotEmpty() -> preset.lineName.take(1)
-                else -> context.getString(R.string.widget_line_symbol_placeholder)
+        private fun adapterIntent(context: Context, appWidgetId: Int): Intent =
+            Intent(context, PresetsWidgetService::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                // ウィジェットIDごとに別のアダプタとして扱わせるためURIを一意にする。
+                // extraだけではIntentが同一とみなされ、複数設置時に片方の一覧が使い回される
+                data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
             }
-            val lineColor = WidgetStateStore.parseColor(
-                preset.lineColor.ifEmpty { WidgetStateStore.PLACEHOLDER_LINE_COLOR },
-                WidgetStateStore.parseColor(WidgetStateStore.PLACEHOLDER_LINE_COLOR, 0)
-            )
-            // 駅名が未取得のプリセットでは路線名だけを出す
-            val route =
-                if (preset.fromStationName.isEmpty() || preset.toStationName.isEmpty()) {
-                    preset.lineName
-                } else {
-                    context.getString(
-                        R.string.widget_presets_route,
-                        preset.fromStationName,
-                        preset.toStationName
-                    )
-                }
 
-            return RemoteViews(context.packageName, R.layout.widget_presets_row).apply {
-                setInt(R.id.widget_preset_circle, "setColorFilter", lineColor)
-                setTextViewText(R.id.widget_preset_symbol, lineSymbol)
-                setTextViewText(R.id.widget_preset_name, preset.name)
-                setTextViewText(R.id.widget_preset_route, route)
-                setContentDescription(R.id.widget_preset_row, "${preset.name} / $route")
-                createPresetIntent(context, preset.id, index)?.let {
-                    setOnClickPendingIntent(R.id.widget_preset_row, it)
-                }
-            }
-        }
-
-        private fun createPresetIntent(
-            context: Context,
-            presetId: String,
-            index: Int
-        ): PendingIntent? {
-            val uri = Uri.Builder()
-                .scheme(context.getString(R.string.app_scheme))
-                .authority("")
-                .appendQueryParameter("preset", presetId)
-                .build()
-            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
-                // 他アプリが同じスキームを宣言していても自アプリへ確実に届くよう明示する
-                setPackage(context.packageName)
+        /**
+         * 行タップ時に使うテンプレート。
+         * 実際のURIは各行がsetOnClickFillInIntentで差し込むため、ここではdataを持たせない。
+         * fillInでdataを受け取る必要があるのでPendingIntentはミュータブルにする。
+         */
+        private fun presetIntentTemplate(context: Context): PendingIntent {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                // ReactInstanceManager.onNewIntentはACTION_VIEWのときだけurlイベントを流すため必須
+                action = Intent.ACTION_VIEW
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
-            if (intent.resolveActivity(context.packageManager) == null) {
-                return createLaunchIntent(context)
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
             }
-            return PendingIntent.getActivity(
-                context,
-                // 行ごとにPendingIntentを作り分けるためrequestCodeを変える。
-                // 同じ値を使うとFLAG_UPDATE_CURRENTで全行が最後のURIに揃ってしまう
-                index + 1,
-                intent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
+            return PendingIntent.getActivity(context, 0, intent, flags)
         }
 
         private fun createLaunchIntent(context: Context): PendingIntent? {
@@ -246,7 +100,7 @@ class PresetsWidgetProvider : AppWidgetProvider() {
                 .getLaunchIntentForPackage(context.packageName) ?: return null
             return PendingIntent.getActivity(
                 context,
-                0,
+                1,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )

--- a/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetService.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetService.kt
@@ -1,0 +1,96 @@
+package me.tinykitten.trainlcd
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+
+/**
+ * プリセットウィジェットの行を供給するサービス。
+ *
+ * 行数をウィジェットの高さから見積もると、端末やランチャーによって実寸が変わるうえ
+ * 縦横で高さも変わるため、必ずどこかでずれる。ListViewのアダプタとして供給すれば
+ * 「入るだけ表示して残りはスクロール」をシステムに任せられるので、高さ計算自体を持たない。
+ */
+class PresetsWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory =
+        PresetsRemoteViewsFactory(applicationContext)
+}
+
+private class PresetsRemoteViewsFactory(
+    private val context: Context
+) : RemoteViewsService.RemoteViewsFactory {
+    private var presets: List<PresetWidgetItem> = emptyList()
+
+    override fun onCreate() {
+        presets = PresetsWidgetStore.load(context)
+    }
+
+    /** notifyAppWidgetViewDataChangedのたびに呼ばれる。ここで最新のプリセットを読み直す */
+    override fun onDataSetChanged() {
+        presets = PresetsWidgetStore.load(context)
+    }
+
+    override fun onDestroy() {
+        presets = emptyList()
+    }
+
+    override fun getCount(): Int = presets.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val preset = presets.getOrNull(position)
+            ?: return RemoteViews(context.packageName, R.layout.widget_presets_row)
+
+        // iOS版と同様に、路線記号が無い路線では路線名の先頭1文字で代替する
+        val lineSymbol = when {
+            preset.lineSymbol.isNotEmpty() -> preset.lineSymbol
+            preset.lineName.isNotEmpty() -> preset.lineName.take(1)
+            else -> context.getString(R.string.widget_line_symbol_placeholder)
+        }
+        val lineColor = WidgetStateStore.parseColor(
+            preset.lineColor.ifEmpty { WidgetStateStore.PLACEHOLDER_LINE_COLOR },
+            WidgetStateStore.parseColor(WidgetStateStore.PLACEHOLDER_LINE_COLOR, 0)
+        )
+        // 駅名が未取得のプリセットでは路線名だけを出す
+        val route = if (preset.fromStationName.isEmpty() || preset.toStationName.isEmpty()) {
+            preset.lineName
+        } else {
+            context.getString(
+                R.string.widget_presets_route,
+                preset.fromStationName,
+                preset.toStationName
+            )
+        }
+
+        return RemoteViews(context.packageName, R.layout.widget_presets_row).apply {
+            setInt(R.id.widget_preset_circle, "setColorFilter", lineColor)
+            setTextViewText(R.id.widget_preset_symbol, lineSymbol)
+            setTextViewText(R.id.widget_preset_name, preset.name)
+            setTextViewText(R.id.widget_preset_route, route)
+            setContentDescription(R.id.widget_preset_row, "${preset.name} / $route")
+            // タップ先はProvider側のsetPendingIntentTemplateと組み合わさる。
+            // ここではテンプレートに差し込むディープリンクのURIだけを渡す
+            setOnClickFillInIntent(
+                R.id.widget_preset_row,
+                Intent().setData(presetUri(context, preset.id))
+            )
+        }
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long = position.toLong()
+
+    override fun hasStableIds(): Boolean = false
+}
+
+/** `trainlcd://?preset=<SavedRoute.id>`。Canaryビルドではスキームがtrainlcd-canaryになる */
+private fun presetUri(context: Context, presetId: String): Uri =
+    Uri.Builder()
+        .scheme(context.getString(R.string.app_scheme))
+        .authority("")
+        .appendQueryParameter("preset", presetId)
+        .build()

--- a/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetStore.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/PresetsWidgetStore.kt
@@ -1,0 +1,100 @@
+package me.tinykitten.trainlcd
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * プリセットウィジェットが表示する1件分のプリセット。
+ * iOS版がApp Groupへ書き込むJSON(PresetsWidgetModule)と同じ項目を持つ。
+ */
+data class PresetWidgetItem(
+    /** SavedRoute.id。ディープリンク(`?preset=<id>`)のペイロードにもなる */
+    val id: String,
+    val name: String,
+    val fromStationName: String,
+    val toStationName: String,
+    val lineName: String,
+    val lineColor: String,
+    val lineSymbol: String
+)
+
+/**
+ * プリセット一覧をSharedPreferencesへ永続化する。
+ *
+ * 乗車情報(WidgetStateStore)と同じ理由でメモリではなく端末ストレージへ置き、
+ * アプリのプロセスが落ちていてもAppWidgetProviderから読めるようにする。
+ * 件数が可変なのでキーを分けず、JSON文字列としてまとめて保存する。
+ */
+object PresetsWidgetStore {
+    private const val PREFS_NAME = "me.tinykitten.trainlcd.widget"
+    private const val KEY_PRESETS = "presets"
+
+    private const val FIELD_ID = "id"
+    private const val FIELD_NAME = "name"
+    private const val FIELD_FROM = "fromStationName"
+    private const val FIELD_TO = "toStationName"
+    private const val FIELD_LINE_NAME = "lineName"
+    private const val FIELD_LINE_COLOR = "lineColor"
+    private const val FIELD_LINE_SYMBOL = "lineSymbol"
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * プリセット一覧を保存する。内容に差分がある場合のみtrueを返し、
+     * 変化のない更新でウィジェット再描画のブロードキャストを投げないようにする。
+     */
+    fun save(context: Context, presets: List<PresetWidgetItem>): Boolean {
+        val json = JSONArray().apply {
+            presets.forEach { preset ->
+                put(
+                    JSONObject()
+                        .put(FIELD_ID, preset.id)
+                        .put(FIELD_NAME, preset.name)
+                        .put(FIELD_FROM, preset.fromStationName)
+                        .put(FIELD_TO, preset.toStationName)
+                        .put(FIELD_LINE_NAME, preset.lineName)
+                        .put(FIELD_LINE_COLOR, preset.lineColor)
+                        .put(FIELD_LINE_SYMBOL, preset.lineSymbol)
+                )
+            }
+        }.toString()
+
+        val prefs = prefs(context)
+        if (prefs.getString(KEY_PRESETS, null) == json) {
+            return false
+        }
+
+        prefs.edit().putString(KEY_PRESETS, json).apply()
+        return true
+    }
+
+    fun load(context: Context): List<PresetWidgetItem> {
+        val json = prefs(context).getString(KEY_PRESETS, null) ?: return emptyList()
+
+        return try {
+            val array = JSONArray(json)
+            // idの無い要素はディープリンクを組み立てられないため読み飛ばす
+            (0 until array.length()).mapNotNull { index ->
+                val obj = array.optJSONObject(index) ?: return@mapNotNull null
+                val id = obj.optString(FIELD_ID)
+                if (id.isEmpty()) {
+                    return@mapNotNull null
+                }
+                PresetWidgetItem(
+                    id = id,
+                    name = obj.optString(FIELD_NAME),
+                    fromStationName = obj.optString(FIELD_FROM),
+                    toStationName = obj.optString(FIELD_TO),
+                    lineName = obj.optString(FIELD_LINE_NAME),
+                    lineColor = obj.optString(FIELD_LINE_COLOR),
+                    lineSymbol = obj.optString(FIELD_LINE_SYMBOL)
+                )
+            }
+        } catch (_: JSONException) {
+            emptyList()
+        }
+    }
+}

--- a/android/app/src/main/java/me/tinykitten/trainlcd/WidgetModule.kt
+++ b/android/app/src/main/java/me/tinykitten/trainlcd/WidgetModule.kt
@@ -3,7 +3,9 @@ package me.tinykitten.trainlcd
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
 
 private fun ReadableMap.optString(key: String, default: String = ""): String =
     if (hasKey(key) && !isNull(key)) getString(key) ?: default else default
@@ -14,6 +16,9 @@ private fun ReadableMap.optString(key: String, default: String = ""): String =
  * iOS版はLiveActivityModuleがライブアクティビティ更新のついでにウィジェット用の
  * App Groupへ書き込んでいるが、Android版のライブアップデート(LiveUpdateModule)は
  * Android 16以降専用のため、ウィジェットの更新経路は独立させている。
+ *
+ * プリセットウィジェット(PresetsWidgetProvider)の更新も、iOS版と違って
+ * 同じSharedPreferencesを共有するためこのモジュールに相乗りさせている。
  */
 class WidgetModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
@@ -42,6 +47,39 @@ class WidgetModule(reactContext: ReactApplicationContext) :
     fun clearWidget() {
         if (WidgetStateStore.clear(reactApplicationContext)) {
             RideWidgetProvider.updateAll(reactApplicationContext)
+        }
+    }
+
+    /** プリセットウィジェットへ表示するプリセット一覧を同期する */
+    @ReactMethod
+    fun updatePresets(presets: ReadableArray?) {
+        if (presets == null) {
+            return
+        }
+
+        val items = (0 until presets.size()).mapNotNull { index ->
+            if (presets.getType(index) != ReadableType.Map) {
+                return@mapNotNull null
+            }
+            val map = presets.getMap(index) ?: return@mapNotNull null
+            val id = map.optString("id")
+            // idが無いとディープリンクを組み立てられないため取り込まない
+            if (id.isEmpty()) {
+                return@mapNotNull null
+            }
+            PresetWidgetItem(
+                id = id,
+                name = map.optString("name"),
+                fromStationName = map.optString("fromStationName"),
+                toStationName = map.optString("toStationName"),
+                lineName = map.optString("lineName"),
+                lineColor = map.optString("lineColor"),
+                lineSymbol = map.optString("lineSymbol")
+            )
+        }
+
+        if (PresetsWidgetStore.save(reactApplicationContext, items)) {
+            PresetsWidgetProvider.updateAll(reactApplicationContext)
         }
     }
 }

--- a/android/app/src/main/res/drawable/widget_preset_numbering_circle.xml
+++ b/android/app/src/main/res/drawable/widget_preset_numbering_circle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  プリセットウィジェットの行に置く小さめのナンバリングサークル。
+  乗車中ウィジェットのwidget_numbering_circleと同じ描き方だが、
+  線幅は直径の約1/7というiOS版の比率を保つため専用のdimenを使う
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@android:color/transparent" />
+    <stroke
+        android:width="@dimen/widget_preset_line_stroke_width"
+        android:color="#FFFFFFFF" />
+</shape>

--- a/android/app/src/main/res/layout/widget_presets.xml
+++ b/android/app/src/main/res/layout/widget_presets.xml
@@ -10,9 +10,11 @@
     android:layout_height="match_parent"
     android:background="@drawable/widget_background"
     android:orientation="vertical"
-    android:padding="12dp">
+    android:padding="10dp">
 
+    <!-- 高さが足りないときはPresetsWidgetProviderがヘッダーを隠して1行分の領域を確保する -->
     <LinearLayout
+        android:id="@+id/widget_presets_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
@@ -40,7 +42,7 @@
         android:id="@+id/widget_presets_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="2dp"
         android:orientation="vertical" />
 
     <TextView

--- a/android/app/src/main/res/layout/widget_presets.xml
+++ b/android/app/src/main/res/layout/widget_presets.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  アプリ内で登録したプリセットを並べるウィジェット。
+  iOS版のPresetsWidget(systemMedium / systemLarge)と同じ体裁で、
+  ヘッダー + 「路線色サークル / プリセット名 / 始発駅→終着駅」の行で構成する
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_presets_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:layout_width="12dp"
+            android:layout_height="12dp"
+            android:layout_marginEnd="4dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_notification_live_update"
+            android:tint="@color/widget_text_secondary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/widget_presets_title"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <!-- 行はPresetsWidgetProviderがwidget_presets_rowをaddViewして組み立てる -->
+    <LinearLayout
+        android:id="@+id/widget_presets_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:orientation="vertical" />
+
+    <TextView
+        android:id="@+id/widget_presets_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:text="@string/widget_presets_empty"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="12sp"
+        android:visibility="gone" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_presets.xml
+++ b/android/app/src/main/res/layout/widget_presets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   アプリ内で登録したプリセットを並べるウィジェット。
-  iOS版のPresetsWidget(systemMedium / systemLarge)と同じ体裁で、
+  iOS版のPresetsWidgetと同じ体裁で、
   ヘッダー + 「路線色サークル / プリセット名 / 始発駅→終着駅」の行で構成する
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -12,9 +12,7 @@
     android:orientation="vertical"
     android:padding="10dp">
 
-    <!-- 高さが足りないときはPresetsWidgetProviderがヘッダーを隠して1行分の領域を確保する -->
     <LinearLayout
-        android:id="@+id/widget_presets_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
@@ -37,14 +35,20 @@
             android:textStyle="bold" />
     </LinearLayout>
 
-    <!-- 行はPresetsWidgetProviderがwidget_presets_rowをaddViewして組み立てる -->
-    <LinearLayout
+    <!--
+      行はPresetsWidgetServiceがアダプタとして供給する。
+      高さに入るぶんだけ表示され、残りはスクロールで辿れる
+    -->
+    <ListView
         android:id="@+id/widget_presets_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginTop="2dp"
-        android:orientation="vertical" />
+        android:layout_weight="1"
+        android:divider="@null"
+        android:dividerHeight="0dp" />
 
+    <!-- setEmptyViewでListViewと排他に切り替わる -->
     <TextView
         android:id="@+id/widget_presets_empty"
         android:layout_width="match_parent"
@@ -53,6 +57,5 @@
         android:gravity="center_vertical"
         android:text="@string/widget_presets_empty"
         android:textColor="@color/widget_text_secondary"
-        android:textSize="12sp"
-        android:visibility="gone" />
+        android:textSize="12sp" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_presets_row.xml
+++ b/android/app/src/main/res/layout/widget_presets_row.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- プリセットウィジェットの1行。iOS版(PresetsWidget.swift)のPresetsWidgetRowに対応する -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_preset_row"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingTop="5dp"
+    android:paddingBottom="5dp">
+
+    <FrameLayout
+        android:layout_width="@dimen/widget_preset_circle_size"
+        android:layout_height="@dimen/widget_preset_circle_size">
+
+        <ImageView
+            android:id="@+id/widget_preset_circle"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            android:src="@drawable/widget_preset_numbering_circle" />
+
+        <TextView
+            android:id="@+id/widget_preset_symbol"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingStart="7dp"
+            android:paddingEnd="7dp"
+            android:text="@string/widget_line_symbol_placeholder"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/widget_preset_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/widget_preset_route"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_presets_row.xml
+++ b/android/app/src/main/res/layout/widget_presets_row.xml
@@ -4,6 +4,7 @@
     android:id="@+id/widget_preset_row"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingTop="3dp"

--- a/android/app/src/main/res/layout/widget_presets_row.xml
+++ b/android/app/src/main/res/layout/widget_presets_row.xml
@@ -6,8 +6,8 @@
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingTop="5dp"
-    android:paddingBottom="5dp">
+    android:paddingTop="3dp"
+    android:paddingBottom="3dp">
 
     <FrameLayout
         android:layout_width="@dimen/widget_preset_circle_size"
@@ -27,11 +27,11 @@
             android:layout_gravity="center"
             android:ellipsize="end"
             android:maxLines="1"
-            android:paddingStart="7dp"
-            android:paddingEnd="7dp"
+            android:paddingStart="6dp"
+            android:paddingEnd="6dp"
             android:text="@string/widget_line_symbol_placeholder"
             android:textColor="@color/widget_text_primary"
-            android:textSize="13sp"
+            android:textSize="12sp"
             android:textStyle="bold" />
     </FrameLayout>
 
@@ -49,7 +49,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:textColor="@color/widget_text_primary"
-            android:textSize="14sp"
+            android:textSize="13sp"
             android:textStyle="bold" />
 
         <TextView

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -13,7 +13,10 @@
     GradientDrawableが角丸を短辺の半分までに丸めるため、そちらの見た目は従来どおり変わらない
   -->
   <dimen name="widget_line_bar_corner_radius">3.5dp</dimen>
-  <!-- プリセットウィジェットの行に置くサークルの直径と、その線幅(直径の約1/7) -->
-  <dimen name="widget_preset_circle_size">34dp</dimen>
-  <dimen name="widget_preset_line_stroke_width">5dp</dimen>
+  <!--
+    プリセットウィジェットの行に置くサークルの直径と、その線幅(直径の約1/7)。
+    2セル分の高さのウィジェットにも2行収まるよう、乗車中ウィジェット(48dp)より小さくしている
+  -->
+  <dimen name="widget_preset_circle_size">30dp</dimen>
+  <dimen name="widget_preset_line_stroke_width">4dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -13,4 +13,7 @@
     GradientDrawableが角丸を短辺の半分までに丸めるため、そちらの見た目は従来どおり変わらない
   -->
   <dimen name="widget_line_bar_corner_radius">3.5dp</dimen>
+  <!-- プリセットウィジェットの行に置くサークルの直径と、その線幅(直径の約1/7) -->
+  <dimen name="widget_preset_circle_size">34dp</dimen>
+  <dimen name="widget_preset_line_stroke_width">5dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,6 +12,11 @@
   <string name="widget_line_not_set">路線が未設定です</string>
   <string name="widget_destination_not_set">方面が未設定です</string>
   <string name="widget_riding_on">%1$sに乗車中</string>
+  <string name="widget_presets_title">プリセット</string>
+  <string name="widget_presets_description">登録したプリセットを表示し、タップですぐに乗車を開始します</string>
+  <string name="widget_presets_empty">アプリでプリセットを登録すると、ここから直接乗車を開始できます。</string>
+  <!-- 駅名が未取得のプリセットでは路線名だけを出すため、区切りは書式側で持たせる -->
+  <string name="widget_presets_route">%1$s → %2$s</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/android/app/src/main/res/xml/presets_widget_info.xml
+++ b/android/app/src/main/res/xml/presets_widget_info.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  既定サイズは乗車中ウィジェット(ride_widget_info)と同じ2x2。
+  ただし極小サイズ用の代替レイアウトを持たないため、縮小の下限は既定サイズと同じにして
+  一覧が崩れた状態で置かれないようにしている(拡大は可能)。
+-->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/widget_presets_description"
     android:initialLayout="@layout/widget_presets"
     android:minHeight="110dp"
     android:minResizeHeight="110dp"
-    android:minResizeWidth="180dp"
-    android:minWidth="180dp"
+    android:minResizeWidth="110dp"
+    android:minWidth="110dp"
     android:previewLayout="@layout/widget_presets"
     android:resizeMode="horizontal|vertical"
     android:targetCellHeight="2"
-    android:targetCellWidth="4"
+    android:targetCellWidth="2"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />

--- a/android/app/src/main/res/xml/presets_widget_info.xml
+++ b/android/app/src/main/res/xml/presets_widget_info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   既定サイズは乗車中ウィジェット(ride_widget_info)と同じ2x2。
-  ただし極小サイズ用の代替レイアウトを持たないため、縮小の下限は既定サイズと同じにして
-  一覧が崩れた状態で置かれないようにしている(拡大は可能)。
+  一覧はListView(PresetsWidgetService)なので、拡大すれば入るぶんだけ表示件数が増え、
+  収まりきらない残りはスクロールで辿れる。
+  縮小の下限は、1行すら成立しない大きさで置かれないよう既定サイズと同じにしている。
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/widget_presets_description"

--- a/android/app/src/main/res/xml/presets_widget_info.xml
+++ b/android/app/src/main/res/xml/presets_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_presets_description"
+    android:initialLayout="@layout/widget_presets"
+    android:minHeight="110dp"
+    android:minResizeHeight="110dp"
+    android:minResizeWidth="180dp"
+    android:minWidth="180dp"
+    android:previewLayout="@layout/widget_presets"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="2"
+    android:targetCellWidth="4"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 ## ドキュメント一覧
 
 - [状態管理ガイドライン (Jotai)](./state-management.md)
+- [ホーム画面ウィジェット](./home-screen-widgets.md)
 - [Apollo Client → TanStack Query 移行メモ](./apollo-to-react-query-migration.md)
 - [canary リリース PR でのバージョン更新](./bump-version-on-canary-pr.md)
 - [本番リリース PR でのバージョン更新](./bump-version-on-release-pr.md)

--- a/docs/home-screen-widgets.md
+++ b/docs/home-screen-widgets.md
@@ -59,6 +59,28 @@ trainlcd-canary://?preset=<SavedRoute.id>   # Canary
 経路そのものは URL に含まれず端末内の DB から解決するため、
 `preset` の値は UUID 書式に一致するもののみ受け付ける。
 
+### サイズ
+
+既定サイズは乗車中ウィジェットと揃えている(iOS は `systemSmall`、Android は 2x2)。
+一覧をまとめて見たい場合に備えて大きいサイズも選べるようにしてあり、
+iOS は `systemSmall` / `systemMedium` / `systemLarge`、Android はリサイズで拡大できる。
+`systemSmall` と `systemMedium` は高さが同じなので表示行数も同じ 2 行になる。
+
+### 表示行数の決め方 (Android)
+
+`PresetsWidgetProvider` はウィジェットの高さから表示行数を導出する。基準に使う値に注意:
+
+- `OPTION_APPWIDGET_MIN_HEIGHT` は**横向き時の高さ**、つまり取り得る中で最小の値。
+  これを基準にすると縦向きで収まるはずの行まで落としてしまうため使わない。
+- Android 12 以降は `OPTION_APPWIDGET_SIZES` で向きごとの実寸が取れるので、
+  サイズごとの `RemoteViews` を `RemoteViews(Map<SizeF, RemoteViews>)` でまとめて渡し、
+  システムに出し分けさせる。
+- それ以前は `OPTION_APPWIDGET_MAX_HEIGHT`(縦向き時の高さ)を使う。
+
+`PADDING_HEIGHT_DP` / `HEADER_HEIGHT_DP` / `ROW_HEIGHT_DP` はレイアウトの実寸から見積もった
+定数のため、`widget_presets.xml` / `widget_presets_row.xml` の余白・文字サイズ・
+サークル径を変えたら合わせて更新する。
+
 ## 変更時に揃えるべき箇所
 
 - ウィジェットの kind 文字列: iOS の `Widget.kind` と、リロードを呼ぶネイティブモジュール側の定数。

--- a/docs/home-screen-widgets.md
+++ b/docs/home-screen-widgets.md
@@ -1,0 +1,68 @@
+# ホーム画面ウィジェット
+
+TrainLCD は iOS / Android の双方でホーム画面ウィジェットを提供している。
+本ドキュメントは各ウィジェットのデータ経路と、追加・変更時に揃えるべき箇所をまとめる。
+
+## ウィジェット一覧
+
+| ウィジェット | 表示内容 | iOS | Android |
+| --- | --- | --- | --- |
+| 乗車中 | 乗車中の路線・方面 | `HomeScreenWidget` | `RideWidgetProvider` |
+| プリセット | 登録済みプリセット一覧 | `PresetsWidget` | `PresetsWidgetProvider` |
+
+iOS の kind 文字列は型名と同じ(`HomeScreenWidget` / `PresetsWidget`)。
+
+いずれも iOS 側はロック画面ウィジェット・ロック画面コントロールと同じ
+`RideSessionActivity` Extension の `WidgetBundle` から配信している。
+
+## データ経路
+
+アプリのプロセスが落ちていてもウィジェットは描画されるため、
+表示に必要な文字列はすべて解決済みの状態でネイティブへ渡し、端末ストレージへ永続化する。
+
+```text
+JS (解決済みの表示用文字列)
+  ├─ iOS     → PresetsWidgetModule → App Group の UserDefaults → WidgetCenter.reloadTimelines
+  └─ Android → WidgetModule        → SharedPreferences        → AppWidgetManager.updateAppWidget
+```
+
+- iOS の App Group ID は `Info.plist` の `APP_GROUP_ID`(既定値 `group.me.tinykitten.trainlcd`)。
+- Android の SharedPreferences 名は `me.tinykitten.trainlcd.widget`。
+- 表示内容に差分が無い更新は書き込まない。iOS は WidgetKit のリロードバジェット、
+  Android は再描画ブロードキャストを無駄に消費しないため。
+
+## プリセットウィジェット
+
+### 同期
+
+`usePresetCarouselData` が取得済みのプリセット(駅情報込み)を `usePresetsWidgetSync` が
+表示用の文字列へ変換してネイティブへ渡す。始発駅・終着駅の解決はアプリ内のプリセットカードと
+共通の `getPresetRouteEndpoints` を使う。
+
+同期される項目は `PresetsWidgetItem`(`src/utils/native/presetsWidget.ts`)で、
+`lineColor` と `lineSymbol` は解決できない場合に空文字を渡し、
+ネイティブ側でブランドカラー・路線名の先頭 1 文字へフォールバックさせる。
+
+### ディープリンク
+
+行をタップすると以下の URL でアプリが起動する。
+
+```text
+trainlcd://?preset=<SavedRoute.id>          # 本番
+trainlcd-canary://?preset=<SavedRoute.id>   # Canary
+```
+
+`useDeepLink` は `preset` を他の経路パラメータ(`id` / `sids` / `sgid`)より優先して処理し、
+クイックアクションと同じ `pendingQuickActionRouteId` を立てて路線選択画面へ戻す。
+`SelectLineScreen` がそれを検知して当該プリセットの行き先選択を開く。
+
+経路そのものは URL に含まれず端末内の DB から解決するため、
+`preset` の値は UUID 書式に一致するもののみ受け付ける。
+
+## 変更時に揃えるべき箇所
+
+- ウィジェットの kind 文字列: iOS の `Widget.kind` と、リロードを呼ぶネイティブモジュール側の定数。
+- ストレージのキー名: iOS の `PresetsEntry.storageKey` と `PresetsWidgetModule.presetsStorageKey`、
+  Android の `PresetsWidgetStore` のフィールド名、JS の `PresetsWidgetItem`。
+- 表示件数の上限: JS の `MAX_PRESETS_WIDGET_ITEMS` と Android の `MAX_ROW_COUNT`。
+- 未設定時のフォールバック表示: iOS / Android の双方で同じ文言・同じ色になるようにする。

--- a/docs/home-screen-widgets.md
+++ b/docs/home-screen-widgets.md
@@ -23,7 +23,7 @@ iOS の kind 文字列は型名と同じ(`HomeScreenWidget` / `PresetsWidget`)�
 ```text
 JS (解決済みの表示用文字列)
   ├─ iOS     → PresetsWidgetModule → App Group の UserDefaults → WidgetCenter.reloadTimelines
-  └─ Android → WidgetModule        → SharedPreferences        → AppWidgetManager.updateAppWidget
+  └─ Android → WidgetModule        → SharedPreferences        → notifyAppWidgetViewDataChanged
 ```
 
 - iOS の App Group ID は `Info.plist` の `APP_GROUP_ID`(既定値 `group.me.tinykitten.trainlcd`)。
@@ -59,32 +59,33 @@ trainlcd-canary://?preset=<SavedRoute.id>   # Canary
 経路そのものは URL に含まれず端末内の DB から解決するため、
 `preset` の値は UUID 書式に一致するもののみ受け付ける。
 
-### サイズ
+### サイズと表示件数
 
 既定サイズは乗車中ウィジェットと揃えている(iOS は `systemSmall`、Android は 2x2)。
-一覧をまとめて見たい場合に備えて大きいサイズも選べるようにしてあり、
-iOS は `systemSmall` / `systemMedium` / `systemLarge`、Android はリサイズで拡大できる。
-`systemSmall` と `systemMedium` は高さが同じなので表示行数も同じ 2 行になる。
+一覧をまとめて見たい場合に備えて大きいサイズも選べる。
 
-### 表示行数の決め方 (Android)
+Android は `ListView` + `RemoteViewsService`(`PresetsWidgetService`)のコレクション
+ウィジェットで、入るぶんだけ表示され残りはスクロールで辿れる。行数をウィジェットの高さから
+dp で見積もる方式は、端末・ランチャー・画面の向きで実寸が変わるため必ずずれる
+(`OPTION_APPWIDGET_MIN_HEIGHT` は横向き時＝取り得る最小の高さで、これを基準にすると
+縦向きで収まるはずの行まで落ちる)。アダプタに任せることで高さ計算自体を持たない。
 
-`PresetsWidgetProvider` はウィジェットの高さから表示行数を導出する。基準に使う値に注意:
+iOS は WidgetKit にスクロールが無いためファミリーごとの固定件数になる。
 
-- `OPTION_APPWIDGET_MIN_HEIGHT` は**横向き時の高さ**、つまり取り得る中で最小の値。
-  これを基準にすると縦向きで収まるはずの行まで落としてしまうため使わない。
-- Android 12 以降は `OPTION_APPWIDGET_SIZES` で向きごとの実寸が取れるので、
-  サイズごとの `RemoteViews` を `RemoteViews(Map<SizeF, RemoteViews>)` でまとめて渡し、
-  システムに出し分けさせる。
-- それ以前は `OPTION_APPWIDGET_MAX_HEIGHT`(縦向き時の高さ)を使う。
+| ファミリー | 件数 | タップ |
+| --- | --- | --- |
+| `systemSmall` | 1 | `widgetURL` でウィジェット全体 |
+| `systemMedium` | 2 | 行ごとの `Link` |
+| `systemLarge` | 5 | 行ごとの `Link` |
 
-`PADDING_HEIGHT_DP` / `HEADER_HEIGHT_DP` / `ROW_HEIGHT_DP` はレイアウトの実寸から見積もった
-定数のため、`widget_presets.xml` / `widget_presets_row.xml` の余白・文字サイズ・
-サークル径を変えたら合わせて更新する。
+`systemSmall` はウィジェット全体が単一のタップ領域で、行ごとの `Link` が個別の
+タップ先にならない。表示とタップ先が食い違わないよう 1 件だけ出して `widgetURL` を張る。
 
 ## 変更時に揃えるべき箇所
 
 - ウィジェットの kind 文字列: iOS の `Widget.kind` と、リロードを呼ぶネイティブモジュール側の定数。
 - ストレージのキー名: iOS の `PresetsEntry.storageKey` と `PresetsWidgetModule.presetsStorageKey`、
   Android の `PresetsWidgetStore` のフィールド名、JS の `PresetsWidgetItem`。
-- 表示件数の上限: JS の `MAX_PRESETS_WIDGET_ITEMS` と Android の `MAX_ROW_COUNT`。
+- 同期する最大件数: JS の `MAX_PRESETS_WIDGET_ITEMS`(両 OS 共通)。
+  描画側の上限は iOS の `largeRowCount` のみで、Android は `ListView` に任せている。
 - 未設定時のフォールバック表示: iOS / Android の双方で同じ文言・同じ色になるようにする。

--- a/ios/Localizable/en.lproj/Localizable.strings
+++ b/ios/Localizable/en.lproj/Localizable.strings
@@ -27,3 +27,6 @@
 "openApp" = "Open TrainLCD";
 "controlDescription" = "Opens TrainLCD from the Lock Screen or Control Center.";
 "widgetDescription" = "Shows the line and destination for your current ride";
+"presetsWidgetTitle" = "Presets";
+"presetsWidgetDescription" = "Shows your saved presets and starts a ride with a tap";
+"presetsWidgetEmpty" = "Save a preset in the app to start a ride straight from here.";

--- a/ios/Localizable/ja.lproj/Localizable.strings
+++ b/ios/Localizable/ja.lproj/Localizable.strings
@@ -27,3 +27,6 @@
 "openApp" = "TrainLCDを開く";
 "controlDescription" = "ロック画面やコントロールセンターからTrainLCDを開きます。";
 "widgetDescription" = "乗車中の路線と方面を表示します";
+"presetsWidgetTitle" = "プリセット";
+"presetsWidgetDescription" = "登録したプリセットを表示し、タップですぐに乗車を開始します";
+"presetsWidgetEmpty" = "アプリでプリセットを登録すると、ここから直接乗車を開始できます。";

--- a/ios/Modules/PresetsWidget/PresetsWidgetModule.swift
+++ b/ios/Modules/PresetsWidget/PresetsWidgetModule.swift
@@ -30,15 +30,23 @@ class PresetsWidgetModule: NSObject {
 
   @objc(updatePresets:)
   func updatePresets(_ presets: NSArray?) {
-    guard let presets = presets as? [NSDictionary] else {
+    guard let presets = presets as? [Any] else {
       return
     }
 
-    // Swift側のデコードが部分的に失敗しないよう、欠けたキーは空文字で埋めてから直列化する
-    let items: [[String: String]] = presets.map { dic in
+    // Swift側のデコードが部分的に失敗しないよう、欠けたキーは空文字で埋めてから直列化する。
+    // 想定外の要素は配列ごと捨てずに要素単位で読み飛ばす
+    let items: [[String: String]] = presets.compactMap { element in
+      guard let dic = element as? NSDictionary else {
+        return nil
+      }
       var item: [String: String] = [:]
       for key in Self.itemKeys {
         item[key] = dic[key] as? String ?? ""
+      }
+      // idが無いとディープリンクを組み立てられないため取り込まない(Android側のWidgetModuleと同じ)
+      if item["id"]?.isEmpty != false {
+        return nil
       }
       return item
     }

--- a/ios/Modules/PresetsWidget/PresetsWidgetModule.swift
+++ b/ios/Modules/PresetsWidget/PresetsWidgetModule.swift
@@ -1,0 +1,68 @@
+import Foundation
+import WidgetKit
+
+/// ホーム画面のプリセットウィジェットが読むApp Groupへ、アプリ内のプリセット一覧を書き込むモジュール。
+///
+/// 乗車中の情報を扱うLiveActivityModuleとは更新タイミングも寿命も異なる(プリセットは
+/// 乗車していなくても表示し続ける)ため、書き込み経路を分けている。
+@objc(PresetsWidgetModule)
+class PresetsWidgetModule: NSObject {
+  // RideSessionActivity側のPresetsWidget.kindと一致させること
+  private let presetsWidgetKind = "PresetsWidget"
+  // RideSessionActivity側のPresetsEntry.storageKeyと一致させること
+  private let presetsStorageKey = "presets"
+
+  // PresetsWidgetItem(Swift)のCodingKeys・JS側のPresetsWidgetItemと一致させること
+  private static let itemKeys = [
+    "id",
+    "name",
+    "fromStationName",
+    "toStationName",
+    "lineName",
+    "lineColor",
+    "lineSymbol",
+  ]
+
+  private var appGroupID: String {
+    Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
+      ?? "group.me.tinykitten.trainlcd"
+  }
+
+  @objc(updatePresets:)
+  func updatePresets(_ presets: NSArray?) {
+    guard let presets = presets as? [NSDictionary] else {
+      return
+    }
+
+    // Swift側のデコードが部分的に失敗しないよう、欠けたキーは空文字で埋めてから直列化する
+    let items: [[String: String]] = presets.map { dic in
+      var item: [String: String] = [:]
+      for key in Self.itemKeys {
+        item[key] = dic[key] as? String ?? ""
+      }
+      return item
+    }
+
+    guard
+      let data = try? JSONSerialization.data(
+        withJSONObject: items, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8),
+      let defaults = UserDefaults(suiteName: appGroupID)
+    else {
+      return
+    }
+
+    // 内容が変わっていないときはWidgetKitのリロードバジェットを消費しない
+    if defaults.string(forKey: presetsStorageKey) == json {
+      return
+    }
+
+    defaults.set(json, forKey: presetsStorageKey)
+    WidgetCenter.shared.reloadTimelines(ofKind: presetsWidgetKind)
+  }
+
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+}

--- a/ios/Modules/PresetsWidget/PresetsWidgetModuleBridge.m
+++ b/ios/Modules/PresetsWidget/PresetsWidgetModuleBridge.m
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(PresetsWidgetModule, NSObject)
+
+RCT_EXTERN_METHOD(updatePresets: (NSArray *) presets)
+
+@end

--- a/ios/RideSessionActivity/LockScreenWidget.swift
+++ b/ios/RideSessionActivity/LockScreenWidget.swift
@@ -10,13 +10,14 @@ import SwiftUI
 import WidgetKit
 
 // ライブアクティビティ・ロック画面ウィジェット・ホーム画面ウィジェット・
-// ロック画面コントロールを同一Extensionで配信するためのバンドル
+// プリセットウィジェット・ロック画面コントロールを同一Extensionで配信するためのバンドル
 @main
 struct RideSessionWidgetBundle: WidgetBundle {
   var body: some Widget {
     RideSessionWidget()
     LockScreenWidget()
     HomeScreenWidget()
+    PresetsWidget()
     // ControlWidgetはiOS 18以降のみ。Extensionのデプロイターゲットは16.1のため条件付きで追加する
     if #available(iOS 18.0, *) {
       LockScreenControl()

--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -16,12 +16,15 @@ import WidgetKit
 // 体裁はアプリ内のプリセットカード(PresetCard.tsx)を踏襲し、
 // 路線色のナンバリングサークル + プリセット名 + 始発駅→終着駅 で構成する。
 
-// systemMedium / systemLargeそれぞれで収まる行数
-private let mediumRowCount = 2
+// 乗車中ウィジェット(HomeScreenWidget)と同じsystemSmall / systemMediumに加え、
+// 一覧をまとめて見たい向けにsystemLargeも選べるようにしている。
+// systemSmallとsystemMediumは高さが同じなので収まる行数も同じ
+private let compactRowCount = 2
 private let largeRowCount = 5
 
-// 行の左に置くナンバリングサークルの直径
-private let rowCircleDiameter: CGFloat = 34
+// 行の左に置くナンバリングサークルの直径。
+// systemSmallの幅でも駅名に十分な余地が残るよう、乗車中ウィジェット(48pt)より小さくしている
+private let rowCircleDiameter: CGFloat = 30
 
 struct PresetsWidgetItem: Codable, Identifiable {
   let id: String
@@ -168,7 +171,7 @@ struct PresetsWidgetEntryView: View {
   }
 
   private var rowCount: Int {
-    family == .systemLarge ? largeRowCount : mediumRowCount
+    family == .systemLarge ? largeRowCount : compactRowCount
   }
 
   private var visiblePresets: [PresetsWidgetItem] {
@@ -257,7 +260,7 @@ struct PresetsWidget: Widget {
     }
     .configurationDisplayName(String(localized: "presetsWidgetTitle"))
     .description(String(localized: "presetsWidgetDescription"))
-    .supportedFamilies([.systemMedium, .systemLarge])
+    .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
   }
 }
 
@@ -265,11 +268,13 @@ struct PresetsWidget_Previews: PreviewProvider {
   static var previews: some View {
     Group {
       PresetsWidgetEntryView(entry: .placeholder)
+        .previewContext(WidgetPreviewContext(family: .systemSmall))
+      PresetsWidgetEntryView(entry: .placeholder)
         .previewContext(WidgetPreviewContext(family: .systemMedium))
       PresetsWidgetEntryView(entry: .placeholder)
         .previewContext(WidgetPreviewContext(family: .systemLarge))
       PresetsWidgetEntryView(entry: .empty)
-        .previewContext(WidgetPreviewContext(family: .systemMedium))
+        .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
   }
 }

--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -1,0 +1,275 @@
+//
+//  PresetsWidget.swift
+//  RideSessionActivity
+//
+//  Copyright © 2026 Facebook. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// アプリ内で登録したプリセットをホーム画面に並べるウィジェット。
+// 行をタップすると `trainlcd://?preset=<SavedRoute.id>` のディープリンクでアプリが起動し、
+// 該当プリセットの行き先選択が開く(JS側のuseDeepLink)。
+//
+// 表示データはPresetsWidgetModuleがApp Groupへ書き込んだJSONを読む。
+// 体裁はアプリ内のプリセットカード(PresetCard.tsx)を踏襲し、
+// 路線色のナンバリングサークル + プリセット名 + 始発駅→終着駅 で構成する。
+
+// systemMedium / systemLargeそれぞれで収まる行数
+private let mediumRowCount = 2
+private let largeRowCount = 5
+
+// 行の左に置くナンバリングサークルの直径
+private let rowCircleDiameter: CGFloat = 34
+
+struct PresetsWidgetItem: Codable, Identifiable {
+  let id: String
+  let name: String
+  let fromStationName: String
+  let toStationName: String
+  let lineName: String
+  let lineColor: String
+  let lineSymbol: String
+
+  // JS側(PresetsWidgetItem)は路線色・路線記号が引けない場合に空文字を送ってくる
+  var displayLineColor: String {
+    lineColor.isEmpty ? LockScreenEntry.fallbackLineColor : lineColor
+  }
+
+  // 路線記号が無い路線はロック画面ウィジェットと同様に路線名の先頭1文字で代替する
+  var displayLineSymbol: String {
+    if !lineSymbol.isEmpty {
+      return lineSymbol
+    }
+    return lineName.isEmpty ? "?" : String(lineName.prefix(1))
+  }
+
+  // 駅名が未取得のプリセットでは路線名だけでも出す
+  var routeDescription: String {
+    if fromStationName.isEmpty || toStationName.isEmpty {
+      return lineName
+    }
+    return "\(fromStationName) → \(toStationName)"
+  }
+}
+
+struct PresetsEntry: TimelineEntry {
+  // PresetsWidgetModule.presetsStorageKeyと一致させること
+  static let storageKey = "presets"
+
+  let date: Date
+  let presets: [PresetsWidgetItem]
+
+  static var empty: PresetsEntry {
+    PresetsEntry(date: Date(), presets: [])
+  }
+
+  static var placeholder: PresetsEntry {
+    PresetsEntry(
+      date: Date(),
+      presets: [
+        PresetsWidgetItem(
+          id: "placeholder-1",
+          name: "通勤",
+          fromStationName: "東京",
+          toStationName: "新宿",
+          lineName: "山手線",
+          lineColor: "80C241",
+          lineSymbol: "JY"
+        ),
+        PresetsWidgetItem(
+          id: "placeholder-2",
+          name: "帰宅",
+          fromStationName: "新宿",
+          toStationName: "東京",
+          lineName: "中央線快速",
+          lineColor: "F15A22",
+          lineSymbol: "JC"
+        ),
+      ]
+    )
+  }
+
+  static func current() -> PresetsEntry {
+    let appGroupID =
+      Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_ID") as? String
+      ?? "group.me.tinykitten.trainlcd"
+
+    guard let defaults = UserDefaults(suiteName: appGroupID),
+      let json = defaults.string(forKey: storageKey),
+      let data = json.data(using: .utf8),
+      let presets = try? JSONDecoder().decode([PresetsWidgetItem].self, from: data)
+    else {
+      return .empty
+    }
+
+    return PresetsEntry(date: Date(), presets: presets)
+  }
+}
+
+struct PresetsProvider: TimelineProvider {
+  func placeholder(in context: Context) -> PresetsEntry {
+    .placeholder
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (PresetsEntry) -> Void) {
+    // ウィジェットギャラリーのプレビューは実データが無いとほぼ空になるためダミーを見せる
+    completion(context.isPreview ? .placeholder : .current())
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<PresetsEntry>) -> Void) {
+    // 表示内容はアプリがApp Groupへ書き込んだ際のreloadTimelinesでのみ変わる
+    completion(Timeline(entries: [.current()], policy: .never))
+  }
+}
+
+struct PresetsWidgetRow: View {
+  let preset: PresetsWidgetItem
+
+  var body: some View {
+    HStack(spacing: 10) {
+      // ホーム画面ウィジェット(乗車中)と同じサークル。路線の見分けが一目で付くようにする
+      HomeScreenNumberingCircle(
+        lineColor: preset.displayLineColor,
+        lineSymbol: preset.displayLineSymbol,
+        diameter: rowCircleDiameter
+      )
+      VStack(alignment: .leading, spacing: 1) {
+        Text(preset.name)
+          .font(.subheadline)
+          .fontWeight(.bold)
+          .lineLimit(1)
+        Text(preset.routeDescription)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.8)
+      }
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    // 行全体をタップ領域にする。Spacerだけでは透明部分がヒットしない
+    .contentShape(Rectangle())
+  }
+}
+
+struct PresetsWidgetEntryView: View {
+  let entry: PresetsEntry
+
+  @Environment(\.widgetFamily) var family
+
+  private var schemeName: String? {
+    Bundle.main.infoDictionary?["CURRENT_SCHEME_NAME"] as? String
+  }
+
+  private var urlScheme: String {
+    schemeName == "CanaryTrainLCD" ? "trainlcd-canary" : "trainlcd"
+  }
+
+  private var rowCount: Int {
+    family == .systemLarge ? largeRowCount : mediumRowCount
+  }
+
+  private var visiblePresets: [PresetsWidgetItem] {
+    Array(entry.presets.prefix(rowCount))
+  }
+
+  private func presetURL(_ preset: PresetsWidgetItem) -> URL? {
+    guard
+      let encoded = preset.id.addingPercentEncoding(
+        withAllowedCharacters: .alphanumerics)
+    else {
+      return nil
+    }
+    return URL(string: "\(urlScheme)://?preset=\(encoded)")
+  }
+
+  // ロック画面コントロール・乗車中ウィジェットと同じtramシンボルで見た目を揃える
+  private var header: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "tram.fill")
+      Text("presetsWidgetTitle")
+      Spacer(minLength: 0)
+    }
+    .font(.caption2)
+    .fontWeight(.bold)
+    .foregroundStyle(.secondary)
+  }
+
+  private var emptyView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      header
+      Spacer(minLength: 0)
+      Text("presetsWidgetEmpty")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(3)
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    // プリセット未登録時はウィジェット全体をアプリ起動のタップ領域にする
+    .widgetURL(URL(string: "\(urlScheme)://"))
+  }
+
+  var body: some View {
+    if entry.presets.isEmpty {
+      emptyView
+    } else {
+      VStack(alignment: .leading, spacing: 6) {
+        header
+        ForEach(visiblePresets) { preset in
+          if let url = presetURL(preset) {
+            Link(destination: url) {
+              PresetsWidgetRow(preset: preset)
+            }
+          } else {
+            PresetsWidgetRow(preset: preset)
+          }
+        }
+        Spacer(minLength: 0)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+  }
+}
+
+extension View {
+  // HomeScreenWidgetと同じくiOS 16.1のデプロイターゲットに合わせて互換ラップする
+  @ViewBuilder
+  fileprivate func presetsContainerBackground() -> some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      containerBackground(.fill.tertiary, for: .widget)
+    } else {
+      padding()
+    }
+  }
+}
+
+struct PresetsWidget: Widget {
+  // PresetsWidgetModule側のpresetsWidgetKindと一致させること
+  let kind: String = "PresetsWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: PresetsProvider()) { entry in
+      PresetsWidgetEntryView(entry: entry)
+        .presetsContainerBackground()
+    }
+    .configurationDisplayName(String(localized: "presetsWidgetTitle"))
+    .description(String(localized: "presetsWidgetDescription"))
+    .supportedFamilies([.systemMedium, .systemLarge])
+  }
+}
+
+struct PresetsWidget_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      PresetsWidgetEntryView(entry: .placeholder)
+        .previewContext(WidgetPreviewContext(family: .systemMedium))
+      PresetsWidgetEntryView(entry: .placeholder)
+        .previewContext(WidgetPreviewContext(family: .systemLarge))
+      PresetsWidgetEntryView(entry: .empty)
+        .previewContext(WidgetPreviewContext(family: .systemMedium))
+    }
+  }
+}

--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -170,8 +170,17 @@ struct PresetsWidgetEntryView: View {
     schemeName == "CanaryTrainLCD" ? "trainlcd-canary" : "trainlcd"
   }
 
+  // systemSmallはウィジェット全体が単一のタップ領域で、行ごとのLinkが効かない。
+  // 行を並べるとタップ先と見た目が食い違うため、1件だけ出してwidgetURLで開く
+  private var isSingleTapTarget: Bool {
+    family == .systemSmall
+  }
+
   private var rowCount: Int {
-    family == .systemLarge ? largeRowCount : compactRowCount
+    if isSingleTapTarget {
+      return 1
+    }
+    return family == .systemLarge ? largeRowCount : compactRowCount
   }
 
   private var visiblePresets: [PresetsWidgetItem] {
@@ -215,24 +224,37 @@ struct PresetsWidgetEntryView: View {
     .widgetURL(URL(string: "\(urlScheme)://"))
   }
 
+  private var listView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      header
+      ForEach(visiblePresets) { preset in
+        // systemSmallではLinkが個別のタップ領域にならないので包まない。
+        // 代わりにウィジェット全体へwidgetURLを張る
+        if !isSingleTapTarget, let url = presetURL(preset) {
+          Link(destination: url) {
+            PresetsWidgetRow(preset: preset)
+          }
+        } else {
+          PresetsWidgetRow(preset: preset)
+        }
+      }
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+
   var body: some View {
     if entry.presets.isEmpty {
       emptyView
+    } else if isSingleTapTarget {
+      // 表示している唯一のプリセットをウィジェット全体のタップ先にする。
+      // URLを組めなかった場合はアプリ起動へ倒す
+      listView
+        .widgetURL(
+          visiblePresets.first.flatMap(presetURL) ?? URL(string: "\(urlScheme)://")
+        )
     } else {
-      VStack(alignment: .leading, spacing: 6) {
-        header
-        ForEach(visiblePresets) { preset in
-          if let url = presetURL(preset) {
-            Link(destination: url) {
-              PresetsWidgetRow(preset: preset)
-            }
-          } else {
-            PresetsWidgetRow(preset: preset)
-          }
-        }
-        Spacer(minLength: 0)
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      listView
     }
   }
 }

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -59,6 +59,12 @@
 		94D3F4692E40A00300000004 /* OpenTrainLCDIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */; };
 		94D3F46B2E40A00400000001 /* HomeScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F46A2E40A00400000000 /* HomeScreenWidget.swift */; };
 		94D3F46C2E40A00400000002 /* HomeScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F46A2E40A00400000000 /* HomeScreenWidget.swift */; };
+		94D3F4712E40A00500000001 /* PresetsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4702E40A00500000000 /* PresetsWidget.swift */; };
+		94D3F4722E40A00500000002 /* PresetsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4702E40A00500000000 /* PresetsWidget.swift */; };
+		94D3F4742E40A00600000001 /* PresetsWidgetModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4732E40A00600000000 /* PresetsWidgetModule.swift */; };
+		94D3F4752E40A00600000002 /* PresetsWidgetModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4732E40A00600000000 /* PresetsWidgetModule.swift */; };
+		94D3F4772E40A00700000001 /* PresetsWidgetModuleBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4762E40A00700000000 /* PresetsWidgetModuleBridge.m */; };
+		94D3F4782E40A00700000002 /* PresetsWidgetModuleBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D3F4762E40A00700000000 /* PresetsWidgetModuleBridge.m */; };
 		942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EAA025890E8500E02655 /* ColorExtension.swift */; };
 		942CB60B2A32AAB4008339D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDE128D3025900D68287 /* SwiftUI.framework */; };
 		942CB60C2A32AAB4008339D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B9CDDF28D3025900D68287 /* WidgetKit.framework */; };
@@ -417,6 +423,9 @@
 		94D3F4622E40A00200000000 /* LockScreenControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenControl.swift; sourceTree = "<group>"; };
 		94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTrainLCDIntent.swift; sourceTree = "<group>"; };
 		94D3F46A2E40A00400000000 /* HomeScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenWidget.swift; sourceTree = "<group>"; };
+		94D3F4702E40A00500000000 /* PresetsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsWidget.swift; sourceTree = "<group>"; };
+		94D3F4732E40A00600000000 /* PresetsWidgetModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PresetsWidgetModule.swift; path = Modules/PresetsWidget/PresetsWidgetModule.swift; sourceTree = SOURCE_ROOT; };
+		94D3F4762E40A00700000000 /* PresetsWidgetModuleBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PresetsWidgetModuleBridge.m; path = Modules/PresetsWidget/PresetsWidgetModuleBridge.m; sourceTree = SOURCE_ROOT; };
 		94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = RideSessionActivity.intentdefinition; sourceTree = "<group>"; };
 		94B9CDF328D3027100D68287 /* RideSessionAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideSessionAttributes.swift; sourceTree = "<group>"; };
 		94BFA3B7258F0FF3001D95E4 /* StationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListView.swift; sourceTree = "<group>"; };
@@ -839,6 +848,7 @@
 				94B9CDE428D3025900D68287 /* RideSessionActivity.swift */,
 				94D3F45F2E40A00100000000 /* LockScreenWidget.swift */,
 				94D3F46A2E40A00400000000 /* HomeScreenWidget.swift */,
+				94D3F4702E40A00500000000 /* PresetsWidget.swift */,
 				94D3F4622E40A00200000000 /* LockScreenControl.swift */,
 				94D3F4652E40A00300000000 /* OpenTrainLCDIntent.swift */,
 				94B9CDE628D3025900D68287 /* RideSessionActivity.intentdefinition */,
@@ -852,9 +862,19 @@
 			isa = PBXGroup;
 			children = (
 				94C1657C29B99DC2007329A6 /* LiveActivity */,
+				94D3F4792E40A00800000000 /* PresetsWidget */,
 				94C1657B29B99D9F007329A6 /* SensitiveNotification */,
 			);
 			name = Modules;
+			sourceTree = "<group>";
+		};
+		94D3F4792E40A00800000000 /* PresetsWidget */ = {
+			isa = PBXGroup;
+			children = (
+				94D3F4732E40A00600000000 /* PresetsWidgetModule.swift */,
+				94D3F4762E40A00700000000 /* PresetsWidgetModuleBridge.m */,
+			);
+			path = PresetsWidget;
 			sourceTree = "<group>";
 		};
 		94C1657B29B99D9F007329A6 /* SensitiveNotification */ = {
@@ -2199,6 +2219,8 @@
 				94D3F4662E40A00300000001 /* OpenTrainLCDIntent.swift in Sources */,
 				94C1658629B99E0A007329A6 /* SensitiveNotificationModuleBridge.m in Sources */,
 				94C1658029B99DEB007329A6 /* LiveActivityModuleBridge.m in Sources */,
+				94D3F4742E40A00600000001 /* PresetsWidgetModule.swift in Sources */,
+				94D3F4772E40A00700000001 /* PresetsWidgetModuleBridge.m in Sources */,
 				9DB892EB978E1EA030B325CF /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2214,6 +2236,8 @@
 				94D3F4672E40A00300000002 /* OpenTrainLCDIntent.swift in Sources */,
 				942CB5BF2A32AA96008339D2 /* SensitiveNotificationModuleBridge.m in Sources */,
 				942CB5C02A32AA96008339D2 /* LiveActivityModuleBridge.m in Sources */,
+				94D3F4752E40A00600000002 /* PresetsWidgetModule.swift in Sources */,
+				94D3F4782E40A00700000002 /* PresetsWidgetModuleBridge.m in Sources */,
 				F4B63ECCFF1E13D682E1521B /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2251,6 +2275,7 @@
 				942CB6082A32AAB4008339D2 /* RideSessionActivity.swift in Sources */,
 				94D3F4612E40A00100000002 /* LockScreenWidget.swift in Sources */,
 				94D3F46C2E40A00400000002 /* HomeScreenWidget.swift in Sources */,
+				94D3F4722E40A00500000002 /* PresetsWidget.swift in Sources */,
 				94D3F4642E40A00200000002 /* LockScreenControl.swift in Sources */,
 				94D3F4692E40A00300000004 /* OpenTrainLCDIntent.swift in Sources */,
 				942CB6092A32AAB4008339D2 /* ColorExtension.swift in Sources */,
@@ -2287,6 +2312,7 @@
 				94B9CDE528D3025900D68287 /* RideSessionActivity.swift in Sources */,
 				94D3F4602E40A00100000001 /* LockScreenWidget.swift in Sources */,
 				94D3F46B2E40A00400000001 /* HomeScreenWidget.swift in Sources */,
+				94D3F4712E40A00500000001 /* PresetsWidget.swift in Sources */,
 				94D3F4632E40A00200000001 /* LockScreenControl.swift in Sources */,
 				94D3F4682E40A00300000003 /* OpenTrainLCDIntent.swift in Sources */,
 				944C2C4F28DADC380004DA72 /* ColorExtension.swift in Sources */,

--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -2190,6 +2190,124 @@ describe('useDeepLink', () => {
     });
   });
 
+  describe('preset (ホーム画面ウィジェット)', () => {
+    const PRESET_ID = '11111111-1111-4111-8111-111111111111';
+
+    it('presetが指定されたらpendingQuickActionRouteIdを立てて路線選択画面へ戻す', async () => {
+      (navigationRef.isReady as jest.Mock).mockReturnValue(true);
+      mockGetInitialURL.mockResolvedValue(`trainlcd://?preset=${PRESET_ID}`);
+      mockParse.mockReturnValue({ queryParams: { preset: PRESET_ID } });
+
+      const { mockSetNavigationState } = setupAtoms();
+      const { mockFetchByLine, mockFetchByIds } = setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockSetNavigationState).toHaveBeenCalled();
+      });
+
+      const navResult = mockSetNavigationState.mock.calls[0][0](
+        createNavigationState()
+      );
+      expect(navResult.pendingQuickActionRouteId).toBe(PRESET_ID);
+
+      expect(navigationRef.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'RESET' })
+      );
+      // 経路はアプリ内DBから解決するため、ディープリンク側では駅を取得しない
+      expect(mockFetchByLine).not.toHaveBeenCalled();
+      expect(mockFetchByIds).not.toHaveBeenCalled();
+    });
+
+    it('UUID形式でないpresetは無視する', async () => {
+      (navigationRef.isReady as jest.Mock).mockReturnValue(true);
+      mockGetInitialURL.mockResolvedValue('trainlcd://?preset=not-a-uuid');
+      mockParse.mockReturnValue({ queryParams: { preset: 'not-a-uuid' } });
+
+      const { mockSetNavigationState } = setupAtoms();
+      setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockGetInitialURL).toHaveBeenCalled();
+      });
+
+      expect(mockSetNavigationState).not.toHaveBeenCalled();
+      expect(navigationRef.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('presetは他の経路パラメータより優先される', async () => {
+      (navigationRef.isReady as jest.Mock).mockReturnValue(true);
+      mockGetInitialURL.mockResolvedValue(
+        `trainlcd://?preset=${PRESET_ID}&sids=1,2`
+      );
+      mockParse.mockReturnValue({
+        queryParams: { preset: PRESET_ID, sids: '1,2' },
+      });
+
+      const { mockSetNavigationState } = setupAtoms();
+      const { mockFetchByIds } = setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockSetNavigationState).toHaveBeenCalled();
+      });
+
+      expect(mockFetchByIds).not.toHaveBeenCalled();
+    });
+
+    it('ナビゲーションが準備できないままならpendingQuickActionRouteIdを戻す', async () => {
+      jest.useFakeTimers();
+      (navigationRef.isReady as jest.Mock).mockReturnValue(false);
+      mockGetInitialURL.mockResolvedValue(`trainlcd://?preset=${PRESET_ID}`);
+      mockParse.mockReturnValue({ queryParams: { preset: PRESET_ID } });
+
+      const { mockSetNavigationState } = setupAtoms();
+      setupQueries();
+
+      render(
+        <HookBridge
+          onReady={() => {
+            /* noop */
+          }}
+        />
+      );
+
+      // waitForNavReadyのリトライ(100/200/400/800ms)を消化させる
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(2000);
+      });
+
+      expect(mockSetNavigationState).toHaveBeenCalledTimes(2);
+      const revertResult = mockSetNavigationState.mock.calls[1][0](
+        createNavigationState({ pendingQuickActionRouteId: PRESET_ID })
+      );
+      expect(revertResult.pendingQuickActionRouteId).toBeNull();
+      expect(navigationRef.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
   it('ナビゲーターがリトライ中に準備完了した場合はナビゲートする', async () => {
     // The previous version used real timers and waited up to 5s for the
     // 100ms retry to fire — under CI load that real-time wait was the

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -26,10 +26,16 @@ import lineState from '../store/atoms/line';
 import navigationState from '../store/atoms/navigation';
 import stationState from '../store/atoms/station';
 import { themePreferenceAtom } from '../store/atoms/theme';
+import { navigateToSelectLine } from '../utils/navigateToSelectLine';
 import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
 
 const MAX_NAV_RETRIES = 5;
 const INITIAL_RETRY_DELAY_MS = 100;
+
+// `?preset=` に渡される SavedRoute.id は expo-crypto の randomUUID 由来。
+// ホーム画面ウィジェットが発行する値のみを受け付けるため書式を厳格に検証する
+const PRESET_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type GetLineStationsData = {
   lineStations: Station[];
@@ -386,6 +392,7 @@ export const useDeepLink = () => {
         sids,
         skips,
         id,
+        preset,
         auto,
         theme,
         ttname,
@@ -405,6 +412,32 @@ export const useDeepLink = () => {
           (Object.values(APP_THEME) as string[]).includes(theme))
           ? (theme as ThemePreference)
           : undefined;
+
+      // `preset` はホーム画面ウィジェットのタップで渡される端末ローカルのプリセットID。
+      // 経路そのものはURLに含まれず端末内のDBから解決するため、他の経路パラメータより優先する。
+      // 適用はクイックアクションと同じく pendingQuickActionRouteId 経由で路線選択画面に委ねる。
+      if (preset != null) {
+        if (typeof preset !== 'string' || !PRESET_ID_PATTERN.test(preset)) {
+          return;
+        }
+        setNavigationState((prev) => ({
+          ...prev,
+          pendingQuickActionRouteId: preset,
+        }));
+        if (!navigateToSelectLine()) {
+          const ready = await waitForNavReady();
+          if (!ready || !navigateToSelectLine()) {
+            console.warn(
+              'useDeepLink: navigationRef not ready after retries, preset navigation skipped'
+            );
+            setNavigationState((prev) => ({
+              ...prev,
+              pendingQuickActionRouteId: null,
+            }));
+          }
+        }
+        return;
+      }
 
       // `id` (resolver short code) supersedes every other route param. When it
       // is present we must not silently fall through to sids/sgid: doing so
@@ -558,7 +591,7 @@ export const useDeepLink = () => {
         theme: parsedTheme,
       });
     },
-    [openLink, openRouteByStationIds]
+    [openLink, openRouteByStationIds, setNavigationState]
   );
 
   const [initialUrlProcessed, setInitialUrlProcessed] = useState(false);

--- a/src/hooks/usePresetsWidgetSync.test.tsx
+++ b/src/hooks/usePresetsWidgetSync.test.tsx
@@ -1,0 +1,185 @@
+import { renderHook } from '@testing-library/react-native';
+import type { Station } from '~/@types/graphql';
+import type { SavedRoute } from '~/models/SavedRoute';
+import type { LoopItem } from '~/store/atoms/navigation';
+import { isJapanese } from '~/translation';
+import { updatePresetsWidget } from '~/utils/native/presetsWidget';
+import {
+  MAX_PRESETS_WIDGET_ITEMS,
+  usePresetsWidgetSync,
+} from './usePresetsWidgetSync';
+
+jest.mock('~/utils/native/presetsWidget', () => ({
+  updatePresetsWidget: jest.fn(),
+}));
+
+const mockUpdatePresetsWidget = updatePresetsWidget as jest.MockedFunction<
+  typeof updatePresetsWidget
+>;
+
+const createStation = (
+  groupId: number,
+  name: string,
+  nameRoman: string,
+  overrides: Partial<Station> = {}
+): Station =>
+  ({
+    id: groupId,
+    groupId,
+    name,
+    nameRoman,
+    ...overrides,
+  }) as Station;
+
+const line = {
+  id: 11302,
+  color: '#80C241',
+  nameShort: '山手線',
+  nameRoman: 'Yamanote Line',
+};
+
+const createLoopItem = (overrides: Partial<LoopItem> = {}): LoopItem =>
+  ({
+    id: '11111111-1111-4111-8111-111111111111',
+    name: '通勤',
+    lineId: line.id,
+    trainTypeId: null,
+    wantedDestinationId: null,
+    direction: null,
+    notifyStationIds: [],
+    hasTrainType: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    __k: 'key-0',
+    stations: [
+      createStation(1, '東京', 'Tokyo', {
+        line,
+        stationNumbers: [{ lineSymbol: 'JY' }],
+      } as Partial<Station>),
+      createStation(2, '新宿', 'Shinjuku', { line } as Partial<Station>),
+    ],
+    ...overrides,
+  }) as LoopItem;
+
+const createRoute = (id: string): SavedRoute =>
+  ({ id, name: '通勤' }) as SavedRoute;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('usePresetsWidgetSync', () => {
+  it('取得済みのプリセットを表示用の文字列へ変換して同期する', () => {
+    const item = createLoopItem();
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [item],
+        routes: [createRoute(item.id)],
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    // 表示言語は端末設定に追従するため、期待値も同じ基準で組み立てる
+    expect(mockUpdatePresetsWidget).toHaveBeenCalledWith([
+      {
+        id: item.id,
+        name: '通勤',
+        fromStationName: isJapanese ? '東京' : 'Tokyo',
+        toStationName: isJapanese ? '新宿' : 'Shinjuku',
+        lineName: isJapanese ? '山手線' : 'Yamanote Line',
+        lineColor: '#80C241',
+        lineSymbol: 'JY',
+      },
+    ]);
+  });
+
+  it('DB未初期化の間は同期しない', () => {
+    const item = createLoopItem();
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [item],
+        routes: [createRoute(item.id)],
+        isRoutesDBInitialized: false,
+      })
+    );
+
+    expect(mockUpdatePresetsWidget).not.toHaveBeenCalled();
+  });
+
+  it('駅情報の取得待ちで一時的に空になっている間は同期しない', () => {
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [],
+        routes: [createRoute('11111111-1111-4111-8111-111111111111')],
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    expect(mockUpdatePresetsWidget).not.toHaveBeenCalled();
+  });
+
+  it('プリセットが0件になった場合は空配列を同期する', () => {
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [],
+        routes: [],
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    expect(mockUpdatePresetsWidget).toHaveBeenCalledWith([]);
+  });
+
+  it('表示内容が変わらない再レンダーでは同期し直さない', () => {
+    const item = createLoopItem();
+    const { rerender } = renderHook(
+      (props: { carouselData: LoopItem[] }) =>
+        usePresetsWidgetSync({
+          carouselData: props.carouselData,
+          routes: [createRoute(item.id)],
+          isRoutesDBInitialized: true,
+        }),
+      { initialProps: { carouselData: [item] } }
+    );
+
+    // 参照が変わっても内容が同じならネイティブへ書き込まない
+    rerender({ carouselData: [{ ...item, __k: 'key-1' }] });
+
+    expect(mockUpdatePresetsWidget).toHaveBeenCalledTimes(1);
+  });
+
+  it('上限を超えたプリセットは切り詰めて同期する', () => {
+    const carouselData = Array.from(
+      { length: MAX_PRESETS_WIDGET_ITEMS + 3 },
+      (_, i) => createLoopItem({ id: `id-${i}`, __k: `key-${i}` })
+    );
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData,
+        routes: carouselData.map((item) => createRoute(item.id)),
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    expect(mockUpdatePresetsWidget.mock.calls[0][0]).toHaveLength(
+      MAX_PRESETS_WIDGET_ITEMS
+    );
+  });
+
+  it('路線記号が無い場合は空文字を渡してネイティブ側のフォールバックに委ねる', () => {
+    const item = createLoopItem({
+      stations: [
+        createStation(1, '東京', 'Tokyo', { line } as Partial<Station>),
+        createStation(2, '新宿', 'Shinjuku', { line } as Partial<Station>),
+      ],
+    });
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [item],
+        routes: [createRoute(item.id)],
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    expect(mockUpdatePresetsWidget.mock.calls[0][0][0].lineSymbol).toBe('');
+  });
+});

--- a/src/hooks/usePresetsWidgetSync.ts
+++ b/src/hooks/usePresetsWidgetSync.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { SavedRoute } from '~/models/SavedRoute';
+import type { LoopItem } from '~/store/atoms/navigation';
+import { isJapanese } from '~/translation';
+import { getLocalizedLineName } from '~/utils/line';
+import {
+  type PresetsWidgetItem,
+  updatePresetsWidget,
+} from '~/utils/native/presetsWidget';
+import { getPresetRouteEndpoints } from '~/utils/presetRouteEndpoints';
+import { getStationName } from '~/utils/station';
+
+/**
+ * ウィジェットへ渡すプリセットの最大件数。
+ * iOS(systemLarge) / Android(5x5)でも表示しきれる件数を上限とし、
+ * プリセットが増えてもApp Group / SharedPreferencesへ書き込む量が膨らまないようにする。
+ */
+export const MAX_PRESETS_WIDGET_ITEMS = 8;
+
+type Params = {
+  carouselData: LoopItem[];
+  routes: SavedRoute[];
+  isRoutesDBInitialized: boolean;
+};
+
+const toWidgetItem = (item: LoopItem): PresetsWidgetItem => {
+  const { from, to } = getPresetRouteEndpoints(item);
+  const line = from?.line;
+
+  return {
+    id: item.id,
+    name: item.name,
+    fromStationName: getStationName(from),
+    toStationName: getStationName(to),
+    lineName: getLocalizedLineName(line, isJapanese),
+    // 空文字はネイティブ側でブランドカラー・路線名の先頭1文字へフォールバックされる
+    lineColor: line?.color ?? '',
+    lineSymbol:
+      from?.stationNumbers?.[0]?.lineSymbol ??
+      line?.lineSymbols?.[0]?.symbol ??
+      '',
+  };
+};
+
+/**
+ * ホーム画面のプリセットウィジェットへ表示内容を同期する。
+ *
+ * プリセットの駅情報は `usePresetCarouselData` が取得済みのものを使い回す。
+ * ウィジェット更新はOSのリロードバジェットを消費するため、
+ * 実際に表示内容が変わったときだけネイティブへ書き込む。
+ */
+export const usePresetsWidgetSync = ({
+  carouselData,
+  routes,
+  isRoutesDBInitialized,
+}: Params): void => {
+  // DB未初期化、または駅情報の取得待ちで一時的に空になっている間は同期しない。
+  // ここで空配列を書き込むと、既に置かれているウィジェットが一瞬空表示になる
+  const isReady =
+    isRoutesDBInitialized && (routes.length === 0 || carouselData.length > 0);
+
+  const presets = useMemo(
+    () => carouselData.slice(0, MAX_PRESETS_WIDGET_ITEMS).map(toWidgetItem),
+    [carouselData]
+  );
+  const serialized = useMemo(() => JSON.stringify(presets), [presets]);
+  const lastSerializedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isReady || lastSerializedRef.current === serialized) {
+      return;
+    }
+    lastSerializedRef.current = serialized;
+    updatePresetsWidget(presets);
+  }, [isReady, presets, serialized]);
+};

--- a/src/hooks/useQuickActions.ts
+++ b/src/hooks/useQuickActions.ts
@@ -1,31 +1,13 @@
-import { CommonActions } from '@react-navigation/native';
 import * as QuickActions from 'expo-quick-actions';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-import { navigationRef } from '~/stacks/rootNavigation';
 import navigationState, { presetRoutesAtom } from '~/store/atoms/navigation';
+import { navigateToSelectLine } from '~/utils/navigateToSelectLine';
 
 const MAX_QUICK_ACTIONS = 4;
 
 let handledInitial = false;
-
-const navigateToSelectLine = () => {
-  if (!navigationRef.isReady()) {
-    console.warn(
-      'useQuickActions: ナビゲーションが未準備のためクイックアクションをスキップ'
-    );
-    return false;
-  }
-
-  navigationRef.dispatch(
-    CommonActions.reset({
-      index: 0,
-      routes: [{ name: 'MainStack', params: { screen: 'SelectLine' } }],
-    })
-  );
-  return true;
-};
 
 /**
  * アプリルートで使用するフック。
@@ -66,6 +48,9 @@ export const useQuickActions = () => {
       }));
 
       if (!navigateToSelectLine()) {
+        console.warn(
+          'useQuickActions: ナビゲーションが未準備のためクイックアクションをスキップ'
+        );
         setNavigationState((prev) => ({
           ...prev,
           pendingQuickActionRouteId: null,

--- a/src/screens/SelectLineScreen.render.test.tsx
+++ b/src/screens/SelectLineScreen.render.test.tsx
@@ -201,6 +201,11 @@ jest.mock('~/utils/line', () => ({
   ),
 }));
 
+// ウィジェット同期は画面の描画結果に影響しない副作用のため切り離す
+jest.mock('~/hooks/usePresetsWidgetSync', () => ({
+  usePresetsWidgetSync: jest.fn(),
+}));
+
 // --- ヘルパー ---
 
 const mockHandleLineSelected = jest.fn();

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -26,6 +26,7 @@ import { useDeviceOrientation } from '~/hooks/useDeviceOrientation';
 import { useInitialNearbyStation } from '~/hooks/useInitialNearbyStation';
 import { useLineSelection } from '~/hooks/useLineSelection';
 import { usePresetCarouselData } from '~/hooks/usePresetCarouselData';
+import { usePresetsWidgetSync } from '~/hooks/usePresetsWidgetSync';
 import { useSelectLineWalkthrough } from '~/hooks/useSelectLineWalkthrough';
 import { useStationsCache } from '~/hooks/useStationsCache';
 import isTablet from '~/utils/isTablet';
@@ -82,6 +83,8 @@ const SelectLineScreen = () => {
   useStationsCache(station);
   const { carouselData, routes, isRoutesDBInitialized } =
     usePresetCarouselData();
+  // 取得済みのプリセットをホーム画面ウィジェットへ同期する
+  usePresetsWidgetSync({ carouselData, routes, isRoutesDBInitialized });
   const {
     handleLineSelected,
     handleTrainTypeSelect,

--- a/src/screens/SelectLineScreen.tsx
+++ b/src/screens/SelectLineScreen.tsx
@@ -74,6 +74,14 @@ const NearbyStationLoader = () => (
   </SkeletonPlaceholder>
 );
 
+// 副作用のみのフックは画面本体ではなくレンダレスコンポーネントに寄せる(docs/state-management.md)
+const FxPresetsWidgetSync: React.FC<
+  Parameters<typeof usePresetsWidgetSync>[0]
+> = (params) => {
+  usePresetsWidgetSync(params);
+  return null;
+};
+
 const SelectLineScreen = () => {
   const [nowHeaderHeight, setNowHeaderHeight] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
@@ -83,8 +91,6 @@ const SelectLineScreen = () => {
   useStationsCache(station);
   const { carouselData, routes, isRoutesDBInitialized } =
     usePresetCarouselData();
-  // 取得済みのプリセットをホーム画面ウィジェットへ同期する
-  usePresetsWidgetSync({ carouselData, routes, isRoutesDBInitialized });
   const {
     handleLineSelected,
     handleTrainTypeSelect,
@@ -303,6 +309,12 @@ const SelectLineScreen = () => {
   // --- JSX ---
   return (
     <>
+      {/* 取得済みのプリセットをホーム画面ウィジェットへ同期する */}
+      <FxPresetsWidgetSync
+        carouselData={carouselData}
+        routes={routes}
+        isRoutesDBInitialized={isRoutesDBInitialized}
+      />
       <SafeAreaView style={[styles.root, !isLEDTheme && styles.screenBg]}>
         <RNAnimated.ScrollView
           style={StyleSheet.absoluteFill}

--- a/src/screens/SelectLineScreenPresets.tsx
+++ b/src/screens/SelectLineScreenPresets.tsx
@@ -10,10 +10,10 @@ import {
   View,
 } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import type { Station } from '~/@types/graphql';
 import { NoPresetsCard } from '~/components/NoPresetsCard';
 import { PresetCard } from '~/components/PresetCard';
 import isTablet from '~/utils/isTablet';
+import { getPresetRouteEndpoints } from '~/utils/presetRouteEndpoints';
 import type { LoopItem } from '../store/atoms/navigation';
 
 type Props = {
@@ -116,24 +116,8 @@ export const SelectLineScreenPresets = ({
 
   const renderItem: ListRenderItem<LoopItem> = useCallback(
     ({ item }) => {
-      // wantedDestinationId と direction がある場合、始発駅と終着駅を差し替える
-      // 保存時の direction options と対応:
-      //   INBOUND:  fromStation = stations[0],             toStation = wantedDestination
-      //   OUTBOUND: fromStation = stations[stations.length-1], toStation = wantedDestination
-      let from: Station | undefined = item.stations[0];
-      let to: Station | undefined = item.stations.at(-1);
-      if (item.wantedDestinationId != null && item.direction) {
-        const destStation = item.stations.find(
-          (s) => s.groupId === item.wantedDestinationId
-        );
-        if (destStation) {
-          from =
-            item.direction === 'INBOUND'
-              ? item.stations[0]
-              : item.stations.at(-1);
-          to = destStation;
-        }
-      }
+      // ホーム画面ウィジェットと同じ端点を表示するため解決ロジックは共通化している
+      const { from, to } = getPresetRouteEndpoints(item);
 
       return isTablet ? (
         <View style={{ width: cardWidth }}>

--- a/src/utils/native/presetsWidget.test.ts
+++ b/src/utils/native/presetsWidget.test.ts
@@ -1,0 +1,61 @@
+import { NativeModules, Platform } from 'react-native';
+
+const iosUpdatePresetsSpy = jest.fn();
+const androidUpdatePresetsSpy = jest.fn();
+
+// presetsWidgetはimport時にNativeModulesを分割代入するため、読み込み前にモジュールを差し込む
+(NativeModules as unknown as Record<string, unknown>).PresetsWidgetModule = {
+  updatePresets: iosUpdatePresetsSpy,
+};
+(NativeModules as unknown as Record<string, unknown>).WidgetModule = {
+  updatePresets: androidUpdatePresetsSpy,
+};
+
+const { updatePresetsWidget } =
+  require('./presetsWidget') as typeof import('./presetsWidget');
+
+// jest-expo の既定 Platform.OS は 'ios'。テストごとに切り替えてafterEachで元へ戻す。
+const originalPlatformOS = Platform.OS;
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+};
+
+const presets = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    name: '通勤',
+    fromStationName: '東京',
+    toStationName: '新宿',
+    lineName: '山手線',
+    lineColor: '#80C241',
+    lineSymbol: 'JY',
+  },
+];
+
+afterEach(() => {
+  setPlatformOS(originalPlatformOS);
+  jest.clearAllMocks();
+});
+
+describe('presetsWidget', () => {
+  it('iOSではPresetsWidgetModuleへプリセットを渡す', () => {
+    setPlatformOS('ios');
+    updatePresetsWidget(presets);
+    expect(iosUpdatePresetsSpy).toHaveBeenCalledWith(presets);
+    expect(androidUpdatePresetsSpy).not.toHaveBeenCalled();
+  });
+
+  it('AndroidではWidgetModuleへプリセットを渡す', () => {
+    setPlatformOS('android');
+    updatePresetsWidget(presets);
+    expect(androidUpdatePresetsSpy).toHaveBeenCalledWith(presets);
+    expect(iosUpdatePresetsSpy).not.toHaveBeenCalled();
+  });
+
+  it('iOS/Android以外ではネイティブモジュールを呼ばない', () => {
+    setPlatformOS('web');
+    updatePresetsWidget(presets);
+    expect(iosUpdatePresetsSpy).not.toHaveBeenCalled();
+    expect(androidUpdatePresetsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/native/presetsWidget.ts
+++ b/src/utils/native/presetsWidget.ts
@@ -1,0 +1,33 @@
+import { NativeModules, Platform } from 'react-native';
+
+// iOS はApp Groupへ書き込む専用モジュール、AndroidはRideウィジェットと同じWidgetModuleに相乗りする。
+// ペイロードが両OSで完全に同一なため、ios/androidへ分けずにこのファイルで吸収する。
+const { PresetsWidgetModule, WidgetModule } = NativeModules;
+
+/**
+ * ホーム画面のプリセットウィジェットが表示する1件分のプリセット。
+ * ウィジェットはアプリのプロセスが落ちていても描画されるため、
+ * 表示に必要な文字列はすべて解決済みの状態で渡す。
+ */
+export type PresetsWidgetItem = {
+  /** SavedRoute.id。ディープリンク(`?preset=<id>`)のペイロードにもなる */
+  id: string;
+  name: string;
+  fromStationName: string;
+  toStationName: string;
+  lineName: string;
+  /** `#RRGGBB`。未取得時は空文字を渡し、ネイティブ側でブランドカラーへフォールバックする */
+  lineColor: string;
+  /** 路線記号。無い路線は空文字を渡し、ネイティブ側で路線名の先頭1文字へフォールバックする */
+  lineSymbol: string;
+};
+
+export const updatePresetsWidget = (presets: PresetsWidgetItem[]) => {
+  if (Platform.OS === 'ios') {
+    PresetsWidgetModule?.updatePresets?.(presets);
+    return;
+  }
+  if (Platform.OS === 'android') {
+    WidgetModule?.updatePresets?.(presets);
+  }
+};

--- a/src/utils/navigateToSelectLine.ts
+++ b/src/utils/navigateToSelectLine.ts
@@ -1,0 +1,24 @@
+import { CommonActions } from '@react-navigation/native';
+import { navigationRef } from '~/stacks/rootNavigation';
+
+/**
+ * 路線選択画面へリセット遷移する。
+ *
+ * プリセットの起動経路(クイックアクション / ホーム画面ウィジェットのディープリンク)は
+ * どちらも「路線選択画面へ戻してからプリセットを適用する」流れのため共通化している。
+ *
+ * @returns ナビゲーションが未準備で遷移できなかった場合は false
+ */
+export const navigateToSelectLine = (): boolean => {
+  if (!navigationRef.isReady()) {
+    return false;
+  }
+
+  navigationRef.dispatch(
+    CommonActions.reset({
+      index: 0,
+      routes: [{ name: 'MainStack', params: { screen: 'SelectLine' } }],
+    })
+  );
+  return true;
+};

--- a/src/utils/presetRouteEndpoints.test.ts
+++ b/src/utils/presetRouteEndpoints.test.ts
@@ -1,0 +1,69 @@
+import type { Station } from '~/@types/graphql';
+import { getPresetRouteEndpoints } from './presetRouteEndpoints';
+
+const createStation = (groupId: number): Station =>
+  ({ id: groupId, groupId, name: `駅${groupId}` }) as Station;
+
+const stations = [1, 2, 3, 4].map(createStation);
+
+describe('getPresetRouteEndpoints', () => {
+  it('行き先未指定なら両端の駅を返す', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: null,
+      direction: null,
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(4);
+  });
+
+  it('INBOUNDでは始発が先頭駅、終着が指定の行き先になる', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 3,
+      direction: 'INBOUND',
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(3);
+  });
+
+  it('OUTBOUNDでは始発が末尾駅、終着が指定の行き先になる', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 2,
+      direction: 'OUTBOUND',
+    });
+    expect(from?.groupId).toBe(4);
+    expect(to?.groupId).toBe(2);
+  });
+
+  it('directionが無い行き先指定は両端の駅にフォールバックする', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 3,
+      direction: null,
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(4);
+  });
+
+  it('行き先が駅一覧に無い場合は両端の駅にフォールバックする', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 999,
+      direction: 'INBOUND',
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(4);
+  });
+
+  it('駅が無い場合はundefinedを返す', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations: [],
+      wantedDestinationId: 3,
+      direction: 'INBOUND',
+    });
+    expect(from).toBeUndefined();
+    expect(to).toBeUndefined();
+  });
+});

--- a/src/utils/presetRouteEndpoints.ts
+++ b/src/utils/presetRouteEndpoints.ts
@@ -1,0 +1,45 @@
+import type { Station } from '~/@types/graphql';
+import type { LineDirection } from '~/models/Bound';
+
+type PresetRouteLike = {
+  stations: Station[];
+  wantedDestinationId?: number | null;
+  direction?: LineDirection | null;
+};
+
+export type PresetRouteEndpoints = {
+  from: Station | undefined;
+  to: Station | undefined;
+};
+
+/**
+ * プリセットの始発駅・終着駅を解決する。
+ *
+ * wantedDestinationId と direction が保存されている場合は保存時の選択に合わせて終着駅を差し替える。
+ *   INBOUND:  from = stations[0],  to = wantedDestination
+ *   OUTBOUND: from = stations.at(-1), to = wantedDestination
+ *
+ * プリセットカードとホーム画面ウィジェットの双方が同じ端点を表示する必要があるため共通化している。
+ */
+export const getPresetRouteEndpoints = ({
+  stations,
+  wantedDestinationId,
+  direction,
+}: PresetRouteLike): PresetRouteEndpoints => {
+  const from: Station | undefined = stations[0];
+  const to: Station | undefined = stations.at(-1);
+
+  if (wantedDestinationId == null || !direction) {
+    return { from, to };
+  }
+
+  const destStation = stations.find((s) => s.groupId === wantedDestinationId);
+  if (!destStation) {
+    return { from, to };
+  }
+
+  return {
+    from: direction === 'INBOUND' ? stations[0] : stations.at(-1),
+    to: destStation,
+  };
+};


### PR DESCRIPTION
## 概要

アプリ内で登録したプリセットをiOS / Androidのホーム画面ウィジェットに一覧表示し、行をタップするとディープリンク経由で該当プリセットの行き先選択がそのまま開くようにしました。

既存の「乗車中ウィジェット」(`HomeScreenWidget` / `RideWidgetProvider`)とはデータも寿命も別物のため、同じ配信基盤(iOSは`RideSessionActivity` Extensionの`WidgetBundle`、Androidは`AppWidgetProvider`)に載せつつ、更新経路は独立させています。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### ウィジェット (iOS)

- `ios/RideSessionActivity/PresetsWidget.swift` を追加し、`RideSessionWidgetBundle` に登録(kind: `PresetsWidget`)。
- 対応サイズは `systemSmall` / `systemMedium` / `systemLarge`。既定サイズは乗車中ウィジェットと揃え、一覧をまとめて見たい場合に備えて `systemLarge` も選べるようにしています。`systemSmall` と `systemMedium` は高さが同じなので表示行数も同じ2行です。
- 各行は `Link` でディープリンクを張り、プリセット未登録時は `widgetURL` でアプリ起動のみに倒します。
- 表示データは `ios/Modules/PresetsWidget/PresetsWidgetModule.swift` が App Group の `UserDefaults` へJSONで書き込み、`WidgetCenter.reloadTimelines(ofKind:)` でリロードします。内容に差分が無い更新はリロードバジェットを消費しないようスキップします。
- 行の体裁は既存の乗車中ウィジェットと共通の `HomeScreenNumberingCircle` を流用し、路線色サークル + プリセット名 + 「始発駅 → 終着駅」で構成。`systemSmall` の幅でも駅名に余地が残るよう、サークルは30ptにしています。
- `Localizable.strings` (ja/en) に `presetsWidgetTitle` / `presetsWidgetDescription` / `presetsWidgetEmpty` を追加。
- `project.pbxproj` に新規ファイルをProd/Canary両ターゲット分登録。

### ウィジェット (Android)

- `PresetsWidgetProvider.kt` / `PresetsWidgetStore.kt` を追加。一覧はJSON文字列として既存ウィジェットと同じ `SharedPreferences` に永続化し、アプリのプロセスが落ちていても描画できるようにしています。
- 既定サイズは乗車中ウィジェットと同じ2x2で、リサイズで拡大できます。極小サイズ用の代替レイアウトを持たないため、縮小の下限は既定サイズと同じにしています。
- 行は `RemoteViews#addView` で組み立て、ウィジェットの高さから表示行数を導出します。基準にする高さは **縦向き時の高さ** で、Android 12以降は `OPTION_APPWIDGET_SIZES` から向きごとの実寸を取って `RemoteViews(Map<SizeF, RemoteViews>)` でシステムに出し分けさせ、それ以前は `OPTION_APPWIDGET_MAX_HEIGHT` を使います。`OPTION_APPWIDGET_MIN_HEIGHT` は横向き時＝取り得る最小の高さのため、これを基準にすると縦向きで収まるはずの行まで落ちてしまいます。
- ヘッダー込みでは1行も置けない高さのときは、ヘッダーを隠して1行を優先します。
- 行ごとに `requestCode` を変えた `PendingIntent` を張り、`FLAG_UPDATE_CURRENT` で全行が同じURIに揃ってしまうのを防いでいます。
- レイアウト (`widget_presets.xml` / `widget_presets_row.xml`)、`presets_widget_info.xml`、文言・寸法リソース、`AndroidManifest.xml` のレシーバーを追加。
- サークルの線幅は「直径の約1/7」というiOS版の比率を保ちつつ、2セル分の高さに2行収まるよう30dp / 4dpにしています。
- JS側からの更新は既存の `WidgetModule` に `updatePresets` を追加して相乗りさせています。

### JS

- `usePresetsWidgetSync` を追加し、`usePresetCarouselData` が取得済みのプリセットを表示用の文字列へ変換してネイティブへ同期します。DB未初期化中・駅情報の取得待ちで一時的に空になっている間は書き込まず、既設のウィジェットが一瞬空表示になるのを防いでいます。内容が変わったときのみ同期します。
- `useDeepLink` に `preset` パラメータを追加。経路自体はURLに含まれず端末内DBから解決するため、`id` / `sids` / `sgid` より優先して処理し、UUID書式に一致する値のみ受け付けます。適用はクイックアクションと同じ `pendingQuickActionRouteId` 経由で路線選択画面に委ねています。
- 始発駅・終着駅の解決を `getPresetRouteEndpoints` に切り出し、プリセットカードとウィジェットで同じ端点が出るようにしました。
- 路線選択画面へのリセット遷移を `navigateToSelectLine` に切り出し、クイックアクションとディープリンクで共有しています。

### ドキュメント

- `docs/home-screen-widgets.md` を追加し、各ウィジェットのデータ経路・ディープリンク書式・サイズ方針・Androidの表示行数の決め方・変更時に揃えるべき定数をまとめました。`docs/README.md` の一覧にも追記しています。

## ディープリンク書式

```text
trainlcd://?preset=<SavedRoute.id>          # 本番
trainlcd-canary://?preset=<SavedRoute.id>   # Canary
```

## 回帰リスクと緩和

- **既存の乗車中ウィジェットへの影響**: プリセット側は別のプロバイダー / 別のkindで、`SharedPreferences` と App Group のキーも分けています。既存の `WidgetStateStore` は色パースのユーティリティを再利用するのみで挙動は変えていません。
- **既存ディープリンクへの影響**: `preset` が無いURLは従来どおりの分岐に落ちます。`preset` の分岐は既存パラメータの処理より前ですが、書式が不正なら他経路へフォールスルーせずno-opにしており、共有された経路が別物として解決されることはありません。既存82ケースを含む `useDeepLink` のテストは全て通っています。
- **プリセットカードの表示**: 端点解決の切り出しは純粋なリファクタリングで、`SelectLineScreenPresets.tsx` の分岐をそのまま関数化したものです。ユニットテストを新規に追加しています。
- **クイックアクション**: 遷移処理の共通化に伴い、未準備時の警告ログを呼び出し側へ移しました。挙動は変わりません。
- **Androidの行数見積もり**: `PADDING_HEIGHT_DP` / `HEADER_HEIGHT_DP` / `ROW_HEIGHT_DP` はレイアウトの実寸から見積もった定数です。レイアウトの余白・文字サイズ・サークル径を変えたら合わせて更新する必要がある旨をドキュメントに明記しています。
- **ネイティブビルド未検証**: 本環境にXcode / Android SDKが無いため、iOS・Androidの実機ビルドと目視確認は未実施です。実機での行数・見切れの確認をお願いします。

## ローカルで実行したコマンド

```bash
npm run lint      # Checked 624 files / エラーなし
npm test          # 212 suites / 2219 tests 全て pass
npm run typecheck # エラーなし
npx markdownlint-cli2 docs/home-screen-widgets.md  # 指摘なし
```

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加したテスト:

- `src/utils/presetRouteEndpoints.test.ts` (6ケース)
- `src/utils/native/presetsWidget.test.ts` (3ケース)
- `src/hooks/usePresetsWidgetSync.test.tsx` (7ケース)
- `src/hooks/useDeepLink.test.tsx` に `preset` の4ケースを追加

## 関連Issue

なし

## スクリーンショット（任意）

ネイティブビルド環境が無いため未添付です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOS・Androidのホーム画面にプリセットウィジェットを追加しました。
  * ウィジェットからプリセットを選択して、該当する路線画面を直接開けます。
  * プリセット未登録時は、アプリを起動できる案内を表示します。
  * ウィジェットのサイズに応じて表示件数を調整します。

* **改善**
  * ウィジェット表示内容をプリセット変更時のみ更新するようにしました。
  * プリセットの駅情報や路線情報の表示を改善しました。

* **ドキュメント**
  * ホーム画面ウィジェットの利用仕様を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->