### PR TITLE
エッジトゥエッジのAndroidでAIチャットの入力欄がキーボードに隠れる問題を修正

### DIFF
--- a/docs/spec/ai-agent/ui.md
+++ b/docs/spec/ai-agent/ui.md
@@ -290,9 +290,15 @@ Figma デザインは人力ではなく Figma MCP で本書を入力として起
 - `SearchBar` のスタイルを踏襲した新規コンポーネント: 高さ 48、
   背景 `#fcfcfc`（LED 時 `#333`）、角丸 8（LED 時 0）、右端に
   48×48 の送信ボタン（黒背景、Ionicons `arrow-up`、白アイコン）。
-- 画面下部固定。`KeyboardAvoidingView`（iOS `padding` / Android は
-  既定動作）でキーボードに追従。下端は
-  `useSafeAreaInsets().bottom` を確保。
+- 画面下部固定。`useKeyboardBottomInset()` が返す下余白でキーボードに
+  追従する（キーボード非表示時は `useSafeAreaInsets().bottom` を確保）。
+  `KeyboardAvoidingView` は使わない: エッジトゥエッジ
+  （`edgeToEdgeEnabled=true`）の Android では `adjustResize` でも
+  ウィンドウが縮まず、RN が送る `endCoordinates.screenY` が画面下端の
+  ままになるため押し上げ量が常に 0 と算出され、入力欄がキーボードに
+  隠れてしまう。
+- キーボード表示でリストの表示領域が縮むため、表示に合わせて
+  末尾へ追従スクロールする。
 - 入力仕様:
   - 複数行入力可（`multiline`、最大 4 行で内部スクロール）。
   - 最大 500 文字（サーバ制約）。450 文字を超えたら右下に

