### PR TITLE
WearOSアプリのtargetSdkを35に引き上げ

### DIFF
--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -11,7 +11,7 @@ android {
   defaultConfig {
     applicationId = "me.tinykitten.trainlcd"
     minSdk = 34
-    targetSdk = 34
+    targetSdk = 35
     vectorDrawables {
       useSupportLibrary = true
     }


### PR DESCRIPTION
## 概要

Wear OS アプリの `targetSdk` を 34 から 35 に引き上げます。`compileSdk` は既に 35 のため変更していません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `android/wearable/build.gradle.kts` の `targetSdk` を 34 → 35 に変更
- `minSdk` は対応端末を減らさないため 34（Wear OS 5）のまま据え置き
- `compileSdk` は変更前から 35 のため差分なし

## テスト

Wear OS 5.1（API 35 / Android 15）エミュレータで動作確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加で実施した確認:

- `./gradlew :wearable:assembleProdDebug` が成功
- マージ後マニフェストが `<uses-sdk android:minSdkVersion="34" android:targetSdkVersion="35" />` になることを確認
- Wear OS 5.1 エミュレータ（384×384 円形）へインストールして起動し、クラッシュなし。`dumpsys package` 上も `minSdk=34 targetSdk=35` として認識
- logcat に `FATAL` / `AndroidRuntime` なし

### リグレッションリスク

Android 15 では `targetSdk` 35 のアプリにエッジトゥエッジが強制適用されるため、レイアウトの縮退が起きないかを重点的に確認しました。`topActivityBoundsLetterboxed=false`、アプリ領域は 384×384 でディスプレイ全域を占有しており、レターボックス化や描画欠けは発生していません。

なお今回の確認範囲はコンパニオン未接続時の画面までです。`WearApp` 本体の UI はスマートフォン側アプリとの Data Layer 接続が前提のため、本 PR では未確認です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Androidの対象SDKを35に更新しました。最新のAndroidプラットフォームへの対応が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->