### PR TITLE
プリセット保存時に始発・終着を保存するか選べるチェックボックスを追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -309,6 +309,8 @@
   "savePresetTitle": "Save preset",
   "presetNameLabel": "Preset name",
   "presetNamePlaceholder": "Preset name",
+  "presetKeepEndpointsLabel": "Save the origin and destination as they are",
+  "presetKeepEndpointsDescription": "When off, only the stopping pattern is saved, without narrowing it down by destination and origin station.",
   "save": "Save",
   "wrongDirectionWarning": "You may be traveling in the wrong direction. Please check your app settings.",
   "wrongDirectionLoopLineWarning": "You may be traveling in the wrong direction. As this is a loop line, you will still arrive, but it will take longer.",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -310,6 +310,8 @@
   "savePresetTitle": "プリセットを保存",
   "presetNameLabel": "プリセット名",
   "presetNamePlaceholder": "プリセット名",
+  "presetKeepEndpointsLabel": "始発・終着駅もそのまま保存する",
+  "presetKeepEndpointsDescription": "オフにすると、行き先と始発駅で絞り込まずに停車パターンだけを保存します。",
   "save": "保存",
   "wrongDirectionWarning": "選択した行き先と逆方向に進んでいる可能性があります。アプリの設定をご確認ください。",
   "wrongDirectionLoopLineWarning": "選択した行き先と逆方向に進んでいる可能性があります。環状線のため到着は可能ですが、遠回りになります。",

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,86 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import {
+  type StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { LED_THEME_BG_COLOR } from '~/constants';
+import { isLEDThemeAtom } from '~/store/atoms/theme';
+import { RFValue } from '~/utils/rfValue';
+import Typography from './Typography';
+
+const BOX_SIZE = 22;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  box: {
+    width: BOX_SIZE,
+    height: BOX_SIZE,
+    borderWidth: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  label: {
+    flex: 1,
+    fontSize: RFValue(13),
+  },
+});
+
+type Props = {
+  checked: boolean;
+  onPress: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export const Checkbox: React.FC<Props> = ({
+  checked,
+  onPress,
+  children,
+  disabled,
+  style,
+}) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+
+  return (
+    <TouchableOpacity
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked, disabled: !!disabled }}
+      onPress={onPress}
+      disabled={disabled}
+      // タップ判定がボックスだけだと小さすぎるため行全体を対象にする
+      style={[styles.container, { opacity: disabled ? 0.5 : 1 }, style]}
+    >
+      <View
+        style={[
+          styles.box,
+          {
+            backgroundColor: checked
+              ? '#008ffe'
+              : isLEDTheme
+                ? LED_THEME_BG_COLOR
+                : '#fff',
+            borderColor: checked ? '#008ffe' : isLEDTheme ? '#fff' : '#aaa',
+            borderRadius: isLEDTheme ? 0 : 4,
+          },
+        ]}
+      >
+        {checked ? <Ionicons name="checkmark" size={16} color="#fff" /> : null}
+      </View>
+      <Typography
+        style={[styles.label, { color: isLEDTheme ? '#fff' : '#000' }]}
+      >
+        {children}
+      </Typography>
+    </TouchableOpacity>
+  );
+};

