### PR TITLE
プリセットの始発駅解決を駅一覧の並び順に依存しないよう修正

### DIFF
--- a/src/hooks/usePresetStops.test.ts
+++ b/src/hooks/usePresetStops.test.ts
@@ -68,6 +68,19 @@ describe('usePresetStops', () => {
       );
       expect(result.current.presetOrigin?.groupId).toBe(ueno.groupId);
     });
+
+    // 駅一覧の並びが保存時と反転していると direction の示す終端が行き先と重なる
+    it('direction の示す終端が wantedDestination と同じ場合は反対側の終端を返す', () => {
+      const { result } = renderHook(() =>
+        usePresetStops({
+          savedRouteDirection: 'OUTBOUND',
+          stations,
+          wantedDestination: ueno,
+          confirmedStation: null,
+        })
+      );
+      expect(result.current.presetOrigin?.groupId).toBe(kitaSenju.groupId);
+    });
   });
 
   describe('presetStops', () => {

--- a/src/hooks/usePresetStops.ts
+++ b/src/hooks/usePresetStops.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import type { Station } from '~/@types/graphql';
 import type { LineDirection } from '~/models/Bound';
 import { findNearestByCoord } from '~/utils/findNearestByCoord';
+import { getPresetOriginStation } from '~/utils/presetRouteEndpoints';
 
 type UsePresetStopsParams = {
   savedRouteDirection: LineDirection | null | undefined;
@@ -16,12 +17,17 @@ export const usePresetStops = ({
   wantedDestination,
   confirmedStation,
 }: UsePresetStopsParams) => {
-  const presetOrigin = useMemo(() => {
-    if (!savedRouteDirection) return null;
-    return savedRouteDirection === 'INBOUND'
-      ? stations[0]
-      : (stations.at(-1) ?? null);
-  }, [savedRouteDirection, stations]);
+  // 始発駅の解決はプリセットカード・ホーム画面ウィジェットと共通化している。
+  // 駅一覧の並びが保存時と反転していても行き先と同じ駅を掴まないようにするため
+  const presetOrigin = useMemo(
+    () =>
+      getPresetOriginStation({
+        stations,
+        wantedDestinationId: wantedDestination?.groupId ?? null,
+        direction: savedRouteDirection ?? null,
+      }) ?? null,
+    [savedRouteDirection, stations, wantedDestination?.groupId]
+  );
 
   const presetStops = useMemo(() => {
     if (!presetOrigin || !wantedDestination) return undefined;

--- a/src/hooks/usePresetsWidgetSync.test.tsx
+++ b/src/hooks/usePresetsWidgetSync.test.tsx
@@ -165,6 +165,30 @@ describe('usePresetsWidgetSync', () => {
     );
   });
 
+  // 駅一覧の並びが保存時と反転して返るケース。
+  // direction をそのまま当てると始発駅と行き先が同じ駅になってしまう
+  it('駅一覧の並びが保存時と反転していても始発駅と行き先が同じにならない', () => {
+    const item = createLoopItem({
+      wantedDestinationId: 2,
+      direction: 'OUTBOUND',
+      stations: [
+        createStation(1, '前橋', 'Maebashi', { line } as Partial<Station>),
+        createStation(2, '小田原', 'Odawara', { line } as Partial<Station>),
+      ],
+    });
+    renderHook(() =>
+      usePresetsWidgetSync({
+        carouselData: [item],
+        routes: [createRoute(item.id)],
+        isRoutesDBInitialized: true,
+      })
+    );
+
+    const synced = mockUpdatePresetsWidget.mock.calls[0][0][0];
+    expect(synced.fromStationName).toBe(isJapanese ? '前橋' : 'Maebashi');
+    expect(synced.toStationName).toBe(isJapanese ? '小田原' : 'Odawara');
+  });
+
   it('路線記号が無い場合は空文字を渡してネイティブ側のフォールバックに委ねる', () => {
     const item = createLoopItem({
       stations: [

--- a/src/utils/presetRouteEndpoints.test.ts
+++ b/src/utils/presetRouteEndpoints.test.ts
@@ -1,5 +1,8 @@
 import type { Station } from '~/@types/graphql';
-import { getPresetRouteEndpoints } from './presetRouteEndpoints';
+import {
+  getPresetOriginStation,
+  getPresetRouteEndpoints,
+} from './presetRouteEndpoints';
 
 const createStation = (groupId: number): Station =>
   ({ id: groupId, groupId, name: `駅${groupId}` }) as Station;
@@ -65,5 +68,79 @@ describe('getPresetRouteEndpoints', () => {
     });
     expect(from).toBeUndefined();
     expect(to).toBeUndefined();
+  });
+
+  // 保存時と表示時で駅一覧の取得クエリが異なり、並びが反転して返ることがある。
+  // その場合でも始発駅が行き先と同じ駅にならないことを担保する
+  it('並びが反転していてもINBOUNDの始発が行き先と重ならない', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 1,
+      direction: 'INBOUND',
+    });
+    expect(from?.groupId).toBe(4);
+    expect(to?.groupId).toBe(1);
+  });
+
+  it('並びが反転していてもOUTBOUNDの始発が行き先と重ならない', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations,
+      wantedDestinationId: 4,
+      direction: 'OUTBOUND',
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(4);
+  });
+
+  it('駅が1駅しか無い場合は倒す先が無いのでその駅を返す', () => {
+    const { from, to } = getPresetRouteEndpoints({
+      stations: [createStation(1)],
+      wantedDestinationId: 1,
+      direction: 'INBOUND',
+    });
+    expect(from?.groupId).toBe(1);
+    expect(to?.groupId).toBe(1);
+  });
+});
+
+describe('getPresetOriginStation', () => {
+  it('directionが無い場合はundefinedを返す', () => {
+    expect(
+      getPresetOriginStation({
+        stations,
+        wantedDestinationId: 3,
+        direction: null,
+      })
+    ).toBeUndefined();
+  });
+
+  it('行き先が未指定ならdirectionの示す終端を返す', () => {
+    expect(
+      getPresetOriginStation({
+        stations,
+        wantedDestinationId: null,
+        direction: 'OUTBOUND',
+      })?.groupId
+    ).toBe(4);
+  });
+
+  it('行き先が途中駅ならdirectionの示す終端をそのまま返す', () => {
+    expect(
+      getPresetOriginStation({
+        stations,
+        wantedDestinationId: 3,
+        direction: 'OUTBOUND',
+      })?.groupId
+    ).toBe(4);
+  });
+
+  it('directionの示す終端が行き先と同じなら反対側の終端を返す', () => {
+    expect(
+      getPresetOriginStation({
+        stations,
+        wantedDestinationId: 4,
+        direction: 'OUTBOUND',
+      })?.groupId
+    ).toBe(1);
   });
 });

--- a/src/utils/presetRouteEndpoints.ts
+++ b/src/utils/presetRouteEndpoints.ts
@@ -13,11 +13,52 @@ export type PresetRouteEndpoints = {
 };
 
 /**
+ * プリセットの始発駅を解決する。
+ *
+ * 保存された direction は「駅一覧のどちら側の終端から乗るか」を表す:
+ *   INBOUND:  stations[0]
+ *   OUTBOUND: stations.at(-1)
+ *
+ * ただし駅一覧の並び順は取得経路で揃っていない。
+ * 保存時は `lineGroupStations` / `lineStations`(単一路線・単一系統)、
+ * プリセット一覧とホーム画面ウィジェットは `lineGroupListStations` / `lineListStations`(一括取得)
+ * を使っており、後者は並びが反転して返ることがある。
+ * その場合 direction をそのまま当てると始発駅が行き先と同じ駅になってしまう。
+ *
+ * 保存時のUI(SavePresetNameModal)は始発駅と行き先が同じ選択肢を除外しているため、
+ * 「direction から求めた終端が行き先と一致する」状態は並びの食い違いでしか起こらない。
+ * そこを検知したら反対側の終端へ倒すことで、並び順に依存せず始発駅を復元する。
+ */
+export const getPresetOriginStation = ({
+  stations,
+  wantedDestinationId,
+  direction,
+}: PresetRouteLike): Station | undefined => {
+  if (!direction) {
+    return undefined;
+  }
+
+  const head: Station | undefined = stations[0];
+  const tail: Station | undefined = stations.at(-1);
+  const origin = direction === 'INBOUND' ? head : tail;
+  const opposite = direction === 'INBOUND' ? tail : head;
+
+  if (
+    wantedDestinationId != null &&
+    origin?.groupId === wantedDestinationId &&
+    opposite?.groupId !== wantedDestinationId
+  ) {
+    return opposite;
+  }
+
+  return origin;
+};
+
+/**
  * プリセットの始発駅・終着駅を解決する。
  *
  * wantedDestinationId と direction が保存されている場合は保存時の選択に合わせて終着駅を差し替える。
- *   INBOUND:  from = stations[0],  to = wantedDestination
- *   OUTBOUND: from = stations.at(-1), to = wantedDestination
+ * 始発駅の解決は `getPresetOriginStation` を参照。
  *
  * プリセットカードとホーム画面ウィジェットの双方が同じ端点を表示する必要があるため共通化している。
  */
@@ -39,7 +80,7 @@ export const getPresetRouteEndpoints = ({
   }
 
   return {
-    from: direction === 'INBOUND' ? stations[0] : stations.at(-1),
+    from: getPresetOriginStation({ stations, wantedDestinationId, direction }),
     to: destStation,
   };
 };


### PR DESCRIPTION
## 概要

ホーム画面のプリセットウィジェットで、始発駅と行き先が同じ駅として表示される不具合（例: 「小田原 ↓ 小田原」、実際は「前橋 → 小田原」）を修正します。

プリセットの端点は保存済みの `direction` を「駅一覧のどちら側の終端から乗るか」として解釈していますが、駅一覧の取得クエリが保存時と表示時で異なり、並びが揃わないことがあります。

| | 使用クエリ |
| ---- | ---- |
| プリセット保存時（`useLineSelection`） | `lineGroupStations` / `lineStations`（単一取得） |
| プリセット一覧・ホーム画面ウィジェット（`usePresetCarouselData`） | `lineGroupListStations` / `lineListStations`（一括取得） |

一括取得側で並びが反転して返ると `direction` の指す終端が行き先そのものになり、`from === to` になります。保存UI（`SelectBoundModal` の `presetDirectionOptions`）は始発駅と行き先が同じ選択肢を明示的に除外しているため、この状態は並び順の食い違いでしか発生しません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/presetRouteEndpoints.ts` に `getPresetOriginStation` を新設し、`direction` から求めた終端が行き先と一致する場合は反対側の終端へ倒すようにした。終端の集合自体は並び順に依存しないため、行き先が終端駅のケースは並びが反転していても始発駅を正しく復元できる
- `getPresetRouteEndpoints` の始発駅解決を `getPresetOriginStation` 経由に変更（ホーム画面ウィジェットとアプリ内プリセットカードの双方に反映される）
- 同じ解決ロジックを持っていた `src/hooks/usePresetStops.ts` の `presetOrigin` も共通化した。未修正だと同じプリセットをタップした際に `presetStops` が1駅に潰れて乗車導線側も壊れるため
- 上記に対するユニットテストを `presetRouteEndpoints.test.ts` / `usePresetStops.test.ts` / `usePresetsWidgetSync.test.tsx` に追加

### 既知の制限

行き先が**途中駅**で並びが反転しているケースは、どちらの終端が始発かを判定する材料が保存データに無いため、反対側の終端が表示され得ます。根本解決には `SavedRoute` に始発駅の `groupId` を持たせるか、一覧側も保存時と同じクエリを使う必要があり、本PRのスコープ外としています。

### 回帰リスクと緩和策

- 影響範囲はプリセットの端点解決のみ（`getPresetRouteEndpoints` / `usePresetStops.presetOrigin`）。`direction` の指す終端が行き先と重ならない従来ケースの挙動は変わらない
- 行き先未指定（`wantedDestinationId` が `null`）のプリセットは従来どおり `direction` の指す終端をそのまま返す。既存テストで担保済み
- `usePresetStops` の変更は `SelectBoundModal` の方面カード表示・区間切り出しに関わるため、既存の `usePresetStops.test.ts` / `SelectBoundModal.render.test.tsx` の通過を確認済み
- ネイティブ側（iOS `PresetsWidget.swift` / Android `PresetsWidgetProvider.kt`）は変更していないため、ウィジェットの描画・リロード経路への影響はない

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

```bash
npm run lint      # Checked 624 files, no fixes applied
npm test          # 212 suites / 2228 tests passed
npm run typecheck # エラーなし
```

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01QXtc54wueuBNTReyz1mnh2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 駅一覧の並び順が保存時と反転していても、始発駅と行き先を正しく解決できるようになりました。
  * 方向や行き先の指定に応じて、適切な始発駅が自動的に選択されます。
  * 1駅のみの場合や指定がない場合など、さまざまな経路条件に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->