### PR TITLE
プリセットウィジェットの行でframeの引数が不正だったiOSビルドエラーを修正

### DIFF
--- a/ios/RideSessionActivity/PresetsWidget.swift
+++ b/ios/RideSessionActivity/PresetsWidget.swift
@@ -202,7 +202,11 @@ struct PresetsWidgetRow: View {
       }
       Spacer(minLength: 0)
     }
-    .frame(maxWidth: .infinity, height: rowHeight, alignment: .leading)
+    // SwiftUIのframeはwidth/heightとmin/ideal/maxを混在できないため、
+    // 横は可変・縦はrowHeight固定をmin/maxの指定で表す
+    .frame(
+      maxWidth: .infinity, minHeight: rowHeight, maxHeight: rowHeight,
+      alignment: .leading)
     // 行全体をタップ領域にする。Spacerだけでは透明部分がヒットしない
     .contentShape(Rectangle())
   }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

iOS Canary ビルド（Archive）が Swift のコンパイルエラーで失敗していたため修正します。

失敗ジョブ: https://github.com/TrainLCD/MobileApp/actions/runs/31142560227/job/92755311004

```text
ios/RideSessionActivity/PresetsWidget.swift:205:41: error: extra argument 'height' in call
    .frame(maxWidth: .infinity, height: rowHeight, alignment: .leading)
```

SwiftUI の `frame` には `frame(width:height:alignment:)`（固定サイズ）と `frame(minWidth:idealWidth:maxWidth:minHeight:idealHeight:maxHeight:alignment:)`（可変サイズ）の 2 つのオーバーロードしかなく、`maxWidth` と `height` を混在させることはできません。`PresetsWidgetRow` に行高さ固定を入れた際に混ざったものです。

なお `** ARCHIVE FAILED **` に併記されていた `UMAppLoader` の "Failed frontend command" は、この Swift エラーでビルドが中断された巻き添えであり原因ではありません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `ios/RideSessionActivity/PresetsWidget.swift` の `PresetsWidgetRow` で、存在しない `frame(maxWidth:height:alignment:)` を呼んでいたのを `frame(maxWidth:minHeight:maxHeight:alignment:)` に置き換え（`minHeight` / `maxHeight` を両方 `rowHeight` にして、横は可変・縦は固定という元の意図を維持）
- 混同しやすい箇所のためインラインコメントを追記

`PresetsWidgetEntryView.rowCount(for:)` が「行の高さは `rowHeight` で固定」を前提に表示件数を算出しているため、`.frame(maxHeight:)` のみ指定するような高さが可変になる書き方は避けています。行の描画サイズは修正前の意図どおり `rowHeight` 固定のままで、レイアウト上の見た目の差分はありません（修正前はそもそもコンパイルが通っていません）。

同種の不正な `frame` 呼び出しが他に無いか `ios/**/*.swift` を横断確認しましたが、本件 1 箇所のみでした。

回帰リスク: 変更は当該ウィジェット行 1 箇所の `frame` 修飾子に限定され、JS/TS 側には影響しません。この環境（Linux、Xcode なし）では Swift のコンパイル検証ができていないため、最終確認は CI の iOS ビルドで行う必要があります。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint` → Checked 624 files, エラーなし
- `npm test` → 212 suites / 2219 tests すべてパス
- `npm run typecheck` → エラーなし

Swift 側の検証は CI の iOS ビルドに委ねています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDW7RJ65d5VQbVfu8o22ei)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プリセットウィジェットの行レイアウトを調整しました。
  * 横幅が変動する場合でも、高さを適切に維持し、表示が安定するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->