### PR TITLE
フィードバックモーダルのデザインを刷新

### DIFF
--- a/src/components/NewReportModal.test.tsx
+++ b/src/components/NewReportModal.test.tsx
@@ -138,6 +138,8 @@ describe('NewReportModal', () => {
         borderRadius: 0,
         color: '#fff',
         backgroundColor: 'transparent',
+        // 非フォーカス時のLEDボーダー色。フォーカス時は #fff に変わる
+        borderColor: 'rgba(255, 255, 255, 0.4)',
       })
     );
   });

--- a/src/components/NewReportModal.test.tsx
+++ b/src/components/NewReportModal.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
 import type React from 'react';
+import { StyleSheet } from 'react-native';
 import NewReportModal from './NewReportModal';
 
 // 実体はフォント読み込みで非同期 setState するため、act 警告を避けて素の View に差し替える
@@ -26,6 +27,7 @@ jest.mock('~/utils/dialogPresentation', () => ({
 }));
 
 const { showDialog } = jest.requireMock('~/utils/dialogPresentation');
+const { useAtomValue } = jest.requireMock('jotai');
 
 const defaultProps = {
   visible: true,
@@ -55,6 +57,8 @@ describe('NewReportModal', () => {
       jest.runOnlyPendingTimers();
     });
     jest.useRealTimers();
+    // clearAllMocks は mockReturnValue を復元しないため、LEDテーマの上書きを明示的に戻す
+    useAtomValue.mockReturnValue(false);
     jest.clearAllMocks();
   });
 
@@ -123,5 +127,18 @@ describe('NewReportModal', () => {
 
     expect(getByText('reportSendInProgress')).toBeTruthy();
     expect(input.props.editable).toBe(false);
+  });
+
+  it('LEDテーマでは入力欄が角丸なし・白文字・透過背景になる', () => {
+    useAtomValue.mockReturnValue(true);
+    const { input } = renderModal();
+
+    expect(StyleSheet.flatten(input.props.style)).toEqual(
+      expect.objectContaining({
+        borderRadius: 0,
+        color: '#fff',
+        backgroundColor: 'transparent',
+      })
+    );
   });
 });

