### PR TITLE
iOSのプリセットウィジェットを高さに収まるだけ表示しsystemSmallは縦積みにする

### DIFF
--- a/docs/home-screen-widgets.md
+++ b/docs/home-screen-widgets.md
@@ -75,7 +75,10 @@ Android は `ListView` + `RemoteViewsService`(`PresetsWidgetService`)のコレ�
 iOS は WidgetKit にスクロールが無いため、表示できる件数はウィジェットの高さで決まる。
 ファミリーごとに件数を決め打ちすると端末サイズ差で余白が出たり見切れたりするため、
 `GeometryReader` で実際の描画高を測り、`rowHeight` / `rowSpacing` から収まる行数を求める。
-行の見た目を変えたらこれらの定数も合わせること。
+
+行数計算が予約する高さと実際の描画がずれると最終行が見切れるため、行とヘッダーは
+`.frame(height:)` で `rowHeight` / `headerHeight` に固定し、Dynamic Type や長い
+ローカライズ文字列で伸びないようにしている。見た目を変えたらこれらの定数も合わせること。
 
 | ファミリー | 表示 | タップ |
 | --- | --- | --- |

--- a/docs/home-screen-widgets.md
+++ b/docs/home-screen-widgets.md
@@ -72,17 +72,22 @@ Android は `ListView` + `RemoteViewsService`(`PresetsWidgetService`)のコレ�
 高さで、これを基準にすると縦向きで収まるはずの行まで落ちる)。アダプタに任せることで
 高さ計算自体を持たない。
 
-iOS は WidgetKit にスクロールが無いため、ファミリーごとの固定件数になる。
-設置時にどのファミリーを選ぶかはユーザーの選択なので、大きいサイズも残している。
+iOS は WidgetKit にスクロールが無いため、表示できる件数はウィジェットの高さで決まる。
+ファミリーごとに件数を決め打ちすると端末サイズ差で余白が出たり見切れたりするため、
+`GeometryReader` で実際の描画高を測り、`rowHeight` / `rowSpacing` から収まる行数を求める。
+行の見た目を変えたらこれらの定数も合わせること。
 
-| ファミリー | 件数 | タップ |
+| ファミリー | 表示 | タップ |
 | --- | --- | --- |
-| `systemSmall` | 1 | `widgetURL` でウィジェット全体 |
-| `systemMedium` | 2 | 行ごとの `Link` |
-| `systemLarge` | 5 | 行ごとの `Link` |
+| `systemSmall` | 1 件を縦に積んで表示 | `widgetURL` でウィジェット全体 |
+| `systemMedium` | 収まるだけの行 | 行ごとの `Link` |
+| `systemLarge` | 収まるだけの行 | 行ごとの `Link` |
 
-`systemSmall` はウィジェット全体が単一のタップ領域で、行ごとの `Link` が個別の
-タップ先にならない。表示とタップ先が食い違わないよう 1 件だけ出して `widgetURL` を張る。
+`systemSmall` はウィジェット全体が単一のタップ領域で、行ごとの `Link` が個別のタップ先に
+ならない。行を並べても 1 件しか開けず件数を増やす意味が無いため、1 件だけを出す
+(`PresetsWidgetFeatured`)。その 1 件は「始発駅 → 終着駅」を横一列に置くと正方形の
+横幅で先に頭打ちになり駅名がすぐ省略されるので、サークル → プリセット名 → 始発駅 →
+下向き矢印 → 終着駅 の順に縦へ積み、1 駅あたりの幅をフルに使う。
 
 ## 変更時に揃えるべき箇所
 
@@ -90,5 +95,5 @@ iOS は WidgetKit にスクロールが無いため、ファミリーごとの�
 - ストレージのキー名: iOS の `PresetsEntry.storageKey` と `PresetsWidgetModule.presetsStorageKey`、
   Android の `PresetsWidgetStore` のフィールド名、JS の `PresetsWidgetItem`。
 - 同期する最大件数: JS の `MAX_PRESETS_WIDGET_ITEMS`(両 OS 共通)。
-  描画側の上限は iOS の `largeRowCount` のみで、Android は `ListView` に任せている。
+  描画側は iOS が実測、Android が `ListView` に任せており、どちらも件数の決め打ちを持たない。
 - 未設定時のフォールバック表示: iOS / Android の双方で同じ文言・同じ色になるようにする。

--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -15,16 +15,29 @@ import WidgetKit
 // 表示データはPresetsWidgetModuleがApp Groupへ書き込んだJSONを読む。
 // 体裁はアプリ内のプリセットカード(PresetCard.tsx)を踏襲し、
 // 路線色のナンバリングサークル + プリセット名 + 始発駅→終着駅 で構成する。
