### PR TITLE
バージョンバンプでWearOSアプリのversionCodeも本体アプリ+1に追従させ衝突を解消

### DIFF
--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -79,18 +79,18 @@ android {
     // :app と applicationId が同じマルチバンドル配信のため、Play は minSdk が高い側
     // (:wearable=34 > :app=24) の versionCode が高いことを要求する。逆転すると Wear バンドルが
     // 常に :app に順位負けし、どの端末にも配信されないためリリースを公開できなくなる。
-    // そのため versionCode は必ず「:app の versionCode + 1」に保ち、:app を bump する際は
-    // 必ず本ファイルも同時に bump すること。
+    // そのため versionCode は必ず「:app の versionCode + 1」に保つ。この追従は
+    // scripts/bump-version.js が機械的に行うので、手作業で編集しないこと。
     create("dev") {
       dimension = "environment"
       applicationIdSuffix = ".dev"
       versionNameSuffix = "-dev"
-      versionCode = 100000580
+      versionCode = 100000581
       versionName = "10.12.0"
     }
     create("prod") {
       dimension = "environment"
-      versionCode = 100000580
+      versionCode = 100000581
       versionName = "10.12.0"
     }
   }

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -8,6 +8,7 @@ const packageJsonPath = path.join(rootDir, 'package.json');
 const packageLockJsonPath = path.join(rootDir, 'package-lock.json');
 const pbxprojPath = path.join(rootDir, 'ios', 'TrainLCD.xcodeproj', 'project.pbxproj');
 const androidBuildGradlePath = path.join(rootDir, 'android', 'app', 'build.gradle');
+const wearableBuildGradlePath = path.join(rootDir, 'android', 'wearable', 'build.gradle.kts');
 
 const semverPattern = /^\d+\.\d+\.\d+$/;
 const allowedIncrements = new Set(['major', 'minor', 'patch']);
@@ -205,6 +206,43 @@ const updateAndroidBuildGradle = (filePath, versionCode, versionName) => {
   fs.writeFileSync(filePath, content);
 };
 
