### PR TITLE
取得中にプリセット一覧が作り直されると駅データが空になる問題を修正

### DIFF
--- a/src/hooks/usePresetCarouselData.test.ts
+++ b/src/hooks/usePresetCarouselData.test.ts
@@ -213,6 +213,8 @@ describe('usePresetCarouselData', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
 
+    // 同じ取得対象なので取得は1回だけで、進行中のリクエストは差し替えられない
+    expect(mockQuery).toHaveBeenCalledTimes(1);
     expect(result.current.carouselData).toHaveLength(1);
     expect(result.current.carouselData[0].stations).toEqual(stations);
   });
@@ -275,5 +277,75 @@ describe('usePresetCarouselData', () => {
     expect(result.current.carouselData).toHaveLength(2);
     expect(result.current.carouselData[0].stations).toEqual(addedStations);
     expect(result.current.carouselData[1].stations).toEqual(existingStations);
+  });
+
+  // 追い越された古い応答が共有キャッシュを上書きすると、
+  // 以降の表示更新で古い駅データが使われてしまう
+  it('新しい応答を追い越した古い応答でキャッシュを上書きしない', async () => {
+    const routeA = createLineRoute('uuid-1', 100);
+    const routeB = createLineRoute('uuid-2', 200);
+    const staleStations = [createStation(1, { line: { id: 100 } })];
+    const freshStations = [
+      createStation(10, { line: { id: 100 } }),
+      createStation(11, { line: { id: 100 } }),
+    ];
+    const stationsB = [createStation(20, { line: { id: 200 } })];
+
+    let resolveOld: (value: unknown) => void = () => {};
+    let resolveNew: (value: unknown) => void = () => {};
+    mockQuery
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveNew = resolve;
+        })
+      );
+
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [routeA],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+
+    const { result, rerender } = renderHook(() => usePresetCarouselData());
+
+    // 取得対象が変わるので新しいリクエストが発行される
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [routeA, routeB],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+    await act(async () => {
+      rerender({});
+    });
+
+    // 新しい応答が先に、古い応答が後から返る
+    await act(async () => {
+      resolveNew({
+        data: { lineListStations: [...freshStations, ...stationsB] },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await act(async () => {
+      resolveOld({ data: { lineListStations: staleStations } });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // 表示項目だけの更新でキャッシュから再構築させる
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [{ ...routeA, name: 'renamed' }, routeB],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+    await act(async () => {
+      rerender({});
+    });
+
+    expect(result.current.carouselData[0].stations).toEqual(freshStations);
+    expect(result.current.carouselData[1].stations).toEqual(stationsB);
   });
 });

--- a/src/hooks/usePresetCarouselData.test.ts
+++ b/src/hooks/usePresetCarouselData.test.ts
@@ -176,4 +176,104 @@ describe('usePresetCarouselData', () => {
     // 同じ routes なので query は1回のみ
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
+
+  // 取得中に updateRoutes() などで routes が作り直されると、
+  // 表示のみの更新として既存 carouselData から駅を引き当てようとして空になっていた
+  it('取得中に routes が作り直されても駅データを取りこぼさない', async () => {
+    const route = createLineRoute('uuid-1', 100);
+    const stations = [createStation(10, { line: { id: 100 } })];
+
+    let resolveQuery: (value: unknown) => void = () => {};
+    mockQuery.mockReturnValue(
+      new Promise((resolve) => {
+        resolveQuery = resolve;
+      })
+    );
+
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [route],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+
+    const { result, rerender } = renderHook(() => usePresetCarouselData());
+
+    // 取得完了前に DB から読み直され、内容は同じだが配列・要素の同一性だけが変わる
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [{ ...route }],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+    await act(async () => {
+      rerender({});
+    });
+
+    await act(async () => {
+      resolveQuery({ data: { lineListStations: stations } });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.carouselData).toHaveLength(1);
+    expect(result.current.carouselData[0].stations).toEqual(stations);
+  });
+
+  // 新規保存したプリセットだけ駅が空のまま固定されるのを防ぐ
+  it('取得中に新しいプリセットが増えた場合も全件の駅データが揃う', async () => {
+    const existing = createLineRoute('uuid-1', 100);
+    const added = createLineRoute('uuid-2', 200);
+    const existingStations = [createStation(10, { line: { id: 100 } })];
+    const addedStations = [createStation(20, { line: { id: 200 } })];
+
+    mockQuery.mockResolvedValue({
+      data: { lineListStations: existingStations },
+    });
+
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [existing],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+
+    const { result, rerender } = renderHook(() => usePresetCarouselData());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // プリセット保存直後: 取得が完了する前に routes が作り直される
+    let resolveQuery: (value: unknown) => void = () => {};
+    mockQuery.mockReturnValue(
+      new Promise((resolve) => {
+        resolveQuery = resolve;
+      })
+    );
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [added, existing],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+    await act(async () => {
+      rerender({});
+    });
+
+    (useSavedRoutes as jest.Mock).mockReturnValue({
+      routes: [{ ...added }, { ...existing }],
+      updateRoutes: mockUpdateRoutes,
+      isInitialized: true,
+    });
+    await act(async () => {
+      rerender({});
+    });
+
+    await act(async () => {
+      resolveQuery({
+        data: { lineListStations: [...addedStations, ...existingStations] },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.carouselData).toHaveLength(2);
+    expect(result.current.carouselData[0].stations).toEqual(addedStations);
+    expect(result.current.carouselData[1].stations).toEqual(existingStations);
+  });
 });

--- a/src/hooks/usePresetCarouselData.ts
+++ b/src/hooks/usePresetCarouselData.ts
@@ -17,10 +17,14 @@ export type UsePresetCarouselDataResult = {
 
 export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
   const [carouselData, setCarouselData] = useState<LoopItem[]>([]);
-  const carouselDataRef = useRef<LoopItem[]>([]);
   const prevFetchKeyRef = useRef('');
   const prevDisplayKeyRef = useRef('');
   const currentRequestIdRef = useRef(0);
+  // 取得済みの駅データは路線ID / 種別(lineGroup)IDをキーに保持する。
+  // carouselData から引き当てる方式だと、取得完了前に routes が作り直された際に
+  // まだ駅を持たないプリセットが空配列で確定してしまう
+  const lineStationsCacheRef = useRef(new Map<number, Station[]>());
+  const trainTypeStationsCacheRef = useRef(new Map<number, Station[]>());
 
   const {
     routes,
@@ -44,96 +48,109 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
       )
       .join(',');
 
-    const needsFetch = fetchKey !== prevFetchKeyRef.current;
+    const lineStationsCache = lineStationsCacheRef.current;
+    const trainTypeStationsCache = trainTypeStationsCacheRef.current;
+
+    // 駅データが未取得のプリセットが1件でもあれば取得する。
+    // fetchKey の一致だけで判断すると、取得が完了していない段階でも
+    // 「取得済み」とみなして空配列のまま確定してしまう
+    const hasAllStations = routes.every((r) =>
+      r.hasTrainType
+        ? trainTypeStationsCache.has(r.trainTypeId)
+        : lineStationsCache.has(r.lineId)
+    );
+
+    const needsFetch = fetchKey !== prevFetchKeyRef.current || !hasAllStations;
     const needsDisplayUpdate = displayKey !== prevDisplayKeyRef.current;
 
     if (!needsFetch && !needsDisplayUpdate) return;
 
+    const applyRoutes = () => {
+      const newData = routes.map((r, i) => ({
+        ...r,
+        __k: `${r.id}-${i}`,
+        stations:
+          (r.hasTrainType
+            ? trainTypeStationsCache.get(r.trainTypeId)
+            : lineStationsCache.get(r.lineId)) ?? [],
+      }));
+      setCarouselData(newData);
+      prevDisplayKeyRef.current = displayKey;
+    };
+
+    // 表示項目だけの更新。進行中の取得を打ち切らないよう requestId は進めない
+    if (!needsFetch) {
+      applyRoutes();
+      return;
+    }
+
     const requestId = ++currentRequestIdRef.current;
     // 同じ fetchKey で重複 fetch しないよう即座にマーク
-    if (needsFetch) {
-      prevFetchKeyRef.current = fetchKey;
-    }
+    prevFetchKeyRef.current = fetchKey;
 
     const fetchAsync = async () => {
       try {
-        const lineStationsMap = new Map<number, Station[]>();
-        const trainTypeStationsMap = new Map<number, Station[]>();
+        const lineRoutes = routes.filter((r) => !r.hasTrainType);
+        const trainTypeRoutes = routes.filter((r) => r.hasTrainType);
 
-        if (needsFetch) {
-          const lineRoutes = routes.filter((r) => !r.hasTrainType);
-          const trainTypeRoutes = routes.filter((r) => r.hasTrainType);
-
-          // !hasTrainType のルートを lineListStations で一括取得
-          const validLineRoutes = lineRoutes.filter((r) => r.lineId !== null);
-          if (validLineRoutes.length > 0) {
-            const lineIds = validLineRoutes.map((r) => r.lineId);
-            const result = await gqlClient.query<{
-              lineListStations: Station[];
-            }>({
-              query: GET_LINE_LIST_STATIONS_PRESET,
-              variables: { lineIds },
-            });
-            for (const s of result.data?.lineListStations ?? []) {
-              const lid = s.line?.id;
-              if (lid == null) continue;
-              const arr = lineStationsMap.get(lid);
-              if (arr) {
-                arr.push(s);
-              } else {
-                lineStationsMap.set(lid, [s]);
-              }
-            }
-          }
-
-          // hasTrainType のルートを lineGroupListStations で一括取得
-          if (trainTypeRoutes.length > 0) {
-            const lineGroupIds = trainTypeRoutes.map((r) => r.trainTypeId);
-            const result = await gqlClient.query<{
-              lineGroupListStations: Station[];
-            }>({
-              query: GET_LINE_GROUP_LIST_STATIONS_PRESET,
-              variables: { lineGroupIds },
-            });
-            for (const s of result.data?.lineGroupListStations ?? []) {
-              const gid = s.trainType?.groupId;
-              if (gid == null) continue;
-              const arr = trainTypeStationsMap.get(gid);
-              if (arr) {
-                arr.push(s);
-              } else {
-                trainTypeStationsMap.set(gid, [s]);
-              }
-            }
-          }
-
-          if (requestId !== currentRequestIdRef.current) return;
-        } else {
-          // fetch不要の場合は既存のcarouselDataから駅データを再利用
-          for (const item of carouselDataRef.current) {
-            if (item.hasTrainType) {
-              trainTypeStationsMap.set(item.trainTypeId, item.stations);
+        // !hasTrainType のルートを lineListStations で一括取得
+        const validLineRoutes = lineRoutes.filter((r) => r.lineId !== null);
+        if (validLineRoutes.length > 0) {
+          const lineIds = validLineRoutes.map((r) => r.lineId);
+          const result = await gqlClient.query<{
+            lineListStations: Station[];
+          }>({
+            query: GET_LINE_LIST_STATIONS_PRESET,
+            variables: { lineIds },
+          });
+          const fetched = new Map<number, Station[]>();
+          for (const s of result.data?.lineListStations ?? []) {
+            const lid = s.line?.id;
+            if (lid == null) continue;
+            const arr = fetched.get(lid);
+            if (arr) {
+              arr.push(s);
             } else {
-              lineStationsMap.set(item.lineId, item.stations);
+              fetched.set(lid, [s]);
             }
+          }
+          // 応答に含まれなかった路線も取得済みとして記録し、再取得を繰り返さないようにする
+          for (const lineId of lineIds) {
+            lineStationsCache.set(lineId, fetched.get(lineId) ?? []);
+          }
+        }
+
+        // hasTrainType のルートを lineGroupListStations で一括取得
+        if (trainTypeRoutes.length > 0) {
+          const lineGroupIds = trainTypeRoutes.map((r) => r.trainTypeId);
+          const result = await gqlClient.query<{
+            lineGroupListStations: Station[];
+          }>({
+            query: GET_LINE_GROUP_LIST_STATIONS_PRESET,
+            variables: { lineGroupIds },
+          });
+          const fetched = new Map<number, Station[]>();
+          for (const s of result.data?.lineGroupListStations ?? []) {
+            const gid = s.trainType?.groupId;
+            if (gid == null) continue;
+            const arr = fetched.get(gid);
+            if (arr) {
+              arr.push(s);
+            } else {
+              fetched.set(gid, [s]);
+            }
+          }
+          for (const groupId of lineGroupIds) {
+            trainTypeStationsCache.set(groupId, fetched.get(groupId) ?? []);
           }
         }
 
         if (requestId !== currentRequestIdRef.current) return;
 
-        const newData = routes.map((r, i) => ({
-          ...r,
-          __k: `${r.id}-${i}`,
-          stations: r.hasTrainType
-            ? (trainTypeStationsMap.get(r.trainTypeId) ?? [])
-            : (lineStationsMap.get(r.lineId) ?? []),
-        }));
-        carouselDataRef.current = newData;
-        setCarouselData(newData);
-        prevDisplayKeyRef.current = displayKey;
+        applyRoutes();
       } catch (err) {
         // fetch失敗時はキーをリセットしてリトライ可能にする
-        if (needsFetch && requestId === currentRequestIdRef.current) {
+        if (requestId === currentRequestIdRef.current) {
           prevFetchKeyRef.current = '';
         }
         console.error(err);

--- a/src/hooks/usePresetCarouselData.ts
+++ b/src/hooks/usePresetCarouselData.ts
@@ -20,6 +20,15 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
   const prevFetchKeyRef = useRef('');
   const prevDisplayKeyRef = useRef('');
   const currentRequestIdRef = useRef(0);
+  // 進行中の取得対象。同じ対象の取得を二重に発行しないために保持する
+  const inFlightFetchKeyRef = useRef<string | null>(null);
+  // 取得完了時は常に最新の routes で表示を組み立てる。
+  // effect のクロージャに閉じ込めると、取得中に routes が変わった場合に
+  // 古い表示内容で確定してしまう
+  const latestRoutesRef = useRef<{ routes: SavedRoute[]; displayKey: string }>({
+    routes: [],
+    displayKey: '',
+  });
   // 取得済みの駅データは路線ID / 種別(lineGroup)IDをキーに保持する。
   // carouselData から引き当てる方式だと、取得完了前に routes が作り直された際に
   // まだ駅を持たないプリセットが空配列で確定してしまう
@@ -48,6 +57,8 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
       )
       .join(',');
 
+    latestRoutesRef.current = { routes, displayKey };
+
     const lineStationsCache = lineStationsCacheRef.current;
     const trainTypeStationsCache = trainTypeStationsCacheRef.current;
 
@@ -60,13 +71,22 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
         : lineStationsCache.has(r.lineId)
     );
 
-    const needsFetch = fetchKey !== prevFetchKeyRef.current || !hasAllStations;
+    // 同じ対象の取得が既に走っている場合は再発行しない。
+    // 未取得判定(hasAllStations)は取得完了まで false のままなので、
+    // これが無いと routes が作り直されるたびに取得をやり直してしまう
+    const isFetchingSameKey = inFlightFetchKeyRef.current === fetchKey;
+    const needsFetch =
+      !isFetchingSameKey &&
+      (fetchKey !== prevFetchKeyRef.current || !hasAllStations);
     const needsDisplayUpdate = displayKey !== prevDisplayKeyRef.current;
 
     if (!needsFetch && !needsDisplayUpdate) return;
 
+    // 表示は常に最新の routes から組み立てる
     const applyRoutes = () => {
-      const newData = routes.map((r, i) => ({
+      const { routes: latestRoutes, displayKey: latestDisplayKey } =
+        latestRoutesRef.current;
+      const newData = latestRoutes.map((r, i) => ({
         ...r,
         __k: `${r.id}-${i}`,
         stations:
@@ -75,11 +95,13 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
             : lineStationsCache.get(r.lineId)) ?? [],
       }));
       setCarouselData(newData);
-      prevDisplayKeyRef.current = displayKey;
+      prevDisplayKeyRef.current = latestDisplayKey;
     };
 
-    // 表示項目だけの更新。進行中の取得を打ち切らないよう requestId は進めない
     if (!needsFetch) {
+      // 進行中の取得と同じ対象なら、その完了時に最新 routes で反映される
+      if (isFetchingSameKey) return;
+      // 表示項目だけの更新。進行中の取得を打ち切らないよう requestId は進めない
       applyRoutes();
       return;
     }
@@ -87,6 +109,7 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
     const requestId = ++currentRequestIdRef.current;
     // 同じ fetchKey で重複 fetch しないよう即座にマーク
     prevFetchKeyRef.current = fetchKey;
+    inFlightFetchKeyRef.current = fetchKey;
 
     const fetchAsync = async () => {
       try {
@@ -103,6 +126,8 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
             query: GET_LINE_LIST_STATIONS_PRESET,
             variables: { lineIds },
           });
+          // 追い越された古い応答で共有キャッシュを汚さない
+          if (requestId !== currentRequestIdRef.current) return;
           const fetched = new Map<number, Station[]>();
           for (const s of result.data?.lineListStations ?? []) {
             const lid = s.line?.id;
@@ -129,6 +154,8 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
             query: GET_LINE_GROUP_LIST_STATIONS_PRESET,
             variables: { lineGroupIds },
           });
+          // 追い越された古い応答で共有キャッシュを汚さない
+          if (requestId !== currentRequestIdRef.current) return;
           const fetched = new Map<number, Station[]>();
           for (const s of result.data?.lineGroupListStations ?? []) {
             const gid = s.trainType?.groupId;
@@ -154,6 +181,11 @@ export const usePresetCarouselData = (): UsePresetCarouselDataResult => {
           prevFetchKeyRef.current = '';
         }
         console.error(err);
+      } finally {
+        // 追い越された古いリクエストが、進行中の新しい取得の印を消さないようにする
+        if (requestId === currentRequestIdRef.current) {
+          inFlightFetchKeyRef.current = null;
+        }
       }
     };
     fetchAsync();


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

新しく保存したプリセットだけが「プリセットの取得に失敗しました」と表示され、そのまま復帰しなくなる問題を修正します。

`PresetCard` がこのエラーを出すのは `from` / `to` が `undefined` のときだけで、`getPresetRouteEndpoints` を辿ると、それが起きるのは `stations` が空配列のときのみです。つまり終着駅や `direction` の値ではなく、駅データの取得結果がプリセットに紐づいていないことが原因でした。

`usePresetCarouselData` にレースコンディションがあります。駅データの取得中に `routes` が作り直されると（`updateRoutes()` による DB 再読み込みなど）、`fetchKey` は変わらないため「取得不要」と判定され、進行中の取得を `requestId` の更新で打ち切ったうえで、既存の `carouselData` から駅を引き当てようとします。新規保存したプリセットはまだ `carouselData` に無いので `?? []` で空配列に確定し、`prevFetchKeyRef` は更新済みなので再取得も走らず、そのプリセットだけエラー表示のまま固定されます。

既存プリセットの駅クエリは react-query のキャッシュに載っていて即座に解決する一方、新規保存したプリセットの路線は未キャッシュでネットワーク待ちになるため、新規保存分だけがこのレースに負けます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 取得済み駅データを `carouselData` から引き当てる方式をやめ、路線ID / 種別(lineGroup)ID をキーにした永続キャッシュ（`lineStationsCacheRef` / `trainTypeStationsCacheRef`）で保持するよう変更。取得完了前に再描画されても、まだ駅を持たないプリセットが空配列で確定しない
- 駅データが未取得のプリセットが1件でもあれば取得する判定（`hasAllStations`）を追加。`fetchKey` の一致だけで「取得済み」と誤認しないようにした
- 表示項目だけの更新では `requestId` を進めないようにし、進行中の取得を打ち切らないよう変更
- 進行中の取得対象を `inFlightFetchKeyRef` で保持し、同じ `fetchKey` の取得を二重発行しないよう変更。`hasAllStations` は取得完了まで `false` のままなので、これが無いと `routes` が作り直されるたびに取得をやり直し、先行リクエストを無効化してしまう
- 取得完了時の表示組み立てを `latestRoutesRef` 経由で最新の `routes` から行うよう変更。effect のクロージャに閉じ込めると、取得中に `routes` が変わった場合に古い表示内容で確定し、以降の再描画も走らなくなる
- 各 `await` の直後・共有キャッシュの更新前に `requestId` を検証し、追い越された古い応答がキャッシュを汚染しないよう変更
- 応答に含まれなかったキーも取得済みとしてキャッシュへ記録し、再取得を繰り返さないようにした
- 未使用になった `carouselDataRef` を削除
- ユニットテストを4件追加（取得中の `routes` 再生成、取得中のプリセット追加、重複取得の抑止、古い応答によるキャッシュ汚染の防止）

### 影響範囲・リグレッションリスク

- 変更は `usePresetCarouselData` に閉じており、保存済みプリセットのデータ構造や `getPresetRouteEndpoints` の解決ロジックには手を入れていない
- 駅データのキャッシュがフック内で存続するようになるため、同一セッション中は同じ路線 / 系統を再取得しない。取得結果が空だったキーも記録するため、無限に再取得を繰り返すことはない
- 表示のみの更新で `requestId` を進めなくなるが、`fetchKey` が変わる更新では従来どおり進めるため、古い応答が新しい応答を上書きすることはない

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

先に失敗するテストを書いて再現を確認してから修正しています。追加した4件はいずれも、対応する修正を戻すと落ちることを個別に確認済みです。`npm test` は 215 suites / 2277 tests すべて成功。

なお、この環境には API の接続情報も実機も無いため、報告された手順（東京メトロ副都心線 地下鉄赤塚駅から新宿三丁目駅を終着に設定）そのものでの再現確認は行えていません。上記のレースは症状と論理的に一致し、テストで再現・修正を確認していますが、修正後も同じエラーが出る場合は別の原因が残ります。その場合に次に疑うべきは、保存された `trainTypeId`（lineGroupId）と `lineGroupListStations` の応答に含まれる `trainType.groupId` の不一致です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
