### PR TITLE
実効性の無くなったios.buildReactNativeFromSource設定を削除

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -37,14 +37,6 @@ export default {
         image: './assets/splash-icon.png',
       },
     ],
-    [
-      'expo-build-properties',
-      {
-        ios: {
-          buildReactNativeFromSource: true,
-        },
-      },
-    ],
   ],
   extra: {
     eas: {

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,7 +1,6 @@
 {
   "expo.jsEngine": "hermes",
   "ios.deploymentTarget": "16.4",
-  "ios.buildReactNativeFromSource": "true",
   "ios.useFrameworks": "static",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "newArchEnabled": "true",


### PR DESCRIPTION
## 概要

iOS で実効性を失っている `ios.buildReactNativeFromSource` 設定を削除し、宣言と実際のビルド挙動の食い違いを解消します。挙動は変わりません（削除前後どちらも prebuilt バイナリを使用）。

Expo SDK 57 の iOS ビルド修正 (#6664) の調査中に、`ios.buildReactNativeFromSource: true` を宣言しているにもかかわらず prebuilt な React Core がダウンロードされていることに気付いたのが発端です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/Podfile.properties.json` から `"ios.buildReactNativeFromSource": "true"` を削除
- `app.config.ts` から `expo-build-properties` プラグイン項目を削除（このオプションのみを保持していたため）

`expo-build-properties` パッケージ自体は `package.json` に残しています。再ロックを伴う変更は避ける方針であり、設定専用プラグインなのでビルドへの影響もありません。

### 実効性が無い理由

React Native 0.86 の `react_native_pods.rb`（`use_react_native!` 内）が、環境変数を明示的に `'0'` にしない限り prebuilt を強制します。

```ruby
# Use the React Native precompiled binaries by default.
# Users can still turn them off and build from source by setting the environment variable to 0.
ENV['RCT_USE_RN_DEP'] = ENV['RCT_USE_RN_DEP'] == '0' ? '0' : '1'
ENV['RCT_USE_PREBUILT_RNCORE'] = ENV['RCT_USE_PREBUILT_RNCORE'] == '0' ? '0' : '1'
```

一方 `ios/Podfile` は Expo SDK 54 期のテンプレートのままで、`'1'` を条件付きで代入することはあっても `'0'` を書きません。

```ruby
ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true' && …
```

したがって `true` を指定しても環境変数は未設定のまま RN 側に渡り、`'1'`（prebuilt）へ上書きされます。React Native が既定をソースビルドから prebuilt へ反転させた際に、テンプレート側が追随していなかったことが原因です。

削除すると Podfile の条件が真になり環境変数へ `'1'` が明示的に入りますが、RN 側の評価結果は `'1'` のままで挙動は同一です。

### 元々の導入経緯と、現在は不要な理由

| 経緯 | 現況 |
| ---- | ---- |
| #5471 で `useHermesV1: true` とセットで導入。`useHermesV1: false` は iOS でソースビルドを要求する（`expo-build-properties` の validation）ため必須だった | **#5503 で `useHermesV1` 自体が削除済み**で、この結合は既に解消 |
| #5494「EASビルド失敗対策」で再追加 | 現在の canary / production ビルドは GitHub Actions + `xcodebuild archive` で、EAS 固有の事情は該当しない |
| ソースビルドが必要なケースとして `patch-package` による react-native 本体へのパッチ | `patches/` に react-native 本体のパッチは無し（`expo-speech` / `expo-task-manager` などは Pod としてソースビルドされるため影響なし） |

## テスト

ローカル（Linux）で実行:

```text
npm run lint       Checked 631 files. No fixes applied.
npm test           218 suites / 2304 tests 全て passed
npm run typecheck  エラーなし
npx expo-doctor    19/19 checks passed
```

CocoaPods / Xcode の検証は `docs/ios-build-workflows.md` の「Safe dry-run」手順に従い、本ブランチに対して **Build iOS Canary** を TestFlight アップロード無効で実行しました。

- [Build iOS Canary (workflow_dispatch, publish_to_testflight=false)](https://github.com/TrainLCD/MobileApp/actions/runs/31585677702) — `** ARCHIVE SUCCEEDED **`、コンパイルエラー 0 件、本体・App Clip とも `Ld` まで到達、dSYM アップロード成功

削除前（#6664 の[検証ビルド](https://github.com/TrainLCD/MobileApp/actions/runs/31583365016)）と同じく `[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt` がログに出ており、ビルド構成が変わっていないことを確認しています。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - iOSアプリのビルド設定を整理しました。
  - React Nativeのソースからのビルドに関する個別設定を削除し、標準のビルド構成に戻しました。
  - アプリの機能や画面表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->