### PR TITLE
タッチ不可モード中は画面横スワイプと戻る操作による前画面への遷移も防止

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -195,7 +195,7 @@
   "e231Like": "E231 Series",
   "untouchableModeTitle": "Untouchable Mode",
   "untouchableModeDescription": "When enabled, the running screen stops responding to taps, edge swipes and the back gesture so the app is not operated by accident in your pocket or bag. Restart the app if you need to release it while riding.",
-  "untouchableModeEnabledNotice": "Untouchable mode is enabled. The app will not respond to taps. To disable this mode, please restart the app.",
+  "untouchableModeEnabledNotice": "Untouchable mode is enabled. The app will not respond to taps, edge swipes or the back gesture. To disable this mode, please restart the app.",
   "communityRoutes": "Community routes",
   "confirmDeleteRouteText": "Are you sure you want to remove \"%{routeName}\"?",
   "routeSavedText": "✅ The preset has been saved.",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -194,7 +194,7 @@
   "odakyuLike": "Odakyu",
   "e231Like": "E231 Series",
   "untouchableModeTitle": "Untouchable Mode",
-  "untouchableModeDescription": "When enabled, the running screen stops responding to taps so the app is not operated by accident in your pocket or bag. Restart the app if you need to release it while riding.",
+  "untouchableModeDescription": "When enabled, the running screen stops responding to taps, edge swipes and the back gesture so the app is not operated by accident in your pocket or bag. Restart the app if you need to release it while riding.",
   "untouchableModeEnabledNotice": "Untouchable mode is enabled. The app will not respond to taps. To disable this mode, please restart the app.",
   "communityRoutes": "Community routes",
   "confirmDeleteRouteText": "Are you sure you want to remove \"%{routeName}\"?",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -196,7 +196,7 @@
   "e231Like": "E231系風",
   "untouchableModeTitle": "タッチ不可モード",
   "untouchableModeDescription": "有効にすると、走行画面がタップ操作に加えて画面端のスワイプや戻る操作も受け付けなくなり、ポケットやカバンの中での誤操作を防げます。走行中に解除したい場合はアプリを再起動してください。",
-  "untouchableModeEnabledNotice": "タッチ不可モードが有効化されました。アプリはタップに反応しません。このモードを無効にするには、アプリを再起動してください。",
+  "untouchableModeEnabledNotice": "タッチ不可モードが有効化されました。アプリはタップや画面端のスワイプ、戻る操作に反応しません。このモードを無効にするには、アプリを再起動してください。",
   "communityRoutes": "コミュニティルート",
   "confirmDeleteRouteText": "本当に「%{routeName}」を削除しますか？",
   "routeSavedText": "✅ プリセットを保存しました。",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -195,7 +195,7 @@
   "odakyuLike": "小田急風",
   "e231Like": "E231系風",
   "untouchableModeTitle": "タッチ不可モード",
-  "untouchableModeDescription": "有効にすると、走行画面がタップ操作を受け付けなくなり、ポケットやカバンの中での誤操作を防げます。走行中に解除したい場合はアプリを再起動してください。",
+  "untouchableModeDescription": "有効にすると、走行画面がタップ操作に加えて画面端のスワイプや戻る操作も受け付けなくなり、ポケットやカバンの中での誤操作を防げます。走行中に解除したい場合はアプリを再起動してください。",
   "untouchableModeEnabledNotice": "タッチ不可モードが有効化されました。アプリはタップに反応しません。このモードを無効にするには、アプリを再起動してください。",
   "communityRoutes": "コミュニティルート",
   "confirmDeleteRouteText": "本当に「%{routeName}」を削除しますか？",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -63,6 +63,7 @@ export { useNextTrainType } from './useNextTrainType';
 export { useNumbering } from './useNumbering';
 export { usePresetCarouselData } from './usePresetCarouselData';
 export { usePresetStops } from './usePresetStops';
+export { usePreventBackInUntouchableMode } from './usePreventBackInUntouchableMode';
 export { usePrevious } from './usePrevious';
 export { usePreviousStation } from './usePreviousStation';
 export { useRefreshLeftStations } from './useRefreshLeftStations';

