### PR TITLE
プリセット保存時の始発駅指定フローを廃止して経路内の最寄駅から自動解決

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -310,8 +310,6 @@
   "presetNameLabel": "Preset name",
   "presetNamePlaceholder": "Preset name",
   "save": "Save",
-  "selectStartStationTitle": "Select starting station",
-  "departure": "Dep.",
   "wrongDirectionWarning": "You may be traveling in the wrong direction. Please check your app settings.",
   "wrongDirectionLoopLineWarning": "You may be traveling in the wrong direction. As this is a loop line, you will still arrive, but it will take longer.",
   "wrongDirectionNotificationTitle": "Direction Alert",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -311,8 +311,6 @@
   "presetNameLabel": "プリセット名",
   "presetNamePlaceholder": "プリセット名",
   "save": "保存",
-  "selectStartStationTitle": "始発駅を選択",
-  "departure": "始発",
   "wrongDirectionWarning": "選択した行き先と逆方向に進んでいる可能性があります。アプリの設定をご確認ください。",
   "wrongDirectionLoopLineWarning": "選択した行き先と逆方向に進んでいる可能性があります。環状線のため到着は可能ですが、遠回りになります。",
   "wrongDirectionNotificationTitle": "方向のお知らせ",

--- a/src/components/SavePresetNameModal.tsx
+++ b/src/components/SavePresetNameModal.tsx
@@ -2,7 +2,6 @@ import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  Animated,
   Keyboard,
   Platform,
   Pressable,
@@ -11,32 +10,20 @@ import {
   type TextInput as TextInputType,
   View,
 } from 'react-native';
-import type { Line, Station } from '~/@types/graphql';
 import { FONTS, LED_THEME_BG_COLOR } from '~/constants';
-import type { LineDirection } from '~/models/Bound';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { RFValue } from '~/utils/rfValue';
-import { getStationName } from '~/utils/station';
 import Button from './Button';
-import { CommonCard } from './CommonCard';
 import { CustomModal } from './CustomModal';
 import { Heading } from './Heading';
 import Typography from './Typography';
 