+//
+// systemMedium / systemLargeは高さに収まるだけ行を並べる(PresetsWidgetRow)。
+// systemSmallはウィジェット全体が単一のタップ領域で1件しか開けないため、
+// 行を並べず1件を縦に積んで見せる(PresetsWidgetFeatured)。
 
 // 乗車中ウィジェット(HomeScreenWidget)と同じsystemSmall / systemMediumに加え、
 // 一覧をまとめて見たい向けにsystemLargeも選べるようにしている。
-// systemSmallとsystemMediumは高さが同じなので収まる行数も同じ
-private let compactRowCount = 2
-private let largeRowCount = 5
 
-// 行の左に置くナンバリングサークルの直径。
-// systemSmallの幅でも駅名に十分な余地が残るよう、乗車中ウィジェット(48pt)より小さくしている
+// 一覧の1行あたりの高さと行間。表示件数はこの値と実際のウィジェット高から導出するため、
+// 行の見た目を変えたらこちらも合わせること
+private let rowHeight: CGFloat = 40
+private let rowSpacing: CGFloat = 6
+
+// ヘッダー(caption2 + アイコン)の高さと、ヘッダーと一覧の間隔
+private let headerHeight: CGFloat = 18
+private let headerSpacing: CGFloat = 6
+
+// 一覧の行に置くナンバリングサークルの直径
 private let rowCircleDiameter: CGFloat = 30
+
+// systemSmallは1件だけを縦に積んで見せる。下に駅名2行と矢印が入るぶん、
+// 乗車中ウィジェットのsystemSmall(48pt)よりは小さくする
+private let featuredCircleDiameter: CGFloat = 36
 
 struct PresetsWidgetItem: Codable, Identifiable {
   let id: String
@@ -48,12 +61,13 @@ struct PresetsWidgetItem: Codable, Identifiable {
     return lineName.isEmpty ? "?" : String(lineName.prefix(1))
   }
 
+  var hasStations: Bool {
+    !fromStationName.isEmpty && !toStationName.isEmpty
+  }
+
   // 駅名が未取得のプリセットでは路線名だけでも出す
   var routeDescription: String {
-    if fromStationName.isEmpty || toStationName.isEmpty {
-      return lineName
-    }
-    return "\(fromStationName) → \(toStationName)"
+    hasStations ? "\(fromStationName) → \(toStationName)" : lineName
   }
 }
 
@@ -89,6 +103,43 @@ struct PresetsEntry: TimelineEntry {
           lineName: "中央線快速",
           lineColor: "F15A22",
           lineSymbol: "JC"
+        ),
+        // systemLargeのギャラリープレビューが空きだらけにならないよう行数分用意する
+        PresetsWidgetItem(
+          id: "placeholder-3",
+          name: "休日おでかけ",
+          fromStationName: "渋谷",
+          toStationName: "横浜",
+          lineName: "東急東横線",
+          lineColor: "DA0442",
+          lineSymbol: "TY"
+        ),
+        PresetsWidgetItem(
+          id: "placeholder-4",
+          name: "空港へ",
+          fromStationName: "品川",
+          toStationName: "羽田空港第1・第2ターミナル",
+          lineName: "京急本線",
+          lineColor: "00BFFF",
+          lineSymbol: "KK"
+        ),
+        PresetsWidgetItem(
+          id: "placeholder-5",
+          name: "実家",
+          fromStationName: "上野",
+          toStationName: "大宮",
+          lineName: "宇都宮線",
+          lineColor: "F68B1E",
+          lineSymbol: "JU"
+        ),
+        PresetsWidgetItem(
+          id: "placeholder-6",
+          name: "ハイキング",
+          fromStationName: "新宿",
+          toStationName: "高尾山口",
+          lineName: "京王線",
+          lineColor: "DD0077",
+          lineSymbol: "KO"
         ),
       ]
     )
@@ -151,9 +202,59 @@ struct PresetsWidgetRow: View {
       }
       Spacer(minLength: 0)
     }
-    .frame(maxWidth: .infinity, alignment: .leading)
+    .frame(maxWidth: .infinity, height: rowHeight, alignment: .leading)
     // 行全体をタップ領域にする。Spacerだけでは透明部分がヒットしない
     .contentShape(Rectangle())
