### PR TITLE
WearOSとversionCodeが衝突しないようAndroidの採番を2刻みに修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,12 +143,12 @@ android {
             dimension "environment"
             applicationId "me.tinykitten.trainlcd.dev"
             versionNameSuffix "-dev"
-            versionCode 100000587
+            versionCode 100000589
             versionName "10.12.1"
         }
         prod {
             dimension "environment"
-            versionCode 100000587
+            versionCode 100000589
             versionName "10.12.1"
         }
     }

--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -85,12 +85,12 @@ android {
       dimension = "environment"
       applicationIdSuffix = ".dev"
       versionNameSuffix = "-dev"
-      versionCode = 100000588
+      versionCode = 100000590
       versionName = "10.12.1"
     }
     create("prod") {
       dimension = "environment"
-      versionCode = 100000588
+      versionCode = 100000590
       versionName = "10.12.1"
     }
   }

--- a/app.config.ts
+++ b/app.config.ts
@@ -60,7 +60,7 @@ export default {
   android: {
     package: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',
     permissions: [],
-    versionCode: 100000587,
+    versionCode: 100000589,
   },
   owner: 'trainlcd',
   experiments: {

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -109,6 +109,14 @@ the **highest** `versionCode` among those whose device requirements are met, and
 `:app` (`minSdk 24`, no watch feature declared) satisfies Wear OS device
 requirements too. `:wearable` must therefore always be `:app` + 1.
 
+Because `:wearable` permanently occupies `:app` + 1, **one release consumes two
+version codes**. `scripts/bump-version.js` therefore advances `:app` by 2 per
+bump — advancing it by 1 would make this release's `:app` reuse the previous
+release's `:wearable`, and Play rejects the upload with
+`Version code ... has already been used.` The script also fails fast when an
+explicit `--android-version` lands at or below the current Wear OS
+`versionCode`.
+
 `scripts/bump-version.js` enforces this automatically and corrects the value
 even when the two have drifted or collided. Do not edit the Wear OS
 `versionCode` by hand.

--- a/docs/bump-version-on-canary-pr.md
+++ b/docs/bump-version-on-canary-pr.md
@@ -14,7 +14,10 @@
 3. `npm ci` で依存関係インストール
 4. `npm run version:bump -- --no-version-increment` を実行
    - アプリのバージョン（`X.Y.Z`）は変更しない
-   - iOS ビルド番号と Android versionCode のみ+1
+   - iOS ビルド番号のみ+1
+   - Android versionCode は`:app`を+2、`:wearable`を`:app`+1に更新
+     （`:wearable`が`:app`+1を占有し1リリースで2つ消費するため。詳細は
+     [android-build-workflows.md](./android-build-workflows.md#versioncode-ordering)）
 5. `peter-evans/create-pull-request@v7` でversion-bump PRを作成
    - ブランチ: `auto-version-bump-<PR番号>`
    - ベースブランチ: PRのヘッドブランチ

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -13,6 +13,13 @@ const wearableBuildGradlePath = path.join(rootDir, 'android', 'wearable', 'build
 const semverPattern = /^\d+\.\d+\.\d+$/;
 const allowedIncrements = new Set(['major', 'minor', 'patch']);
 
+// :wearable は :app と同じ applicationId を共有し、その versionCode は必ず
+// 「:app + 1」に固定される（理由は updateWearableBuildGradle のコメントを参照）。
+// つまり 1 リリースで versionCode を 2 つ消費するため、:app の増分を 1 にすると
+// 前回の :wearable と今回の :app が同じ値になり、Play が
+// "Version code ... has already been used." を返してアップロードが失敗する。
+const ANDROID_VERSION_CODE_STEP = 2;
+
 const args = process.argv.slice(2);
 let explicitVersion = null;
 let increment = null;
@@ -372,13 +379,29 @@ let nextAndroidVersionCode;
 if (resolvedAndroidExplicit !== null) {
   nextAndroidVersionCode = resolvedAndroidExplicit;
 } else if (shouldIncrementAndroid) {
-  nextAndroidVersionCode = currentAndroidVersionCode + 1;
+  nextAndroidVersionCode = currentAndroidVersionCode + ANDROID_VERSION_CODE_STEP;
 } else {
   nextAndroidVersionCode = currentAndroidVersionCode;
 }
 
 if (!Number.isInteger(nextAndroidVersionCode)) {
   console.error('エラー: AndroidのversionCodeは整数である必要があります。');
+  process.exit(1);
+}
+
+// versionCode を進める意図があるときだけ検査する。据え置き（--no-android-increment）では
+// :app < :wearable が正常な状態なので、この検査を通すと必ず落ちてしまう。
+const androidVersionCodeShouldAdvance =
+  resolvedAndroidExplicit !== null || shouldIncrementAndroid;
+if (
+  androidVersionCodeShouldAdvance &&
+  nextAndroidVersionCode <= currentWearableVersionCode
+) {
+  console.error(
+    `エラー: AndroidのversionCode ${nextAndroidVersionCode} は現在のWear OS versionCode ${currentWearableVersionCode} 以下です。` +
+      'Playでは両モジュールがversionCodeの名前空間を共有するため、既に消費済みの番号と衝突します。' +
+      `--android-version には ${currentWearableVersionCode + 1} 以上を指定してください。`
+  );
   process.exit(1);
 }
 

--- a/scripts/bump-version.test.js
+++ b/scripts/bump-version.test.js
@@ -1,0 +1,202 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const scriptSource = path.resolve(__dirname, 'bump-version.js');
+
+const appConfigTemplate = (version, versionCode, iosBuildNumber) => `export default {
+  name: 'TrainLCD',
+  version: '${version}',
+  ios: {
+    bundleIdentifier: 'me.tinykitten.trainlcd',
+    buildNumber: '${iosBuildNumber}',
+  },
+  android: {
+    package: 'me.tinykitten.trainlcd',
+    versionCode: ${versionCode},
+  },
+};
+`;
+
+const appBuildGradleTemplate = (versionCode, versionName) => `android {
+    flavorDimensions += "environment"
+    productFlavors {
+        dev {
+            dimension "environment"
+            applicationId "me.tinykitten.trainlcd.dev"
+            versionNameSuffix "-dev"
+            versionCode ${versionCode}
+            versionName "${versionName}"
+        }
+        prod {
+            dimension "environment"
+            versionCode ${versionCode}
+            versionName "${versionName}"
+        }
+    }
+}
+`;
+
+const wearableBuildGradleTemplate = (versionCode, versionName) => `android {
+  productFlavors {
+    create("dev") {
+      dimension = "environment"
+      applicationIdSuffix = ".dev"
+      versionNameSuffix = "-dev"
+      versionCode = ${versionCode}
+      versionName = "${versionName}"
+    }
+    create("prod") {
+      dimension = "environment"
+      versionCode = ${versionCode}
+      versionName = "${versionName}"
+    }
+  }
+}
+`;
+
+const pbxprojTemplate = (projectVersion, marketingVersion) => `
+    CURRENT_PROJECT_VERSION = ${projectVersion};
+    MARKETING_VERSION = ${marketingVersion};
+`;
+
+const workspaces = [];
+
+/**
+ * bump-version.js はリポジトリルートを `__dirname/..` で解決する実行スクリプトなので、
+ * import して単体で叩けない。スクリプトごと一時ディレクトリへ複製し、最小構成の
+ * バージョン定義ファイルを置いた擬似リポジトリで実行して振る舞いを検証する。
+ */
+const createWorkspace = ({
+  version = '10.12.1',
+  appVersionCode = 100000586,
+  wearableVersionCode = appVersionCode + 1,
+  iosBuildNumber = 2824,
+} = {}) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-version-'));
+  workspaces.push(root);
+
+  fs.mkdirSync(path.join(root, 'scripts'));
+  fs.mkdirSync(path.join(root, 'android', 'app'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'android', 'wearable'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'ios', 'TrainLCD.xcodeproj'), {
+    recursive: true,
+  });
+
+  fs.copyFileSync(scriptSource, path.join(root, 'scripts', 'bump-version.js'));
+  fs.writeFileSync(
+    path.join(root, 'app.config.ts'),
+    appConfigTemplate(version, appVersionCode, iosBuildNumber)
+  );
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    `${JSON.stringify({ name: 'trainlcd', version }, null, 2)}\n`
+  );
+  fs.writeFileSync(
+    path.join(root, 'android', 'app', 'build.gradle'),
+    appBuildGradleTemplate(appVersionCode, version)
+  );
+  fs.writeFileSync(
+    path.join(root, 'android', 'wearable', 'build.gradle.kts'),
+    wearableBuildGradleTemplate(wearableVersionCode, version)
+  );
+  fs.writeFileSync(
+    path.join(root, 'ios', 'TrainLCD.xcodeproj', 'project.pbxproj'),
+    pbxprojTemplate(iosBuildNumber, version)
+  );
+
+  return root;
+};
+
+const runBump = (root, args = []) =>
+  execFileSync(
+    process.execPath,
+    [path.join(root, 'scripts', 'bump-version.js'), ...args],
+    { encoding: 'utf8' }
+  );
+
+const readAppVersionCode = (root) => {
+  const content = fs.readFileSync(
+    path.join(root, 'android', 'app', 'build.gradle'),
+    'utf8'
+  );
+  return Number(/prod\s*\{[\s\S]*?versionCode\s+(\d+)/m.exec(content)[1]);
+};
+
+const readWearableVersionCode = (root) => {
+  const content = fs.readFileSync(
+    path.join(root, 'android', 'wearable', 'build.gradle.kts'),
+    'utf8'
+  );
+  return Number(
+    /create\("prod"\)\s*\{[\s\S]*?versionCode\b\s*=\s*(\d+)/m.exec(content)[1]
+  );
+};
+
+afterEach(() => {
+  while (workspaces.length > 0) {
+    fs.rmSync(workspaces.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('bump-version.js の Android versionCode 採番', () => {
+  it(':wearable を :app + 1 に追従させる', () => {
+    const root = createWorkspace({ appVersionCode: 100000586 });
+
+    runBump(root, ['--no-version-increment']);
+
+    expect(readWearableVersionCode(root)).toBe(readAppVersionCode(root) + 1);
+  });
+
+  it('1リリースあたり2つ消費するため :app を2ずつ進める', () => {
+    const root = createWorkspace({ appVersionCode: 100000586 });
+
+    runBump(root, ['--no-version-increment']);
+
+    expect(readAppVersionCode(root)).toBe(100000588);
+    expect(readWearableVersionCode(root)).toBe(100000589);
+  });
+
+  // 回帰テスト: 増分が1だと前回の :wearable と今回の :app が同値になり、Play が
+  // "Version code ... has already been used." を返してアップロードが落ちていた。
+  it('連続してbumpしてもPlayで消費済みのversionCodeと衝突しない', () => {
+    const root = createWorkspace({ appVersionCode: 100000586 });
+    const consumed = [readAppVersionCode(root), readWearableVersionCode(root)];
+
+    for (let i = 0; i < 5; i += 1) {
+      runBump(root, ['--no-version-increment']);
+      consumed.push(readAppVersionCode(root), readWearableVersionCode(root));
+    }
+
+    expect(new Set(consumed).size).toBe(consumed.length);
+  });
+
+  it('現在の :wearable 以下のversionCodeを明示指定したら失敗する', () => {
+    const root = createWorkspace({
+      appVersionCode: 100000586,
+      wearableVersionCode: 100000587,
+    });
+
+    expect(() =>
+      runBump(root, [
+        '--no-version-increment',
+        '--android-version',
+        '100000587',
+      ])
+    ).toThrow();
+    expect(readAppVersionCode(root)).toBe(100000586);
+  });
+
+  it('据え置き指定では :app < :wearable のままでも失敗しない', () => {
+    const root = createWorkspace({
+      appVersionCode: 100000586,
+      wearableVersionCode: 100000587,
+    });
+
+    runBump(root, ['--no-version-increment', '--no-android-increment']);
+
+    expect(readAppVersionCode(root)).toBe(100000586);
+    expect(readWearableVersionCode(root)).toBe(100000587);
+  });
+});


### PR DESCRIPTION
## 概要

Android の canary ビルドが Google Play へのアップロードで `Version code 100000587 has already been used.` を返して失敗していた問題（[Actions run 31345700721](https://github.com/TrainLCD/MobileApp/actions/runs/31345700721/job/93327103174)）を、versionCode 採番の根本原因から修正します。

`:app` と `:wearable` は `applicationId` を共有するため Play 上で versionCode の名前空間がひとつです。#6616 で `:wearable` を `:app` + 1 に追従させた一方、`:app` の増分は +1 のままでした。その結果 **1 リリースで versionCode を 2 つ消費するのに 1 しか進まず**、毎回「前回の `:wearable`」と「今回の `:app`」が同値になって衝突します。

実際に直近で 2 回発生しています。

| ラン | `:app` | `:wearable` | 結果 |
| --- | --- | --- | --- |
| 31288189172 | 582 | **583** | success（583 を消費） |
| 31297036156 | **583** | 584 | failure（583 が重複） |
| — | 585 | 586 | 手動で 584 を飛ばして復旧（#6627） |
| 31298966973 | 586 | **587** | success（587 を消費） |
| 31345700721 | **587** | 588 | failure（587 が重複） |

#6627 は現在値を手で飛ばしただけで採番ロジックは直っていなかったため、同じ失敗を繰り返していました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `scripts/bump-version.js` に `ANDROID_VERSION_CODE_STEP = 2` を導入し、`:app` の versionCode を 2 ずつ進めるよう変更（`:wearable` が `:app` + 1 を恒久的に占有するため）。
- `--android-version` の明示指定が現在の Wear OS versionCode 以下になる場合にエラー終了するガードを追加。人力採番でも Play へ投げる前に気付けるようにする。据え置き（`--no-android-increment`）時は `:app < :wearable` が正常な状態なので検査対象から除外。
- 消費済みの `:app` 100000587 を是正し、`:app` を 100000589 / `:wearable` を 100000590 へ更新（`app.config.ts` も追従）。100000588 は失敗ランで AAB がビルドだけされている番号のため、artifact の取り違えを避けて跨いでいます。
- `scripts/bump-version.test.js` を新規追加。スクリプトを一時ディレクトリの擬似リポジトリへ複製して実行する方式で 5 ケースを検証し、うち 1 件は「連続 5 回 bump しても消費済み versionCode が重複しない」ことを直接確認する回帰テストです。
- `docs/android-build-workflows.md` の versionCode ordering 節に「1 リリースで 2 消費・`:app` は +2」を追記し、`docs/bump-version-on-canary-pr.md` の「versionCode のみ +1」という実態と異なる記述を修正。

### 回帰リスクと緩和策

- **リスク**: versionCode の採番が変わるため、以後 Play 上の番号が 2 刻みで進みます。versionCode は単調増加であればよく、連番である必要はないため機能影響はありません。
- **リスク**: 現在値を 587 → 589 へ飛ばしています。588 が未消費であることは失敗ランで Wear OS アップロードのステップが skip されている（`-` 表示）ことから確認済みです。
- **緩和策**: 追加したガードにより、万一 `:app` が `:wearable` 以下に落ちる採番になった場合は Play へ投げる前にスクリプトが失敗します。回帰テストで採番ロジック自体も CI で保護されます。
- iOS のビルド番号は本件と無関係なため `--no-ios-increment` を指定して据え置き（2824 のまま）です。

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

```bash
npm run lint      # Checked 626 files, No fixes applied
npm run typecheck # エラーなし
npm test          # 215 suites / 2261 tests passed（うち新規 5 tests）
```

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - AndroidアプリおよびWear OSアプリのリリースバージョンを更新しました。
  - AndroidとWear OSで重複しないバージョン番号を自動管理できるようになりました。

- **ドキュメント**
  - AndroidおよびWear OSのバージョン番号運用ルールを明確化しました。

- **品質改善**
  - バージョン番号の連続更新や不正な指定を検証し、リリース時の設定ミスを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->