### PR TITLE
NSMotionUsageDescriptionを各iOSターゲットに追加してTestFlight配信のブロックを解消

### DIFF
--- a/ios/CanaryAppClip/Info.plist
+++ b/ios/CanaryAppClip/Info.plist
@@ -33,6 +33,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSMotionUsageDescription</key>
+	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/ios/CanaryAppClip/Info.plist
+++ b/ios/CanaryAppClip/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</dict>
 	<key>NSMotionUsageDescription</key>
-	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
+	<string>位置情報とあわせて乗車中や徒歩などの移動状況を判定するためにモーションセンサーの情報を使用します。</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/ios/ProdAppClip/Info.plist
+++ b/ios/ProdAppClip/Info.plist
@@ -33,6 +33,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSMotionUsageDescription</key>
+	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/ios/ProdAppClip/Info.plist
+++ b/ios/ProdAppClip/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</dict>
 	<key>NSMotionUsageDescription</key>
-	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
+	<string>位置情報とあわせて乗車中や徒歩などの移動状況を判定するためにモーションセンサーの情報を使用します。</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -69,7 +69,7 @@
 		</dict>
 	</dict>
 	<key>NSMotionUsageDescription</key>
-	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
+	<string>位置情報とあわせて乗車中や徒歩などの移動状況を判定するためにモーションセンサーの情報を使用します。</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -68,6 +68,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSMotionUsageDescription</key>
+	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -62,6 +62,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSMotionUsageDescription</key>
+	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -63,7 +63,7 @@
 		</dict>
 	</dict>
 	<key>NSMotionUsageDescription</key>
-	<string>画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。</string>
+	<string>位置情報とあわせて乗車中や徒歩などの移動状況を判定するためにモーションセンサーの情報を使用します。</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -9,4 +9,4 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSLocationAlwaysUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSPhotoLibraryAddUsageDescription" = "Save the screenshot image to your iPhone.";
-"NSMotionUsageDescription" = "Motion sensor data may be used to adjust on-screen effects in response to device movement.";
+"NSMotionUsageDescription" = "Motion sensor data is used together with your location to determine your movement activity, such as riding a train or walking.";

--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -9,3 +9,4 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSLocationAlwaysUsageDescription" = "Location information is continuously used while the application is in use to retrieve the nearest station.";
 "NSPhotoLibraryAddUsageDescription" = "Save the screenshot image to your iPhone.";
+"NSMotionUsageDescription" = "Motion sensor data may be used to adjust on-screen effects in response to device movement.";

--- a/ios/ja.lproj/InfoPlist.strings
+++ b/ios/ja.lproj/InfoPlist.strings
@@ -9,3 +9,4 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSLocationAlwaysUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSPhotoLibraryAddUsageDescription" = "スクリーンショット画像をiPhoneに保存します。";
+"NSMotionUsageDescription" = "画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。";

--- a/ios/ja.lproj/InfoPlist.strings
+++ b/ios/ja.lproj/InfoPlist.strings
@@ -9,4 +9,4 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSLocationAlwaysUsageDescription" = "最寄り駅を取得するためにアプリ使用中は継続的に位置情報を使用します。";
 "NSPhotoLibraryAddUsageDescription" = "スクリーンショット画像をiPhoneに保存します。";
-"NSMotionUsageDescription" = "画面の演出を端末の動きに合わせて調整するためにモーションセンサーを使用する場合があります。";
+"NSMotionUsageDescription" = "位置情報とあわせて乗車中や徒歩などの移動状況を判定するためにモーションセンサーの情報を使用します。";


### PR DESCRIPTION
## 概要

Expo SDK 57 の `expo-location` が iOS の `CMMotionActivityManager` を参照するようになり、`NSMotionUsageDescription` 未設定を理由に TestFlight でテストを開始できない状態になっていた。各 iOS ターゲットに purpose string を追加してブロックを解消する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ios/TrainLCD/Schemes/Prod/Info.plist` と `ios/TrainLCD/Schemes/Dev/Info.plist` に `NSMotionUsageDescription` を追加
- `ios/ProdAppClip/Info.plist` と `ios/CanaryAppClip/Info.plist` にも同キーを追加（App Clip は Podfile 上でアプリターゲットのネストターゲットであり、同じ Pod をリンクするため）
- `ios/ja.lproj/InfoPlist.strings` / `ios/en.lproj/InfoPlist.strings` にローカライズ済みの説明文を追加（既存の位置情報・写真ライブラリの purpose string と同じ運用に合わせた）

背景:

- `expo-location@57.0.9` の `ios/Providers/MotionActivityStreamer.swift` / `ios/Requesters/MotionActivityPermissionRequester.swift` / `ios/LocationModule.swift` が `import CoreMotion` と `CMMotionActivityManager` を使用している（SDK 57 で追加された `getMotionActivityAsync` / `watchMotionActivityAsync` 用）
- 同梱の config plugin は `NSMotionUsageDescription` を既定値で注入する設計だが、本リポジトリは `ios/` を直接管理しており Info.plist も `Schemes/{Prod,Dev}` 配下の独自パスのため、plugin による注入が届かない
- アプリ側の JS からモーションアクティビティ API を呼んでいる箇所は現状無いが、バイナリが CoreMotion をリンクしている以上 purpose string は必須

リグレッションリスク: 変更は Info.plist へのキー 1 件追加とローカライズ文字列の追加のみで、既存キーの変更・削除は無い。実行時の挙動には影響せず、モーションアクティビティ API を呼んだ場合にのみ本文言が表示される。

## テスト

- [x] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

作業環境が Node 22 / npm 10 で `engines: npm>=11` と不整合になり `npm ci` が失敗するため、`npm test` / `npm run typecheck` はローカル実行できていない。`npm run lint` 相当の `biome check ./src`（631 ファイル）のみ単体実行し指摘なし。差分は iOS の Info.plist / InfoPlist.strings のみで JS/TS を含まないため、残り 2 つは CI での確認をお願いしたい。あわせて 4 つの plist が `plistlib` でパースできることを確認済み。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01En5fqKFDDaQo9kpstNC1QL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 移動状況の判定にモーションセンサーを使用することを、iOSの許可画面で明示するようになりました。
  * 位置情報とモーションセンサー情報を組み合わせて、乗車中や徒歩などの移動状況を判定します。
  * 許可メッセージを日本語・英語に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->