### PR TITLE
ホーム画面ウィジェットの行き先から矢印アイコンを削除

### DIFF
--- a/ios/RideSessionActivity/HomeScreenWidget.swift
+++ b/ios/RideSessionActivity/HomeScreenWidget.swift
@@ -187,19 +187,11 @@ struct HomeScreenWidgetEntryView: View {
       .minimumScaleFactor(0.7)
   }
 
-  // 乗車中は行き先であることが伝わるよう矢印を添える。
-  // 未乗車時は「方面が未設定です」という案内文なので矢印は付けない
   private var boundForLabel: some View {
-    HStack(spacing: 3) {
-      if entry.loaded {
-        Image(systemName: "arrow.forward")
-          .imageScale(.small)
-      }
-      Text(entry.boundFor)
-        .lineLimit(2)
-        .minimumScaleFactor(0.8)
-    }
-    .opacity(0.85)
+    Text(entry.boundFor)
+      .lineLimit(2)
+      .minimumScaleFactor(0.8)
+      .opacity(0.85)
   }
 
   // 正方形なのでバッジを上に置き、その下に路線名と方面を積む


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ホーム画面ウィジェット（systemSmall / systemMedium）の行き先表示に添えていた矢印アイコン（`arrow.forward`）が不要との指摘を受けて削除します。表示は `→ 小山方面` から `小山方面` になります。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `HomeScreenWidgetEntryView.boundForLabel` から `Image(systemName: "arrow.forward")` を削除
- 矢印とテキストを横並びにするためだけに存在していた `HStack(spacing: 3)` を解体し、`Text(entry.boundFor)` 単体へ整理。`lineLimit(2)` / `minimumScaleFactor(0.8)` / `opacity(0.85)` は従来の値をそのまま引き継いでいるため、フォント・行数・不透明度・レイアウトは変わりません
- 矢印の有無（乗車中のみ表示）を説明していたコメントを削除

補足:

- Android 版のホーム画面ウィジェット（`RideWidgetProvider.kt` / `widget_ride_small.xml` / `widget_ride_rectangular.xml`）には元々矢印が無いため変更なし。今回の削除で両 OS の表示が揃います
- ライブアクティビティ（`RideSessionActivity.swift` の駅遷移表示）とプリセットウィジェット（`PresetsWidget.swift` の「始発駅 → 終着駅」）の矢印は用途が異なるため対象外
- リグレッションリスク: 変更は `HomeScreenWidget.swift` の表示要素 1 つのみで、`LockScreenEntry` などのデータ供給側や他ターゲットには手を入れていないため低。影響範囲はホーム画面ウィジェットの見た目に限られます

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

チェックが OFF の理由: 変更が iOS ウィジェットの Swift 1 ファイルのみで `src/**` に差分が無く、上記 3 コマンド（Biome / Jest / tsc の対象は `src/`）のスコープ外のため未実行です。あわせて、シミュレータ・実機でのウィジェット表示確認も未実施です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_019ExYfB32owx3nWESDMkwmb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 乗車中の表示から進行方向の矢印アイコンを削除し、方面テキストのみを表示するよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->