### PR TITLE
App Store審査で指摘されたマイク用途文字列をInfoPlist.stringsから削除

### DIFF
--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -9,4 +9,3 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSLocationAlwaysUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSPhotoLibraryAddUsageDescription" = "Save the screenshot image to your iPhone.";
-"NSMicrophoneUsageDescription" = "This app does not require access to the microphone.";

--- a/ios/ja.lproj/InfoPlist.strings
+++ b/ios/ja.lproj/InfoPlist.strings
@@ -9,4 +9,3 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSLocationAlwaysUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSPhotoLibraryAddUsageDescription" = "スクリーンショット画像をiPhoneに保存します。";
-"NSMicrophoneUsageDescription" = "このアプリはマイクを使用しません。";


### PR DESCRIPTION
## 概要

App Store の自動審査で `NSMicrophoneUsageDescription` が「プレースホルダーまたは不十分な用途説明」として指摘された件への対応です。調査の結果、本アプリはマイクを一切使用しておらず、当該キーは `Info.plist` に存在しない宙に浮いたローカライズエントリだったため、`ios/en.lproj/InfoPlist.strings` と `ios/ja.lproj/InfoPlist.strings` から削除しました。

指摘された文言は以下の通りで、内容自体が「使用しません」という宣言になっており、用途説明としては成立していませんでした。

- en: `"This app does not require access to the microphone."`
- ja: `"このアプリはマイクを使用しません。"`

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 削除したもの

- `ios/en.lproj/InfoPlist.strings` から `NSMicrophoneUsageDescription` の行を削除
- `ios/ja.lproj/InfoPlist.strings` から `NSMicrophoneUsageDescription` の行を削除

### 調査結果（マイク不使用の根拠）

コードベース全体を確認し、マイクを利用する実装が存在しないことを確認しました。

- `expo-audio` は導入済みだが、使用箇所は `src/hooks/useTTS.ts` の `setAudioModeAsync` のみ。同呼び出しでは `allowsRecording: false` を明示している
- `useAudioRecorder` / `AudioRecorder` / `requestRecordingPermission` / `RecordingPresets` の参照は 0 件
- 音声認識系ライブラリ（`expo-speech-recognition`、`@react-native-voice/voice` 等）は未導入
- `expo-speech` は TTS（音声出力）専用
- Android 側に `RECORD_AUDIO` の記述はなく、`app.config.ts` の `android.permissions` は空配列
- `Info.plist`（Prod / Dev の両スキーム）に `NSMicrophoneUsageDescription` キーは存在しない

なお `UIBackgroundModes` の `audio` は TTS のバックグラウンド読み上げ用であり、マイクとは無関係です。

### 混入経緯

`app.config.ts` の `plugins` に `expo-audio` が指定されており、同プラグインは既定で `NSMicrophoneUsageDescription` を注入する実装になっています（`plugin/build/withAudio.js`）。ただし本リポジトリは `ios/` をコミット済みの bare プロジェクトとして管理しており、CI（`ios/ci_scripts/ci_post_clone.sh`）も `npm ci` と `pod install` のみで prebuild を実行していないため、このプラグインによる注入は実際には適用されていません。過去に手動で追記されたものが残っていたと考えられます。

### 影響範囲

`Info.plist` に本体キーが存在しないため、実行時の挙動に変化はありません。iOS はまず `Info.plist` のキーを参照し、その上で `InfoPlist.strings` による上書きを探す仕様のため、本体キーのない翻訳エントリは元々参照されていませんでした。今回の削除により、App Store のバンドル走査で拾われる箇所がなくなります。

## リグレッションリスクと緩和策

リスクは低いと判断しています。JavaScript / TypeScript のコード変更はなく、削除対象は実行時に参照されていないローカライズ文字列のみです。

想定される唯一の懸念として、`expo-audio` のネイティブコードが録音 API（AVAudioRecorder 系）を参照しているため、将来 Apple のバイナリ走査で逆に `ITMS-90683: Missing purpose string` が発生する可能性が理論上あります。その場合は削除ではなく、`Info.plist` へ本体キーを追加した上で正確な用途文言を設定する対応に切り替える必要があります。次回の提出結果で確認可能です。

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること — `Checked 624 files in 787ms. No fixes applied.`
- [x] `npm test` が通ること — `Test Suites: 212 passed, 212 total` / `Tests: 2219 passed, 2219 total`
- [x] `npm run typecheck` が通ること — エラーなし

実行コマンド:

```bash
npm ci
npm run lint
npm test
npm run typecheck
```

## 関連Issue

なし（App Store Connect の審査指摘に基づく対応）

## スクリーンショット（任意）

UI 変更はないため添付なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaeLArTZHG4nWMMYTR5rg1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - iOS版のマイク使用許可に関する説明文を、日本語・英語の両方で削除しました。
  - マイク権限の確認時に表示される案内が更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->