--- a/src/components/SavePresetNameModal.test.tsx
+++ b/src/components/SavePresetNameModal.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { SavePresetNameModal } from './SavePresetNameModal';
+
+jest.mock('@expo/vector-icons', () => {
+  const { View } = require('react-native');
+  return { Ionicons: View };
+});
+
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(() => false),
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: true,
+}));
+
+jest.mock('./CustomModal', () => ({
+  CustomModal: ({
+    visible,
+    children,
+  }: {
+    visible: boolean;
+    children: React.ReactNode;
+  }) => {
+    const { View } = require('react-native');
+    return visible ? <View testID="custom-modal">{children}</View> : null;
+  },
+}));
+
+const renderModal = (
+  props: Partial<Parameters<typeof SavePresetNameModal>[0]>
+) =>
+  render(
+    <SavePresetNameModal
+      visible
+      onClose={jest.fn()}
+      onSubmit={jest.fn()}
+      defaultName="テストプリセット"
+      {...props}
+    />
+  );
+
+describe('SavePresetNameModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('showKeepEndpointsOptionが未指定ならチェックボックスを表示しない', () => {
+    const screen = renderModal({});
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('チェックボックスは既定でオンで、keepEndpoints: trueを渡す', () => {
+    const onSubmit = jest.fn();
+    const screen = renderModal({ onSubmit, showKeepEndpointsOption: true });
+
+    expect(screen.queryByRole('checkbox', { checked: true })).not.toBeNull();
+
+    fireEvent.press(screen.getByText('save'));
+    expect(onSubmit).toHaveBeenCalledWith('テストプリセット', true);
+  });
+
+  it('チェックボックスをオフにするとkeepEndpoints: falseを渡す', () => {
+    const onSubmit = jest.fn();
+    const screen = renderModal({ onSubmit, showKeepEndpointsOption: true });
+
+    fireEvent.press(screen.getByRole('checkbox'));
+    expect(screen.queryByRole('checkbox', { checked: false })).not.toBeNull();
+
+    fireEvent.press(screen.getByText('save'));
+    expect(onSubmit).toHaveBeenCalledWith('テストプリセット', false);
+  });
+
+  it('再表示時はチェック状態が既定のオンへ戻る', () => {
+    const onSubmit = jest.fn();
+    const screen = renderModal({ onSubmit, showKeepEndpointsOption: true });
+
+    fireEvent.press(screen.getByRole('checkbox'));
+    screen.rerender(
+      <SavePresetNameModal
+        visible={false}
+        onClose={jest.fn()}
+        onSubmit={onSubmit}
+        defaultName="テストプリセット"
+        showKeepEndpointsOption
+      />
+    );
+    screen.rerender(
+      <SavePresetNameModal
+        visible
+        onClose={jest.fn()}
+        onSubmit={onSubmit}
+        defaultName="テストプリセット"
+        showKeepEndpointsOption
+      />
+    );
+
+    expect(screen.queryByRole('checkbox', { checked: true })).not.toBeNull();
+  });
+});

--- a/src/components/SavePresetNameModal.tsx
+++ b/src/components/SavePresetNameModal.tsx
@@ -15,6 +15,7 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { RFValue } from '~/utils/rfValue';
 import Button from './Button';
+import { Checkbox } from './Checkbox';
 import { CustomModal } from './CustomModal';
 import { Heading } from './Heading';
 import Typography from './Typography';