+  }
+}
+
+/// systemSmall専用の1件表示。
+///
+/// 行を並べても1件しかタップできないため件数を増やす意味が無い。
+/// 正方形の領域に対して「始発駅 → 終着駅」を横一列に置くと横幅で先に頭打ちになり、
+/// 駅名がすぐ省略されるので、縦に積んで1駅あたりの幅をフルに使う。
+/// 空いた領域はSpacerで均し、上下に寄った余白が残らないようにする。
+struct PresetsWidgetFeatured: View {
+  let preset: PresetsWidgetItem
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HomeScreenNumberingCircle(
+        lineColor: preset.displayLineColor,
+        lineSymbol: preset.displayLineSymbol,
+        diameter: featuredCircleDiameter
+      )
+      Spacer(minLength: 6)
+      Text(preset.name)
+        .font(.caption)
+        .fontWeight(.bold)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+      Spacer(minLength: 2)
+      if preset.hasStations {
+        Text(preset.fromStationName)
+          .font(.title3)
+          .fontWeight(.bold)
+          .lineLimit(1)
+          .minimumScaleFactor(0.6)
+        Image(systemName: "arrow.down")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+        Text(preset.toStationName)
+          .font(.title3)
+          .fontWeight(.bold)
+          .lineLimit(1)
+          .minimumScaleFactor(0.6)
+      } else {
+        // 駅名が未取得のときは路線名だけ出す
+        Text(preset.lineName)
+          .font(.headline)
+          .lineLimit(2)
+          .minimumScaleFactor(0.7)
+      }
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
   }
 }
 
@@ -171,20 +272,20 @@ struct PresetsWidgetEntryView: View {
   }
 
   // systemSmallはウィジェット全体が単一のタップ領域で、行ごとのLinkが効かない。
-  // 行を並べるとタップ先と見た目が食い違うため、1件だけ出してwidgetURLで開く
+  // 行を並べても1件しかタップできず件数を増やす意味が無いため、1件を大きく見せる
   private var isSingleTapTarget: Bool {
     family == .systemSmall
   }
 
