### PR TITLE
TTSのRemote Config判定をプラットフォーム別キーのみに変更して旧バージョンへの影響を防ぐ

### DIFF
--- a/src/components/FxTTS.test.tsx
+++ b/src/components/FxTTS.test.tsx
@@ -88,7 +88,7 @@ describe('FxTTS', () => {
     expect(mockedUseTTS).toHaveBeenCalled();
     mockedUseTTS.mockClear();
 
-    // 起動時の非同期取得が後から tts_enabled=false を返したケースを再現する
+    // 起動時の非同期取得が後からTTS無効(プラットフォーム別キーがfalse)を返したケースを再現する
     mockedIsTTSFeatureEnabled.mockReturnValue(false);
     emitRemoteConfigUpdate();
 

--- a/src/components/FxTTS.tsx
+++ b/src/components/FxTTS.tsx
@@ -11,7 +11,8 @@ const FxTTSInner: React.FC = () => {
 
 // TTS無効時は useTTSText のテキスト構築（毎tick約19ms）ごとスキップする。
 // 有効化時にマウントされ直し、行先選択直後と同じ初回発話抑止から始まる。
-// Remote Config のキルスイッチ(tts_enabled=false)時は、ユーザー設定が有効でも
+// Remote Config のキルスイッチ(tts_enabled_ios / tts_enabled_android)が無効を示す場合は、
+// ユーザー設定が有効でも
 // 再生を止める。設定画面のトグル表示(無効化)と実挙動を一致させるため。
 // 起動時の非同期取得完了後に false が届いたケースでも購読経由で確実にアンマウントする。
 export const FxTTS: React.FC = () => {

--- a/src/hooks/useTTSFeatureEnabled.ts
+++ b/src/hooks/useTTSFeatureEnabled.ts
@@ -1,7 +1,8 @@
 import { useSyncExternalStore } from 'react';
 import { isTTSFeatureEnabled, subscribeRemoteConfig } from '~/lib/remoteConfig';
 
-// TTS機能キルスイッチ(tts_enabled)のリアクティブ版。setupRemoteConfig は起動時に
+// TTS機能キルスイッチ(tts_enabled_ios / tts_enabled_android)のリアクティブ版。
+// setupRemoteConfig は起動時に
 // 非同期で完了するため、同期読みだけではコールドスタート時にフォールバック(true)で
 // 描画された後、false 到着時の再レンダーが保証されない。キャッシュ更新を購読して
 // 確実に再評価させる。

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -182,14 +182,16 @@ describe('isTTSFeatureEnabled（サーバー側キルスイッチ）', () => {
   });
 
   it('returns the remote boolean after setup', async () => {
-    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled: false });
+    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled_ios: false });
     await setupRemoteConfig();
+    setPlatformOS('ios');
     expect(isTTSFeatureEnabled()).toBe(false);
   });
 
   it('RemoteがONなら有効', async () => {
-    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled: true });
+    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled_ios: true });
     await setupRemoteConfig();
+    setPlatformOS('ios');
     expect(isTTSFeatureEnabled()).toBe(true);
   });
 
@@ -209,8 +211,8 @@ describe('isTTSFeatureEnabled（サーバー側キルスイッチ）', () => {
 });
 
 describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () => {
-  it('プラットフォーム別キーが未配信ならマスタースイッチに従う', async () => {
-    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled: true });
+  it('プラットフォーム別キーが未配信なら両OSで有効', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500 });
     await setupRemoteConfig();
 
     setPlatformOS('ios');
@@ -222,7 +224,6 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
   it('iOSのみ有効な配信ではAndroidが無効になる', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
-      tts_enabled: true,
       tts_enabled_ios: true,
       tts_enabled_android: false,
     });
@@ -237,7 +238,6 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
   it('Androidのみ有効な配信ではiOSが無効になる', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
-      tts_enabled: true,
       tts_enabled_ios: false,
       tts_enabled_android: true,
     });
