### PR TITLE
AndroidのCIでWearOSアプリのAABもビルドしWear専用トラックへ配信

### DIFF
--- a/.github/workflows/build_android_canary.yml
+++ b/.github/workflows/build_android_canary.yml
@@ -127,8 +127,8 @@ jobs:
             fi
           done
 
-      # :wearable は :app と applicationId が同一のマルチバンドル配信のため、Play の同一
-      # リリースに両方の AAB を含める必要がある。:app 単体で公開すると Wear OS トラックに
+      # :wearable は :app と applicationId が同一だが、Play では Wear OS 専用トラックへ
+      # 別建てで配信する。:app しかビルドしないと Wear OS トラックに
       # android.hardware.type.watch を宣言した AAB が存在せず、既存 Wear ユーザーへ
       # アップグレードを提供できずリリースが公開ブロックされる。
       - name: Build devRelease
@@ -151,13 +151,9 @@ jobs:
           path: android/wearable/build/outputs/bundle/devRelease/*.aab
           if-no-files-found: error
 
-      # releaseFiles は「カンマ区切りのみ・要素の trim なし」で解釈されるため、改行や
-      # 余分な空白を挟まず 1 行で列挙する。
-      # mappingFile は指定すると各 versionCode へ同一ファイルが適用され、:wearable に
-      # :app のマッピングが貼られてしまう。両モジュールとも R8 有効
-      # (android.enableMinifyInReleaseBuilds=true) で AAB 内の
-      # BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map を Play が
-      # 自動で取り込むため、明示指定はしない。
+      # :app と :wearable はフォームファクタ別トラックへ個別に配信する。アクションは
+      # releaseFiles 全体の versionCodes を tracks の各トラックへ一律に適用するため、
+      # 1 ステップに両方の AAB を渡してもトラック単位で振り分けられない。
       - name: Upload to Google Play (internal track)
         if: github.event_name == 'push' || inputs.upload_to_play
         # v1.1.5
@@ -165,6 +161,22 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: me.tinykitten.trainlcd.dev
-          releaseFiles: "android/app/build/outputs/bundle/devRelease/*.aab,android/wearable/build/outputs/bundle/devRelease/*.aab"
+          releaseFiles: android/app/build/outputs/bundle/devRelease/*.aab
           tracks: internal
           status: completed
+          mappingFile: android/app/build/outputs/mapping/devRelease/mapping.txt
+
+      # Wear OS 専用トラックは android.hardware.type.watch を宣言した AAB しか受け付けない。
+      # トラック ID は Play Console のフォームファクタ設定に依存する ([prefix]:trackName 形式)
+      # ため、フォームファクタ構成を変えたときは実際のトラック ID と一致しているか確認する。
+      - name: Upload Wear OS AAB to Google Play (Wear OS internal track)
+        if: github.event_name == 'push' || inputs.upload_to_play
+        # v1.1.5
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: me.tinykitten.trainlcd.dev
+          releaseFiles: android/wearable/build/outputs/bundle/devRelease/*.aab
+          tracks: "wear:internal"
+          status: completed
+          mappingFile: android/wearable/build/outputs/mapping/devRelease/mapping.txt

--- a/.github/workflows/build_android_canary.yml
+++ b/.github/workflows/build_android_canary.yml
@@ -127,11 +127,15 @@ jobs:
             fi
           done
 
+      # :wearable は :app と applicationId が同一のマルチバンドル配信のため、Play の同一
+      # リリースに両方の AAB を含める必要がある。:app 単体で公開すると Wear OS トラックに
+      # android.hardware.type.watch を宣言した AAB が存在せず、既存 Wear ユーザーへ
+      # アップグレードを提供できずリリースが公開ブロックされる。
       - name: Build devRelease
         working-directory: android
         env:
           EXPERIMENTAL_TELEMETRY_TOKEN: "${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}"
-        run: ./gradlew :app:bundleDevRelease --no-daemon
+        run: ./gradlew :app:bundleDevRelease :wearable:bundleDevRelease --no-daemon
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
@@ -140,6 +144,20 @@ jobs:
           path: android/app/build/outputs/bundle/devRelease/*.aab
           if-no-files-found: error
 
+      - name: Upload Wear OS AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wearable-devRelease
+          path: android/wearable/build/outputs/bundle/devRelease/*.aab
+          if-no-files-found: error
+
+      # releaseFiles は「カンマ区切りのみ・要素の trim なし」で解釈されるため、改行や
+      # 余分な空白を挟まず 1 行で列挙する。
+      # mappingFile は指定すると各 versionCode へ同一ファイルが適用され、:wearable に
+      # :app のマッピングが貼られてしまう。両モジュールとも R8 有効
+      # (android.enableMinifyInReleaseBuilds=true) で AAB 内の
+      # BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map を Play が
+      # 自動で取り込むため、明示指定はしない。
       - name: Upload to Google Play (internal track)
         if: github.event_name == 'push' || inputs.upload_to_play
         # v1.1.5
@@ -147,7 +165,6 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: me.tinykitten.trainlcd.dev
-          releaseFiles: android/app/build/outputs/bundle/devRelease/*.aab
+          releaseFiles: "android/app/build/outputs/bundle/devRelease/*.aab,android/wearable/build/outputs/bundle/devRelease/*.aab"
           tracks: internal
           status: completed
-          mappingFile: android/app/build/outputs/mapping/devRelease/mapping.txt

--- a/.github/workflows/build_android_production.yml
+++ b/.github/workflows/build_android_production.yml
@@ -127,11 +127,15 @@ jobs:
             fi
           done
 
+      # :wearable は :app と applicationId が同一のマルチバンドル配信のため、Play の同一
+      # リリースに両方の AAB を含める必要がある。:app 単体で公開すると Wear OS トラックに
+      # android.hardware.type.watch を宣言した AAB が存在せず、既存 Wear ユーザーへ
+      # アップグレードを提供できずリリースが公開ブロックされる。
       - name: Build prodRelease
         working-directory: android
         env:
           EXPERIMENTAL_TELEMETRY_TOKEN: "${{ secrets.EXPERIMENTAL_TELEMETRY_TOKEN }}"
-        run: ./gradlew :app:bundleProdRelease --no-daemon
+        run: ./gradlew :app:bundleProdRelease :wearable:bundleProdRelease --no-daemon
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
@@ -140,6 +144,20 @@ jobs:
           path: android/app/build/outputs/bundle/prodRelease/*.aab
           if-no-files-found: error
 
+      - name: Upload Wear OS AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wearable-prodRelease
+          path: android/wearable/build/outputs/bundle/prodRelease/*.aab
+          if-no-files-found: error
+
+      # releaseFiles は「カンマ区切りのみ・要素の trim なし」で解釈されるため、改行や
+      # 余分な空白を挟まず 1 行で列挙する。
+      # mappingFile は指定すると各 versionCode へ同一ファイルが適用され、:wearable に
+      # :app のマッピングが貼られてしまう。両モジュールとも R8 有効
+      # (android.enableMinifyInReleaseBuilds=true) で AAB 内の
+      # BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map を Play が
+      # 自動で取り込むため、明示指定はしない。
       - name: Upload to Google Play (internal track)
         if: github.event_name == 'push' || inputs.upload_to_play
         # v1.1.5
@@ -147,7 +165,6 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: me.tinykitten.trainlcd
-          releaseFiles: android/app/build/outputs/bundle/prodRelease/*.aab
+          releaseFiles: "android/app/build/outputs/bundle/prodRelease/*.aab,android/wearable/build/outputs/bundle/prodRelease/*.aab"
           tracks: internal
           status: completed
-          mappingFile: android/app/build/outputs/mapping/prodRelease/mapping.txt

--- a/.github/workflows/build_android_production.yml
+++ b/.github/workflows/build_android_production.yml
@@ -127,8 +127,8 @@ jobs:
             fi
           done
 
-      # :wearable は :app と applicationId が同一のマルチバンドル配信のため、Play の同一
-      # リリースに両方の AAB を含める必要がある。:app 単体で公開すると Wear OS トラックに
+      # :wearable は :app と applicationId が同一だが、Play では Wear OS 専用トラックへ
+      # 別建てで配信する。:app しかビルドしないと Wear OS トラックに
       # android.hardware.type.watch を宣言した AAB が存在せず、既存 Wear ユーザーへ
       # アップグレードを提供できずリリースが公開ブロックされる。
       - name: Build prodRelease
@@ -151,13 +151,9 @@ jobs:
           path: android/wearable/build/outputs/bundle/prodRelease/*.aab
           if-no-files-found: error
 
-      # releaseFiles は「カンマ区切りのみ・要素の trim なし」で解釈されるため、改行や
-      # 余分な空白を挟まず 1 行で列挙する。
-      # mappingFile は指定すると各 versionCode へ同一ファイルが適用され、:wearable に
-      # :app のマッピングが貼られてしまう。両モジュールとも R8 有効
-      # (android.enableMinifyInReleaseBuilds=true) で AAB 内の
-      # BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map を Play が
-      # 自動で取り込むため、明示指定はしない。
+      # :app と :wearable はフォームファクタ別トラックへ個別に配信する。アクションは
+      # releaseFiles 全体の versionCodes を tracks の各トラックへ一律に適用するため、
+      # 1 ステップに両方の AAB を渡してもトラック単位で振り分けられない。
       - name: Upload to Google Play (internal track)
         if: github.event_name == 'push' || inputs.upload_to_play
         # v1.1.5
@@ -165,6 +161,22 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: me.tinykitten.trainlcd
-          releaseFiles: "android/app/build/outputs/bundle/prodRelease/*.aab,android/wearable/build/outputs/bundle/prodRelease/*.aab"
+          releaseFiles: android/app/build/outputs/bundle/prodRelease/*.aab
           tracks: internal
           status: completed
+          mappingFile: android/app/build/outputs/mapping/prodRelease/mapping.txt
+
+      # Wear OS 専用トラックは android.hardware.type.watch を宣言した AAB しか受け付けない。
+      # トラック ID は Play Console のフォームファクタ設定に依存する ([prefix]:trackName 形式)
+      # ため、フォームファクタ構成を変えたときは実際のトラック ID と一致しているか確認する。
+      - name: Upload Wear OS AAB to Google Play (Wear OS internal track)
+        if: github.event_name == 'push' || inputs.upload_to_play
+        # v1.1.5
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: me.tinykitten.trainlcd
+          releaseFiles: android/wearable/build/outputs/bundle/prodRelease/*.aab
+          tracks: "wear:internal"
+          status: completed
+          mappingFile: android/wearable/build/outputs/mapping/prodRelease/mapping.txt

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -5,6 +5,11 @@ App Bundles and optionally upload them to the Google Play internal track. A push
 to `canary` or `master` uploads the corresponding build automatically. A manual
 run defaults to a build-only dry-run.
 
+Each workflow builds **two** App Bundles — the handheld app (`:app`) and the
+Wear OS app (`:wearable`) — and uploads both into a single Google Play release.
+See [Wear OS multi-bundle release](#wear-os-multi-bundle-release) for why both
+are required.
+
 ## Prerequisites
 
 - A GitHub-hosted `ubuntu-22.04` runner with Node.js 22 and Java 17.
@@ -46,8 +51,61 @@ SSH key remain step-scoped secrets.
 3. Leave **Upload the AAB to Google Play (internal track)** disabled.
 4. Run the workflow and confirm that dependency installation, environment
    validation, signing, bundle creation, and artifact upload succeed.
-5. Confirm that **Upload to Google Play (internal track)** is skipped.
+5. Confirm that both the `app-*Release` and `wearable-*Release` artifacts are
+   produced.
+6. Confirm that **Upload to Google Play (internal track)** is skipped.
 
 Enable **Upload the AAB to Google Play (internal track)** only when the selected
 ref is intended for distribution. Push-triggered Canary and Production workflows
 always upload to the internal track.
+
+## Wear OS multi-bundle release
+
+`:app` and `:wearable` share the same `applicationId`, so Google Play treats
+them as a multi-bundle (multi-form-factor) delivery. Both AABs must land in the
+**same** Play release.
+
+Publishing `:app` alone leaves the Wear OS track without a bundle that declares
+`android.hardware.type.watch`, which makes Play reject the release with:
+
+```text
+This release is not allowed to be published because it does not allow existing
+users to upgrade to the newly added app bundles.
+
+The APK or Android App Bundle in this track must request the
+android.hardware.type.watch feature.
+```
+
+### versionCode ordering
+
+Play delivers the bundle with the **highest** `versionCode` among those whose
+device requirements are met. `:app` (`minSdk 24`, no watch feature declared)
+also satisfies Wear OS device requirements, so it wins on any watch unless
+`:wearable` outranks it. `:wearable` must therefore always be
+`:app` + 1.
+
+`scripts/bump-version.js` enforces this automatically and corrects the value
+even when the two have drifted or collided. Do not edit the Wear OS
+`versionCode` by hand.
+
+### Deobfuscation mapping
+
+Neither workflow passes `mappingFile` to the upload action. The action applies a
+single `mappingFile` to **every** uploaded `versionCode`, which would attach the
+`:app` mapping to the Wear OS bundle.
+
+Both modules build with R8 enabled
+(`android.enableMinifyInReleaseBuilds=true` in `android/gradle.properties`), so
+each AAB already embeds its own mapping at
+`BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map`, and Play
+picks it up automatically.
+
+### releaseFiles syntax
+
+The upload action splits `releaseFiles` on commas only and does not trim the
+resulting entries. List the globs on a single line with no surrounding
+whitespace or newlines:
+
+```yaml
+releaseFiles: "android/app/build/outputs/bundle/prodRelease/*.aab,android/wearable/build/outputs/bundle/prodRelease/*.aab"
+```

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -6,16 +6,17 @@ to `canary` or `master` uploads the corresponding build automatically. A manual
 run defaults to a build-only dry-run.
 
 Each workflow builds **two** App Bundles — the handheld app (`:app`) and the
-Wear OS app (`:wearable`) — and uploads both into a single Google Play release.
-See [Wear OS multi-bundle release](#wear-os-multi-bundle-release) for why both
-are required.
+Wear OS app (`:wearable`) — and uploads each one to its own form-factor track:
+`:app` to `internal` and `:wearable` to `wear:internal`. See
+[Wear OS delivery](#wear-os-delivery) for why the two uploads must stay
+separate.
 
 ## Prerequisites
 
 - A GitHub-hosted `ubuntu-22.04` runner with Node.js 22 and Java 17.
 - A release keystore and its alias and passwords.
 - A Google Play service account with permission to publish both application IDs
-  to the internal track.
+  to the internal track and to the Wear OS track.
 - An SSH deploy key with read access to the private Fonts submodule.
 
 Configure these GitHub Actions secrets:
@@ -53,20 +54,22 @@ SSH key remain step-scoped secrets.
    validation, signing, bundle creation, and artifact upload succeed.
 5. Confirm that both the `app-*Release` and `wearable-*Release` artifacts are
    produced.
-6. Confirm that **Upload to Google Play (internal track)** is skipped.
+6. Confirm that both **Upload to Google Play (internal track)** and **Upload
+   Wear OS AAB to Google Play (Wear OS internal track)** are skipped.
 
 Enable **Upload the AAB to Google Play (internal track)** only when the selected
 ref is intended for distribution. Push-triggered Canary and Production workflows
-always upload to the internal track.
+always upload to the internal tracks.
 
-## Wear OS multi-bundle release
+## Wear OS delivery
 
-`:app` and `:wearable` share the same `applicationId`, so Google Play treats
-them as a multi-bundle (multi-form-factor) delivery. Both AABs must land in the
-**same** Play release.
+Google Play separates distribution by form factor. Wear OS uses its own tracks,
+identified by a `[prefix]:trackName` pattern (`wear:internal`,
+`wear:production`, …), and a Wear OS track only accepts bundles that declare
+`android.hardware.type.watch`.
 
-Publishing `:app` alone leaves the Wear OS track without a bundle that declares
-`android.hardware.type.watch`, which makes Play reject the release with:
+Building `:app` alone leaves the Wear OS track without such a bundle, which
+makes Play reject the release with:
 
 ```text
 This release is not allowed to be published because it does not allow existing
@@ -76,13 +79,35 @@ The APK or Android App Bundle in this track must request the
 android.hardware.type.watch feature.
 ```
 
+### One upload step per track
+
+`r0adkll/upload-google-play` applies the version codes of **all** `releaseFiles`
+to **every** track listed in `tracks` — it cannot route one artifact to one
+track and another artifact to another. Passing both AABs in a single step would
+therefore register the Wear OS bundle on the handheld track as well.
+
+Each workflow consequently runs two independent upload steps:
+
+Bundle directories are relative to `android/`, where `<variant>` is
+`prodRelease` (Production) or `devRelease` (Canary).
+
+| Module | Track | Bundle |
+| --- | --- | --- |
+| `:app` | `internal` | `app/build/outputs/bundle/<variant>/` |
+| `:wearable` | `wear:internal` | `wearable/build/outputs/bundle/<variant>/` |
+
+The Wear OS track ID depends on the form-factor configuration in Play Console.
+Re-check it against the actual track ID whenever that configuration changes.
+
+The Google Play service account needs publishing permission on **both** tracks.
+
 ### versionCode ordering
 
-Play delivers the bundle with the **highest** `versionCode` among those whose
-device requirements are met. `:app` (`minSdk 24`, no watch feature declared)
-also satisfies Wear OS device requirements, so it wins on any watch unless
-`:wearable` outranks it. `:wearable` must therefore always be
-`:app` + 1.
+`:app` and `:wearable` share the same `applicationId`, so their version codes
+live in one namespace and must never collide. Play also delivers the bundle with
+the **highest** `versionCode` among those whose device requirements are met, and
+`:app` (`minSdk 24`, no watch feature declared) satisfies Wear OS device
+requirements too. `:wearable` must therefore always be `:app` + 1.
 
 `scripts/bump-version.js` enforces this automatically and corrects the value
 even when the two have drifted or collided. Do not edit the Wear OS
@@ -90,22 +115,8 @@ even when the two have drifted or collided. Do not edit the Wear OS
 
 ### Deobfuscation mapping
 
-Neither workflow passes `mappingFile` to the upload action. The action applies a
-single `mappingFile` to **every** uploaded `versionCode`, which would attach the
-`:app` mapping to the Wear OS bundle.
-
 Both modules build with R8 enabled
-(`android.enableMinifyInReleaseBuilds=true` in `android/gradle.properties`), so
-each AAB already embeds its own mapping at
-`BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map`, and Play
-picks it up automatically.
-
-### releaseFiles syntax
-
-The upload action splits `releaseFiles` on commas only and does not trim the
-resulting entries. List the globs on a single line with no surrounding
-whitespace or newlines:
-
-```yaml
-releaseFiles: "android/app/build/outputs/bundle/prodRelease/*.aab,android/wearable/build/outputs/bundle/prodRelease/*.aab"
-```
+(`android.enableMinifyInReleaseBuilds=true` in `android/gradle.properties`), and
+each upload step passes its own module's `mapping.txt`. Keep the `mappingFile`
+path aligned with the module of that step — a mismatched mapping silently
+corrupts crash deobfuscation for the affected bundle.


### PR DESCRIPTION
## 概要

Android の Canary / Production ワークフローで Wear OS アプリ (`:wearable`) の AAB もビルドし、Play の Wear OS 専用トラックへ配信するようにします。

`:wearable` モジュールは #6609〜#6616 で targetSdk・署名・versionCode を整備済みでしたが、CI にビルド経路が無く (`eas.json` / `gradlew` がいずれも `:app` のみ)、AAB が一度も Play に提出されていませんでした。その結果 Play には Wear OS 版として v9.0.1 系の versionCode `90001011` が残ったままで、本体アプリ (`100000578`) が versionCode で追い越している状態です。

この状態で Wear OS トラックへリリースしようとすると、Play が次の 2 つのエラーで公開をブロックします。

```text
このリリースは公開できません。既存のユーザーに対し、新たに追加された App Bundle へのアップグレードを許可していないためです。

このトラックの APK または Android App Bundle で機能 android.hardware.type.watch を要求する必要があります。
```

`:app` の manifest には `android.hardware.type.watch` の宣言が無いため (宣言は `:wearable` 側にのみ存在)、`:app` 単体では Wear OS トラックの要件を満たせないことが原因です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `build_android_production.yml` / `build_android_canary.yml` の Gradle 呼び出しに `:wearable:bundleProdRelease` / `:wearable:bundleDevRelease` を追加 (設定フェーズを 1 回に抑えるため `:app` と同一コマンドにまとめる)
- Wear OS AAB を `wearable-prodRelease` / `wearable-devRelease` として artifact 化するステップを追加 (既存の `app-*Release` artifact は名前ごと据え置き)
- Play へのアップロードをフォームファクタ別に 2 ステップへ分離
  - `:app` → `internal` トラック
  - `:wearable` → `wear:internal` トラック
- `mappingFile` は各ステップでそれぞれのモジュールの `mapping.txt` を指定
- `docs/android-build-workflows.md` に「Wear OS delivery」節を追加し、トラック分離が必要な理由・versionCode の順位規則・mapping の対応付け・service account に必要な権限を記載

### アップロードを 2 ステップに分離した理由

`r0adkll/upload-google-play` の `addReleasesToTracks` は `options.tracks` をループし、**全 `releaseFiles` の `versionCodes` を各トラックへ一律に適用**します。artifact 単位でトラックを振り分ける機能は無いため、1 ステップに両方の AAB を渡すと Wear OS バンドルが本体トラックにも登録されてしまいます。

Play はフォームファクタごとにトラックを分けており、Wear OS トラックは `[prefix]:trackName` 形式 (`wear:internal`, `wear:production` 等) で識別され、`android.hardware.type.watch` を宣言した AAB しか受け付けません。したがってモジュールとトラックが 1 対 1 になるようステップを分けています。

分離により AAB とトラックが 1 対 1 で対応するため、`mappingFile` も各モジュールのものを正しく指定できます。

> [!IMPORTANT]
> `wear:internal` というトラック ID は Play Console のフォームファクタ設定に依存します。フォームファクタ構成を変更した際は、実際のトラック ID と一致しているか確認してください。また Play service account には **本体トラックと Wear OS トラックの両方**への公開権限が必要です。

## 回帰リスクと緩和策

| リスク | 緩和策 |
| --- | --- |
| Wear OS アプリが v9.0.1 相当から実質更新されておらず、実機動作が未検証 | Canary (`me.tinykitten.trainlcd.dev`) にも同じ変更を入れ、本番より先に internal トラックで検証できるようにした |
| `wear:internal` トラック ID が Play Console の構成と食い違う可能性 | 手動実行 (`upload_to_play` 無効) の dry-run で確認できる。ワークフローと docs の双方に要確認である旨を明記 |
| Wear OS AAB のビルド失敗で本体のリリースまで巻き込まれる | 事前にローカルで `:wearable:bundleProdRelease` の成果物生成を確認済み |
| `mappingFile` とモジュールの対応ずれによる難読化解除の破損 | ステップごとにモジュールと `mapping.txt` を 1 対 1 で対応させ、docs にも注意を明記 |
| `versionCode` の逆転再発 | `scripts/bump-version.js` が `:wearable = :app + 1` を機械的に矯正する (#6616)。docs にも手動編集禁止を明記 |

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: アプリのコード本体 (`src/**`, `android/**`, `ios/**`, `assets/**`) に変更が無いため。参考までにローカルで実行し、いずれも成功している (`npm run lint` / `npm test` 213 suites・2237 tests / `npm run typecheck`)。

CI/ドキュメント側は以下を確認した。

- 両ワークフローの YAML を `yaml.safe_load` でパースし、ステップ構成・`releaseFiles`・`tracks`・`mappingFile` の対応を検証
- `markdownlint-cli2 docs/android-build-workflows.md` → 0 issues

マージ後は **Canary の dry-run (手動実行・`upload_to_play` 無効) で Wear OS AAB のビルド成功を確認してから** push トリガーでの配信に進めることを推奨します。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