--- a/src/hooks/usePreventBackInUntouchableMode.test.tsx
+++ b/src/hooks/usePreventBackInUntouchableMode.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import { BackHandler } from 'react-native';
+import tuningState from '~/store/atoms/tuning';
+import { usePreventBackInUntouchableMode } from './usePreventBackInUntouchableMode';
+
+let mockIsFocused = true;
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => mockIsFocused,
+}));
+
+const renderWithStore = (untouchableModeEnabled: boolean) => {
+  const store = createStore();
+  store.set(tuningState, (prev) => ({ ...prev, untouchableModeEnabled }));
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return renderHook(() => usePreventBackInUntouchableMode(), { wrapper });
+};
+
+describe('usePreventBackInUntouchableMode', () => {
+  const mockRemove = jest.fn();
+  let addEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockIsFocused = true;
+    addEventListenerSpy = jest
+      .spyOn(BackHandler, 'addEventListener')
+      .mockReturnValue({ remove: mockRemove } as ReturnType<
+        typeof BackHandler.addEventListener
+      >);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('タッチ不可モードが有効な場合は戻る操作を握りつぶす', () => {
+    renderWithStore(true);
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    const [eventName, handler] = addEventListenerSpy.mock.calls[0];
+    expect(eventName).toBe('hardwareBackPress');
+    // trueを返すことで戻る操作が画面遷移へ伝播しない
+    expect(handler()).toBe(true);
+  });
+
+  it('タッチ不可モードが無効な場合は戻る操作を購読しない', () => {
+    renderWithStore(false);
+
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+  });
+
+  it('走行画面がフォーカスを失っている場合は購読しない', () => {
+    mockIsFocused = false;
+
+    renderWithStore(true);
+
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+  });
+
+  it('アンマウント時に購読を解除する', () => {
+    const { unmount } = renderWithStore(true);
+
+    unmount();
+
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePreventBackInUntouchableMode.ts
+++ b/src/hooks/usePreventBackInUntouchableMode.ts
@@ -1,0 +1,32 @@
+import { useIsFocused } from '@react-navigation/native';
+import { useAtomValue } from 'jotai';
+import { useEffect } from 'react';
+import { BackHandler } from 'react-native';
+import { untouchableModeEnabledAtom } from '~/store/atoms/tuning';
+
+/**
+ * タッチ不可モード中に、Androidの戻るキー・戻るジェスチャーで走行画面から
+ * 前の画面へ抜けてしまうのを防ぐ。
+ *
+ * iOSの画面端スワイプはMainStack側の `gestureEnabled: false` でネイティブごと
+ * 無効化しているため、ここではJS側へ伝播してくるAndroidの戻る操作だけを握りつぶす。
+ * beforeRemoveでの一律ブロックにしないのは、ディープリンクやクイックアクション
+ * 由来のreset遷移まで巻き込んでしまい、誤操作でない遷移まで止まるため。
+ */
+export const usePreventBackInUntouchableMode = (): void => {
+  const untouchableModeEnabled = useAtomValue(untouchableModeEnabledAtom);
+  // 走行画面が前面にあるときだけ握りつぶす。上に積まれた画面からは通常どおり戻れる
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (!untouchableModeEnabled || !isFocused) {
+      return;
+    }
+
+    const subscription = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => true
+    );
+    return () => subscription.remove();
+  }, [untouchableModeEnabled, isFocused]);
+};

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -44,6 +44,7 @@ import {
   useLazyGraphQLQuery,
   useLoopLine,
   useNextStation,
+  usePreventBackInUntouchableMode,
   useRefreshLeftStations,
   useRefreshStation,
   useResetMainState,
@@ -192,6 +193,11 @@ const FxAndroidPictureInPicture: React.FC = () => {
   useAndroidPictureInPicture();
   return null;
 };
+// iOS の BackHandler は何も発火しないため、購読するのは Android のときだけにする
+const FxPreventBackInUntouchableMode: React.FC = () => {
+  usePreventBackInUntouchableMode();
+  return null;
+};
 
 const MainScreenEffects: React.FC = () => {
   return (
@@ -211,6 +217,7 @@ const MainScreenEffects: React.FC = () => {
       <FxUpdateLiveActivities />
       {Platform.OS === 'android' && <FxUpdateWidget />}
       {Platform.OS === 'android' && <FxAndroidPictureInPicture />}
+      {Platform.OS === 'android' && <FxPreventBackInUntouchableMode />}
     </>
   );
 };

--- a/src/stacks/MainStack.test.tsx
+++ b/src/stacks/MainStack.test.tsx
@@ -1,0 +1,120 @@
+import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import tuningState from '~/store/atoms/tuning';
+import MainStack from './MainStack';
+
+type ScreenProps = {
+  name: string;
+  options?: { gestureEnabled?: boolean };
+};
+
+const screenProps: ScreenProps[] = [];
+
+jest.mock('@react-navigation/native-stack', () => ({
+  createNativeStackNavigator: () => ({
+    Navigator: ({ children }: { children: React.ReactNode }) => children,
+    Screen: (props: ScreenProps) => {
+      screenProps.push(props);
+      return null;
+    },
+  }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useConnectivity: () => true,
+  useUnderMaintenance: () => false,
+}));
+
+// 画面コンポーネント本体はここでの検証対象ではなく、
+// ネイティブ依存の解決コストだけが増えるため空実装へ差し替える
+jest.mock('~/components/Permitted', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+// jest.mock はファイル先頭へ巻き上げられる必要があるため、ループでまとめず個別に書く
+jest.mock('~/screens/AndroidSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/AppSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/BatterySettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/DestinationAgent', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/EnabledLanguagesSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/ExperimentalSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/Licenses', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/Main', () => ({ __esModule: true, default: () => null }));
+jest.mock('~/screens/NotificationSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/RouteSearchScreen', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/SelectLineScreen', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/ThemeSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/screens/TTSSettings', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('~/components/ErrorScreen', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const renderWithStore = (untouchableModeEnabled: boolean) => {
+  const store = createStore();
+  store.set(tuningState, (prev) => ({ ...prev, untouchableModeEnabled }));
+
+  return render(
+    <Provider store={store}>
+      <MainStack />
+    </Provider>
+  );
+};
+
+const getMainScreenProps = () =>
+  screenProps.find((props) => props.name === 'Main');
+
+describe('MainStack', () => {
+  beforeEach(() => {
+    screenProps.length = 0;
+  });
+
+  it('タッチ不可モードが有効な場合は走行画面のスワイプバックを無効化する', () => {
+    renderWithStore(true);
+
+    expect(getMainScreenProps()?.options?.gestureEnabled).toBe(false);
+  });
+
+  it('タッチ不可モードが無効な場合は走行画面のスワイプバックを許可する', () => {
+    renderWithStore(false);
+
+    expect(getMainScreenProps()?.options?.gestureEnabled).toBe(true);
+  });
+});

--- a/src/stacks/MainStack.test.tsx
+++ b/src/stacks/MainStack.test.tsx
@@ -106,6 +106,10 @@ describe('MainStack', () => {
     screenProps.length = 0;
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('タッチ不可モードが有効な場合は走行画面のスワイプバックを無効化する', () => {
     renderWithStore(true);
 

--- a/src/stacks/MainStack.tsx
+++ b/src/stacks/MainStack.tsx
@@ -22,6 +22,7 @@ import SelectLine from '../screens/SelectLineScreen';
 import ThemeSettings from '../screens/ThemeSettings';
 import { selectedBoundAtom, stationAtom } from '../store/atoms/station';
 import { isLEDThemeAtom } from '../store/atoms/theme';
+import { untouchableModeEnabledAtom } from '../store/atoms/tuning';
 import { translate } from '../translation';
 
 const Stack = createNativeStackNavigator();
@@ -36,6 +37,7 @@ const MainStack: React.FC = () => {
   const selectedBound = useAtomValue(selectedBoundAtom);
 
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const untouchableModeEnabled = useAtomValue(untouchableModeEnabledAtom);
 
   const isUnderMaintenance = useUnderMaintenance();
   const isInternetAvailable = useConnectivity();
@@ -48,6 +50,17 @@ const MainStack: React.FC = () => {
       },
     }),
     [isLEDTheme]
+  );
+
+  // タッチ不可モード中は走行画面からの離脱操作も誤操作とみなし、iOSの画面端
+  // スワイプ(スワイプバック)をネイティブごと無効化する。Androidの戻るキー・
+  // 戻るジェスチャーは usePreventBackInUntouchableMode 側で握りつぶしている。
+  const mainScreenOptions = useMemo<NativeStackNavigationOptions>(
+    () => ({
+      ...optionsWithCustomStyle,
+      gestureEnabled: !untouchableModeEnabled,
+    }),
+    [optionsWithCustomStyle, untouchableModeEnabled]
   );
 
   if (isUnderMaintenance) {
@@ -81,7 +94,7 @@ const MainStack: React.FC = () => {
           component={SelectLine}
         />
         <Stack.Screen
-          options={optionsWithCustomStyle}
+          options={mainScreenOptions}
           name="Main"
           component={Main}
         />

--- a/src/store/atoms/tuning.ts
+++ b/src/store/atoms/tuning.ts
@@ -23,4 +23,10 @@ const tuningState = atom<TuningState>({
   telemetryEnabled: false,
 });
 
+// タッチ不可モードだけを見る購読者（MainStack など）が、他のチューニング値の
+// 変更で再レンダーされないようにするための派生atom
+export const untouchableModeEnabledAtom = atom(
+  (get) => get(tuningState).untouchableModeEnabled
+);
+
 export default tuningState;


### PR DESCRIPTION
## 概要

タッチ不可モードが有効なとき、タップだけでなく「画面横スワイプ（iOS のスワイプバック）」と「Android の戻るキー・戻るジェスチャー」による走行画面からの離脱も防ぐようにしました。従来はタッチ不可モード中でも横スワイプ 1 回で路線選択画面へ戻れてしまい、ポケットやカバンの中での誤操作防止という本来の目的を満たせていませんでした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `MainStack` の Main 画面に `gestureEnabled: !untouchableModeEnabled` を設定し、iOS の画面端スワイプバックをネイティブごと無効化
- `usePreventBackInUntouchableMode` を追加し、Android の戻るキー・戻るジェスチャーを `BackHandler` で握りつぶす（`useIsFocused()` でゲートしているため、上に積まれた画面からは通常どおり戻れる）
- 上記フックは `Main.tsx` のレンダーレス副作用ホスト `MainScreenEffects` に `FxPreventBackInUntouchableMode` として、iOS では発火しないため Android 限定でマウント
- `untouchableModeEnabledAtom`（派生 atom）を追加し、`MainStack` が他のチューニング値の更新で再レンダーされないようにした
- ja/en の `untouchableModeDescription` と `untouchableModeEnabledNotice` を、タップに加えて画面端スワイプ・戻る操作も無効になる旨へ更新
- `usePreventBackInUntouchableMode` と `MainStack`（`gestureEnabled` の切り替え）のユニットテストを追加

### 設計上の判断

一律に `beforeRemove` / `usePreventRemove` で離脱をブロックする方法は採りませんでした。`beforeRemove` はネストした画面にも伝播するため、ディープリンクやクイックアクション由来の `CommonActions.reset`（`src/utils/navigateToSelectLine.ts`）まで巻き込んでしまい、誤操作ではない遷移まで止まってしまいます。今回はスワイプ／戻る操作という「誤操作の入口」だけを塞ぐ実装にしています。Main の `beforeRemove` による `resetMainState` は `preventDefault` していないため、既存の状態リセット挙動もそのままです。

### リグレッションリスクと緩和策

| リスク | 緩和策 |
| ---- | ---- |
| タッチ不可モード OFF 時にスワイプバックまで効かなくなる | `gestureEnabled` は `!untouchableModeEnabled` で切り替え。OFF 時に `true` になることを `MainStack.test.tsx` で検証 |
| 設定画面など Main の上に積まれた画面から戻れなくなる | `useIsFocused()` で走行画面が前面のときだけ購読。フォーカス喪失時に購読しないことをテストで検証 |
| ディープリンク・クイックアクションからの遷移が止まる | `beforeRemove` を使わず戻る操作のみを対象にしたため、プログラムによる `reset` / `replace` 遷移は従来どおり |
| BackHandler の購読リーク | アンマウント時に `subscription.remove()` することをテストで検証 |
| モード有効時に走行画面から抜けられない | 仕様どおりの挙動（設定説明文のとおりアプリ再起動で解除）。説明文と有効化通知も今回の変更に合わせて更新済み |

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカルで実行したコマンドと結果:

```bash
npm run lint       # biome check ./src — 629 files, 指摘なし
npm run typecheck  # tsc --noEmit — エラーなし
npm test           # 217 suites / 2286 tests 全パス（新規 6 件を含む）
```

実機・シミュレータでの動作確認は未実施です（ビルド手段のない環境で作業したため）。iOS のスワイプバックと Android の戻るジェスチャーの実挙動は端末での確認をお願いします。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * タッチ不可モード中、Androidの戻る操作とiOSの画面端スワイプによる戻る操作を無効化しました。
  * タッチ不可モードの説明に、対象となる操作と解除方法を追記しました。

* **テスト**
  * タッチ不可モードの有効・無効時および画面状態ごとの操作制御を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->