-export type DirectionOption = {
-  direction: LineDirection;
-  fromStation: Station;
-  toStation: Station;
-  line: Line;
-};
-
 type Props = {
   visible: boolean;
   onClose: () => void;
-  onSubmit: (name: string, direction: LineDirection | null) => void;
+  onSubmit: (name: string) => void;
   defaultName: string;
-  directionOptions?: DirectionOption[];
 };
 
 const styles = StyleSheet.create({
@@ -70,15 +57,6 @@ const styles = StyleSheet.create({
   saveButton: {
     width: 120,
   },
-  directionSectionTitle: {
-    fontSize: RFValue(13),
-    fontWeight: 'bold',
-    marginTop: 32,
-    marginBottom: 16,
-  },
-  directionCardContainer: {
-    marginBottom: 16,
-  },
 });
 
 export const SavePresetNameModal: React.FC<Props> = ({
@@ -86,62 +64,18 @@ export const SavePresetNameModal: React.FC<Props> = ({
   onClose,
   onSubmit,
   defaultName,
-  directionOptions,
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const textInputRef = useRef<TextInputType>(null);
   const textRef = useRef(defaultName);
   const [isEmpty, setIsEmpty] = useState(false);
-  const [selectedDirection, setSelectedDirection] =
-    useState<LineDirection | null>(null);
-  const inboundOpacity = useRef(new Animated.Value(1)).current;
-  const outboundOpacity = useRef(new Animated.Value(1)).current;
-
-  const hasDirectionOptions =
-    directionOptions != null && directionOptions.length > 0;
 
   useEffect(() => {
     if (visible) {
       textRef.current = defaultName;
       setIsEmpty(!defaultName.trim());
-      setSelectedDirection(
-        directionOptions?.length === 1 ? directionOptions[0].direction : null
-      );
-      inboundOpacity.setValue(1);
-      outboundOpacity.setValue(1);
     }
-  }, [visible, defaultName, directionOptions, inboundOpacity, outboundOpacity]);
-
-  useEffect(() => {
-    const duration = 200;
-    if (selectedDirection === null) {
-      Animated.parallel([
-        Animated.timing(inboundOpacity, {
-          toValue: 1,
-          duration,
-          useNativeDriver: true,
-        }),
-        Animated.timing(outboundOpacity, {
-          toValue: 1,
-          duration,
-          useNativeDriver: true,
-        }),
-      ]).start();
-    } else {
-      Animated.parallel([
-        Animated.timing(inboundOpacity, {
-          toValue: selectedDirection === 'INBOUND' ? 1 : 0.4,
-          duration,
-          useNativeDriver: true,
-        }),
-        Animated.timing(outboundOpacity, {
-          toValue: selectedDirection === 'OUTBOUND' ? 1 : 0.4,
-          duration,
-          useNativeDriver: true,
-        }),
-      ]).start();
-    }
-  }, [selectedDirection, inboundOpacity, outboundOpacity]);
+  }, [visible, defaultName]);
 
   const handleChangeText = useCallback((text: string) => {
     textRef.current = text;
@@ -151,9 +85,8 @@ export const SavePresetNameModal: React.FC<Props> = ({
   const handleSubmit = useCallback(() => {
     const name = textRef.current.trim();
     if (!name) return;
-    if (hasDirectionOptions && !selectedDirection) return;
-    onSubmit(name, selectedDirection);
-  }, [onSubmit, selectedDirection, hasDirectionOptions]);
+    onSubmit(name);
+  }, [onSubmit]);
 
   const handleShow = useCallback(() => {
     if (Platform.OS === 'ios') {
@@ -161,8 +94,6 @@ export const SavePresetNameModal: React.FC<Props> = ({
     }
   }, []);
 
-  const canSubmit =
-    !isEmpty && (!hasDirectionOptions || selectedDirection !== null);
   const textColor = isLEDTheme ? '#fff' : '#000';
 
   return (
@@ -205,51 +136,13 @@ export const SavePresetNameModal: React.FC<Props> = ({
           onSubmitEditing={handleSubmit}
         />
 
-        {hasDirectionOptions && directionOptions.length > 1 && (
-          <>
-            <Typography
-              style={[styles.directionSectionTitle, { color: textColor }]}
-            >
-              {translate('selectStartStationTitle')}
-            </Typography>
-            {directionOptions.map((opt) => {
-              const fromName = getStationName(opt.fromStation);
-              const toName = getStationName(opt.toStation);
-              const title = `${fromName}(${translate('departure')})`;
-              const subtitle = `${fromName} → ${toName}`;
-              const animatedOpacity =
-                opt.direction === 'INBOUND' ? inboundOpacity : outboundOpacity;
-              return (
-                <Animated.View
-                  key={opt.direction}
-                  style={[
-                    styles.directionCardContainer,
-                    { opacity: animatedOpacity },
-                  ]}
-                >
-                  <CommonCard
-                    line={opt.line}
-                    title={title}
-                    hideParens
-                    hideChevron
-                    checked={selectedDirection === opt.direction}
-                    subtitle={subtitle}
-                    targetStation={opt.fromStation}
-                    onPress={() => setSelectedDirection(opt.direction)}
-                  />
-                </Animated.View>
-              );
-            })}
-          </>
-        )}
-
         <View style={styles.buttonContainer}>
           <Button onPress={onClose} outline>
             {translate('cancel')}
           </Button>
           <Button
             style={styles.saveButton}
-            disabled={!canSubmit}
+            disabled={isEmpty}
             onPress={handleSubmit}
           >
             {translate('save')}

--- a/src/components/SelectBoundModal.render.test.tsx
+++ b/src/components/SelectBoundModal.render.test.tsx
@@ -1,4 +1,9 @@
-import { fireEvent, render, within } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from '@testing-library/react-native';
 import { useAtom, useAtomValue } from 'jotai';
 import type React from 'react';
 import { pendingLineAtom, selectedLineAtom } from '../store/atoms/line';
@@ -18,6 +23,7 @@ import { isLEDThemeAtom } from '../store/atoms/theme';
 import { SelectBoundModal } from './SelectBoundModal';
 
 const mockRouteInfoModal = jest.fn();
+const mockSaveRoute = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   CommonActions: { navigate: jest.fn() },
@@ -41,7 +47,7 @@ jest.mock('~/hooks', () => ({
   useSavedRoutes: jest.fn(() => ({
     isInitialized: true,
     find: jest.fn(() => null),
-    save: jest.fn(),
+    save: mockSaveRoute,
     remove: jest.fn(),
   })),
   usePresetStops: jest.fn(() => ({
@@ -126,11 +132,24 @@ jest.mock('./TrainTypeListModal', () => ({
   TrainTypeListModal: () => null,
 }));
 jest.mock('./SavePresetNameModal', () => ({
-  SavePresetNameModal: ({ visible }: { visible: boolean }) =>
+  SavePresetNameModal: ({
+    visible,
+    onSubmit,
+  }: {
+    visible: boolean;
+    onSubmit: (name: string) => void;
+  }) =>
     visible
       ? (() => {
-          const { View } = require('react-native');
-          return <View testID="save-preset-modal" />;
+          const { Pressable, View } = require('react-native');
+          return (
+            <View testID="save-preset-modal">
+              <Pressable
+                testID="save-preset-submit"
+                onPress={() => onSubmit('テストプリセット')}
+              />
+            </View>
+          );
         })()
       : null,
 }));
@@ -242,5 +261,49 @@ describe('SelectBoundModal', () => {
     const props = lastCall?.[0] as { stations: Array<{ groupId: number }> };
 
     expect(props.stations.map((station) => station.groupId)).toEqual([1, 2, 3]);
+  });
+
+  // 乗車駅が未設定だと effectiveStation は stations[0] へ倒れるため、
+  // そこから向きを決めると常に INBOUND になってしまう
+  it('乗車駅が未設定の場合はGPS確定駅の座標から保存する向きを決める', async () => {
+    const routeStations = [
+      { groupId: 1, latitude: 35.75, longitude: 139.8 },
+      { groupId: 2, latitude: 35.74, longitude: 139.79 },
+      { groupId: 3, latitude: 35.72, longitude: 139.77 },
+      { groupId: 4, latitude: 35.7, longitude: 139.75 },
+    ].map(({ groupId, latitude, longitude }) => ({
+      id: groupId,
+      groupId,
+      latitude,
+      longitude,
+      line: { id: 10 },
+      lines: [{ id: 10 }],
+    }));
+
+    mockAtomValues({
+      // GPS確定駅は駅一覧の末尾側(駅4付近)にあり、行き先(駅2)の反対側になる
+      station: { id: 99, groupId: 99, latitude: 35.701, longitude: 139.751 },
+      pendingStation: null,
+      pendingStations: routeStations,
+      wantedDestination: routeStations[1],
+      pendingLine: { id: 10, name: '山手線', nameRoman: 'Yamanote Line' },
+    });
+
+    const screen = render(
+      <SelectBoundModal
+        visible={true}
+        onClose={jest.fn()}
+        loading={false}
+        error={null}
+        onTrainTypeSelect={jest.fn()}
+        onBoundSelect={jest.fn()}
+      />
+    );
+
+    fireEvent.press(screen.getByText('saveCurrentRoute'));
+    fireEvent.press(screen.getByTestId('save-preset-submit'));
+
+    await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
+    expect(mockSaveRoute.mock.calls[0][0].direction).toBe('OUTBOUND');
   });
 });

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -31,6 +31,7 @@ import {
 import getIsPass from '~/utils/isPass';
 import isTablet from '~/utils/isTablet';
 import { getLocalizedLineName, isBusLine } from '~/utils/line';
+import { resolvePresetSaveDirection } from '~/utils/presetRouteEndpoints';
 import { showToast } from '~/utils/toast';
 import Button from '../components/Button';
 import { navigationRef } from '../stacks/rootNavigation';
@@ -52,10 +53,7 @@ import stationState, {
 import { CommonCard } from './CommonCard';
 import { CustomModal } from './CustomModal';
 import { RouteInfoModal } from './RouteInfoModal';
-import {
-  type DirectionOption,
-  SavePresetNameModal,
-} from './SavePresetNameModal';
+import { SavePresetNameModal } from './SavePresetNameModal';
 import { SelectBoundSettingListModal } from './SelectBoundSettingListModal';
 import { TrainTypeListModal } from './TrainTypeListModal';
 
@@ -641,32 +639,16 @@ export const SelectBoundModal: React.FC<Props> = ({
     setIsPresetNameModalVisible(true);
   }, [savedRoute, removeCurrentRoute, line]);
 
-  const presetDirectionOptions = useMemo(() => {
-    if (!wantedDestination || !line || !stations.length) return undefined;
-    const options: DirectionOption[] = [];
-    // INBOUND: stations リスト先頭側から終点方向へ向かう列車
-    const firstStation = stations[0];
-    const lastStation = stations[stations.length - 1];
-    if (inboundStations.length && firstStation) {
-      options.push({
-        direction: 'INBOUND',
-        fromStation: firstStation,
-        toStation: wantedDestination,
-        line: (firstStation.line as Line) ?? line,
-      });
-    }
-    // OUTBOUND: stations リスト末尾側から始点方向へ向かう列車
-    if (outboundStations.length && lastStation) {
-      options.push({
-        direction: 'OUTBOUND',
-        fromStation: lastStation,
-        toStation: wantedDestination,
-        line: (lastStation.line as Line) ?? line,
-      });
-    }
-    // fromStation と toStation が同じ場合は除外
-    return options.filter((o) => o.fromStation.groupId !== o.toStation.groupId);
-  }, [wantedDestination, line, stations, inboundStations, outboundStations]);
+  // 終点を明示指定した場合の始発駅はユーザーに選ばせず、経路内の最寄駅から自動で決める
+  const presetSaveDirection = useMemo(
+    () =>
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: wantedDestination?.groupId ?? null,
+        currentStation: effectiveStation ?? confirmedStation,
+      }),
+    [stations, wantedDestination?.groupId, effectiveStation, confirmedStation]
+  );
 
   const presetDefaultName = useMemo(() => {
     const trainName = pendingTrainType
@@ -678,8 +660,10 @@ export const SelectBoundModal: React.FC<Props> = ({
   }, [pendingTrainType, line]);
 
   const handlePresetNameSubmit = useCallback(
-    async (name: string, direction: LineDirection | null) => {
+    async (name: string) => {
       if (!line) return;
+
+      const direction = presetSaveDirection;
 
       // 有効な駅IDのみ保存する（wantedDestinationで区間を絞った場合に範囲外を除外）
       const validStationIds = new Set(
@@ -737,6 +721,7 @@ export const SelectBoundModal: React.FC<Props> = ({
       wantedDestination?.groupId,
       targetStationIds,
       effectiveStations,
+      presetSaveDirection,
     ]
   );
 
@@ -1024,7 +1009,6 @@ export const SelectBoundModal: React.FC<Props> = ({
         onClose={() => setIsPresetNameModalVisible(false)}
         onSubmit={handlePresetNameSubmit}
         defaultName={presetDefaultName}
-        directionOptions={presetDirectionOptions}
       />
     </>
   );

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -227,19 +227,30 @@ export const SelectBoundModal: React.FC<Props> = ({
     [wantedDestination, stations]
   );
 
+  // 終点を明示指定した場合の始発駅はユーザーに選ばせず、経路内の最寄駅から自動で決める。
+  // effectiveStation は区間外なら stations[0] へ倒れてしまい実際の現在地を表さないので、
+  // 生の pendingStation を渡して未設定・区間外のときだけ GPS 確定駅の座標へフォールバックさせる
+  const presetSaveDirection = useMemo(
+    () =>
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: wantedDestination?.groupId ?? null,
+        currentStation: station ?? confirmedStation,
+      }),
+    [stations, wantedDestination?.groupId, station, confirmedStation]
+  );
+
+  // 保存対象の区間。direction から導くことで、保存する向きと通知駅の絞り込み範囲がズレないようにする
   const effectiveStations = useMemo(() => {
-    if (!applicableWantedDestination || !effectiveStation) return stations;
-    const currentIdx = stations.findIndex(
-      (s) => s.groupId === effectiveStation.groupId
-    );
+    if (!applicableWantedDestination || !presetSaveDirection) return stations;
     const destIdx = stations.findIndex(
       (s) => s.groupId === applicableWantedDestination.groupId
     );
-    if (currentIdx === -1 || destIdx === -1) return stations;
-    return currentIdx <= destIdx
+    if (destIdx === -1) return stations;
+    return presetSaveDirection === 'INBOUND'
       ? stations.slice(0, destIdx + 1)
       : stations.slice(destIdx);
-  }, [stations, applicableWantedDestination, effectiveStation]);
+  }, [stations, applicableWantedDestination, presetSaveDirection]);
 
   const currentIndex = stations.findIndex(
     (s) => s.groupId === effectiveStation?.groupId
@@ -638,17 +649,6 @@ export const SelectBoundModal: React.FC<Props> = ({
 
     setIsPresetNameModalVisible(true);
   }, [savedRoute, removeCurrentRoute, line]);
-
-  // 終点を明示指定した場合の始発駅はユーザーに選ばせず、経路内の最寄駅から自動で決める
-  const presetSaveDirection = useMemo(
-    () =>
-      resolvePresetSaveDirection({
-        stations,
-        wantedDestinationId: wantedDestination?.groupId ?? null,
-        currentStation: effectiveStation ?? confirmedStation,
-      }),
-    [stations, wantedDestination?.groupId, effectiveStation, confirmedStation]
-  );
 
   const presetDefaultName = useMemo(() => {
     const trainName = pendingTrainType

--- a/src/utils/presetRouteEndpoints.test.ts
+++ b/src/utils/presetRouteEndpoints.test.ts
@@ -2,6 +2,7 @@ import type { Station } from '~/@types/graphql';
 import {
   getPresetOriginStation,
   getPresetRouteEndpoints,
+  resolvePresetSaveDirection,
 } from './presetRouteEndpoints';
 
 const createStation = (groupId: number): Station =>
@@ -142,5 +143,125 @@ describe('getPresetOriginStation', () => {
         direction: 'OUTBOUND',
       })?.groupId
     ).toBe(1);
+  });
+});
+
+describe('resolvePresetSaveDirection', () => {
+  // 座標付きの駅一覧: 1(北)→4(南) の順に並ぶ
+  const coordStations = [
+    { groupId: 1, latitude: 35.75, longitude: 139.8 },
+    { groupId: 2, latitude: 35.74, longitude: 139.79 },
+    { groupId: 3, latitude: 35.72, longitude: 139.77 },
+    { groupId: 4, latitude: 35.7, longitude: 139.75 },
+  ].map(({ groupId, latitude, longitude }) => ({
+    ...createStation(groupId),
+    latitude,
+    longitude,
+  }));
+
+  it('行き先が未指定ならnullを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: null,
+        currentStation: stations[0],
+      })
+    ).toBeNull();
+  });
+
+  it('行き先が駅一覧に無い場合はnullを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 999,
+        currentStation: stations[0],
+      })
+    ).toBeNull();
+  });
+
+  it('駅が1駅しか無い場合は始発駅になり得る駅が無いのでnullを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations: [createStation(1)],
+        wantedDestinationId: 1,
+        currentStation: createStation(1),
+      })
+    ).toBeNull();
+  });
+
+  it('行き先が先頭駅なら始発駅は末尾側に定まるのでOUTBOUNDを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 1,
+        currentStation: stations[0],
+      })
+    ).toBe('OUTBOUND');
+  });
+
+  it('行き先が末尾駅なら始発駅は先頭側に定まるのでINBOUNDを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 4,
+        currentStation: stations[3],
+      })
+    ).toBe('INBOUND');
+  });
+
+  it('現在駅が行き先より手前ならINBOUNDを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 3,
+        currentStation: stations[1],
+      })
+    ).toBe('INBOUND');
+  });
+
+  it('現在駅が行き先より奥ならOUTBOUNDを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 2,
+        currentStation: stations[3],
+      })
+    ).toBe('OUTBOUND');
+  });
+
+  it('現在駅が駅一覧に無い場合は座標最寄りの駅から向きを決める', () => {
+    // 駅3の近くにいるが駅一覧には含まれない駅
+    const offRoute = {
+      ...createStation(99),
+      latitude: 35.7205,
+      longitude: 139.7705,
+    };
+    expect(
+      resolvePresetSaveDirection({
+        stations: coordStations,
+        wantedDestinationId: 2,
+        currentStation: offRoute,
+      })
+    ).toBe('OUTBOUND');
+  });
+
+  it('現在駅が行き先そのものでも座標最寄りの駅から向きを決める', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations: coordStations,
+        wantedDestinationId: 2,
+        currentStation: coordStations[1],
+      })
+    ).toBe('INBOUND');
+  });
+
+  it('現在駅が無く座標も引けない場合はnullを返す', () => {
+    expect(
+      resolvePresetSaveDirection({
+        stations,
+        wantedDestinationId: 2,
+        currentStation: null,
+      })
+    ).toBeNull();
   });
 });

