### PR TITLE
CIのNodeバージョンを24へ統一しnpm ciのlock不整合を解消

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,8 +79,8 @@ src/
 
 ## 開発環境
 
-- **Node.js 22.x**を使用
-- **npm 10.x**を使用（Node.js 22 同梱版）
+- **Node.js 24.x**を使用
+- **npm 11.x**を使用（Node.js 24 同梱版）
 - Metro キャッシュ問題が発生した場合のみ`expo start --clear`を実行
 - GraphQL codegen には`.env.local`に`GQL_API_URL`が必要
 

--- a/.github/workflows/build_android_canary.yml
+++ b/.github/workflows/build_android_canary.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/build_android_production.yml
+++ b/.github/workflows/build_android_production.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/build_ios_canary.yml
+++ b/.github/workflows/build_ios_canary.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/build_ios_production.yml
+++ b/.github/workflows/build_ios_production.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 
 ## Tooling & Environment Expectations
 
-- Target **Node.js 22.x** and **npm 10.x**.
+- Target **Node.js 24.x** and **npm 11.x**, matching `.nvmrc`. All GitHub Actions workflows pin the same major; keep them in sync when bumping, otherwise a `package-lock.json` generated locally can fail `npm ci` on a runner carrying an older npm.
 - Run `npm install` when dependencies shift; avoid re-locking packages unless instructed.
 - Metro cache issues: run `expo start --clear` only when debugging build failures and document the action.
 - For native builds, rely on project scripts (`npm run android`, `npm run ios`).

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ This app recreates the authentic experience of Japanese train travel by displayi
 
 Before you begin, ensure you have met the following requirements:
 
-- **Node.js 22.x** (pinned via `.nvmrc`; run `nvm use` to switch automatically)
-- **npm 10.x** (bundled with Node.js 22; `engines` + `engine-strict=true` block `npm install` on other versions)
+- **Node.js 24.x** (pinned via `.nvmrc`; run `nvm use` to switch automatically)
+- **npm 11.x** (bundled with Node.js 24; `engines` + `engine-strict=true` block `npm install` on other versions)
 - **React Native development environment** set up
 - **Expo CLI** installed globally
 - **Android Studio** (for Android development)

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -13,7 +13,7 @@ separate.
 
 ## Prerequisites
 
-- A GitHub-hosted `ubuntu-22.04` runner with Node.js 22 and Java 17.
+- A GitHub-hosted `ubuntu-22.04` runner with Node.js 24 and Java 17.
 - A release keystore and its alias and passwords.
 - A Google Play service account with permission to publish both application IDs
   to the internal track and to the Wear OS track.

--- a/docs/bump-version-on-canary-pr.md
+++ b/docs/bump-version-on-canary-pr.md
@@ -10,7 +10,7 @@
 ## 動作
 
 1. PRのヘッドブランチをチェックアウト
-2. npm + Node.js 22 をセットアップ
+2. npm + Node.js 24 をセットアップ
 3. `npm ci` で依存関係インストール
 4. `npm run version:bump -- --no-version-increment` を実行
    - アプリのバージョン（`X.Y.Z`）は変更しない

--- a/docs/ios-build-workflows.md
+++ b/docs/ios-build-workflows.md
@@ -12,7 +12,7 @@ GitHub Actions run number.
 
 ## Prerequisites
 
