### PR TITLE
WearOSアプリのdebug署名を本体アプリと同じ鍵に統一

### DIFF
--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -8,6 +8,19 @@ android {
   namespace = "me.tinykitten.trainlcd"
   compileSdk = 35
 
+  signingConfigs {
+    // Wear OS の Data Layer はパッケージ名と署名の両方が一致する場合のみ
+    // スマホ・ウォッチ間の通信を許可する。AGP 既定の ~/.android/debug.keystore を
+    // 使うと :app と証明書が食い違い、ローカルの debug ビルド同士で疎通できないため、
+    // :app と同じ鍵を明示的に指定する。
+    getByName("debug") {
+      storeFile = file("../app/debug.keystore")
+      storePassword = "android"
+      keyAlias = "androiddebugkey"
+      keyPassword = "android"
+    }
+  }
+
   defaultConfig {
     applicationId = "me.tinykitten.trainlcd"
     minSdk = 34


### PR DESCRIPTION
## 概要

Wear OS アプリの debug 署名を、本体アプリ（`:app`）と同じ鍵に統一します。証明書の不一致により、ローカルの debug ビルドではスマートフォンとウォッチ間の Data Layer 通信が成立しない状態でした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `android/wearable/build.gradle.kts` に `signingConfigs` を追加し、`debug` が `android/app/debug.keystore` を参照するよう明示

### 背景

`:app` はリポジトリ管理下の `android/app/debug.keystore` で署名される一方、`:wearable` には `signingConfigs` の定義がなく AGP 既定の `~/.android/debug.keystore` が使われていました。その結果、両モジュールの証明書が別物になっていました。

```text
:app       fac61745dc0903786fb9ede62a962b399f7348f0bb6f899b8332667591033b9c
:wearable  c5507a1b724b506f21cebe732a874c806f327374cded634c0eb573996e44055c
```

Wear OS の Data Layer（`play-services-wearable`）はパッケージ名と署名の**両方**が一致する場合のみ端末間通信を許可するため、この状態ではローカルの debug ビルドでコンパニオン連携を検証できません。実機向けの配布ビルドは Play App Signing により署名が揃うため、影響を受けるのはローカル開発時のみです。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加で実施した確認:

- `./gradlew :wearable:assembleDevDebug` が成功
- ビルド成果物の証明書が `:app` と一致することを `apksigner verify --print-certs` で確認（両者とも `fac61745…`）
- Wear OS 5.1 エミュレータへインストールして起動し、クラッシュなし

### リグレッションリスク

`getByName("debug")` を上書きするため、同じ署名設定を参照している `buildTypes.release` にも適用されます。ただし変更前後どちらも debug 鍵であり、本番配布用の署名（Play App Signing / アップロード鍵）には影響しません。

参照先の `android/app/debug.keystore` はリポジトリに含まれているため、従来の「各開発者ごとに異なるローカル鍵」よりもビルドの再現性はむしろ向上します。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Wear OS版でデバッグビルドを安定して署名できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->