### PR TITLE
TTSのRemote Configにプラットフォーム別スイッチを追加してiOS/Android個別に停止できるようにする

### DIFF
--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import {
   getEtaFallbackArrivalConfirmMarginSec,
@@ -28,9 +29,17 @@ const mockRemoteConfig = (body: unknown, ok = true) => {
   });
 };
 
+// jest-expo の既定 Platform.OS は 'ios'。プラットフォーム別キーのテストでは明示的に
+// 切り替え、afterEach で必ず元へ戻す。
+const originalPlatformOS = Platform.OS;
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+};
+
 afterEach(() => {
   jest.clearAllMocks();
   resetRemoteConfigCache();
+  setPlatformOS(originalPlatformOS);
 });
 
 afterAll(() => {
@@ -195,6 +204,134 @@ describe('isTTSFeatureEnabled（サーバー側キルスイッチ）', () => {
     await expect(setupRemoteConfig()).rejects.toThrow(
       'remote config fetch failed: 503'
     );
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+});
+
+describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () => {
+  it('プラットフォーム別キーが未配信ならマスタースイッチに従う', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled: true });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+
+  it('iOSのみ有効な配信ではAndroidが無効になる', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_ios: true,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  it('Androidのみ有効な配信ではiOSが無効になる', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_ios: false,
+      tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(false);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+
+  it('両方のプラットフォーム別キーがfalseなら両OSで無効', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_ios: false,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(false);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  it('マスタースイッチがfalseならプラットフォーム別キーがtrueでも無効', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: false,
+      tts_enabled_ios: true,
+      tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(false);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  it('マスタースイッチ未配信でもプラットフォーム別キーで片方を止められる', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  it('真偽値以外のプラットフォーム別キーは無視してフォールバックする', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_ios: 'false',
+      tts_enabled_android: 0,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+
+  it('iOS/Android以外のプラットフォームではマスタースイッチのみで判定する', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_ios: false,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('web');
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+
+  it('resetRemoteConfigCache でプラットフォーム別キーも破棄される', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: true,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+
+    resetRemoteConfigCache();
     expect(isTTSFeatureEnabled()).toBe(true);
   });
 });

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
 import { workerUrl } from './workerApi';
 
@@ -16,9 +17,14 @@ export const REMOTE_CONFIG_KEYS = {
   // ETAフォールバックを継続してよい最大時間(分)。GPS喪失がこれを超えて続く場合は
   // フォールバックを打ち切り、不確実な推定に依存し続けないようにする。
   ETA_FALLBACK_MAX_DURATION_MIN: 'eta_fallback_max_duration_min',
-  // TTS(自動アナウンス)機能の有効/無効。false のとき設定画面のTTSトグルを無効化し、
-  // 音声合成バックエンド障害時などにサーバー側から機能を止められるようにする。
+  // TTS(自動アナウンス)機能の全体マスタースイッチ。false のとき設定画面のTTSトグルを
+  // 無効化し、音声合成バックエンド障害時などにサーバー側から機能を止められるようにする。
   TTS_ENABLED: 'tts_enabled',
+  // TTS機能のプラットフォーム別スイッチ。iOS/Android 片方だけで音声合成が壊れた場合に、
+  // 該当プラットフォームのみ false を配信して止められるようにする。マスタースイッチとの
+  // AND で評価されるため、tts_enabled=false は常に全プラットフォームを止める。
+  TTS_ENABLED_IOS: 'tts_enabled_ios',
+  TTS_ENABLED_ANDROID: 'tts_enabled_android',
   // AIエージェント(行き先相談)機能の有効/無効。障害・コスト超過時にサーバー側から
   // エントリポイントごと機能を止められるようにするキルスイッチ。
   AI_AGENT_ENABLED: 'ai_agent_enabled',
@@ -31,6 +37,8 @@ type RemoteConfigResponse = {
   eta_fallback_arrival_confirm_margin_sec?: number;
   eta_fallback_max_duration_min?: number;
   tts_enabled?: boolean;
+  tts_enabled_ios?: boolean;
+  tts_enabled_android?: boolean;
   ai_agent_enabled?: boolean;
 };
 
@@ -48,6 +56,11 @@ const ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK = 30;
 // TTS機能のフォールバック既定値。キルスイッチ用途のため、未配信・取得失敗時は
 // 既存挙動（利用可能）を維持する true をフォールバックとする。
 const TTS_ENABLED_FALLBACK = true;
+
+// TTS機能のプラットフォーム別スイッチのフォールバック既定値。プラットフォーム別キーは
+// 「特定OSだけを止めたいとき」に配信する追加の絞り込みであり、未配信時はマスタースイッチの
+// 判定をそのまま通す必要があるため true をフォールバックとする。
+const TTS_PLATFORM_ENABLED_FALLBACK = true;
 
 // AIエージェント機能のフォールバック既定値。LLM 利用料が発生する機能のため、
 // 未配信・取得失敗時は安全側に倒して無効とする。
@@ -71,6 +84,8 @@ let cachedEtaAssistEnabled: boolean | null = null;
 let cachedEtaFallbackArrivalConfirmMarginSec: number | null = null;
 let cachedEtaFallbackMaxDurationMin: number | null = null;
 let cachedTTSEnabled: boolean | null = null;
+let cachedTTSEnabledIOS: boolean | null = null;
+let cachedTTSEnabledAndroid: boolean | null = null;
 let cachedAIAgentEnabled: boolean | null = null;
 
 // setupRemoteConfig は起動時に非同期で完了するため、初回レンダー後にキャッシュが
@@ -100,6 +115,8 @@ export const resetRemoteConfigCache = (): void => {
   cachedEtaFallbackArrivalConfirmMarginSec = null;
   cachedEtaFallbackMaxDurationMin = null;
   cachedTTSEnabled = null;
+  cachedTTSEnabledIOS = null;
+  cachedTTSEnabledAndroid = null;
   cachedAIAgentEnabled = null;
   notifyRemoteConfigListeners();
 };
@@ -139,6 +156,12 @@ export const setupRemoteConfig = async (): Promise<void> => {
   }
   if (typeof data.tts_enabled === 'boolean') {
     cachedTTSEnabled = data.tts_enabled;
+  }
+  if (typeof data.tts_enabled_ios === 'boolean') {
+    cachedTTSEnabledIOS = data.tts_enabled_ios;
+  }
+  if (typeof data.tts_enabled_android === 'boolean') {
+    cachedTTSEnabledAndroid = data.tts_enabled_android;
   }
   if (typeof data.ai_agent_enabled === 'boolean') {
     cachedAIAgentEnabled = data.ai_agent_enabled;
@@ -198,14 +221,31 @@ export const getEtaFallbackMaxDurationMin = (): number => {
   return ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK;
 };
 
-// TTS(自動アナウンス)機能の有効/無効を同期的に取得する。setupRemoteConfig 完了後は
-// 取得済みのリモート値を、未設定・取得失敗時はフォールバック(true=利用可能)を返す。
-// false のとき設定画面のTTSトグルは無効化される(サーバー側キルスイッチ)。
-export const isTTSFeatureEnabled = (): boolean => {
-  if (cachedTTSEnabled != null) {
-    return cachedTTSEnabled;
+// 実行中プラットフォーム向けのTTSスイッチを同期的に取得する。iOS/Android 以外
+// (web など)はプラットフォーム別キーを持たないため、常にフォールバック(true)を返して
+// マスタースイッチの判定へ委ねる。
+const isTTSPlatformEnabled = (): boolean => {
+  switch (Platform.OS) {
+    case 'ios':
+      return cachedTTSEnabledIOS ?? TTS_PLATFORM_ENABLED_FALLBACK;
+    case 'android':
+      return cachedTTSEnabledAndroid ?? TTS_PLATFORM_ENABLED_FALLBACK;
+    default:
+      return TTS_PLATFORM_ENABLED_FALLBACK;
   }
-  return TTS_ENABLED_FALLBACK;
+};
+
+// TTS(自動アナウンス)機能の有効/無効を同期的に取得する。全体マスタースイッチ
+// (tts_enabled)と実行中プラットフォームのスイッチ(tts_enabled_ios / tts_enabled_android)の
+// AND で判定するため、以下をサーバー側から表現できる。
+//   - iOS/Android 両方有効: tts_enabled=true（プラットフォーム別キーは未配信または両方 true）
+//   - 片方のみ有効: tts_enabled=true かつ止めたい側のみ false
+//   - 全体停止: tts_enabled=false（プラットフォーム別キーの値によらず停止）
+// setupRemoteConfig 完了後は取得済みのリモート値を、未設定・取得失敗時はフォールバック
+// (true=利用可能)を返す。false のとき設定画面のTTSトグルは無効化される(サーバー側キルスイッチ)。
+export const isTTSFeatureEnabled = (): boolean => {
+  const masterEnabled = cachedTTSEnabled ?? TTS_ENABLED_FALLBACK;
+  return masterEnabled && isTTSPlatformEnabled();
 };
 
 // AIエージェント(行き先相談)機能の有効/無効を同期的に取得する。setupRemoteConfig 完了後は


### PR DESCRIPTION
## 概要

TTS(自動アナウンス)機能の Remote Config による利用可否を、iOS / Android で個別に制御できるようにしました。

これまで `tts_enabled` の 1 キーしか無く「全プラットフォーム有効」か「全プラットフォーム無効」の二択でしたが、プラットフォーム別キー `tts_enabled_ios` / `tts_enabled_android` を追加し、以下 3 パターンをサーバー側から表現できるようにしています。

| ケース | 配信する値 |
| ---- | ---- |
| iOS/Android 両方で利用可能 | `tts_enabled: true`（プラットフォーム別キーは未配信でよい） |
| どちらか一方のみ利用可能 | `tts_enabled: true` + 止めたい側のみ `false`（例: `tts_enabled_android: false`） |
| そもそも利用不可 | `tts_enabled: false`（プラットフォーム別キーの値によらず全停止） |

判定はマスタースイッチ(`tts_enabled`)と実行中プラットフォームのスイッチの **AND** です。オーバーライドではなく AND にすることで、障害時のキルスイッチである `tts_enabled: false` が常に最優先で全停止する挙動を保証しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/remoteConfig.ts`: `REMOTE_CONFIG_KEYS` に `TTS_ENABLED_IOS` (`tts_enabled_ios`) / `TTS_ENABLED_ANDROID` (`tts_enabled_android`) を追加し、レスポンス型・キャッシュ・`resetRemoteConfigCache` を対応。
- `src/lib/remoteConfig.ts`: `isTTSFeatureEnabled()` を、マスタースイッチと `Platform.OS` に応じたプラットフォーム別スイッチの AND で判定するよう変更。プラットフォーム解決は非公開の `isTTSPlatformEnabled()` に切り出し。
- `src/lib/remoteConfig.test.ts`: プラットフォーム別スイッチのテストを 9 ケース追加（iOSのみ有効 / Androidのみ有効 / 両方false / マスターfalse優先 / マスター未配信＋片側停止 / 非boolean値の無視 / iOS・Android以外のプラットフォーム / キャッシュリセット）。

補足:

- **後方互換**: プラットフォーム別キーが未配信の場合は従来どおりマスタースイッチのみで判定するため、BFF 側を変更するまでは現行と完全に同一の挙動になります。
- **フォールバック**: 取得失敗・未配信・非 boolean 値（`"false"` や `0` など）は無視して `true` に倒し、既存の「未配信時は利用可能」方針を踏襲しています。
- iOS / Android 以外（web など）はプラットフォーム別キーを持たないため、マスタースイッチのみで判定します。
- 呼び出し側（`useTTSFeatureEnabled` / `FxTTS` / `TTSSettings`）は無改修です。既存の `subscribeRemoteConfig` 購読経由で、起動時の非同期取得完了後も設定画面のトグル無効化と `FxTTS` のアンマウントが反映されます。

なお、実際に配信するには別リポジトリ [TrainLCD/BFF](https://github.com/TrainLCD/BFF) 側の `GET /config/remote`（KV `config:remote`）へ新キーを追加する必要があります。本 PR の範囲外です。

## テスト

`npm run lint` / `npm test` / `npm run typecheck` をローカルで実行し、すべて成功することを確認しました。

- lint: `Checked 626 files` エラーなし
- test: 214 suites / 2256 tests すべて成功
- typecheck: エラーなし

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_011TgTZ5BQW2ChyHgpsC9j8R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * TTS（音声読み上げ）の有効・無効を、iOSとAndroidで個別に設定できるようになりました。
  * 全体設定とプラットフォーム別設定の両方が有効な場合のみ、TTSが利用されます。
  * iOS・Android以外の環境では、プラットフォーム別設定の影響を受けずにTTSを利用できます。

* **改善**
  * リモート設定のキャッシュ更新・リセット時にも、TTS設定が正しく反映されるようになりました。
  * 未設定や不正な設定値でも、安定して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->