--- a/src/utils/presetRouteEndpoints.ts
+++ b/src/utils/presetRouteEndpoints.ts
@@ -1,5 +1,6 @@
 import type { Station } from '~/@types/graphql';
 import type { LineDirection } from '~/models/Bound';
+import { findNearestByCoord } from './findNearestByCoord';
 
 type PresetRouteLike = {
   stations: Station[];
@@ -25,7 +26,7 @@ export type PresetRouteEndpoints = {
  * を使っており、後者は並びが反転して返ることがある。
  * その場合 direction をそのまま当てると始発駅が行き先と同じ駅になってしまう。
  *
- * 保存時のUI(SavePresetNameModal)は始発駅と行き先が同じ選択肢を除外しているため、
+ * 保存時の direction 解決(`resolvePresetSaveDirection`)は始発駅が行き先と同じになる向きを選ばないため、
  * 「direction から求めた終端が行き先と一致する」状態は並びの食い違いでしか起こらない。
  * そこを検知したら反対側の終端へ倒すことで、並び順に依存せず始発駅を復元する。
  */
@@ -52,6 +53,70 @@ export const getPresetOriginStation = ({
   }
 
   return origin;
+};
+
+type ResolvePresetSaveDirectionParams = {
+  stations: Station[];
+  wantedDestinationId?: number | null;
+  /** 乗車駅として扱う駅(選択中の乗車駅、無ければGPS確定駅) */
+  currentStation?: Station | null;
+};
+
+/**
+ * プリセット保存時の direction を自動解決する。
+ *
+ * direction は「駅一覧のどちら側の終端から乗るか」を表す(`getPresetOriginStation` 参照)。
+ * 保存する経路は行き先を境に片側だけなので、経路内の最寄駅がどちら側にあるかで向きが一意に決まる。
+ * 実際の始発駅は復元時に `usePresetStops` が経路内の最寄駅として解決する。
+ *
+ * 最寄駅は現在駅が駅一覧に含まれていればその駅を、含まれていなければ座標距離で最も近い駅を採る。
+ *
+ * 行き先そのものは始発駅になり得ないため候補から除外する。
+ * これは `getPresetOriginStation` が並び順の食い違いを検知するための前提でもある。
+ */
+export const resolvePresetSaveDirection = ({
+  stations,
+  wantedDestinationId,
+  currentStation,
+}: ResolvePresetSaveDirectionParams): LineDirection | null => {
+  if (wantedDestinationId == null) {
+    return null;
+  }
+
+  const destIndex = stations.findIndex(
+    (s) => s.groupId === wantedDestinationId
+  );
+  if (destIndex === -1) {
+    return null;
+  }
+
+  // 行き先が終端にある場合、始発駅になり得る終端は反対側だけに定まる
+  const isHead = destIndex === 0;
+  const isTail = destIndex === stations.length - 1;
+  if (isHead && isTail) {
+    return null;
+  }
+  if (isHead) {
+    return 'OUTBOUND';
+  }
+  if (isTail) {
+    return 'INBOUND';
+  }
+
+  const candidates = stations.filter((s) => s.groupId !== wantedDestinationId);
+  const nearest =
+    candidates.find((s) => s.groupId === currentStation?.groupId) ??
+    findNearestByCoord(
+      currentStation?.latitude,
+      currentStation?.longitude,
+      candidates
+    );
+  if (!nearest) {
+    return null;
+  }
+
+  const nearestIndex = stations.findIndex((s) => s.groupId === nearest.groupId);
+  return nearestIndex < destIndex ? 'INBOUND' : 'OUTBOUND';
 };
 
 /**


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

プリセット保存時、終点を明示的にユーザーが設定した場合にだけ表示されていた「始発駅を選択」フローを廃止しました。代わりに、保存する経路内の最寄駅から始発駅（保存される `direction`）を自動で解決します。ユーザーはプリセット名を入力するだけで保存できます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `SavePresetNameModal` から始発駅選択セクション（方向カード2枚・選択必須バリデーション・不透明度アニメーション）を削除。`DirectionOption` 型と `directionOptions` prop も撤去し、`onSubmit` を `(name: string) => void` に簡素化
- `src/utils/presetRouteEndpoints.ts` に `resolvePresetSaveDirection` を追加。保存する経路は行き先を境に片側だけなので、経路内の最寄駅がどちら側にあるかで `direction`（＝駅一覧のどちら側の終端から乗るか）が一意に決まる。最寄駅は「現在駅が駅一覧に含まれていればその駅 → 含まれなければ座標距離で最も近い駅」の順に解決する
- 行き先が駅一覧の終端にある場合は反対側に一意に定まるため、座標計算を経ずに確定させる
- 行き先そのものは始発駅候補から除外。これは既存の `getPresetOriginStation` が駅一覧の並び順の食い違いを検知するための前提（従来は保存時UIのフィルタが担保していたもの）を引き継ぐため
- `SelectBoundModal` の `presetDirectionOptions` を `presetSaveDirection` に置き換え。方向解決には生の `pendingStation`（無ければ GPS 確定駅）を渡す。`effectiveStation` は区間外だと `stations[0]` へ倒れて実際の現在地を表さないため
- `effectiveStations`（`notifyStationIds` の絞り込み範囲）を `presetSaveDirection` から導出するよう変更。復元時の `usePresetStops.presetStops` と同じ切り方に揃えることで、保存する向きと通知駅の絞り込み範囲が構造的にズレないようにした
- 未使用になった翻訳キー `selectStartStationTitle` / `departure` を ja/en 双方から削除
- `resolvePresetSaveDirection` のユニットテストを11件追加（終端ケース、座標フォールバック、現在駅＝行き先のケース、解決不能時の null など）
- `SelectBoundModal.render.test.tsx` に、乗車駅未設定時に GPS 確定駅の座標から向きが決まることを検証するテストを追加

実際の始発駅は復元時に既存の `usePresetStops` の `nearestPresetStation`（経路内の最寄中間駅）が解決するため、「保存した経路内の最寄駅から乗る」挙動はランタイムで成立します。

### 影響範囲・リグレッションリスク

- 保存済みプリセットのデータ構造（`saved_routes` テーブル）は変更していないため、既存プリセットの互換性に影響なし
- `direction` の意味・復元ロジック（`getPresetOriginStation` / `getPresetRouteEndpoints`）は不変。変わるのは保存時に `direction` を誰が決めるか（ユーザー選択 → 自動解決）だけ
- 従来ユーザーが「現在地と逆側の終端から乗る」プリセットを意図的に作れたが、今後は現在地側に自動で寄る。この経路を作る手段は無くなる
- `effectiveStations` の導出変更により、行き先が駅一覧の先頭にある場合の絞り込み範囲が `[行き先]` の1駅から経路全体に変わる（保存される `direction` と整合する側へ修正）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 215 suites / 2274 tests すべて成功。追加したリグレッションテストは、修正前のコードでは `INBOUND` を返して失敗することも確認済みです。なお本セッションの環境にはシミュレータ／エミュレータが無いため、実機でのUI確認は未実施です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プリセット保存時の方向を、現在駅・最寄り駅・行き先から自動判定するようになりました。
  - 保存時に方向を手動で選択する必要がなくなりました。

- **改善**
  - プリセット名の入力を整理し、名前のみで保存できるようになりました。
  - 名前の前後の空白は自動的に除去され、未入力時のみ保存ボタンが無効になります。
  - 不要になった方向選択関連の表示と翻訳を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->