### PR TITLE
Expo SDK 57に追随してiOSネイティブ設定を更新しビルド失敗を解消

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -52,6 +52,8 @@ export default {
     },
   },
   ios: {
+    // Expo SDK 57 の各モジュール（expo / expo-modules-core ほか）は podspec で iOS 16.4 以上を要求する
+    deploymentTarget: '16.4',
     buildNumber: '2832',
     scheme: IS_DEV ? 'CanaryTrainLCD' : 'ProdTrainLCD',
     bundleIdentifier: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',

--- a/ios/CanaryAppClip/AppDelegate.h
+++ b/ios/CanaryAppClip/AppDelegate.h
@@ -6,8 +6,10 @@
 //  Copyright © 2025 Facebook. All rights reserved.
 //
 
-#import <RCTAppDelegate.h>
 #import <UIKit/UIKit.h>
+// RCTAppDelegate は <Expo/Expo.h> が読み込む React-Core-prebuilt 側の umbrella から解決する。
+// <RCTAppDelegate.h> を直接 import すると React-RCTAppDelegate 側の同名ヘッダも展開され、
+// 同一クラスが二重定義になってコンパイルできない（Expo SDK 57 / React Native 0.86）。
 #import <Expo/Expo.h>
 
 @interface AppDelegate : RCTAppDelegate

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] =
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true' && podfile_properties['newArchEnabled'] != 'false'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true' && podfile_properties['newArchEnabled'] != 'false'
-platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
 
 prepare_react_native_project!
 

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,5 +1,6 @@
 {
   "expo.jsEngine": "hermes",
+  "ios.deploymentTarget": "16.4",
   "ios.buildReactNativeFromSource": "true",
   "ios.useFrameworks": "static",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",

--- a/ios/ProdAppClip/AppDelegate.h
+++ b/ios/ProdAppClip/AppDelegate.h
@@ -6,8 +6,10 @@
 //  Copyright © 2025 Facebook. All rights reserved.
 //
 
-#import <RCTAppDelegate.h>
 #import <UIKit/UIKit.h>
+// RCTAppDelegate は <Expo/Expo.h> が読み込む React-Core-prebuilt 側の umbrella から解決する。
+// <RCTAppDelegate.h> を直接 import すると React-RCTAppDelegate 側の同名ヘッダも展開され、
+// 同一クラスが二重定義になってコンパイルできない（Expo SDK 57 / React Native 0.86）。
 #import <Expo/Expo.h>
 
 @interface AppDelegate : RCTAppDelegate

--- a/ios/TrainLCD.xcodeproj/project.pbxproj
+++ b/ios/TrainLCD.xcodeproj/project.pbxproj
@@ -2467,7 +2467,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Prod/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TrainLCD;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2506,7 +2506,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Prod/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TrainLCD;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2752,7 +2752,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Dev/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "TrainLCD Canary";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2792,7 +2792,7 @@
 				DEVELOPMENT_TEAM = E6R2G33Z36;
 				INFOPLIST_FILE = TrainLCD/Schemes/Dev/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "TrainLCD Canary";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## 概要

Expo SDK 57 へのアップグレード (#6658) 以降、canary / production の iOS ビルドが失敗していた問題を修正します。#6658 は `ios/` 配下を一切更新していないため、ネイティブ側が SDK 57 の前提に追随できていませんでした。段階の異なる 2 つの失敗が連鎖しています。

1. `pod install` が Expo モジュール全 35 件を解決できず exit 1（デプロイメントターゲット 15.1 < 要求 16.4）
2. 1 を解消した後の `Archive` で App Clip がコンパイル不能（`RCTAppDelegate` などの二重定義）

失敗例: [Build iOS Canary #4610](https://github.com/TrainLCD/MobileApp/actions/runs/31581406294)

```text
[!] CocoaPods could not find compatible versions for pod "Expo":
[!] [Expo] expo was not linked: requires iOS 16.4 but app targets 15.1
```

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 1. iOS デプロイメントターゲットを 16.4 へ引き上げ

- `ios/Podfile.properties.json` に `ios.deploymentTarget: "16.4"` を追加（`ios/Podfile` の `platform :ios` はこの値を参照する）
- `ios/Podfile` のフォールバック値を `'15.1'` から `'16.4'` へ更新し、SDK 57 のテンプレートと揃えた
- `ios/TrainLCD.xcodeproj/project.pbxproj` の `IPHONEOS_DEPLOYMENT_TARGET` を、アプリ本体 2 ターゲット（`ProdTrainLCD` / `CanaryTrainLCD`）の Debug / Release 計 4 箇所で `15.1` から `16.4` へ引き上げ
- `app.config.ts` に `ios.deploymentTarget: '16.4'` を宣言。SDK 56 以降はこれが正式な指定先で（`expo-build-properties` 側の同名オプションは deprecated）、`expo prebuild` 実行時に上記 2 ファイルへ同じ値が展開される

SDK 57 で `expo` / `expo-modules-core` ほかの podspec が `:ios => '16.4'` に引き上げられた一方、本リポジトリは bare workflow で `ios/` をコミット管理しており、`ios/Podfile` の当該行は SDK 54 期 (#5475) から変わっていませんでした。React Native 0.86 自体の `min_ios_version_supported` は 15.1 なので、制約を上げているのは Expo 側のみです。

なお `RideSessionActivity`（Live Activities 拡張、16.1）とプロジェクトレベルの既定値 12.0 は変更していません。前者は Pod をリンクしない App Extension で、拡張のデプロイメントターゲットがホストアプリより低いことは Xcode 上許容されます。後者は全 iOS ターゲットが明示値を持つため実効性がなく（watchOS ターゲットは `WATCHOS_DEPLOYMENT_TARGET` を使用）、いずれも今回の解決には不要なため差分を最小に留めています。

### 2. App Clip の AppDelegate から `RCTAppDelegate.h` の直接 import を削除

- `ios/CanaryAppClip/AppDelegate.h` および `ios/ProdAppClip/AppDelegate.h` の `#import <RCTAppDelegate.h>` を削除し、`<Expo/Expo.h>` 経由の解決に一本化（削除理由をコメントで明記）

SDK 57 / RN 0.86 では prebuilt な React Core が使われ、`Pods/Headers/Public/` に `React-RCTAppDelegate/` と `React-Core-prebuilt/React_RCTAppDelegate/` という同一クラスを含む 2 つのヘッダツリーが並存します。App Clip の `AppDelegate.h` は両方を 1 つの translation unit へ取り込んでいたため、`RCTAppDelegate` / `RCTRootViewFactory` / `RCTRootViewFactoryConfiguration` が duplicate interface definition となり `main.m` と `AppDelegate.m` がコンパイルできませんでした。`RCTAppDelegate` は `<Expo/Expo.h>` → `RCTAppDelegateUmbrella.h` → `React_RCTAppDelegate-umbrella.h` の経路で得られるため、直接 import は不要です。

本体アプリは `ios/AppDelegate.swift`（`ExpoAppDelegate` ベース）なのでこの問題の影響を受けず、失敗していたのは App Clip ターゲットのみでした。

### 回帰リスクと緩和策

**サポート端末が変わります。** アプリの最小 iOS バージョンが 15.1 から 16.4 へ上がるため、iOS 15 系が上限の端末（iPhone 6s / 6s Plus / 7 / 7 Plus / SE 第 1 世代、iPad Air 2 など）は以降のアップデート対象外になります。iOS 16.4 は iOS 16 に更新できる全端末へ配信済みのため、それ以外の端末は OS を更新すれば影響を受けません。これは Expo SDK 57 が課す制約であり、SDK を戻さない限り回避手段はありません。

App Clip 側の変更は import の削除のみで、`AppDelegate` の継承関係・実装には手を加えていません。Prod / Canary の両 App Clip に同じ修正を入れているため、`Build iOS Production` 側でも同じ失敗は起きません。

## テスト

ローカル（Linux）で実行:

```text
npm run lint       Checked 631 files. No fixes applied.
npm test           218 suites / 2304 tests 全て passed
npm run typecheck  エラーなし
npx expo-doctor    19/19 checks passed
```

CocoaPods / Xcode の検証は Linux では行えないため、`docs/ios-build-workflows.md` の「Safe dry-run」手順に従い、本ブランチに対して **Build iOS Canary** を TestFlight アップロード無効で実行しています。

| 実行 | 結果 |
| ---- | ---- |
| [1 回目](https://github.com/TrainLCD/MobileApp/actions/runs/31582104684)（変更 1 のみ） | `Install CocoaPods dependencies` 成功 → `Archive canary` で App Clip のコンパイル失敗を検出 |
| [2 回目](https://github.com/TrainLCD/MobileApp/actions/runs/31583365016)（変更 1 + 2） | **成功**。`** ARCHIVE SUCCEEDED **` / コンパイルエラー 0 件 / dSYM アップロードまで完了、TestFlight アップロードは想定どおりスキップ |

2 回目では本体ターゲット `CanaryTrainLCD` の Swift コンパイルとリンク（`Ld …/CanaryTrainLCD.app/CanaryTrainLCD`）にも到達しています。1 回目は App Clip が本体の依存ターゲットであるため、そこで失敗した時点で本体の残り工程がスキップされていました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
