### PR TITLE
WearOSアプリのversionCodeが本体アプリを下回る逆転を解消しrelease署名を本体アプリのアップロード鍵に統一

### DIFF
--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -1,3 +1,7 @@
+// signingConfigs ブロック内では `java` が Gradle の java 拡張に解決され java.io.File を
+// 完全修飾名で参照できないため、ここで import しておく。
+import java.io.File
+
 plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")
@@ -19,6 +23,23 @@ android {
       keyAlias = "androiddebugkey"
       keyPassword = "android"
     }
+
+    // release も :app と同じアップロード鍵で署名する。debug 鍵で署名した AAB は Play の
+    // アップロード鍵と一致せず受け付けられないため、:app の signingConfigs.release と
+    // 同じ TRAINLCD_UPLOAD_* プロパティを参照する。TRAINLCD_UPLOAD_STORE_FILE は :app
+    // モジュール起点の相対パス (例: release.jks) として運用されているため、:wearable からは
+    // app/ を基準に解決する。storeFile が空の signingConfig を割り当てると署名タスクが
+    // NPE で落ちるため、プロパティが揃っている場合のみ生成する（未設定時は未署名になる）。
+    val uploadStoreFile = findProperty("TRAINLCD_UPLOAD_STORE_FILE") as String?
+    if (uploadStoreFile != null) {
+      create("release") {
+        val keystore = File(uploadStoreFile)
+        storeFile = if (keystore.isAbsolute) keystore else rootProject.file("app/$uploadStoreFile")
+        storePassword = findProperty("TRAINLCD_UPLOAD_STORE_PASSWORD") as String?
+        keyAlias = findProperty("TRAINLCD_UPLOAD_KEY_ALIAS") as String?
+        keyPassword = findProperty("TRAINLCD_UPLOAD_KEY_PASSWORD") as String?
+      }
+    }
   }
 
   defaultConfig {
@@ -35,7 +56,7 @@ android {
       signingConfig = signingConfigs.getByName("debug")
     }
     release {
-      signingConfig = signingConfigs.getByName("debug")
+      signingConfig = signingConfigs.findByName("release")
       isMinifyEnabled = true
       isShrinkResources = true
       proguardFiles(
@@ -47,17 +68,22 @@ android {
 
   flavorDimensions += "environment"
   productFlavors {
+    // :app と applicationId が同じマルチバンドル配信のため、Play は minSdk が高い側
+    // (:wearable=34 > :app=24) の versionCode が高いことを要求する。逆転すると Wear バンドルが
+    // 常に :app に順位負けし、どの端末にも配信されないためリリースを公開できなくなる。
+    // そのため versionCode は必ず「:app の versionCode + 1」に保ち、:app を bump する際は
+    // 必ず本ファイルも同時に bump すること。
     create("dev") {
       dimension = "environment"
       applicationIdSuffix = ".dev"
       versionNameSuffix = "-dev"
-      versionCode = 100000000
-      versionName = "10.0.0"
+      versionCode = 100000580
+      versionName = "10.12.0"
     }
     create("prod") {
       dimension = "environment"
-      versionCode = 100000000
-      versionName = "10.0.0"
+      versionCode = 100000580
+      versionName = "10.12.0"
     }
   }
 

--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -28,16 +28,24 @@ android {
     // アップロード鍵と一致せず受け付けられないため、:app の signingConfigs.release と
     // 同じ TRAINLCD_UPLOAD_* プロパティを参照する。TRAINLCD_UPLOAD_STORE_FILE は :app
     // モジュール起点の相対パス (例: release.jks) として運用されているため、:wearable からは
-    // app/ を基準に解決する。storeFile が空の signingConfig を割り当てると署名タスクが
-    // NPE で落ちるため、プロパティが揃っている場合のみ生成する（未設定時は未署名になる）。
-    val uploadStoreFile = findProperty("TRAINLCD_UPLOAD_STORE_FILE") as String?
-    if (uploadStoreFile != null) {
+    // app/ を基準に解決する。項目が欠けた signingConfig を割り当てると署名タスクが NPE で
+    // 落ちるため、4 つのプロパティが揃っている場合のみ生成する（未設定時は未署名になる）。
+    // 値は trim せず isNotBlank() のみで判定する（パスワード前後の空白を壊さないため）。
+    val uploadStoreFile = (findProperty("TRAINLCD_UPLOAD_STORE_FILE") as String?)?.takeIf { it.isNotBlank() }
+    val uploadStorePassword = (findProperty("TRAINLCD_UPLOAD_STORE_PASSWORD") as String?)?.takeIf { it.isNotBlank() }
+    val uploadKeyAlias = (findProperty("TRAINLCD_UPLOAD_KEY_ALIAS") as String?)?.takeIf { it.isNotBlank() }
+    val uploadKeyPassword = (findProperty("TRAINLCD_UPLOAD_KEY_PASSWORD") as String?)?.takeIf { it.isNotBlank() }
+    if (uploadStoreFile != null &&
+      uploadStorePassword != null &&
+      uploadKeyAlias != null &&
+      uploadKeyPassword != null
+    ) {
       create("release") {
         val keystore = File(uploadStoreFile)
         storeFile = if (keystore.isAbsolute) keystore else rootProject.file("app/$uploadStoreFile")
-        storePassword = findProperty("TRAINLCD_UPLOAD_STORE_PASSWORD") as String?
-        keyAlias = findProperty("TRAINLCD_UPLOAD_KEY_ALIAS") as String?
-        keyPassword = findProperty("TRAINLCD_UPLOAD_KEY_PASSWORD") as String?
+        storePassword = uploadStorePassword
+        keyAlias = uploadKeyAlias
+        keyPassword = uploadKeyPassword
       }
     }
   }


### PR DESCRIPTION
## 概要

Google Play で Wear OS バンドルを含むリリースが「このリリースは公開できません。既存のユーザーに対し、新たに追加された App Bundle へのアップグレードを許可していないためです。」と拒否される問題を修正します。

あわせて、`:wearable` の release ビルドが debug 鍵で署名されていて Play にアップロードできない状態だったため、`:app` と同じアップロード鍵に統一します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `:wearable` の `versionCode` を `100000000` → `100000580`（`:app` の `100000579` + 1）に修正し、`wearable = app + 1` の採番規約を復元
- `:wearable` の `versionName` を `10.0.0` → `10.12.0` に更新し `:app` と揃える
- `:wearable` の release 署名を `signingConfigs.debug` から、`:app` と同じ `TRAINLCD_UPLOAD_*` プロパティを参照する `release` config に変更

### 公開が拒否された原因

`:app` と `:wearable` は applicationId が同一（`me.tinykitten.trainlcd`）のマルチバンドル配信です。この構成では Play は minSdk が高い側（`:wearable` = 34 > `:app` = 24）の versionCode が高いことを要求します。この大小関係が逆転していたため、新規追加した Wear バンドルが常に `:app` に順位負けしてどの端末にも配信されず、公開がブロックされていました。

| 時期 | `:app` | `:wearable` | 関係 |
| ---- | ---- | ---- | ---- |
| 9.0.1（Play の現行 Wear バンドル） | 90001010 | 90001011 | app + 1 ✅ |
| 10.0.0 | 100000000 | 100000001 | app + 1 ✅ |
| EASにお引越し (#4539) | 100000079 | 100000000 | 逆転 ❌ |
| 修正前 HEAD (10.12.0) | 100000579 | 100000000 | 逆転 ❌ |
| 本 PR | 100000579 | 100000580 | app + 1 ✅ |

`#4539` で `:app` だけが 100000079 に進み、`:wearable` は 100000000 に固定されたまま `:app` のみインクリメントされ続けたことが原因です。

### release 署名について

`:wearable` の release ビルドタイプが `signingConfigs.getByName("debug")` を参照していたため、生成される AAB が debug 鍵（`CN=Android Debug`）で署名され、Play のアップロード鍵と一致しない状態でした。`:app` と同じ `TRAINLCD_UPLOAD_*` プロパティ方式に統一しています。

`TRAINLCD_UPLOAD_STORE_FILE` は `:app` モジュール起点の相対パス（`release.jks`）として運用されているため、`:wearable` からは `app/` を基準に解決しています。また `storeFile` が空の signingConfig を割り当てると `signProdReleaseBundle` が NPE で落ちるため、プロパティが揃っている場合のみ signingConfig を生成し、未設定時は `:app` と同様に未署名となるようにしています。

### 回帰リスクと対策

- **debug 署名への影響なし**: `signingReport` で `prodDebug` が引き続き `android/app/debug.keystore` を参照することを確認済み（#6610 の Data Layer 疎通設定は不変）。
- **minSdk / targetSdk は不変**: 34 / 35 のまま。現行の Play 公開バンドル（9.0.1）も minSdk 34 のため、既存ユーザーの切り捨ては発生しません。
- **採番規約の脆弱性は未解消**: `wearable = app + 1` は手動での lockstep bump が前提のため、`:app` を bump する際は本ファイルも必ず同時に bump する必要があります。この制約はコード内コメントに明記しました。versionCode の一元管理と CI への Wear ビルド追加は本 PR のスコープ外です。
- **実鍵での署名検証は未実施**: 検証用 keystore を生成できなかったため、`signingReport` による解決先の一致確認までにとどまります。下記コマンドで実鍵での確認が可能です。

```bash
cd android && ./gradlew :wearable:bundleProdRelease \
  -PTRAINLCD_UPLOAD_STORE_FILE=release.jks \
  -PTRAINLCD_UPLOAD_STORE_PASSWORD=... \
  -PTRAINLCD_UPLOAD_KEY_ALIAS=... \
  -PTRAINLCD_UPLOAD_KEY_PASSWORD=...
keytool -printcert -jarfile wearable/build/outputs/bundle/prodRelease/wearable-prod-release.aab
```

## テスト

`npm run lint` / `npm test` / `npm run typecheck` に加え、Gradle 側で以下を確認しました。

| 確認項目 | 結果 |
| ---- | ---- |
| `./gradlew :wearable:bundleProdRelease` | BUILD SUCCESSFUL |
| 生成 AAB のマニフェスト | `versionCode=100000580` / `versionName=10.12.0` / `minSdk=34` / `targetSdk=35` |
| `:wearable:signingReport` prodRelease | `android/app/release.jks` |
| `:app:signingReport` prodRelease | `android/app/release.jks`（一致） |
| `:wearable:signingReport` prodDebug | `android/app/debug.keystore`（変更なし） |

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - リリースビルドで、設定された署名情報を自動的に適用できるようになりました。
  - 署名情報が未設定の場合は、署名なしでビルドされます。
  - 絶対パスまたはアプリ基準の相対パスでキーストアを指定できます。
  - 開発版および製品版のバージョン番号を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->