@@ -252,6 +252,50 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
   it('両方のプラットフォーム別キーがfalseなら両OSで無効', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
+      tts_enabled_ios: false,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(false);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  it('片方のプラットフォーム別キーだけ配信された場合、未配信側はフォールバック(有効)になる', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled_android: false,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+  });
+
+  // 旧バージョン(プラットフォーム別キー非対応)向けの tts_enabled とは独立して制御できる
+  // ことを保証する回帰テスト。tts_enabled=false のまま当バージョンだけ再開できる。
+  it('旧バージョン向けの tts_enabled は参照しない', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled: false,
+      tts_enabled_ios: true,
+      tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isTTSFeatureEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(true);
+  });
+
+  it('tts_enabled=true でもプラットフォーム別キーがfalseなら無効', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
       tts_enabled: true,
       tts_enabled_ios: false,
       tts_enabled_android: false,
@@ -264,38 +308,19 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
     expect(isTTSFeatureEnabled()).toBe(false);
   });
 
-  it('マスタースイッチがfalseならプラットフォーム別キーがtrueでも無効', async () => {
-    mockRemoteConfig({
-      max_permit_accuracy: 1500,
-      tts_enabled: false,
-      tts_enabled_ios: true,
-      tts_enabled_android: true,
-    });
-    await setupRemoteConfig();
-
-    setPlatformOS('ios');
-    expect(isTTSFeatureEnabled()).toBe(false);
-    setPlatformOS('android');
-    expect(isTTSFeatureEnabled()).toBe(false);
-  });
-
-  it('マスタースイッチ未配信でもプラットフォーム別キーで片方を止められる', async () => {
-    mockRemoteConfig({
-      max_permit_accuracy: 1500,
-      tts_enabled_android: false,
-    });
+  it('プラットフォーム別キー未配信時に tts_enabled=false でもフォールバック(有効)になる', async () => {
+    mockRemoteConfig({ max_permit_accuracy: 1500, tts_enabled: false });
     await setupRemoteConfig();
 
     setPlatformOS('ios');
     expect(isTTSFeatureEnabled()).toBe(true);
     setPlatformOS('android');
-    expect(isTTSFeatureEnabled()).toBe(false);
+    expect(isTTSFeatureEnabled()).toBe(true);
   });
 
-  it('真偽値以外のプラットフォーム別キーは無視してフォールバックする', async () => {
+  it('真偽値以外のプラットフォーム別キーは無視してフォールバック(有効)する', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
-      tts_enabled: true,
       tts_enabled_ios: 'false',
       tts_enabled_android: 0,
     });
@@ -307,10 +332,9 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
     expect(isTTSFeatureEnabled()).toBe(true);
   });
 
-  it('iOS/Android以外のプラットフォームではマスタースイッチのみで判定する', async () => {
+  it('iOS/Android以外のプラットフォームでは常にフォールバック(有効)になる', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
-      tts_enabled: true,
       tts_enabled_ios: false,
       tts_enabled_android: false,
     });
@@ -323,7 +347,6 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
   it('resetRemoteConfigCache でプラットフォーム別キーも破棄される', async () => {
     mockRemoteConfig({
       max_permit_accuracy: 1500,
-      tts_enabled: true,
       tts_enabled_android: false,
     });
     await setupRemoteConfig();

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -17,12 +17,14 @@ export const REMOTE_CONFIG_KEYS = {
   // ETAフォールバックを継続してよい最大時間(分)。GPS喪失がこれを超えて続く場合は
   // フォールバックを打ち切り、不確実な推定に依存し続けないようにする。
   ETA_FALLBACK_MAX_DURATION_MIN: 'eta_fallback_max_duration_min',
-  // TTS(自動アナウンス)機能の全体マスタースイッチ。false のとき設定画面のTTSトグルを
-  // 無効化し、音声合成バックエンド障害時などにサーバー側から機能を止められるようにする。
+  // TTS(自動アナウンス)機能の旧マスタースイッチ。プラットフォーム別キーを解釈しない
+  // 旧バージョンのアプリだけがこのキーを見るため、当バージョンでは参照しない。
+  // Worker 側は旧バージョンの制御用に配信を継続する必要がある(旧バージョンのTTSを
+  // 止め続けたい場合は false のまま維持する)。
   TTS_ENABLED: 'tts_enabled',
-  // TTS機能のプラットフォーム別スイッチ。iOS/Android 片方だけで音声合成が壊れた場合に、
-  // 該当プラットフォームのみ false を配信して止められるようにする。マスタースイッチとの
-  // AND で評価されるため、tts_enabled=false は常に全プラットフォームを止める。
+  // TTS機能のプラットフォーム別スイッチ。当バージョンはこの2キーだけでTTSの有効/無効を
+  // 判定するため、旧バージョン向けの tts_enabled とは独立して iOS/Android を個別に
+  // 停止・再開できる。未配信・不正値のときはフォールバック(true=利用可能)。
   TTS_ENABLED_IOS: 'tts_enabled_ios',
   TTS_ENABLED_ANDROID: 'tts_enabled_android',
   // AIエージェント(行き先相談)機能の有効/無効。障害・コスト超過時にサーバー側から
@@ -36,6 +38,7 @@ type RemoteConfigResponse = {
   eta_assist_enabled?: boolean;
   eta_fallback_arrival_confirm_margin_sec?: number;
   eta_fallback_max_duration_min?: number;
+  // 旧バージョン向けに配信され続けるが、当バージョンでは読み取らない(下記2キーで判定する)。
   tts_enabled?: boolean;
   tts_enabled_ios?: boolean;
   tts_enabled_android?: boolean;
@@ -53,14 +56,9 @@ const ETA_FALLBACK_ARRIVAL_CONFIRM_MARGIN_SEC_FALLBACK = 30;
 // ETAフォールバックを継続してよい最大時間(分)のフォールバック既定値。
 const ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK = 30;
 
-// TTS機能のフォールバック既定値。キルスイッチ用途のため、未配信・取得失敗時は
-// 既存挙動（利用可能）を維持する true をフォールバックとする。
+// TTS機能(プラットフォーム別スイッチ)のフォールバック既定値。キルスイッチ用途のため、
+// 未配信・取得失敗時は既存挙動（利用可能）を維持する true をフォールバックとする。
 const TTS_ENABLED_FALLBACK = true;
-
-// TTS機能のプラットフォーム別スイッチのフォールバック既定値。プラットフォーム別キーは
-// 「特定OSだけを止めたいとき」に配信する追加の絞り込みであり、未配信時はマスタースイッチの
-// 判定をそのまま通す必要があるため true をフォールバックとする。
-const TTS_PLATFORM_ENABLED_FALLBACK = true;
 
 // AIエージェント機能のフォールバック既定値。LLM 利用料が発生する機能のため、
 // 未配信・取得失敗時は安全側に倒して無効とする。
@@ -83,7 +81,6 @@ let cachedForceNotArrivedEnabled: boolean | null = null;
 let cachedEtaAssistEnabled: boolean | null = null;
 let cachedEtaFallbackArrivalConfirmMarginSec: number | null = null;
 let cachedEtaFallbackMaxDurationMin: number | null = null;
-let cachedTTSEnabled: boolean | null = null;
 let cachedTTSEnabledIOS: boolean | null = null;
 let cachedTTSEnabledAndroid: boolean | null = null;
 let cachedAIAgentEnabled: boolean | null = null;
@@ -114,7 +111,6 @@ export const resetRemoteConfigCache = (): void => {
   cachedEtaAssistEnabled = null;
   cachedEtaFallbackArrivalConfirmMarginSec = null;
   cachedEtaFallbackMaxDurationMin = null;
-  cachedTTSEnabled = null;
   cachedTTSEnabledIOS = null;
   cachedTTSEnabledAndroid = null;
   cachedAIAgentEnabled = null;
@@ -154,9 +150,7 @@ export const setupRemoteConfig = async (): Promise<void> => {
   if (maxDurationMin != null) {
     cachedEtaFallbackMaxDurationMin = maxDurationMin;
   }
-  if (typeof data.tts_enabled === 'boolean') {
-    cachedTTSEnabled = data.tts_enabled;
-  }
+  // tts_enabled は旧バージョン専用キーのため、ここでは取り込まない。
   if (typeof data.tts_enabled_ios === 'boolean') {
     cachedTTSEnabledIOS = data.tts_enabled_ios;
   }
@@ -221,31 +215,25 @@ export const getEtaFallbackMaxDurationMin = (): number => {
   return ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK;
 };
 
-// 実行中プラットフォーム向けのTTSスイッチを同期的に取得する。iOS/Android 以外
-// (web など)はプラットフォーム別キーを持たないため、常にフォールバック(true)を返して
-// マスタースイッチの判定へ委ねる。
-const isTTSPlatformEnabled = (): boolean => {
-  switch (Platform.OS) {
-    case 'ios':
-      return cachedTTSEnabledIOS ?? TTS_PLATFORM_ENABLED_FALLBACK;
-    case 'android':
-      return cachedTTSEnabledAndroid ?? TTS_PLATFORM_ENABLED_FALLBACK;
-    default:
-      return TTS_PLATFORM_ENABLED_FALLBACK;
-  }
-};
-
-// TTS(自動アナウンス)機能の有効/無効を同期的に取得する。全体マスタースイッチ
-// (tts_enabled)と実行中プラットフォームのスイッチ(tts_enabled_ios / tts_enabled_android)の
-// AND で判定するため、以下をサーバー側から表現できる。
-//   - iOS/Android 両方有効: tts_enabled=true（プラットフォーム別キーは未配信または両方 true）
-//   - 片方のみ有効: tts_enabled=true かつ止めたい側のみ false
-//   - 全体停止: tts_enabled=false（プラットフォーム別キーの値によらず停止）
+// TTS(自動アナウンス)機能の有効/無効を同期的に取得する。判定は実行中プラットフォームの
+// スイッチ(tts_enabled_ios / tts_enabled_android)のみで行い、旧バージョン専用となった
+// マスタースイッチ(tts_enabled)は参照しない。旧バージョンは tts_enabled しか見ないため、
+// 両者を独立して配信することで以下を表現できる。
+//   - 旧バージョンだけ止める: tts_enabled=false かつ tts_enabled_ios/android=true
+//   - 片方のプラットフォームだけ止める: 止めたい側のみ false
+//   - 全プラットフォーム停止: tts_enabled_ios / tts_enabled_android の両方を false
+// iOS/Android 以外(web など)はプラットフォーム別キーを持たないため常にフォールバックを返す。
 // setupRemoteConfig 完了後は取得済みのリモート値を、未設定・取得失敗時はフォールバック
 // (true=利用可能)を返す。false のとき設定画面のTTSトグルは無効化される(サーバー側キルスイッチ)。
 export const isTTSFeatureEnabled = (): boolean => {
-  const masterEnabled = cachedTTSEnabled ?? TTS_ENABLED_FALLBACK;
-  return masterEnabled && isTTSPlatformEnabled();
+  switch (Platform.OS) {
+    case 'ios':
+      return cachedTTSEnabledIOS ?? TTS_ENABLED_FALLBACK;
+    case 'android':
+      return cachedTTSEnabledAndroid ?? TTS_ENABLED_FALLBACK;
+    default:
+      return TTS_ENABLED_FALLBACK;
+  }
 };
 
 // AIエージェント(行き先相談)機能の有効/無効を同期的に取得する。setupRemoteConfig 完了後は

--- a/src/screens/TTSSettings.test.tsx
+++ b/src/screens/TTSSettings.test.tsx
@@ -108,7 +108,7 @@ describe('TTSSettingsScreen', () => {
     expect(storage.contains(STORAGE_KEYS.TTS_ENABLED_LANGUAGES)).toBe(false);
   });
 
-  describe('feature flag(tts_enabled)がfalseの場合', () => {
+  describe('feature flag(プラットフォーム別TTSキー)がfalseの場合', () => {
     beforeEach(() => {
       mockedIsTTSFeatureEnabled.mockReturnValue(false);
     });


### PR DESCRIPTION
## 概要

Remote Config による TTS の有効/無効判定を、旧マスタースイッチ `tts_enabled` から切り離し、プラットフォーム別キー `tts_enabled_ios` / `tts_enabled_android` のみで行うように変更する。

従来は `tts_enabled` とプラットフォーム別キーの AND で判定していたため、`tts_enabled: false` で TTS を停止している状態から特定プラットフォームだけ再開するには `tts_enabled` を `true` に戻す必要があり、プラットフォーム別キーを解釈しない旧バージョンのアプリでも TTS が復活してしまう問題があった。判定を分離することで、旧バージョン向けの `tts_enabled` と対応バージョン向けのプラットフォーム別キーを独立して制御できるようにする。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `isTTSFeatureEnabled()` を `Platform.OS` に応じた `tts_enabled_ios` / `tts_enabled_android` のみで判定するよう変更（iOS/Android 以外はフォールバック `true`）
- `tts_enabled` のキャッシュ・取り込み処理と AND 合成ヘルパー `isTTSPlatformEnabled()` を削除し、`TTS_PLATFORM_ENABLED_FALLBACK` を `TTS_ENABLED_FALLBACK` へ一本化
- `REMOTE_CONFIG_KEYS.TTS_ENABLED` と `RemoteConfigResponse.tts_enabled` は Worker 側との対応表として定義のみ残し、「旧バージョン専用キーで当バージョンは参照しない」旨をコメントで明記
- `src/lib/remoteConfig.test.ts` のテストをプラットフォーム別キーベースへ全面移行。`tts_enabled: false` でもプラットフォーム別キーが `true` なら有効になること、`tts_enabled: true` でもプラットフォーム別キーが `false` なら無効になることを回帰テストとして追加
- `FxTTS.tsx` / `useTTSFeatureEnabled.ts` および関連テストのコメント・`describe` 名を新しい判定基準に合わせて更新

### 回帰リスクと緩和策

- **リリース順序の依存**: プラットフォーム別キー未配信時のフォールバックは `true`（利用可能）のため、`/config/remote` が `tts_enabled_ios` / `tts_enabled_android` を返さない状態で本変更をリリースすると、現在 `tts_enabled: false` で停止中の TTS が本バージョンでのみ有効化される。**BFF（TrainLCD/BFF）で両キーの配信を先に有効化してからリリースすること**で回避する。
- **全プラットフォーム停止の操作変更**: 全体停止は `tts_enabled: false` ではなく `tts_enabled_ios` / `tts_enabled_android` の両方を `false` にする操作へ変わる。この運用は `REMOTE_CONFIG_KEYS` および `isTTSFeatureEnabled()` のコメントに明記済み。
- **判定範囲の限定**: 変更は Remote Config の TTS 判定のみで、TTS の再生ロジック・ユーザー設定・他の Remote Config キーには手を入れていない。既存の `FxTTS` マウント制御と設定画面のトグル無効化はキルスイッチの購読経路をそのまま利用しており、挙動は不変（既存テストで担保）。

## テスト

`npm run lint` / `npm test` / `npm run typecheck` をローカルで実行し、いずれも成功することを確認済み（215 suites / 2263 tests パス）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 音声読み上げ（TTS）の有効・無効設定を、iOSとAndroidで個別に制御できるようになりました。
  * 各プラットフォームの設定が無効の場合、ユーザー設定が有効でもTTSの再生を停止します。
  * 対応する設定が配信されていない場合の動作を整理しました。

* **テスト**
  * プラットフォーム別設定や各種フォールバック動作の検証を追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->