@@ -22,8 +23,14 @@ import Typography from './Typography';
 type Props = {
   visible: boolean;
   onClose: () => void;
-  onSubmit: (name: string) => void;
+  /**
+   * @param keepEndpoints 始発駅・終着駅をそのまま保存するか。
+   * false のときは行き先と始発駅で絞らず停車パターンのみを保存する
+   */
+  onSubmit: (name: string, keepEndpoints: boolean) => void;
   defaultName: string;
+  /** 始発・終着を保存するかの選択肢を出すか（行き先を指定しているときのみ意味を持つ） */
+  showKeepEndpointsOption?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -47,6 +54,14 @@ const styles = StyleSheet.create({
     marginTop: 8,
     borderRadius: 8,
   },
+  keepEndpointsContainer: {
+    marginTop: 24,
+  },
+  keepEndpointsDescription: {
+    fontSize: RFValue(11),
+    marginTop: 8,
+    opacity: 0.8,
+  },
   buttonContainer: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -64,16 +79,20 @@ export const SavePresetNameModal: React.FC<Props> = ({
   onClose,
   onSubmit,
   defaultName,
+  showKeepEndpointsOption = false,
 }) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const textInputRef = useRef<TextInputType>(null);
   const textRef = useRef(defaultName);
   const [isEmpty, setIsEmpty] = useState(false);
+  const [keepEndpoints, setKeepEndpoints] = useState(true);
 
   useEffect(() => {
     if (visible) {
       textRef.current = defaultName;
       setIsEmpty(!defaultName.trim());
+      // 表示のたびに既定(オン)へ戻し、前回の選択を持ち越さない
+      setKeepEndpoints(true);
     }
   }, [visible, defaultName]);
 
@@ -82,11 +101,16 @@ export const SavePresetNameModal: React.FC<Props> = ({
     setIsEmpty(!text.trim());
   }, []);
 
+  const handleToggleKeepEndpoints = useCallback(
+    () => setKeepEndpoints((prev) => !prev),
+    []
+  );
+
   const handleSubmit = useCallback(() => {
     const name = textRef.current.trim();
     if (!name) return;
-    onSubmit(name);
-  }, [onSubmit]);
+    onSubmit(name, keepEndpoints);
+  }, [onSubmit, keepEndpoints]);
 
   const handleShow = useCallback(() => {
     if (Platform.OS === 'ios') {
@@ -135,6 +159,22 @@ export const SavePresetNameModal: React.FC<Props> = ({
           returnKeyType="done"
           onSubmitEditing={handleSubmit}
         />
+
+        {showKeepEndpointsOption ? (
+          <View style={styles.keepEndpointsContainer}>
+            <Checkbox
+              checked={keepEndpoints}
+              onPress={handleToggleKeepEndpoints}
+            >
+              {translate('presetKeepEndpointsLabel')}
+            </Checkbox>
+            <Typography
+              style={[styles.keepEndpointsDescription, { color: textColor }]}
+            >
+              {translate('presetKeepEndpointsDescription')}
+            </Typography>
+          </View>
+        ) : null}
 
         <View style={styles.buttonContainer}>
           <Button onPress={onClose} outline>

--- a/src/components/SelectBoundModal.render.test.tsx
+++ b/src/components/SelectBoundModal.render.test.tsx
@@ -23,6 +23,7 @@ import { isLEDThemeAtom } from '../store/atoms/theme';
 import { SelectBoundModal } from './SelectBoundModal';
 
 const mockRouteInfoModal = jest.fn();
+const mockSavePresetNameModal = jest.fn();
 const mockSaveRoute = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
@@ -135,23 +136,31 @@ jest.mock('./SavePresetNameModal', () => ({
   SavePresetNameModal: ({
     visible,
     onSubmit,
+    showKeepEndpointsOption,
   }: {
     visible: boolean;
-    onSubmit: (name: string) => void;
-  }) =>
-    visible
+    onSubmit: (name: string, keepEndpoints: boolean) => void;
+    showKeepEndpointsOption?: boolean;
+  }) => {
+    mockSavePresetNameModal({ visible, showKeepEndpointsOption });
+    return visible
       ? (() => {
           const { Pressable, View } = require('react-native');
           return (
             <View testID="save-preset-modal">
               <Pressable
                 testID="save-preset-submit"
-                onPress={() => onSubmit('テストプリセット')}
+                onPress={() => onSubmit('テストプリセット', true)}
+              />
+              <Pressable
+                testID="save-preset-submit-without-endpoints"
+                onPress={() => onSubmit('テストプリセット', false)}
               />
             </View>
           );
         })()
-      : null,
+      : null;
+  },
 }));
 
 jest.mock('../stacks/rootNavigation', () => ({
@@ -305,5 +314,125 @@ describe('SelectBoundModal', () => {
 
     await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
     expect(mockSaveRoute.mock.calls[0][0].direction).toBe('OUTBOUND');
+  });
+
+  describe('始発・終着を保存するかの選択', () => {
+    const routeStations = [1, 2, 3, 4].map((groupId) => ({
+      id: groupId,
+      groupId,
+      latitude: 35.7 + groupId * 0.01,
+      longitude: 139.75 + groupId * 0.01,
+      line: { id: 10 },
+      lines: [{ id: 10 }],
+    }));
+
+    const setupWithDestination = (targetStationIds: number[] = []) => {
+      mockAtomValues({
+        station: routeStations[3],
+        pendingStation: routeStations[3],
+        pendingStations: routeStations,
+        wantedDestination: routeStations[1],
+        pendingLine: { id: 10, name: '山手線', nameRoman: 'Yamanote Line' },
+      });
+      (useAtom as jest.Mock).mockImplementation((atom: unknown) => {
+        if (atom === notifyState) {
+          return [{ targetStationIds }, jest.fn()];
+        }
+        return [{}, jest.fn()];
+      });
+
+      return render(
+        <SelectBoundModal
+          visible={true}
+          onClose={jest.fn()}
+          loading={false}
+          error={null}
+          onTrainTypeSelect={jest.fn()}
+          onBoundSelect={jest.fn()}
+        />
+      );
+    };
+
+    it('行き先が未指定なら選択肢を出さない', () => {
+      render(
+        <SelectBoundModal
+          visible={true}
+          onClose={jest.fn()}
+          loading={false}
+          error={null}
+          onTrainTypeSelect={jest.fn()}
+          onBoundSelect={jest.fn()}
+        />
+      );
+
+      const lastCall =
+        mockSavePresetNameModal.mock.calls[
+          mockSavePresetNameModal.mock.calls.length - 1
+        ];
+      expect(lastCall?.[0].showKeepEndpointsOption).toBe(false);
+    });
+
+    it('行き先を指定している場合は選択肢を出す', () => {
+      setupWithDestination();
+
+      const lastCall =
+        mockSavePresetNameModal.mock.calls[
+          mockSavePresetNameModal.mock.calls.length - 1
+        ];
+      expect(lastCall?.[0].showKeepEndpointsOption).toBe(true);
+    });
+
+    it('オンのままなら行き先・始発駅を含めて保存する', async () => {
+      const screen = setupWithDestination();
+
+      fireEvent.press(screen.getByText('saveCurrentRoute'));
+      fireEvent.press(screen.getByTestId('save-preset-submit'));
+
+      await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
+      expect(mockSaveRoute.mock.calls[0][0]).toMatchObject({
+        wantedDestinationId: 2,
+        originStationId: 4,
+        direction: 'OUTBOUND',
+      });
+    });
+
+    it('オフにすると行き先・始発駅を保存しない', async () => {
+      const screen = setupWithDestination();
+
+      fireEvent.press(screen.getByText('saveCurrentRoute'));
+      fireEvent.press(
+        screen.getByTestId('save-preset-submit-without-endpoints')
+      );
+
+      await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
+      expect(mockSaveRoute.mock.calls[0][0]).toMatchObject({
+        wantedDestinationId: null,
+        originStationId: null,
+        direction: null,
+      });
+    });
+
+    // 区間で絞らない以上、絞り込み範囲の外にある通知駅も落としてはいけない
+    it('オフにすると全区間の通知駅を保存する', async () => {
+      const screen = setupWithDestination([1, 4]);
+
+      fireEvent.press(screen.getByText('saveCurrentRoute'));
+      fireEvent.press(
+        screen.getByTestId('save-preset-submit-without-endpoints')
+      );
+
+      await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
+      expect(mockSaveRoute.mock.calls[0][0].notifyStationIds).toEqual([1, 4]);
+    });
+
+    it('オンのままなら保存区間内の通知駅だけを保存する', async () => {
+      const screen = setupWithDestination([1, 4]);
+
+      fireEvent.press(screen.getByText('saveCurrentRoute'));
+      fireEvent.press(screen.getByTestId('save-preset-submit'));
+
+      await waitFor(() => expect(mockSaveRoute).toHaveBeenCalled());
+      expect(mockSaveRoute.mock.calls[0][0].notifyStationIds).toEqual([4]);
+    });
   });
 });

--- a/src/components/SelectBoundModal.tsx
+++ b/src/components/SelectBoundModal.tsx
@@ -663,48 +663,64 @@ export const SelectBoundModal: React.FC<Props> = ({
   }, [pendingTrainType, line]);
 
   const handlePresetNameSubmit = useCallback(
-    async (name: string) => {
+    async (name: string, keepEndpointsInput: boolean) => {
       if (!line) return;
 
-      const { originStation, direction } = presetSaveRoute;
+      // 行き先を指定していなければそもそも絞り込みが無く、チェックの有無で結果は変わらない
+      const keepEndpoints = keepEndpointsInput || !wantedDestination;
+
+      const { originStation, direction } = keepEndpoints
+        ? presetSaveRoute
+        : { originStation: undefined, direction: null };
+      // 端点を捨てる場合は区間を絞らないため、通知駅の範囲も全区間に戻す
+      const savedStations = keepEndpoints ? effectiveStations : stations;
 
       // 有効な駅IDのみ保存する（wantedDestinationで区間を絞った場合に範囲外を除外）
       const validStationIds = new Set(
-        effectiveStations
-          .map((s) => s.id)
-          .filter((id): id is number => id != null)
+        savedStations.map((s) => s.id).filter((id): id is number => id != null)
       );
       const filteredNotifyStationIds = targetStationIds.filter((id) =>
         validStationIds.has(id)
       );
+      const wantedDestinationId = keepEndpoints
+        ? (wantedDestination?.groupId ?? null)
+        : null;
 
       try {
+        let saved: SavedRoute;
         if (pendingTrainType?.groupId) {
           const newRoute: SavedRouteWithTrainTypeInput = {
             hasTrainType: true,
             name,
             lineId: line.id ?? 0,
             trainTypeId: pendingTrainType?.groupId,
-            wantedDestinationId: wantedDestination?.groupId ?? null,
+            wantedDestinationId,
             originStationId: originStation?.groupId ?? null,
             direction,
             notifyStationIds: filteredNotifyStationIds,
             createdAt: new Date(),
           };
-          setSavedRoute(await saveCurrentRoute(newRoute));
+          saved = await saveCurrentRoute(newRoute);
         } else {
           const newRoute: SavedRouteWithoutTrainTypeInput = {
             hasTrainType: false,
             name,
             lineId: line.id ?? 0,
             trainTypeId: null,
-            wantedDestinationId: wantedDestination?.groupId ?? null,
+            wantedDestinationId,
             originStationId: originStation?.groupId ?? null,
             direction,
             notifyStationIds: filteredNotifyStationIds,
             createdAt: new Date(),
           };
-          setSavedRoute(await saveCurrentRoute(newRoute));
+          saved = await saveCurrentRoute(newRoute);
+        }
+
+        // 端点を捨てた場合、保存したプリセットは現在の選択（行き先で絞った経路）とは
+        // 別物なので保存済み表示にはしない。findSavedRoute も一致させないため、
+        // ここで立てても直後の再検索で戻ってしまう
+        if (keepEndpoints) {
+          setSavedRoute(saved);
         }
 
         setIsPresetNameModalVisible(false);
@@ -723,9 +739,10 @@ export const SelectBoundModal: React.FC<Props> = ({
       saveCurrentRoute,
       line,
       pendingTrainType,
-      wantedDestination?.groupId,
+      wantedDestination,
       targetStationIds,
       effectiveStations,
+      stations,
       presetSaveRoute,
     ]
   );
@@ -1014,6 +1031,7 @@ export const SelectBoundModal: React.FC<Props> = ({
         onClose={() => setIsPresetNameModalVisible(false)}
         onSubmit={handlePresetNameSubmit}
         defaultName={presetDefaultName}
+        showKeepEndpointsOption={!!wantedDestination}
       />
     </>
   );


### PR DESCRIPTION
## 概要

プリセット保存モーダルに「始発・終着駅もそのまま保存する」チェックボックスを追加しました。デフォルトはオンで既存の挙動と同じです。オフにすると、行き先と始発駅で絞り込まずに停車パターンだけをプリセットとして保存できます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/Checkbox.tsx` を新規追加。LEDテーマ対応の汎用チェックボックスで、行全体がタップ領域。`accessibilityRole="checkbox"` を付与している
- `SavePresetNameModal` にチェックボックスを追加。デフォルトはオンで、モーダルを開くたびにオンへリセットされる。`onSubmit` のシグネチャを `(name, keepEndpoints)` に変更し、チェックボックス自体は新規 prop `showKeepEndpointsOption` が真のときだけ表示する
- `SelectBoundModal` 側は行き先を指定しているときのみ選択肢を出す（`showKeepEndpointsOption={!!wantedDestination}`）。行き先が未指定ならそもそも絞り込みが無く、チェックの有無で保存結果が変わらないため
- オフで保存した場合は `wantedDestinationId` / `originStationId` / `direction` をすべて `null` にする。結果としてプリセット表示時は路線の両端がそのまま始発・終着になる
- オフのときは通知駅の絞り込み範囲も全区間（`stations`）に戻す。区間で絞らない以上、範囲外の通知駅を落とすのは不整合なため
- オフで保存したときは「保存済み（削除ボタン）」表示に切り替えない。保存したプリセットは現在の選択（行き先で絞った経路）とは別物で `findSavedRoute` が一致せず、フラグを立てても直後の再検索で戻ってしまうため
- `presetKeepEndpointsLabel` / `presetKeepEndpointsDescription` を ja / en の翻訳に追加

### 退行リスクと緩和策

- `SavePresetNameModal.onSubmit` の引数が 1 個から 2 個に増えるが、呼び出し元は `SelectBoundModal` の 1 箇所のみ（`rg` で確認済み）。型チェックも通過している
- 既定値がオンのため、チェックボックスを触らない限り保存されるプリセットの内容は従来と完全に同一。既存プリセットのデータ移行は不要
- オフで保存したプリセットは `direction: null` になるが、これは `originStationId` 追加前の古いプリセットと同じ形で、`getPresetRouteEndpoints` / `usePresetStops` は既に null を扱えるようになっている
- チェックボックスが増えることでモーダルが縦に伸びるため、小さい端末での見切れが理論上の懸念点。`CustomModal` の `avoidKeyboard` 配下にあるため通常は問題にならない想定だが、実機確認が未実施（下記参照）

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカルで実行したコマンド:

```bash
npm install          # 依存が未インストールだったため。package-lock.json の差分は revert 済み
npm run format
npm run lint         # Checked 631 files, No fixes applied
npm run typecheck    # エラーなし
npm test             # 218 suites / 2303 tests 全パス
```

追加したテスト:

- `src/components/SavePresetNameModal.test.tsx`（新規 4 件）— チェックボックスの表示条件、既定オン、オフ時に `keepEndpoints: false` が渡ること、再表示でオンへ戻ること
- `src/components/SelectBoundModal.render.test.tsx`（新規 6 件）— 行き先の有無による選択肢の出し分け、オン／オフでの `wantedDestinationId` / `originStationId` / `direction` の保存内容、通知駅の絞り込み範囲

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

実行環境に iOS シミュレータ／Android エミュレータが無いため、UI のスクリーンショットは未添付です。マージ前に実機での見た目確認をお願いします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JADooBLsCWVKkEJ5A76Rui)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プリセット保存時に、始発駅・終着駅を保持するか選択できるようになりました。
  - 端点を保持しない場合、駅の指定を除いた停車パターンとして保存できます。
  - 保存した条件に応じて、通知対象駅が自動的に設定されます。
  - 保存ダイアログに、設定内容を説明するチェックボックスを追加しました。
- **テスト**
  - 端点保持設定や保存内容に関する動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->