### PR TITLE
useDeepLinkテストのナビゲーションリトライタイマーのリークを断ちpreset無視テストのflakyを解消

### DIFF
--- a/src/hooks/useDeepLink.test.tsx
+++ b/src/hooks/useDeepLink.test.tsx
@@ -158,6 +158,19 @@ describe('useDeepLink', () => {
   };
 
   beforeEach(() => {
+    // Every test runs on fake timers, including the ones that never advance
+    // them. `waitForNavReady` retries through real `setTimeout`
+    // (100/200/400/800ms), and a test that finishes before that chain settles
+    // leaves it pending: ~1.5s later the callback fires inside whichever test
+    // is running then, reads the *shared* `navigationRef` mock, and — if that
+    // test stubbed `isReady()` as true — dispatches `NAVIGATE → MainStack/Main`
+    // into the shared `dispatch` mock, breaking its negative assertions
+    // (#6607). Fake timers make those pending callbacks discardable, which is
+    // what `jest.clearAllTimers()` in afterEach does; with real timers that
+    // call had nothing to clear. It also stops the chains from keeping the
+    // Node event loop alive ("Jest did not exit one second after...").
+    jest.useFakeTimers();
+
     // jest.clearAllMocks (afterEach) clears call history but not
     // mockReturnValue / mockReturnValueOnce settings — those leak across
     // tests and cause order-dependent flakes (e.g. an isReady queue from
@@ -177,9 +190,12 @@ describe('useDeepLink', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    // Belt-and-suspenders: if a test forgot to call useRealTimers, leaked
-    // fake timers would silently change the behavior of every subsequent
-    // test. Force-restore real timers and drop any pending fake timers.
+    // Drop every timer the test left behind — notably the `waitForNavReady`
+    // retry chains described in beforeEach — before handing control to the
+    // next test. Their promises stay unresolved forever, which is exactly
+    // what we want: the abandoned continuation can no longer touch the
+    // shared navigationRef mocks. Restoring real timers afterwards keeps the
+    // fake clock from bleeding into unrelated suites.
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -2234,16 +2250,22 @@ describe('useDeepLink', () => {
       const { mockSetNavigationState } = setupAtoms();
       setupQueries();
 
+      const hookRef: { current: HookResult } = { current: null };
       render(
         <HookBridge
-          onReady={() => {
-            /* noop */
+          onReady={(value) => {
+            hookRef.current = value;
           }}
         />
       );
 
+      // `getInitialURL` having been called only proves the effect started —
+      // handleUrl still has async work ahead of it, so a negative assertion
+      // placed right after that would pass before the code under test has had
+      // a chance to misbehave. `initialUrlProcessed` flips in the effect's
+      // `finally`, which is the real "deep link handling is done" signal.
       await waitFor(() => {
-        expect(mockGetInitialURL).toHaveBeenCalled();
+        expect(hookRef.current?.initialUrlProcessed).toBe(true);
       });
 
       expect(mockSetNavigationState).not.toHaveBeenCalled();


### PR DESCRIPTION
## 概要

`src/hooks/useDeepLink.test.tsx` の `preset (ホーム画面ウィジェット) › UUID形式でないpresetは無視する` がフルスイート実行時にまれに失敗する問題（#6607）を解消します。原因はテスト間の非同期リークであり、製品コードの不具合ではありません。

推定ではなく決定的な再現手順を作って原因を確定させました。機序は以下のとおりです。

`useDeepLink.ts` の `waitForNavReady` は実タイマー（`setTimeout` 100/200/400/800ms）でリトライします。多くのテストは `navigateToMain()` に到達したあと、このリトライ列が決着する前に終了するため、コールバックが保留のまま残ります。約 1.5 秒後、そのコールバックは「たまたまその時点で実行中の別テスト」の中で発火し、共有モックである `navigationRef` を参照します。そのテストが `isReady()` を `true` にスタブしていると（`UUID形式でないpresetは無視する` がまさにそうです）、リトライ列は準備完了と判断して `NAVIGATE → MainStack/Main` を共有 `dispatch` モックへ流し込み、negative assertion を壊します。

Issue に記載された「dispatch の型が `RESET` ではなく `NAVIGATE` だった」「2 回呼ばれた（=リーク列が 2 本）」という観測は、いずれもこの機序で説明できます。あわせて報告されていた `Jest did not exit one second after the test run has completed.` も同じ保留タイマーが原因で、当該ファイル単独実行でも再現していました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

テストのみの変更で、製品コードには手を入れていません。

- `beforeEach` で `jest.useFakeTimers()` を有効化し、`waitForNavReady` のリトライ列をフェイクタイマー上に載せました。既存の `afterEach` は元から `jest.clearAllTimers()` を呼んでいましたが、実タイマーに対しては破棄できるものが何もありませんでした。フェイクタイマー化によってこの呼び出しが実効化し、テスト境界で保留中のコールバックが確実に破棄されます。継続は未解決のまま放棄されるため、共有モックへ到達できなくなります。
- `afterEach` のコメントを、上記の実際の役割に合わせて更新しました。
- `UUID形式でないpresetは無視する` の同期点を `waitFor(getInitialURL が呼ばれた)` から `waitFor(initialUrlProcessed === true)` に強化しました。前者は「effect が始まった」ことしか保証せず、`handleUrl` の非同期処理が残っている段階で negative assertion が走っていました。後者は effect の `finally` で立つため、ディープリンク処理が一巡したことを表します。

補足: 同期点の強化だけでは今回の flaky は直りません。混入源は当該テスト自身ではなく「他のテスト」が残した保留タイマーであるため、根本対処はフェイクタイマー化の側にあります。同期点の強化は、Issue の対応案にも挙がっていた「テスト自身の弱い同期点」を独立に潰すための追加分です。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

### 決定的な再現と、その解消

negative assertion の直前に実時間 1.6 秒の待機を挿入して（フルスイート実行時の負荷を模擬）、`初回URLがある場合にstateを設定する` と `UUID形式でないpresetは無視する` の 2 件だけを実行したところ、Issue と同一の失敗を再現しました。

```text
● useDeepLink › preset (ホーム画面ウィジェット) › UUID形式でないpresetは無視する

  expect(jest.fn()).not.toHaveBeenCalled()

  Expected number of calls: 0
  Received number of calls: 1

  1: {"payload": {"name": "MainStack", "params": {"screen": "Main"}}, "type": "NAVIGATE"}
```

修正後は同じ再現手順で成功します。再現用の待機は本 PR の差分には含めていません。

### 副次的な改善

`npx jest src/hooks/useDeepLink.test.tsx` 単独実行の前後比較です。

| 項目 | 修正前 | 修正後 |
| ---- | ---- | ---- |
| `Jest did not exit ...` 警告 | 1 | 0 |
| `not wrapped in act` 警告 | 4 | 2 |
| 実行時間 | 10.8s | 2.5s |

実行時間の短縮は、実時間で待っていた `waitFor` のポーリングとリトライ待ちが無くなったためです。

### 実行したコマンド

- `npm run lint` → 626 files をチェックしクリーン
- `npm test` → 215 suites / 2277 tests すべて成功、`did not exit` 警告なし
- `npm run typecheck` → クリーン

## リグレッションリスクと緩和策

- **リスク**: スイート全体をフェイクタイマー化するため、実タイマー前提のテストが壊れる可能性。
  - **緩和**: `@testing-library/react-native` の `waitFor` はフェイクタイマーを検知して `jest.advanceTimersByTime` で進める実装（`build/wait-for.js`）になっており、本ファイルの 40 箇所の `waitFor` はすべて期待どおり動作します。当該ファイル 82 件、フルスイート 2277 件すべての成功を確認済みです。
- **リスク**: フェイクタイマーが他スイートへ漏れる。
  - **緩和**: `afterEach` の `jest.useRealTimers()` で必ず戻します（既存の実装を維持）。
- 製品コードは無変更のため、アプリ挙動へのリグレッションはありません。

## 関連Issue

Closes #6607

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

UI 変更なし（テストのみの変更）のため添付はありません。


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5CNFjS7EbqWAU6hXqFwUC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - ディープリンク処理のテストを安定化しました。
  - ナビゲーション準備待ちの再試行やURL処理の完了を適切に検証できるようになり、テスト実行時の遅延や不安定さを軽減しました。
  - プリセット無効化時に、不要な状態変更やナビゲーションが発生しないことをより確実に確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->