### PR TITLE
種別を自動選択した際に駅一覧を系統全体へ揃えて始発駅と終着駅のずれを防ぐ

### DIFF
--- a/src/hooks/useLineSelection.test.tsx
+++ b/src/hooks/useLineSelection.test.tsx
@@ -307,6 +307,127 @@ describe('useLineSelection', () => {
     expect(navResult.pendingTrainType).toBeNull();
   });
 
+  // 種別だけ設定して路線単独の駅一覧を残すと、プリセット復元時に使う
+  // lineGroupStations と範囲が食い違い、始発駅・終着駅がずれる
+  it('鉄道路線で station.trainType が指定されていれば lineGroup の駅一覧へ差し替える', async () => {
+    const { mockSetStationState, mockSetNavigationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    // 路線単独の駅一覧（副都心線のみに相当）
+    const lineStations = [
+      createStation(10, { trainType: { id: 1 } } as Parameters<
+        typeof createStation
+      >[1]),
+      createStation(20),
+    ];
+    mockFetchByLineId.mockResolvedValue({
+      data: { lineStations },
+    });
+
+    const trainTypes = [
+      { id: 1, groupId: 500, name: '各駅停車' } as TrainType,
+      { id: 2, groupId: 501, name: '急行' } as TrainType,
+    ];
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: trainTypes },
+    });
+
+    // 直通を含む系統全体の駅一覧
+    const groupStations = [
+      createStation(1),
+      createStation(10),
+      createStation(20),
+      createStation(30),
+    ];
+    mockFetchByGroupId.mockResolvedValue({
+      data: { lineGroupStations: groupStations },
+    });
+
+    const line = createLine(100, {
+      transportType: TransportType.Rail,
+      station: { id: 10, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      await hookRef.current?.handleLineSelected(line);
+    });
+
+    // 指定種別の groupId で駅一覧を取得している
+    expect(mockFetchByGroupId).toHaveBeenCalledWith({
+      variables: { lineGroupId: 500 },
+    });
+
+    const navSetterCalls = mockSetNavigationState.mock.calls;
+    const lastNavSetter = navSetterCalls[navSetterCalls.length - 1][0];
+    const navResult = lastNavSetter(createNavigationState());
+    expect(navResult.pendingTrainType).toEqual(trainTypes[0]);
+
+    const stationSetterCalls = mockSetStationState.mock.calls;
+    const lastStationSetter =
+      stationSetterCalls[stationSetterCalls.length - 1][0];
+    const stationResult = lastStationSetter(createStationState());
+    expect(stationResult.pendingStations).toEqual(groupStations);
+    expect(stationResult.pendingStation?.id).toBe(10);
+  });
+
+  it('lineGroup の駅一覧が空なら路線単独の駅一覧を残す', async () => {
+    const { mockSetStationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    const lineStations = [
+      createStation(10, { trainType: { id: 1 } } as Parameters<
+        typeof createStation
+      >[1]),
+      createStation(20),
+    ];
+    mockFetchByLineId.mockResolvedValue({
+      data: { lineStations },
+    });
+    mockFetchTrainTypes.mockResolvedValue({
+      data: {
+        stationTrainTypes: [{ id: 1, groupId: 500, name: '各駅停車' }],
+      },
+    });
+    mockFetchByGroupId.mockResolvedValue({
+      data: { lineGroupStations: [] },
+    });
+
+    const line = createLine(100, {
+      transportType: TransportType.Rail,
+      station: { id: 10, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      await hookRef.current?.handleLineSelected(line);
+    });
+
+    const stationSetterCalls = mockSetStationState.mock.calls;
+    const lastStationSetter =
+      stationSetterCalls[stationSetterCalls.length - 1][0];
+    const stationResult = lastStationSetter(createStationState());
+    expect(stationResult.pendingStations).toEqual(lineStations);
+  });
+
   it('handleTrainTypeSelect が groupId で駅を取得する', async () => {
     const { mockSetStationState, mockSetNavigationState } = setupMolecules();
     const { mockFetchByGroupId } = setupQueries();

--- a/src/hooks/useLineSelection.test.tsx
+++ b/src/hooks/useLineSelection.test.tsx
@@ -316,7 +316,7 @@ describe('useLineSelection', () => {
 
     // 路線単独の駅一覧（副都心線のみに相当）
     const lineStations = [
-      createStation(10, { trainType: { id: 1 } } as Parameters<
+      createStation(10, { groupId: 100, trainType: { id: 1 } } as Parameters<
         typeof createStation
       >[1]),
       createStation(20),
@@ -333,10 +333,11 @@ describe('useLineSelection', () => {
       data: { stationTrainTypes: trainTypes },
     });
 
-    // 直通を含む系統全体の駅一覧
+    // 直通を含む系統全体の駅一覧。
+    // 直通系統では同じ駅でも駅IDが変わるため、駅ID 10 は含まれず groupId 100 で引き当てる
     const groupStations = [
       createStation(1),
-      createStation(10),
+      createStation(110, { groupId: 100 }),
       createStation(20),
       createStation(30),
     ];
@@ -377,7 +378,8 @@ describe('useLineSelection', () => {
       stationSetterCalls[stationSetterCalls.length - 1][0];
     const stationResult = lastStationSetter(createStationState());
     expect(stationResult.pendingStations).toEqual(groupStations);
-    expect(stationResult.pendingStation?.id).toBe(10);
+    // 駅IDでは引き当てられないので groupId 一致の駅が選ばれる
+    expect(stationResult.pendingStation?.id).toBe(110);
   });
 
   it('lineGroup の駅一覧が空なら路線単独の駅一覧を残す', async () => {
@@ -426,6 +428,97 @@ describe('useLineSelection', () => {
       stationSetterCalls[stationSetterCalls.length - 1][0];
     const stationResult = lastStationSetter(createStationState());
     expect(stationResult.pendingStations).toEqual(lineStations);
+  });
+
+  // 路線を選び直したとき、前の選択の取得結果が新しい状態を上書きしてはいけない
+  it('取得中に別の路線が選ばれたら古い系統駅一覧で上書きしない', async () => {
+    const { mockSetStationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    const lineStationsA = [
+      createStation(10, { trainType: { id: 1 } } as Parameters<
+        typeof createStation
+      >[1]),
+    ];
+    const lineStationsB = [
+      createStation(20, { trainType: { id: 2 } } as Parameters<
+        typeof createStation
+      >[1]),
+    ];
+    // 呼び出し順ではなく引数で解決先を決める（A と B の実行が入れ替わっても壊れないように）
+    mockFetchByLineId.mockImplementation(
+      ({ variables }: { variables: { lineId: number } }) =>
+        Promise.resolve({
+          data: {
+            lineStations:
+              variables.lineId === 100 ? lineStationsA : lineStationsB,
+          },
+        })
+    );
+
+    mockFetchTrainTypes.mockResolvedValue({
+      data: {
+        stationTrainTypes: [
+          { id: 1, groupId: 500, name: 'A' },
+          { id: 2, groupId: 600, name: 'B' },
+        ],
+      },
+    });
+
+    const groupStationsA = [createStation(910)];
+    const groupStationsB = [createStation(920)];
+    let resolveGroupA: ((value: unknown) => void) | undefined;
+    mockFetchByGroupId.mockImplementation(
+      ({ variables }: { variables: { lineGroupId: number } }) => {
+        if (variables.lineGroupId === 500) {
+          return new Promise((resolve) => {
+            resolveGroupA = resolve;
+          });
+        }
+        return Promise.resolve({
+          data: { lineGroupStations: groupStationsB },
+        });
+      }
+    );
+
+    const lineA = createLine(100, {
+      transportType: TransportType.Rail,
+      station: { id: 10, hasTrainTypes: true } as Line['station'],
+    });
+    const lineB = createLine(200, {
+      transportType: TransportType.Rail,
+      station: { id: 20, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      // A を系統駅一覧の取得待ちまで進める
+      const pendingA = hookRef.current?.handleLineSelected(lineA);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(resolveGroupA).toBeDefined();
+
+      // A が系統駅一覧を待っている間に B を選び直す
+      await hookRef.current?.handleLineSelected(lineB);
+
+      // 後から A の応答が返る
+      resolveGroupA?.({ data: { lineGroupStations: groupStationsA } });
+      await pendingA;
+    });
+
+    const stationSetterCalls = mockSetStationState.mock.calls;
+    const lastStationSetter =
+      stationSetterCalls[stationSetterCalls.length - 1][0];
+    const stationResult = lastStationSetter(createStationState());
+    expect(stationResult.pendingStations).toEqual(groupStationsB);
   });
 
   it('handleTrainTypeSelect が groupId で駅を取得する', async () => {

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -165,18 +165,28 @@ export const useLineSelection = (): UseLineSelectionResult => {
           pendingTrainType: initialTrainType as TrainType | null,
         }));
 
-        if (fallbackTrainType?.groupId != null) {
+        // 種別を自動選択したら駅一覧もその系統(直通を含む)へ揃える。
+        // 路線単独の駅一覧のまま種別だけ設定すると、プリセット復元時に使う
+        // lineGroupStations と並び・範囲が食い違い、始発駅・終着駅がずれる
+        if (initialTrainType?.groupId != null) {
           const groupResult = await fetchStationsByLineGroupId({
-            variables: { lineGroupId: fallbackTrainType.groupId },
+            variables: { lineGroupId: initialTrainType.groupId },
           });
           const lineGroupStations = groupResult.data?.lineGroupStations ?? [];
-          setStationState((prev) => ({
-            ...prev,
-            pendingStations: lineGroupStations,
-            pendingStation:
-              lineGroupStations.find((s) => s.id === lineStationId) ??
-              prev.pendingStation,
-          }));
+          // 取得できなかった場合は路線単独の駅一覧を残す（空で潰さない）
+          if (lineGroupStations.length) {
+            setStationState((prev) => ({
+              ...prev,
+              pendingStations: lineGroupStations,
+              // 直通系統では同じ駅でも駅IDが変わりうるため groupId でも引き当てる
+              pendingStation:
+                lineGroupStations.find((s) => s.id === lineStationId) ??
+                lineGroupStations.find(
+                  (s) => s.groupId === pendingStation?.groupId
+                ) ??
+                prev.pendingStation,
+            }));
+          }
         }
       }
     },

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -1,7 +1,7 @@
 import findNearest from 'geolib/es/findNearest';
 import orderByDistance from 'geolib/es/orderByDistance';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
   GET_LINE_GROUP_STATIONS,
@@ -57,6 +57,8 @@ export type UseLineSelectionResult = {
 
 export const useLineSelection = (): UseLineSelectionResult => {
   const [isSelectBoundModalOpen, setIsSelectBoundModalOpen] = useState(false);
+  // 路線を選び直した際に、前の選択の取得結果が新しい状態を上書きしないよう世代を管理する
+  const selectionGenerationRef = useRef(0);
   const setStationState = useSetAtom(stationState);
   const setLineState = useSetAtom(lineStateAtom);
   const setNavigationState = useSetAtom(navigationState);
@@ -97,6 +99,8 @@ export const useLineSelection = (): UseLineSelectionResult => {
       const lineStationId = line.station?.id;
       if (!lineId || !lineStationId) return;
 
+      const generation = ++selectionGenerationRef.current;
+
       setIsSelectBoundModalOpen(true);
 
       setStationState((prev) => ({
@@ -132,6 +136,9 @@ export const useLineSelection = (): UseLineSelectionResult => {
             })
           : null,
       ]);
+      // 取得中に別の路線が選ばれていたら、この呼び出しの結果は破棄する
+      if (generation !== selectionGenerationRef.current) return;
+
       const fetchedStations = data?.lineStations ?? [];
 
       const pendingStation =
@@ -172,6 +179,8 @@ export const useLineSelection = (): UseLineSelectionResult => {
           const groupResult = await fetchStationsByLineGroupId({
             variables: { lineGroupId: initialTrainType.groupId },
           });
+          if (generation !== selectionGenerationRef.current) return;
+
           const lineGroupStations = groupResult.data?.lineGroupStations ?? [];
           // 取得できなかった場合は路線単独の駅一覧を残す（空で潰さない）
           if (lineGroupStations.length) {


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別を持つ路線を選んだとき、プリセットの始発駅・終着駅が意図しない終端になる問題を修正します。

`useLineSelection.handleLineSelected` は、駅の指定種別（`station.trainType`）を `pendingTrainType` へ自動選択する一方、**駅一覧 `pendingStations` は路線単独の `lineStations` のまま**でした。系統全体を取り直す処理はバス経路（`fallbackTrainType`）にしか掛かっていません。

その結果、同じプリセットが2つの異なる駅一覧で表現されます。

- **保存時**（`handleLineSelected`）: `hasTrainType: true` と `trainTypeId` を保存する一方、`direction` や通知駅は**路線単独の並び**で解決する
- **復元時**（`handlePresetPress` → `openModalByTrainTypeId`）: `lineGroupStations` で**直通を含む系統全体**を取得する

保存時の並びで決めた `direction` を、範囲も並びも異なる系統全体のリストへ当てるため、始発駅・終着駅がずれます。東京メトロ副都心線のように直通運転で系統が複数路線にまたがるほど差が大きくなります。

既存テストでも、バス経路には「最初の種別を自動選択し lineGroup の駅を取得する」ケースがある一方、鉄道で `station.trainType` が指定されているケースはテストも再取得もありませんでした。同じ目的の処理がバス側にだけ入っていることから、取得漏れと判断しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `lineGroupStations` の再取得条件を `fallbackTrainType`（バスの自動選択のみ）から `initialTrainType`（指定種別とバスの自動選択の両方）へ拡張。種別を自動選択したら駅一覧も同じ系統へ揃え、`handleTrainTypeSelect` / `openModalByTrainTypeId` と同じ状態になるようにした
- `lineGroupStations` が空で返った場合は路線単独の駅一覧を残すガードを追加（従来は空配列で潰していた）
- 直通系統では同じ駅でも駅IDが変わりうるため、`pendingStation` の引き当てに `groupId` によるフォールバックを追加
- `handleLineSelected` に選択世代（`selectionGenerationRef`）を導入し、Promise.all の直後と `fetchStationsByLineGroupId` の直後で世代を照合。路線を選び直した際に、前の選択の取得結果が新しい `pendingStations` / `pendingStation` を上書きしないようにした（前者は元からあった同種の穴も塞ぐ）
- 鉄道路線で指定種別がある場合に系統全体の駅一覧へ差し替わり、`groupId` フォールバックで乗車駅を引き当てることを検証するテストを追加
- `lineGroupStations` が空のときに路線単独の駅一覧を維持することを検証するテストを追加
- 取得中に別の路線が選ばれた場合に古い系統駅一覧で上書きしないことを検証するテストを追加

### 影響範囲・リグレッションリスク

- 種別を持つ鉄道路線を選択した際、方面選択モーダルに表示される駅一覧が路線単独から系統全体（直通を含む）へ変わる。これは種別を手動で選び直した場合（`handleTrainTypeSelect`）やプリセット復元時（`openModalByTrainTypeId`）と同じ状態であり、従来はこの経路だけが食い違っていた
- 路線選択時に `lineGroupStations` の取得が1回増えるが、`fetchStationsByLineGroupIdLoading` は既に方面選択モーダルのローディング判定に含まれているためスケルトン表示となり、UXの退行はない
- バス経路の挙動は変わらない（`initialTrainType` は `fallbackTrainType` を含むため）。空応答時に駅一覧を潰さなくなる点のみ改善される
- 世代管理は `handleLineSelected` にのみ導入しており、`handleTrainTypeSelect` / `openModalByTrainTypeId` の挙動は変えていない

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加した3件のテストは、いずれも対応する修正を個別に戻すと落ちることを確認済みです。`npm test` は 215 suites / 2280 tests すべて成功。

なお、この環境には API の接続情報も実機も無いため、実際の副都心線データでの表示確認は行えていません。修正はロジックの整合性とユニットテストで担保しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 鉄道路線で列車種別が指定されている場合、対応する駅グループの駅一覧を表示できるようになりました。
  * 駅グループの情報がない場合は、従来の路線駅一覧を引き続き表示します。
  * 選択中の駅は、駅IDまたは駅グループIDを基に適切に引き継がれます。
  * 路線をすばやく切り替えた際、以前の路線情報が後から表示を上書きしないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->