-  private var rowCount: Int {
-    if isSingleTapTarget {
+  /// 与えられた高さに収まる行数。
+  /// ファミリーごとに件数を決め打ちすると端末サイズ差で余白が出たり見切れたりするため、
+  /// 実際に描画される高さから求める。行の高さはrowHeightで固定しているので計算は一致する。
+  private func rowCount(for height: CGFloat) -> Int {
+    let available = height - headerHeight - headerSpacing
+    guard available > 0 else {
       return 1
     }
-    return family == .systemLarge ? largeRowCount : compactRowCount
-  }
-
-  private var visiblePresets: [PresetsWidgetItem] {
-    Array(entry.presets.prefix(rowCount))
+    return max(1, Int((available + rowSpacing) / (rowHeight + rowSpacing)))
   }
 
   private func presetURL(_ preset: PresetsWidgetItem) -> URL? {
@@ -224,35 +325,37 @@ struct PresetsWidgetEntryView: View {
     .widgetURL(URL(string: "\(urlScheme)://"))
   }
 
+  // systemMedium / systemLarge。高さに収まるだけ行を詰めて余白を残さない
   private var listView: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      header
-      ForEach(visiblePresets) { preset in
-        // systemSmallではLinkが個別のタップ領域にならないので包まない。
-        // 代わりにウィジェット全体へwidgetURLを張る
-        if !isSingleTapTarget, let url = presetURL(preset) {
-          Link(destination: url) {
-            PresetsWidgetRow(preset: preset)
+    GeometryReader { proxy in
+      VStack(alignment: .leading, spacing: headerSpacing) {
+        header
+        VStack(alignment: .leading, spacing: rowSpacing) {
+          ForEach(entry.presets.prefix(rowCount(for: proxy.size.height))) { preset in
+            if let url = presetURL(preset) {
+              Link(destination: url) {
+                PresetsWidgetRow(preset: preset)
+              }
+            } else {
+              PresetsWidgetRow(preset: preset)
+            }
           }
-        } else {
-          PresetsWidgetRow(preset: preset)
         }
+        // 登録件数が収まる行数に満たないときだけ効く。通常は0
+        Spacer(minLength: 0)
       }
-      Spacer(minLength: 0)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
   }
 
   var body: some View {
     if entry.presets.isEmpty {
       emptyView
-    } else if isSingleTapTarget {
+    } else if isSingleTapTarget, let preset = entry.presets.first {
       // 表示している唯一のプリセットをウィジェット全体のタップ先にする。
       // URLを組めなかった場合はアプリ起動へ倒す
-      listView
-        .widgetURL(
-          visiblePresets.first.flatMap(presetURL) ?? URL(string: "\(urlScheme)://")
-        )
+      PresetsWidgetFeatured(preset: preset)
+        .widgetURL(presetURL(preset) ?? URL(string: "\(urlScheme)://"))
     } else {
       listView
     }

--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -303,11 +303,15 @@ struct PresetsWidgetEntryView: View {
     HStack(spacing: 4) {
       Image(systemName: "tram.fill")
       Text("presetsWidgetTitle")
+        .lineLimit(1)
       Spacer(minLength: 0)
     }
     .font(.caption2)
     .fontWeight(.bold)
     .foregroundStyle(.secondary)
+    // rowCount(for:)がheaderHeightぶんを予約するので、実際の高さも必ずそこへ揃える。
+    // Dynamic Typeや長いローカライズ文字列で伸びると最終行が見切れる
+    .frame(height: headerHeight, alignment: .leading)
   }
 
   private var emptyView: some View {


### PR DESCRIPTION
## 概要

iOS のプリセットウィジェットが余白を持て余していた点を改善しました。#6585 / #6586 のフォローアップです。

- `systemMedium` / `systemLarge`: 件数の決め打ちをやめ、実際の描画高に収まるだけ行を詰めるようにしました。
- `systemSmall`: 1 件表示は維持しつつ、横一列だった「始発駅 → 終着駅」を縦積みに変更し、余白を使い切るようにしました。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [x] その他（UI 調整）

## 変更内容

### 表示件数を実測ベースに変更

これまでは `compactRowCount = 2` / `largeRowCount = 5` とファミリーごとに決め打ちしていました。この方式では端末サイズ差で余白が出たり見切れたりするため、`GeometryReader` で実際の描画高を測り、`rowHeight` / `rowSpacing` / `headerHeight` から収まる行数を求める形に変更しています。

行の高さは `PresetsWidgetRow` に `.frame(height: rowHeight)` を付けて固定したので、計算値と実際の描画が一致します。Android 側で高さを dp で見積もって破綻した経緯がありますが、そちらは OS から渡る値が端末・ランチャー・向きで変わるのが原因でした。iOS は自分が指定した行高を自分で数えるだけなのでずれません。

### systemSmall を縦積みに変更

`systemSmall` はウィジェット全体が単一のタップ領域で、行ごとの `Link` が個別のタップ先になりません。行を並べても 1 件しか開けないため件数は 1 件のままとし、代わりにレイアウトを作り直しました（`PresetsWidgetFeatured`）。

正方形の領域に「始発駅 → 終着駅」を横一列で置くと横幅で先に頭打ちになり、駅名がすぐ省略されます。そこで以下の順に縦へ積み、1 駅あたりの幅をフルに使うようにしました。

```text
⬤ JY          ← ナンバリングサークル(36pt)
通勤           ← プリセット名 (caption, secondary)
東京           ← 始発駅 (title3, bold)
 ↓
新宿           ← 終着駅 (title3, bold)
```

`Spacer` で余白を均し、上下どちらかに寄った空きが残らないようにしています。駅名が未取得のプリセットでは従来どおり路線名のみを表示します。

### その他

- ウィジェットギャラリーのプレビュー用ダミーデータを 2 件から 6 件に増やしました。`systemLarge` のプレビューが空きだらけになるのを防ぐためです。
- `PresetsWidgetItem.hasStations` を追加し、駅名の有無判定を `routeDescription` と縦積み表示で共有しています。
- `docs/home-screen-widgets.md` のサイズ・表示件数の記述を更新しました。

Android 側は変更していません。

## 回帰リスクと緩和

- **表示件数の算出**: `rowHeight` などの定数はレイアウトの実寸と対応させる必要があるため、行の見た目を変えたら合わせて更新する旨をコメントとドキュメントに明記しています。`GeometryReader` の高さが 0 以下の場合は 1 行にフォールバックします。
- **タップ挙動**: `systemMedium` / `systemLarge` の行ごとの `Link`、`systemSmall` の `widgetURL` はいずれも従来の経路のままで、ディープリンクの組み立て（`presetURL`）にも変更はありません。
- **同期処理**: JS 側・App Group への書き込み経路には一切触れていません。

## ローカルで実行したコマンド

```bash
npm run lint      # Checked 624 files / エラーなし
npm test          # 212 suites / 2219 tests 全て pass
npm run typecheck # エラーなし
npx markdownlint-cli2 docs/home-screen-widgets.md  # 指摘なし
```

本 PR は iOS の Swift とドキュメントのみの変更で、JS/TS には手を入れていません（上記は影響が無いことの確認として実行）。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ネイティブビルド環境が無いため、実機での表示確認は未実施です。

## 関連Issue

#6585 / #6586 のフォローアップ

## スクリーンショット（任意）

ネイティブビルド環境が無いため未添付です。


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnY1Ffc9te3qeT6wUvzcCp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * iOSウィジェットの表示件数を、ウィジェットの実際の高さに合わせて自動調整するよう改善しました。
  * 中サイズ・大サイズでは、画面に収まる分だけプリセットを表示します。
  * 小サイズでは、注目プリセットを1件、縦型レイアウトで表示します。
  * 駅名が登録されていない場合は、路線名を表示するようになりました。

* **ドキュメント**
  * ウィジェットの固定表示上限に関する案内を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->