--- a/src/hooks/useKeyboardBottomInset.test.ts
+++ b/src/hooks/useKeyboardBottomInset.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react-native';
+import {
+  type EmitterSubscription,
+  Keyboard,
+  type KeyboardEvent,
+  type KeyboardEventName,
+  Platform,
+} from 'react-native';
+import { useKeyboardBottomInset } from './useKeyboardBottomInset';
+
+const mockInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
+
+// jest-expo の既定 Platform.OS は 'ios'。プラットフォーム固有の挙動は
+// 明示的に切り替えてから検証する
+const originalPlatformOS = Platform.OS;
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+};
+
+const listeners = new Map<string, (event: KeyboardEvent) => void>();
+
+const emit = (name: KeyboardEventName, event: Partial<KeyboardEvent>) =>
+  act(() => {
+    listeners.get(name)?.(event as KeyboardEvent);
+  });
+
+const keyboardEvent = (height: number, duration = 0): Partial<KeyboardEvent> =>
+  ({
+    duration,
+    easing: 'keyboard',
+    endCoordinates: { height, width: 375, screenX: 0, screenY: 0 },
+  }) as Partial<KeyboardEvent>;
+
+const loadHook = (os: typeof Platform.OS) => {
+  setPlatformOS(os);
+  return renderHook(() => useKeyboardBottomInset());
+};
+
+describe('useKeyboardBottomInset', () => {
+  beforeEach(() => {
+    listeners.clear();
+    mockInsets.bottom = 0;
+    jest
+      .spyOn(Keyboard, 'addListener')
+      .mockImplementation((name, handler): EmitterSubscription => {
+        listeners.set(name, handler as (event: KeyboardEvent) => void);
+        return {
+          remove: () => {
+            listeners.delete(name);
+          },
+        } as EmitterSubscription;
+      });
+  });
+
+  afterEach(() => {
+    setPlatformOS(originalPlatformOS);
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('iOS', () => {
+    it('キーボード非表示時は安全領域の下端を返す', () => {
+      mockInsets.bottom = 34;
+      const { result } = loadHook('ios');
+
+      expect(result.current.value).toBe(34);
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('will系イベントを購読し、キーボード高さをそのまま余白にする', () => {
+      mockInsets.bottom = 34;
+      const { result } = loadHook('ios');
+
+      expect(listeners.has('keyboardWillShow')).toBe(true);
+      expect(listeners.has('keyboardDidShow')).toBe(false);
+
+      // iOS の endCoordinates.height はホームインジケータ領域を含むため加算しない
+      emit('keyboardWillShow', keyboardEvent(336, 250));
+
+      expect(result.current.value).toBe(336);
+      expect(result.current.duration).toBe(250);
+      expect(result.current.visible).toBe(true);
+    });
+
+    it('キーボードを閉じると安全領域の下端へ戻る', () => {
+      mockInsets.bottom = 34;
+      const { result } = loadHook('ios');
+
+      emit('keyboardWillShow', keyboardEvent(336, 250));
+      emit('keyboardWillHide', keyboardEvent(0, 250));
+
+      expect(result.current.value).toBe(34);
+      expect(result.current.visible).toBe(false);
+    });
+  });
+
+  describe('Android', () => {
+    it('did系イベントを購読する', () => {
+      loadHook('android');
+
+      expect(listeners.has('keyboardDidShow')).toBe(true);
+      expect(listeners.has('keyboardWillShow')).toBe(false);
+    });
+
+    // RN は imeInsets.bottom - barInsets.bottom を送るため、エッジトゥエッジで
+    // ウィンドウ下端からの重なり量へ戻すにはナビゲーションバー分を足し直す
+    it('ナビゲーションバー分を加算した余白を返す', () => {
+      mockInsets.bottom = 48;
+      const { result } = loadHook('android');
+
+      emit('keyboardDidShow', keyboardEvent(300));
+
+      expect(result.current.value).toBe(348);
+      expect(result.current.visible).toBe(true);
+    });
+
+    // did 系は duration: 0 で届くため、追従アニメーション時間はフック側で補う
+    it('duration が 0 でもアニメーション時間を補完する', () => {
+      const { result } = loadHook('android');
+
+      emit('keyboardDidShow', keyboardEvent(300));
+
+      expect(result.current.duration).toBeGreaterThan(0);
+    });
+
+    it('システムバー非表示時は加算せずキーボード高さのみを返す', () => {
+      mockInsets.bottom = 0;
+      const { result } = loadHook('android');
+
+      emit('keyboardDidShow', keyboardEvent(300));
+
+      expect(result.current.value).toBe(300);
+    });
+  });
+
+  it('アンマウント時にリスナを解除する', () => {
+    const { unmount } = loadHook('android');
+
+    expect(listeners.size).toBe(2);
+
+    unmount();
+
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/src/hooks/useKeyboardBottomInset.test.ts
+++ b/src/hooks/useKeyboardBottomInset.test.ts
@@ -86,6 +86,15 @@ describe('useKeyboardBottomInset', () => {
       expect(result.current.visible).toBe(true);
     });
 
+    // iOS でも duration が 0 で届くことがあり、そのまま使うと追従が瞬間移動になる
+    it('duration が 0 で届いた場合はフォールバック値を使う', () => {
+      const { result } = loadHook('ios');
+
+      emit('keyboardWillShow', keyboardEvent(336, 0));
+
+      expect(result.current.duration).toBe(250);
+    });
+
     it('キーボードを閉じると安全領域の下端へ戻る', () => {
       mockInsets.bottom = 34;
       const { result } = loadHook('ios');
@@ -118,13 +127,16 @@ describe('useKeyboardBottomInset', () => {
       expect(result.current.visible).toBe(true);
     });
 
-    // did 系は duration: 0 で届くため、追従アニメーション時間はフック側で補う
-    it('duration が 0 でもアニメーション時間を補完する', () => {
+    // did 系は IME の遷移後に届きうるため、そこからさらにアニメーションさせると
+    // 入力バーが隠れたままの時間が伸びる。即座に確定させる
+    it('追従アニメーションを行わない', () => {
       const { result } = loadHook('android');
 
       emit('keyboardDidShow', keyboardEvent(300));
+      expect(result.current.duration).toBe(0);
 
-      expect(result.current.duration).toBeGreaterThan(0);
+      emit('keyboardDidHide', keyboardEvent(0));
+      expect(result.current.duration).toBe(0);
     });
 
     it('システムバー非表示時は加算せずキーボード高さのみを返す', () => {

--- a/src/hooks/useKeyboardBottomInset.ts
+++ b/src/hooks/useKeyboardBottomInset.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, type KeyboardEvent, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// Android の keyboardDidShow / keyboardDidHide は IME のアニメーション完了後に
+// duration: 0 で届くため、追従アニメーションの時間はこちらで補う
+// (Android 既定の IME アニメーションに近い値)。
+const ANDROID_KEYBOARD_ANIMATION_DURATION = 250;
+
+// iOS はアニメーション開始前に will 系が届くので duration をそのまま使えるが、
+// 稀に 0 で届くことがあるため下限を設ける。
+const IOS_FALLBACK_ANIMATION_DURATION = 250;
+
+type KeyboardBottomInset = {
+  /** 画面下端に固定した要素をキーボードで隠さないために確保すべき余白(dp) */
+  value: number;
+  /** value の変化へ追従させるアニメーション時間(ms) */
+  duration: number;
+  /** キーボードが表示されているか */
+  visible: boolean;
+};
+
+/**
+ * 画面下端固定の入力欄をキーボードの上へ逃がすための下余白を返す。
+ *
+ * `KeyboardAvoidingView` はエッジトゥエッジ(`edgeToEdgeEnabled=true`)の Android では
+ * 機能しない。`adjustResize` を指定してもウィンドウが縮まなくなり、RN が送る
+ * `endCoordinates.screenY` が画面下端のままになるため、`behavior` を与えても
+ * 押し上げ量が常に 0 と算出されるためである。キーボードの高さ自体は
+ * `endCoordinates.height` として正しく届くので、そこから余白を組み立てる。
+ */
+export const useKeyboardBottomInset = (): KeyboardBottomInset => {
+  const insets = useSafeAreaInsets();
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    const isIOS = Platform.OS === 'ios';
+    const resolveDuration = (event: KeyboardEvent) =>
+      isIOS
+        ? event.duration || IOS_FALLBACK_ANIMATION_DURATION
+        : ANDROID_KEYBOARD_ANIMATION_DURATION;
+
+    const handleShow = (event: KeyboardEvent) => {
+      setKeyboardHeight(event.endCoordinates.height);
+      setDuration(resolveDuration(event));
+    };
+    const handleHide = (event: KeyboardEvent) => {
+      setKeyboardHeight(0);
+      setDuration(resolveDuration(event));
+    };
+
+    // iOS はアニメーション開始前に発火する will 系で先回りできる。
+    // Android は will 系が発火しないため did 系を購読する。
+    const subscriptions = [
+      Keyboard.addListener(
+        isIOS ? 'keyboardWillShow' : 'keyboardDidShow',
+        handleShow
+      ),
+      Keyboard.addListener(
+        isIOS ? 'keyboardWillHide' : 'keyboardDidHide',
+        handleHide
+      ),
+    ];
+
+    return () => {
+      for (const subscription of subscriptions) {
+        subscription.remove();
+      }
+    };
+  }, []);
+
+  // Android の endCoordinates.height はナビゲーションバー分を除いた IME の高さ
+  // (ReactRootView が imeInsets.bottom - barInsets.bottom を送る)。エッジトゥエッジでは
+  // コンテンツがバーの裏まで伸びているため、ウィンドウ下端からの重なり量へ戻す。
+  // iOS の height はホームインジケータ領域を含んだ値なので加算しない。
+  const overlap =
+    keyboardHeight > 0 && Platform.OS !== 'ios'
+      ? keyboardHeight + insets.bottom
+      : keyboardHeight;
+
+  return {
+    value: Math.max(overlap, insets.bottom),
+    duration,
+    visible: keyboardHeight > 0,
+  };
+};

--- a/src/hooks/useKeyboardBottomInset.ts
+++ b/src/hooks/useKeyboardBottomInset.ts
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { Keyboard, type KeyboardEvent, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-// Android の keyboardDidShow / keyboardDidHide は IME のアニメーション完了後に
-// duration: 0 で届くため、追従アニメーションの時間はこちらで補う
-// (Android 既定の IME アニメーションに近い値)。
-const ANDROID_KEYBOARD_ANIMATION_DURATION = 250;
+// Android は will 系イベントを持たず、keyboardDidShow / keyboardDidHide は IME の
+// 遷移が終わってから届きうる。そこからさらに時間をかけて動かすと、キーボードが
+// 出揃った後も入力バーが隠れたままの時間が伸びてしまうため、追従アニメーションは
+// 行わず即座に確定させる(`withTiming` は duration: 0 で目標値を即時反映する)。
+const ANDROID_KEYBOARD_ANIMATION_DURATION = 0;
 
 // iOS はアニメーション開始前に will 系が届くので duration をそのまま使えるが、
 // 稀に 0 で届くことがあるため下限を設ける。

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -3,8 +3,6 @@ import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
-  KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   type TextInput,
@@ -16,11 +14,10 @@ import Animated, {
   FadeInDown,
   FadeOut,
   LinearTransition,
+  useAnimatedStyle,
+  withTiming,
 } from 'react-native-reanimated';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import type { Station } from '~/@types/graphql';
 import { CommonCard } from '~/components/CommonCard';
@@ -33,6 +30,7 @@ import {
   useDestinationAgent,
 } from '~/hooks/useDestinationAgent';
 import { useDestinationSelection } from '~/hooks/useDestinationSelection';
+import { useKeyboardBottomInset } from '~/hooks/useKeyboardBottomInset';
 import { useLazyGraphQLQuery } from '~/hooks/useLazyGraphQLQuery';
 import { GET_STATIONS_BY_IDS } from '~/lib/graphql/queries';
 import { stationAtom } from '~/store/atoms/station';
@@ -147,11 +145,13 @@ const styles = StyleSheet.create({
 
 const SUGGESTION_SKELETON_HEIGHT = 72;
 
+// 入力バーと画面下端(キーボード表示時はキーボード上端)との間隔
+const INPUT_BAR_BOTTOM_GAP = 8;
+
 const SAFE_AREA_EDGES = ['top', 'left', 'right'] as const;
 
 const DestinationAgentScreen = () => {
   const navigation = useNavigation();
-  const insets = useSafeAreaInsets();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const station = useAtomValue(stationAtom);
 
@@ -174,6 +174,12 @@ const DestinationAgentScreen = () => {
   // 会話の世代。リセット時にインクリメントし、リセット前に送った
   // リクエストの遅延応答が新しい(空の)会話へ紛れ込むのを防ぐ
   const conversationGenRef = useRef(0);
+
+  const {
+    value: keyboardBottomInset,
+    duration: keyboardAnimationDuration,
+    visible: keyboardVisible,
+  } = useKeyboardBottomInset();
 
   const { sendMessages } = useDestinationAgent();
   const {
@@ -214,6 +220,25 @@ const DestinationAgentScreen = () => {
     }
     scrollRef.current?.scrollToEnd({ animated: true });
   }, [scrollAnchor]);
+
+  // キーボードの分だけリストの表示領域が縮むため、直前まで見えていた末尾の
+  // メッセージがキーボードの裏へ隠れないよう追従させる
+  useEffect(() => {
+    if (!keyboardVisible) {
+      return;
+    }
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [keyboardVisible]);
+
+  // 入力バーをキーボードの上へ逃がす。キーボード非表示時は安全領域の下端を確保する
+  const inputBarAnimatedStyle = useAnimatedStyle(
+    () => ({
+      paddingBottom: withTiming(keyboardBottomInset + INPUT_BAR_BOTTOM_GAP, {
+        duration: keyboardAnimationDuration,
+      }),
+    }),
+    [keyboardBottomInset, keyboardAnimationDuration]
+  );
 
   // 提案は軽量情報(stationId 等)しか持たないため、CommonCard が必要とする
   // Line オブジェクトを得るために Station 完全体を一括再取得する。
@@ -528,7 +553,7 @@ const DestinationAgentScreen = () => {
   return (
     <SafeAreaView
       style={[styles.root, isLEDTheme ? styles.ledBg : styles.bg]}
-      // 下端は入力バー側で insets.bottom を確保するため除外する
+      // 下端は入力バー側でキーボード / 安全領域に応じた余白を確保するため除外する
       edges={SAFE_AREA_EDGES}
     >
       <AgentHeader
@@ -537,10 +562,7 @@ const DestinationAgentScreen = () => {
         onReset={handleReset}
       />
 
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      >
+      <View style={styles.flex}>
         <ScrollView
           ref={scrollRef}
           style={styles.flex}
@@ -613,11 +635,11 @@ const DestinationAgentScreen = () => {
           </Animated.View>
         )}
 
-        <View
+        <Animated.View
           style={[
             styles.contentWidth,
             styles.inputBarContainer,
-            { paddingBottom: insets.bottom + 8 },
+            inputBarAnimatedStyle,
           ]}
         >
           <AgentInputBar
@@ -628,8 +650,8 @@ const DestinationAgentScreen = () => {
             rateLimited={rateLimited}
             inputRef={inputRef}
           />
-        </View>
-      </KeyboardAvoidingView>
+        </Animated.View>
+      </View>
 
       <SelectBoundModal
         visible={selectBoundModalVisible}


### PR DESCRIPTION
## 概要

Pixel 9a (Android 17) で AI に行き先を相談する画面のキーボード表示時、入力バーがキーボードに覆われて見えなくなる不具合を修正します。

原因は `KeyboardAvoidingView` の設定ではなく、エッジトゥエッジ環境 (`edgeToEdgeEnabled=true`) の Android では `KeyboardAvoidingView` そのものが機能しないことでした。

- エッジトゥエッジでは `android:windowSoftInputMode="adjustResize"` を指定してもウィンドウが縮まない。
- そのため `ReactRootView.checkForKeyboardEvents()` が送る `endCoordinates.screenY` は常に画面下端のままになる。
- `KeyboardAvoidingView._relativeKeyboardHeight()` は `frame.y + frame.height - screenY` を押し上げ量とするため、結果が常に 0 になり `behavior` に何を渡しても効かない（Android は `undefined` を渡していたため二重に効いていなかった）。
- 一方で `endCoordinates.height` は `imeInsets.bottom - barInsets.bottom` として正しく届くので、これを起点に下余白を組み立てる方式へ変更しました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useKeyboardBottomInset.ts` を追加。キーボードイベントから画面下端に確保すべき余白・追従アニメーション時間・表示状態を返す。
  - Android は `keyboardDidShow` / `keyboardDidHide` を購読し、`endCoordinates.height`（ナビゲーションバー分を除いた IME 高さ）に `useSafeAreaInsets().bottom` を足してウィンドウ下端からの重なり量へ戻す。did 系イベントは IME の遷移後に届きうるため、追従アニメーションは行わず即座に確定させる（`duration: 0`）。
  - iOS は `keyboardWillShow` / `keyboardWillHide` を購読。`endCoordinates.height` はホームインジケータ領域を含むため加算せず、イベントの `duration` をそのまま使う（0 で届いた場合は 250ms にフォールバック）。
  - キーボード非表示時は `useSafeAreaInsets().bottom` を返すため、従来の下端余白の挙動は据え置き。
- `src/screens/DestinationAgent/index.tsx` から `KeyboardAvoidingView` を削除し、入力バーのコンテナを `Animated.View` にして `withTiming` で `paddingBottom` を追従させる。
- あわせて、キーボード表示でリストの表示領域が縮んだ際に末尾のメッセージがキーボードの裏へ隠れないよう追従スクロールを追加。
- `src/hooks/useKeyboardBottomInset.test.ts` を追加。iOS / Android 双方の余白計算、購読するイベント名、`duration` の解決、リスナ解除を検証（9 ケース）。
- `docs/spec/ai-agent/ui.md` の入力バー仕様を実装に合わせて更新し、`KeyboardAvoidingView` を使わない理由を記録。

### 回帰リスクと緩和

- 影響範囲は AI 相談画面 (`DestinationAgent`) のみ。他画面のキーボード挙動には触れていません。
- iOS は従来 `behavior="padding"` で入力バーを持ち上げていましたが、入力バーは画面最下部にあるため押し上げ量は「キーボード高さ」と一致し、新実装と等価です。キーボード非表示時の余白も従来どおり `insets.bottom + 8` を維持しています。
- Android の `duration: 0` は、RN のイベントが IME 遷移の開始時に届く場合でも終了後に届く場合でも「入力欄が隠れている時間が最短」になる選択です。実機で入力バーの先行移動が気になる場合は短い値への調整余地があります。
- 同じ理由で `src/components/CustomModal.tsx` の `avoidKeyboard`（`SavePresetNameModal` / `NewReportModal`）も Android では効いていないと考えられますが、本 PR のスコープ外としています。必要であれば同じフックを流用して別途対応します。

## テスト

ローカルで以下を実行し、いずれも成功することを確認しています（`npm test`: 213 suites / 2237 tests all pass）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

実機・エミュレータを操作できない環境で作業したため、スクリーンショット / 録画は未添付です。マージ前に報告端末である Pixel 9a (Android 17) での目視確認をお願いします。