--- a/src/components/NewReportModal.test.tsx
+++ b/src/components/NewReportModal.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import type React from 'react';
+import NewReportModal from './NewReportModal';
+
+// 実体はフォント読み込みで非同期 setState するため、act 警告を避けて素の View に差し替える
+jest.mock('@expo/vector-icons', () => {
+  const { View } = require('react-native');
+  return { Ionicons: View };
+});
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(() => false),
+  atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('@gorhom/portal', () => ({
+  Portal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+jest.mock('~/utils/dialogPresentation', () => ({
+  showDialog: jest.fn(),
+}));
+
+const { showDialog } = jest.requireMock('~/utils/dialogPresentation');
+
+const defaultProps = {
+  visible: true,
+  sending: false,
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+  descriptionLowerLimit: 10,
+};
+
+const renderModal = (props: Partial<typeof defaultProps> = {}) => {
+  const view = render(<NewReportModal {...defaultProps} {...props} />);
+  return {
+    ...view,
+    input: view.getByPlaceholderText('reportPlaceholder'),
+  };
+};
+
+describe('NewReportModal', () => {
+  // プログレスバーの Animated.timing がタイマー経由で state を更新するため、
+  // fake timers で act 内に閉じ込めて警告を防ぐ
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('タイトル・ラベル・注意書きを表示する', () => {
+    const { getByText } = renderModal();
+
+    expect(getByText('reportModalTitle')).toBeTruthy();
+    expect(getByText('reportBodyTitle')).toBeTruthy();
+    expect(getByText('reportCaution')).toBeTruthy();
+  });
+
+  it('下限未満の入力では残り文字数を表示し、送信してもonSubmitが呼ばれない', () => {
+    const onSubmit = jest.fn();
+    const { input, getByText, queryByText } = renderModal({ onSubmit });
+
+    fireEvent.changeText(input, 'short');
+
+    expect(getByText('remainingCharacters')).toBeTruthy();
+    expect(queryByText('sendable')).toBeNull();
+
+    fireEvent.press(getByText('reportSend'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('下限以上の入力で送信可能になり、onSubmitに入力内容を渡す', () => {
+    const onSubmit = jest.fn();
+    const text = 'あ'.repeat(10);
+    const { input, getByText, queryByText } = renderModal({ onSubmit });
+
+    fireEvent.changeText(input, text);
+
+    expect(getByText('sendable')).toBeTruthy();
+    expect(queryByText('remainingCharacters')).toBeNull();
+
+    fireEvent.press(getByText('reportSend'));
+    expect(onSubmit).toHaveBeenCalledWith(text);
+  });
+
+  it('未入力で閉じると確認ダイアログなしでonCloseを呼ぶ', () => {
+    const onClose = jest.fn();
+    const { getByText } = renderModal({ onClose });
+
+    fireEvent.press(getByText('close'));
+
+    expect(showDialog).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('入力済みで閉じると破棄確認ダイアログを表示し、即時にはonCloseを呼ばない', () => {
+    const onClose = jest.fn();
+    const { input, getByText } = renderModal({ onClose });
+
+    fireEvent.changeText(input, '入力済みのフィードバック');
+    fireEvent.press(getByText('close'));
+
+    expect(showDialog).toHaveBeenCalledWith(
+      'confirmDiscardTitle',
+      'confirmDiscardMessage',
+      expect.any(Array)
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('送信中はボタンが送信中表記になり、入力欄が編集不可になる', () => {
+    const { input, getByText } = renderModal({ sending: true });
+
+    expect(getByText('reportSendInProgress')).toBeTruthy();
+    expect(input.props.editable).toBe(false);
+  });
+});

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -219,7 +219,7 @@ const NewReportModal: React.FC<Props> = ({
   const remainingCount = Math.max(descriptionLowerLimit - charCount, 0);
 
   const accentColor = isLEDTheme ? '#fff' : ACCENT_COLOR;
-  const mutedTextColor = isLEDTheme ? 'rgba(255, 255, 255, 0.7)' : '#777';
+  const mutedTextColor = isLEDTheme ? 'rgba(255, 255, 255, 0.7)' : '#767676';
   const inputBorderColor = (() => {
     if (isLEDTheme) {
       return inputFocused ? '#fff' : 'rgba(255, 255, 255, 0.4)';
@@ -254,7 +254,7 @@ const NewReportModal: React.FC<Props> = ({
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <Pressable onPress={Keyboard.dismiss}>
+        <Pressable accessible={false} onPress={Keyboard.dismiss}>
           <View style={styles.header}>
             <View style={[styles.iconBadge, isLEDTheme && styles.iconBadgeLED]}>
               <Ionicons

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -1,6 +1,8 @@
+import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Animated,
   Keyboard,
   Platform,
   Pressable,
@@ -28,68 +30,113 @@ type Props = {
   descriptionLowerLimit: number;
 };
 
+const ACCENT_COLOR = '#008ffe';
+
 const styles = StyleSheet.create({
   backdrop: {
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
   },
   modalView: {
-    flex: 1,
     maxHeight: '100%',
-    borderRadius: 16,
   },
   scrollContent: {
-    flexGrow: 1,
-    paddingHorizontal: 32,
-    paddingVertical: 32,
+    paddingHorizontal: 24,
+    paddingVertical: 24,
   },
-  pressableContent: {
-    flex: 1,
-  },
-  textInput: {
-    borderWidth: 1,
-    borderColor: '#aaa',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    width: '100%',
-    height: 128,
-    fontSize: RFValue(14),
-    marginTop: 8,
-    textAlignVertical: 'top',
-    borderRadius: 8,
-  },
-  caution: {
-    fontSize: RFValue(11),
-    fontWeight: 'bold',
-    marginTop: 12,
-    color: '#555',
-  },
-  buttonContainer: {
-    alignItems: 'center',
+  header: {
     flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconBadge: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
     justifyContent: 'center',
-    marginTop: 32,
-    gap: 16,
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 143, 254, 0.1)',
   },
-  sendButton: {
-    width: 150,
-  },
-  charCount: {
-    fontWeight: 'bold',
-    textAlign: 'right',
-    color: '#555',
-    marginTop: 4,
-    fontSize: RFValue(11),
+  iconBadgeLED: {
+    borderRadius: 0,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#fff',
   },
   title: {
     textAlign: 'left',
-  },
-  modalContent: {
     flex: 1,
-    marginTop: 21,
   },
-  subtitle: {
-    textAlign: 'left',
+  inputLabel: {
+    fontSize: RFValue(13),
+    fontWeight: 'bold',
+    marginTop: 20,
+  },
+  textInput: {
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    width: '100%',
+    height: 140,
     fontSize: RFValue(14),
+    marginTop: 8,
+    textAlignVertical: 'top',
+    borderRadius: 12,
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 10,
+  },
+  progressTrack: {
+    flex: 1,
+    height: 4,
+    borderRadius: 2,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 2,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  statusText: {
+    fontWeight: 'bold',
+    fontSize: RFValue(11),
+  },
+  cautionBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0, 143, 254, 0.06)',
+  },
+  cautionBoxLED: {
+    borderRadius: 0,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.4)',
+  },
+  cautionText: {
+    flex: 1,
+    fontSize: RFValue(10),
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginTop: 24,
+    gap: 12,
+  },
+  closeButton: {
+    flex: 1,
+  },
+  sendButton: {
+    flex: 1,
   },
 });
 
@@ -104,6 +151,8 @@ const NewReportModal: React.FC<Props> = ({
   const textInputRef = useRef<TextInputType>(null);
   const textRef = useRef('');
   const [charCount, setCharCount] = useState(0);
+  const [inputFocused, setInputFocused] = useState(false);
+  const progressAnim = useRef(new Animated.Value(0)).current;
 
   // モーダルが開かれたときに初期化
   useEffect(() => {
@@ -113,6 +162,16 @@ const NewReportModal: React.FC<Props> = ({
       textInputRef.current?.clear();
     }
   }, [visible]);
+
+  // 下限文字数に対する進捗をプログレスバーに反映する
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: Math.min(charCount / descriptionLowerLimit, 1),
+      duration: 200,
+      // NOTE: width をアニメーションするため native driver は使えない
+      useNativeDriver: false,
+    }).start();
+  }, [charCount, descriptionLowerLimit, progressAnim]);
 
   const handleChangeText = useCallback((text: string) => {
     textRef.current = text;
@@ -128,6 +187,9 @@ const NewReportModal: React.FC<Props> = ({
       textInputRef.current?.focus();
     }
   }, []);
+
+  const handleFocus = useCallback(() => setInputFocused(true), []);
+  const handleBlur = useCallback(() => setInputFocused(false), []);
 
   const handleClose = useCallback(() => {
     const hasInput = textRef.current.trim().length > 0;
@@ -153,7 +215,17 @@ const NewReportModal: React.FC<Props> = ({
     }
   }, [onClose]);
 
-  const needsLeftCount = charCount - descriptionLowerLimit;
+  const sendable = charCount >= descriptionLowerLimit;
+  const remainingCount = Math.max(descriptionLowerLimit - charCount, 0);
+
+  const accentColor = isLEDTheme ? '#fff' : ACCENT_COLOR;
+  const mutedTextColor = isLEDTheme ? 'rgba(255, 255, 255, 0.7)' : '#777';
+  const inputBorderColor = (() => {
+    if (isLEDTheme) {
+      return inputFocused ? '#fff' : 'rgba(255, 255, 255, 0.4)';
+    }
+    return inputFocused ? ACCENT_COLOR : '#dde3ea';
+  })();
 
   return (
     <CustomModal
@@ -163,9 +235,17 @@ const NewReportModal: React.FC<Props> = ({
       backdropStyle={styles.backdrop}
       contentContainerStyle={[
         styles.modalView,
-        {
-          backgroundColor: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
-        },
+        isLEDTheme
+          ? {
+              backgroundColor: LED_THEME_BG_COLOR,
+              borderRadius: 0,
+              borderWidth: 1,
+              borderColor: '#fff',
+            }
+          : {
+              backgroundColor: '#fff',
+              borderRadius: 16,
+            },
       ]}
       dismissOnBackdropPress={!sending}
       avoidKeyboard
@@ -174,64 +254,131 @@ const NewReportModal: React.FC<Props> = ({
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <Pressable onPress={Keyboard.dismiss} style={styles.pressableContent}>
-          <Heading style={styles.title}>
-            {translate('reportModalTitle')}
-          </Heading>
-
-          <View style={styles.modalContent}>
-            <Heading style={styles.subtitle}>
-              {translate('reportBodyTitle')}
+        <Pressable onPress={Keyboard.dismiss}>
+          <View style={styles.header}>
+            <View style={[styles.iconBadge, isLEDTheme && styles.iconBadgeLED]}>
+              <Ionicons
+                name="chatbubble-ellipses"
+                size={22}
+                color={accentColor}
+              />
+            </View>
+            <Heading style={styles.title}>
+              {translate('reportModalTitle')}
             </Heading>
-
-            <TextInput
-              ref={textInputRef}
-              autoFocus={Platform.OS !== 'ios'}
-              defaultValue=""
-              onChangeText={handleChangeText}
-              multiline
-              style={[
-                styles.textInput,
-                {
-                  color: isLEDTheme ? '#fff' : '#000',
-                  fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
-                },
-              ]}
-              placeholder={translate('reportPlaceholder', {
-                lowerLimit: descriptionLowerLimit,
-              })}
-            />
-
-            {needsLeftCount < 0 ? (
-              <Typography style={styles.charCount}>
-                {translate('remainingCharacters', { count: -needsLeftCount })}
-              </Typography>
-            ) : (
-              <Typography style={styles.charCount}>
-                {translate('sendable')}
-              </Typography>
-            )}
           </View>
 
-          <Typography
+          <Typography style={styles.inputLabel}>
+            {translate('reportBodyTitle')}
+          </Typography>
+
+          <TextInput
+            ref={textInputRef}
+            autoFocus={Platform.OS !== 'ios'}
+            defaultValue=""
+            onChangeText={handleChangeText}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            editable={!sending}
+            multiline
             style={[
-              styles.caution,
+              styles.textInput,
               {
-                color: isLEDTheme ? '#fff' : '#000',
-                lineHeight: Platform.select({ ios: RFValue(14) }),
+                color: isLEDTheme ? '#fff' : '#333',
+                fontFamily: isLEDTheme ? FONTS.JFDotJiskan24h : undefined,
+                borderColor: inputBorderColor,
+                backgroundColor: isLEDTheme ? 'transparent' : '#f6f8fa',
+                borderRadius: isLEDTheme ? 0 : 12,
               },
             ]}
-          >
-            {translate('reportCaution')}
-          </Typography>
+            placeholder={translate('reportPlaceholder', {
+              lowerLimit: descriptionLowerLimit,
+            })}
+            placeholderTextColor={
+              isLEDTheme ? 'rgba(255, 255, 255, 0.5)' : '#999'
+            }
+          />
+
+          <View style={styles.progressRow}>
+            <View
+              style={[
+                styles.progressTrack,
+                {
+                  backgroundColor: isLEDTheme
+                    ? 'rgba(255, 255, 255, 0.25)'
+                    : '#e5eaf0',
+                },
+              ]}
+            >
+              <Animated.View
+                style={[
+                  styles.progressFill,
+                  {
+                    backgroundColor: accentColor,
+                    width: progressAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: ['0%', '100%'],
+                    }),
+                  },
+                ]}
+              />
+            </View>
+            <View style={styles.statusRow}>
+              {sendable ? (
+                <>
+                  <Ionicons
+                    name="checkmark-circle"
+                    size={RFValue(12)}
+                    color={accentColor}
+                  />
+                  <Typography
+                    style={[styles.statusText, { color: accentColor }]}
+                  >
+                    {translate('sendable')}
+                  </Typography>
+                </>
+              ) : (
+                <Typography
+                  style={[styles.statusText, { color: mutedTextColor }]}
+                >
+                  {translate('remainingCharacters', { count: remainingCount })}
+                </Typography>
+              )}
+            </View>
+          </View>
+
+          <View style={[styles.cautionBox, isLEDTheme && styles.cautionBoxLED]}>
+            <Ionicons
+              name="shield-checkmark-outline"
+              size={20}
+              color={accentColor}
+            />
+            <Typography
+              style={[
+                styles.cautionText,
+                {
+                  color: isLEDTheme ? '#fff' : '#555',
+                  lineHeight: RFValue(15),
+                },
+              ]}
+            >
+              {translate('reportCaution')}
+            </Typography>
+          </View>
+
           <View style={styles.buttonContainer}>
-            <Button disabled={sending} onPress={handleClose} outline>
+            <Button
+              style={styles.closeButton}
+              disabled={sending}
+              onPress={handleClose}
+              outline
+            >
               {translate('close')}
             </Button>
 
             <Button
               style={styles.sendButton}
-              disabled={charCount < descriptionLowerLimit || sending}
+              disabled={!sendable || sending}
               onPress={handleSubmit}
             >
               {sending


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `NewReportModal` のデザインを刷新（`src/components/NewReportModal.tsx`）
  - ヘッダーにアクセントカラーのチャットアイコンバッジを追加
  - 入力欄を塗り背景 + 角丸に変更し、フォーカス時にアクセント色ボーダーを表示
  - 文字数下限までの進捗を示すアニメーション付きプログレスバーと、到達時のチェックマーク付き「送信可能」表示を追加
  - 注意書きをシールドアイコン付きのインフォボックス化
  - ボタンを横幅いっぱいの2分割配置に変更
  - モーダルの `flex: 1` をやめてコンテンツに沿った高さに変更
  - LEDテーマでは角丸なし・白ボーダー・モノクロ調に統一（従来はLEDでも角丸が付いていた）
  - 送信中は入力欄を編集不可に変更
- `NewReportModal` のレンダーテストを新規追加（`src/components/NewReportModal.test.tsx`、7ケース）
- CodeRabbit レビュー対応
  - キーボード解除用 `Pressable` に `accessible={false}` を指定し、子の入力欄・ボタンを個別にフォーカス可能に
  - ステータス文字色を `#777` → `#767676` に変更し WCAG AA (4.5:1) を満たすコントラストに
  - LEDテーマ分岐のテストケースを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新規レポート入力モーダルに、入力文字数に応じた進捗バーと残り文字数表示を追加しました。
  - 送信可能状態を分かりやすく表示し、送信中は入力を編集できないようにしました。
  - 入力フォーカス時の表示や、通常テーマ・LEDテーマ向けのデザインを改善しました。
  - モーダル内にアイコンを追加しました。

- **テスト**
  - 入力、送信、破棄確認、送信中の状態など、モーダルの主要な動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