-- A GitHub-hosted `macos-26` runner with Node.js 22 and CocoaPods available.
+- A GitHub-hosted `macos-26` runner with Node.js 24 and CocoaPods available.
 - An App Store Connect API key whose role permits build upload and provisioning
   management for both app identifiers.
 - Apple development and distribution certificates, each exported with its

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "private": true,
   "engines": {
-    "npm": ">=10"
+    "npm": ">=11"
   },
   "expo": {
     "doctor": {


### PR DESCRIPTION
## 概要

Expo SDK 57 へのアップグレード (#6658) 以降、canary / production のネイティブビルドで `npm ci` が `Missing: typescript@5.9.3 from lock file` により失敗していた問題を修正します。CI 上の Node メジャーバージョンを 24 に統一し、`.nvmrc` および他ワークフローと揃えます。

失敗例: [Build iOS Canary #4609](https://github.com/TrainLCD/MobileApp/actions/runs/31576346680/job/94050856323)

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- ネイティブビルド系ワークフロー 4 本の `node-version` を `"22"` から `"24"` へ変更（`build_ios_canary` / `build_ios_production` / `build_android_canary` / `build_android_production`）
- `package.json` の `engines.npm` を `>=10` から `>=11` へ更新し、実際に要求される npm と宣言を一致させた
- `AGENTS.md` の「Tooling & Environment Expectations」を Node.js 24.x / npm 11.x に更新し、ワークフロー間で Node メジャーを揃えて維持する旨を追記
- `README.md` / `.github/copilot-instructions.md` / `docs/android-build-workflows.md` / `docs/ios-build-workflows.md` / `docs/bump-version-on-canary-pr.md` の Node.js・npm 版数記述を 24.x / 11.x へ同期（CodeRabbit 指摘対応）

`.npmrc` に `engine-strict=true` が設定されているため、`engines` の宣言はインストール可否に直結します。README の前提条件が npm 10.x のままだと実際の制約と食い違うため、あわせて更新しました。なお `docs/bump-version-on-canary-pr.md` は対応する `bump_version_on_canary_pr.yml` が本 PR 以前から `node-version: 24` であり、記述側が当初からワークフローと一致していなかったものを是正しています。

### 原因

Expo SDK 57 で `typescript` を `~6.0.3` へ引き上げたことが引き金です。`@expo/image-utils` 経由で入る `@expo/require-utils@55.0.6` の peerDependency が `typescript: "^5.0.0 || ^5.0.0-0"` のままで TypeScript 6 に対応しておらず、この optional peer の扱いが npm のメジャーによって分かれていました。

| 環境 | npm | 挙動 |
| ---- | ---- | ---- |
| ローカル / `test.yml` / `typecheck.yml` (Node 24) | 11.x | optional peer を解決対象とせず lock を生成するため成功 |
| ビルド系ワークフロー (Node 22) | 10.x | peer を満たすため `@expo/image-utils/node_modules/typescript@5.9.3` を要求するが lock に存在せず `EUSAGE` |

`package-lock.json` は Node 24 (npm 11) 環境で生成される一方、ビルド系ワークフローだけが Node 22 (npm 10) のまま取り残されていたことが原因でした。`.nvmrc` は既に `24` で、`test.yml` / `typecheck.yml` / `bump_version_*.yml` も 24 だったため、同一コミットでも Jest だけは成功していました。

### 検証

`package.json` と `package-lock.json` を作業ツリー外へ複製し、npm 10 / npm 11 の双方で `npm ci --dry-run` を実行して切り分けました。

```text
修正前 npm 10: npm error Missing: typescript@5.9.3 from lock file
修正後 npm 11: added 1320 packages   ← Node 24 化後の CI 相当
```

`package-lock.json` は変更していません。lock を npm 10 で再生成する案も検証しましたが、lightningcss の Linux バイナリが持つ `libc` フィールドが失われ、ローカルの `npm install` の度に差分が往復するため採用していません。

### 回帰リスクと緩和策

Node 24 化によりネイティブビルドの実行環境が変わります。ローカルでは iOS / Android の実ビルドまでは検証できないため、マージ後の canary ビルドで確認が必要です。JS 側は Node 24 で `test.yml` / `typecheck.yml` が既に安定稼働しており、リスクは限定的と判断しています。

## テスト

コード本体（`src/**` ほか）に変更が無いため、テンプレのチェック欄は省略しています。ただし `engines` 変更の影響確認としてローカルで一通り実行し、いずれも通過することを確認済みです。

```text
npm run lint       Checked 631 files. No fixes applied.
npm test           218 suites / 2304 tests 全て passed
npm run typecheck  エラーなし
```

加えて、変更した 4 ファイルの YAML パース検証と、リポジトリ内の `node-version` 指定 8 箇所がすべて 24 に揃っていることを確認しました。

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * AndroidおよびiOSのビルド環境で使用するNode.jsを24系に更新しました。
  * npmの必要バージョンを11以上に更新し、開発環境と自動ビルド環境のバージョン要件を統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