+// :wearable は Kotlin DSL のため Groovy 側 (`versionCode 1`) と構文が異なり
+// (`create("prod") { versionCode = 1 }`)、専用の置換関数が必要になる。
+// `versionName\b` の \b は versionNameSuffix への誤マッチを防ぐ。
+const replaceKtsFlavorNumericSetting = (source, flavor, key, value) => {
+  const regex = new RegExp(`(create\\("${flavor}"\\)\\s*\\{[\\s\\S]*?${key}\\b\\s*=\\s*)(\\d+)`, 'm');
+  if (!regex.test(source)) {
+    throw new Error(`build.gradle.kts の ${flavor} フレーバーに ${key} が見つかりません。`);
+  }
+  return source.replace(regex, `$1${value}`);
+};
+
+const replaceKtsFlavorStringSetting = (source, flavor, key, value) => {
+  const regex = new RegExp(`(create\\("${flavor}"\\)\\s*\\{[\\s\\S]*?${key}\\b\\s*=\\s*)"([^"]*)"`, 'm');
+  if (!regex.test(source)) {
+    throw new Error(`build.gradle.kts の ${flavor} フレーバーに ${key} が見つかりません。`);
+  }
+  return source.replace(regex, `$1"${value}"`);
+};
+
+// :wearable は :app と applicationId が同一のマルチバンドル配信のため、Play は minSdk が
+// 高い側 (:wearable) の versionCode が高いことを要求する。逆転・同値になるとリリースを
+// 公開できないため、:app の versionCode + 1 に必ず追従させる。
+// 追従を忘れると :app だけが進んで逆転する事故が起きるので、ここで機械的に更新する。
+const updateWearableBuildGradle = (filePath, versionCode, versionName) => {
+  let content = fs.readFileSync(filePath, 'utf8');
+
+  content = replaceKtsFlavorNumericSetting(content, 'dev', 'versionCode', versionCode);
+  content = replaceKtsFlavorNumericSetting(content, 'prod', 'versionCode', versionCode);
+
+  if (versionName) {
+    content = replaceKtsFlavorStringSetting(content, 'dev', 'versionName', versionName);
+    content = replaceKtsFlavorStringSetting(content, 'prod', 'versionName', versionName);
+  }
+
+  fs.writeFileSync(filePath, content);
+};
+
 const extractVersionFromAppConfig = (filePath) => {
   const content = fs.readFileSync(filePath, 'utf8');
   const match = content.match(/version:\s*['"]([^'"]+)['"]/);
@@ -220,6 +258,15 @@ const extractVersionCodeFromBuildGradle = (filePath) => {
   const match = content.match(/prod\s*\{[\s\S]*?versionCode\s+(\d+)/m);
   if (!match) {
     throw new Error('build.gradle の prod フレーバーから versionCode を取得できません。');
+  }
+  return Number(match[1]);
+};
+
+const extractVersionCodeFromWearableBuildGradle = (filePath) => {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const match = content.match(/create\("prod"\)\s*\{[\s\S]*?versionCode\b\s*=\s*(\d+)/m);
+  if (!match) {
+    throw new Error('build.gradle.kts の prod フレーバーから versionCode を取得できません。');
   }
   return Number(match[1]);
 };
@@ -264,6 +311,7 @@ const packageJson = readJson(packageJsonPath);
 
 const currentVersion = extractVersionFromAppConfig(appConfigPath);
 const currentAndroidVersionCode = extractVersionCodeFromBuildGradle(androidBuildGradlePath);
+const currentWearableVersionCode = extractVersionCodeFromWearableBuildGradle(wearableBuildGradlePath);
 const currentIosBuildNumber = extractIosBuildNumberFromPbxproj(pbxprojPath);
 
 let nextVersion = explicitVersion;
@@ -366,6 +414,10 @@ if (versionChanged) {
 updatePbxproj(pbxprojPath, nextIosBuildNumber, versionChanged ? nextVersion : null);
 updateAndroidBuildGradle(androidBuildGradlePath, Math.trunc(nextAndroidVersionCode), versionChanged ? nextVersion : null);
 
+// :wearable は常に :app + 1 に揃える（現在値が同値・逆転していても矯正される）
+const nextWearableVersionCode = Math.trunc(nextAndroidVersionCode) + 1;
+updateWearableBuildGradle(wearableBuildGradlePath, nextWearableVersionCode, versionChanged ? nextVersion : null);
+
 if (versionChanged) {
   console.log(`バージョンを ${currentVersion} → ${nextVersion} に更新しました。`);
 } else {
@@ -373,3 +425,4 @@ if (versionChanged) {
 }
 console.log(`iOS ビルド番号: ${currentIosBuildNumber} → ${nextIosBuildNumber}`);
 console.log(`Android versionCode: ${currentAndroidVersionCode} → ${Math.trunc(nextAndroidVersionCode)}`);
+console.log(`Wear OS versionCode: ${currentWearableVersionCode} → ${nextWearableVersionCode}`);


### PR DESCRIPTION
## 概要

`scripts/bump-version.js` が `android/wearable/build.gradle.kts` を更新対象に含んでいなかったため、バージョンバンプで `:app` の `versionCode` だけが進み、`:wearable` との大小関係が壊れる問題を修正します。

canary リリースの bump (#6615) で `:app` が `100000579` → `100000580` に上がった結果、`:wearable` の `100000580` と**完全に同値**になっていました。同一 `applicationId` のマルチバンドル配信では `versionCode` が全体でユニークである必要があるため、この状態では Play が一方のアップロードを拒否します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `scripts/bump-version.js` が `:wearable` の `versionCode` を常に「`:app` の `versionCode` + 1」に更新するよう拡張（`versionName` も同期）
- Kotlin DSL 用の置換関数 `replaceKtsFlavorNumericSetting` / `replaceKtsFlavorStringSetting` を追加
- 現在発生している衝突を解消（`:wearable` を `100000580` → `100000581`）
- 手動 bump を前提としていた `:wearable` 側のコメントを、スクリプトが自動追従する旨に更新

### なぜ再発したか

`#6613` で `wear = app + 1` の採番規約を復元しましたが、`bump-version.js` の更新対象は以下 3 ファイルのみで `:wearable` を含んでいませんでした。

- `app.config.ts`
- `ios/TrainLCD.xcodeproj/project.pbxproj`
- `android/app/build.gradle`

そのため bump が 1 回走るだけで `+1` の差が食い潰され、規約が構造的に維持できない状態でした。今回スクリプト側で機械的に追従させることで、canary / release どちらの bump でも規約が保たれます。

`:wearable` は Kotlin DSL のため Groovy 側 (`versionCode 1`) と構文が異なり (`create("prod") { versionCode = 1 }`)、既存の置換関数が使えないので専用実装を追加しています。`versionName\b` の `\b` は `versionNameSuffix` への誤マッチを防ぐためのものです。

### 回帰リスクと対策

- **スクリプトの実挙動を確認済み**: `node scripts/bump-version.js 10.12.1` を実行し、`:app` `100000580` → `100000581`、`:wearable` `100000581` → `100000582`（= app + 1）、`versionName` 両者 `10.12.1` に更新されることを確認（検証後に bump 分は revert し、本 PR には含めていません）。
- **現在値が同値・逆転していても矯正される**: `nextWearableVersionCode` は `:app` の次値から算出するため、`:wearable` の現在値に依存しません。
- **Wear モジュールが見つからない場合は例外で停止**: 黙って skip すると今回と同じ事故が起きるため、意図的に loud failure にしています。
- **`scripts/` は `npm run lint` のスコープ外**（`biome check ./src`）。参考として `npx biome check scripts/bump-version.js` を実行したところ 6 件の指摘が出ますが、修正前の HEAD 版と**ルール・件数が完全に一致**（行番号のみシフト）しており、本 PR による新規指摘は 0 件です。既存指摘（`require('fs')` の `node:` プロトコル、未使用の `toNumberOrZero` 等）は本 PR のスコープ外としました。

## テスト

`npm run lint` / `npm test` / `npm run typecheck` に加え、以下を確認しました。

| 確認項目 | 結果 |
| ---- | ---- |
| `node scripts/bump-version.js 10.12.1` | `:app` 581 / `:wearable` 582 / versionName 10.12.1 に更新 |
| `./gradlew :wearable:bundleProdRelease` | BUILD SUCCESSFUL |
| 生成 AAB のマニフェスト | `versionCode=100000581` / `versionName=10.12.0` |

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
