### PR TITLE
AIチャットの提案から同一駅の重複を除外

### DIFF
--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -185,8 +185,10 @@ Firebase callable 互換（`{ data: {...} }` → `{ result: {...} }`）とし、
 
 同一の物理駅が路線ごとに別 `stationId` を持つため（例: 熱海駅の
 東海道線 / 東海道本線 / 伊東線）、`suggestions` には同じ駅が複数件
-含まれうる。クライアントは受信時に `stationGroupId` で重複を落とし、
+含まれうる。クライアントは同一駅のカードが並ばないよう重複を落とし、
 最初の 1 件だけを残す（詳細は「クライアント設計 > 提案駅選択」）。
+`suggestions[].stationGroupId` はサーバの実在性検証（ツール結果との
+`stationId` 突合）の対象外なので untrusted として扱う。
 
 ### 会話状態管理
 
@@ -720,12 +722,14 @@ Expo SDK 更新時はこのパッチの要否を再確認する。
 
 1. エージェントの `suggestions` は軽量情報（stationId 等）しか持たない
    ため、`GET_STATIONS_BY_IDS`（`stations(ids:)`）で `StationFields`
-   完全な `Station` を再取得する。再取得の前後で同一駅の重複を落とす:
-   受信時は `dedupeAgentSuggestions`（`useDestinationAgent`）が
-   `stationGroupId` で、再取得後は `dedupeStationsByGroupId`
-   （`src/utils/station.ts`）が API 由来の `groupId` で間引く
-   （提案の `stationGroupId` はサーバ検証の対象外＝untrusted なため
-   二段構えにする）。いずれもモデルが提示した優先順は保つ。
+   完全な `Station` を再取得する。同一物理駅の重複は、再取得後に
+   `dedupeStationsByGroupId`（`src/utils/station.ts`）が API 由来の
+   `groupId` で間引く。提案の `stationGroupId` は untrusted で、誤った値が
+   別々の駅に付いていると取得前に落とした駅を復元できないため、
+   グループ単位の間引きは取得前に行わない。受信時
+   （`dedupeAgentSuggestions` / `useDestinationAgent`）は同じ `stationId`
+   の完全重複だけを落とす（再取得 ID と React key の重複防止）。
+   いずれもモデルが提示した優先順は保つ。
 2. `RouteSearchScreen.tsx` の `handleLineSelected` 相当のロジック
    （`GET_ROUTE_TYPES_LIGHT` → 種別選択 → `pendingStations` 構築）を
    共有フック（例: `src/hooks/useDestinationSelection.ts`）に抽出し、

--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -183,6 +183,11 @@ Firebase callable 互換（`{ data: {...} }` → `{ result: {...} }`）とし、
 - `refused`: トピックゲートで謝絶した場合 `true`。クライアントは
   定型文を表示するだけでよい。
 
+同一の物理駅が路線ごとに別 `stationId` を持つため（例: 熱海駅の
+東海道線 / 東海道本線 / 伊東線）、`suggestions` には同じ駅が複数件
+含まれうる。クライアントは受信時に `stationGroupId` で重複を落とし、
+最初の 1 件だけを残す（詳細は「クライアント設計 > 提案駅選択」）。
+
 ### 会話状態管理
 
 サーバはステートレスとする（KV へのセッション保存はしない）。会話履歴は
@@ -715,7 +720,12 @@ Expo SDK 更新時はこのパッチの要否を再確認する。
 
 1. エージェントの `suggestions` は軽量情報（stationId 等）しか持たない
    ため、`GET_STATIONS_BY_IDS`（`stations(ids:)`）で `StationFields`
-   完全な `Station` を再取得する。
+   完全な `Station` を再取得する。再取得の前後で同一駅の重複を落とす:
+   受信時は `dedupeAgentSuggestions`（`useDestinationAgent`）が
+   `stationGroupId` で、再取得後は `dedupeStationsByGroupId`
+   （`src/utils/station.ts`）が API 由来の `groupId` で間引く
+   （提案の `stationGroupId` はサーバ検証の対象外＝untrusted なため
+   二段構えにする）。いずれもモデルが提示した優先順は保つ。
 2. `RouteSearchScreen.tsx` の `handleLineSelected` 相当のロジック
    （`GET_ROUTE_TYPES_LIGHT` → 種別選択 → `pendingStations` 構築）を
    共有フック（例: `src/hooks/useDestinationSelection.ts`）に抽出し、

--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -371,6 +371,59 @@ describe('useDestinationAgent', () => {
     }
   });
 
+  it('同一駅(stationGroupId が同じ)の重複提案は最初の 1 件だけ残す', async () => {
+    // 熱海駅のように 1 つの駅が路線ごとに別 stationId を持つケース
+    mockStreamResponse([
+      doneEvent({
+        reply: 'ok',
+        suggestions: [
+          {
+            stationId: 1131301,
+            stationGroupId: 1131301,
+            name: '熱海',
+            nameRoman: 'Atami',
+            lineNames: ['東海道線'],
+          },
+          {
+            stationId: 1132401,
+            stationGroupId: 1131301,
+            name: '熱海',
+            nameRoman: 'Atami',
+            lineNames: ['東海道本線'],
+          },
+          {
+            stationId: 1133101,
+            stationGroupId: 1131301,
+            name: '熱海',
+            nameRoman: 'Atami',
+            lineNames: ['伊東線'],
+          },
+          {
+            stationId: 1121301,
+            stationGroupId: 1121301,
+            name: '鬼怒川温泉',
+            nameRoman: 'Kinugawa-Onsen',
+            lineNames: ['東武鬼怒川線'],
+          },
+        ],
+        refused: false,
+      }),
+    ]);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([
+      { role: 'user', content: '温泉のある観光地に行きたい' },
+    ]);
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      // 提案順(モデルの優先順)を保ったまま先頭の熱海だけが残る
+      expect(res.data.suggestions.map((s) => s.stationId)).toEqual([
+        1131301, 1121301,
+      ]);
+    }
+  });
+
   it('429 は rateLimited を返す', async () => {
     mockErrorResponse(429);
 

--- a/src/hooks/useDestinationAgent.test.ts
+++ b/src/hooks/useDestinationAgent.test.ts
@@ -371,8 +371,55 @@ describe('useDestinationAgent', () => {
     }
   });
 
-  it('同一駅(stationGroupId が同じ)の重複提案は最初の 1 件だけ残す', async () => {
-    // 熱海駅のように 1 つの駅が路線ごとに別 stationId を持つケース
+  it('同じ stationId の重複提案は最初の 1 件だけ残す', async () => {
+    mockStreamResponse([
+      doneEvent({
+        reply: 'ok',
+        suggestions: [
+          {
+            stationId: 1131301,
+            stationGroupId: 1131301,
+            name: '熱海',
+            nameRoman: 'Atami',
+            lineNames: ['東海道線'],
+          },
+          {
+            stationId: 1131301,
+            stationGroupId: 1131301,
+            name: '熱海',
+            nameRoman: 'Atami',
+            lineNames: ['東海道線'],
+          },
+          {
+            stationId: 1121301,
+            stationGroupId: 1121301,
+            name: '鬼怒川温泉',
+            nameRoman: 'Kinugawa-Onsen',
+            lineNames: ['東武鬼怒川線'],
+          },
+        ],
+        refused: false,
+      }),
+    ]);
+
+    const sendMessages = renderSendMessages();
+    const res = await sendMessages([
+      { role: 'user', content: '温泉のある観光地に行きたい' },
+    ]);
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      // 提案順(モデルの優先順)は保つ
+      expect(res.data.suggestions.map((s) => s.stationId)).toEqual([
+        1131301, 1121301,
+      ]);
+    }
+  });
+
+  it('stationGroupId が同じでも stationId が違う提案は落とさない', async () => {
+    // stationGroupId は untrusted(サーバ検証は stationId 突合のみ)なので、
+    // 取得前に落とすと別駅だった場合に復元できなくなる。同一物理駅の間引きは
+    // 再取得後に API 由来の groupId で行う
     mockStreamResponse([
       doneEvent({
         reply: 'ok',
@@ -398,13 +445,6 @@ describe('useDestinationAgent', () => {
             nameRoman: 'Atami',
             lineNames: ['伊東線'],
           },
-          {
-            stationId: 1121301,
-            stationGroupId: 1121301,
-            name: '鬼怒川温泉',
-            nameRoman: 'Kinugawa-Onsen',
-            lineNames: ['東武鬼怒川線'],
-          },
         ],
         refused: false,
       }),
@@ -417,9 +457,8 @@ describe('useDestinationAgent', () => {
 
     expect(res.ok).toBe(true);
     if (res.ok) {
-      // 提案順(モデルの優先順)を保ったまま先頭の熱海だけが残る
       expect(res.data.suggestions.map((s) => s.stationId)).toEqual([
-        1131301, 1121301,
+        1131301, 1132401, 1133101,
       ]);
     }
   });

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -74,6 +74,31 @@ const isAgentSuggestion = (value: unknown): value is AgentSuggestion => {
   );
 };
 
+/**
+ * 同じ駅が複数の提案に分かれて返ってくるケース(例: 熱海駅の 東海道線 /
+ * 東海道本線 / 伊東線 のように、1 つの駅が路線ごとに別レコードとして
+ * 存在する)で、同じ駅名のカードが並ぶのを防ぐため、`stationGroupId`
+ * (同一物理駅の識別子)が一致する提案を最初の出現だけ残して間引く。
+ * モデルが提示した優先順は保つ。
+ */
+export const dedupeAgentSuggestions = (
+  suggestions: AgentSuggestion[]
+): AgentSuggestion[] => {
+  if (suggestions.length <= 1) {
+    return suggestions;
+  }
+  const seen = new Set<number>();
+  const result: AgentSuggestion[] = [];
+  for (const suggestion of suggestions) {
+    if (seen.has(suggestion.stationGroupId)) {
+      continue;
+    }
+    seen.add(suggestion.stationGroupId);
+    result.push(suggestion);
+  }
+  return result;
+};
+
 const parseEventData = (data: string): Record<string, unknown> | null => {
   try {
     const parsed: unknown = JSON.parse(data);
@@ -100,9 +125,10 @@ const toChatResultFromObject = (
   }
   return {
     reply: parsed.reply,
-    // サーバー応答は untrusted として扱い、形の合わない要素は落とす
+    // サーバー応答は untrusted として扱い、形の合わない要素は落とし、
+    // 同一駅を指す重複提案は 1 件に間引く
     suggestions: Array.isArray(parsed.suggestions)
-      ? parsed.suggestions.filter(isAgentSuggestion)
+      ? dedupeAgentSuggestions(parsed.suggestions.filter(isAgentSuggestion))
       : [],
     refused: parsed.refused === true,
   };

--- a/src/hooks/useDestinationAgent.ts
+++ b/src/hooks/useDestinationAgent.ts
@@ -75,11 +75,16 @@ const isAgentSuggestion = (value: unknown): value is AgentSuggestion => {
 };
 
 /**
- * 同じ駅が複数の提案に分かれて返ってくるケース(例: 熱海駅の 東海道線 /
- * 東海道本線 / 伊東線 のように、1 つの駅が路線ごとに別レコードとして
- * 存在する)で、同じ駅名のカードが並ぶのを防ぐため、`stationGroupId`
- * (同一物理駅の識別子)が一致する提案を最初の出現だけ残して間引く。
+ * まったく同じ駅(`stationId` が一致)を指す提案を最初の出現だけ残して間引く。
+ * 再取得の ID とスケルトンの React key が重複しないようにするのが目的で、
  * モデルが提示した優先順は保つ。
+ *
+ * ここで `stationGroupId` は見ない。サーバ側の実在性検証はツール結果との
+ * `stationId` 突合だけなので `stationGroupId` は untrusted であり、誤った値が
+ * 別々の駅に付いていると、取得前に落とした駅は `GET_STATIONS_BY_IDS` に
+ * 渡らず復元できなくなる。同一物理駅(例: 熱海駅の 東海道線 / 東海道本線 /
+ * 伊東線)の間引きは、再取得後に API 由来の `groupId` で行う
+ * (`dedupeStationsByGroupId`)。
  */
 export const dedupeAgentSuggestions = (
   suggestions: AgentSuggestion[]
@@ -90,10 +95,10 @@ export const dedupeAgentSuggestions = (
   const seen = new Set<number>();
   const result: AgentSuggestion[] = [];
   for (const suggestion of suggestions) {
-    if (seen.has(suggestion.stationGroupId)) {
+    if (seen.has(suggestion.stationId)) {
       continue;
     }
-    seen.add(suggestion.stationGroupId);
+    seen.add(suggestion.stationId);
     result.push(suggestion);
   }
   return result;
@@ -126,7 +131,7 @@ const toChatResultFromObject = (
   return {
     reply: parsed.reply,
     // サーバー応答は untrusted として扱い、形の合わない要素は落とし、
-    // 同一駅を指す重複提案は 1 件に間引く
+    // 同じ `stationId` を指す重複提案は 1 件に間引く
     suggestions: Array.isArray(parsed.suggestions)
       ? dedupeAgentSuggestions(parsed.suggestions.filter(isAgentSuggestion))
       : [],

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -38,6 +38,7 @@ import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { isJapanese, translate } from '~/translation';
 import { showDialog } from '~/utils/dialogPresentation';
 import isTablet from '~/utils/isTablet';
+import { dedupeStationsByGroupId } from '~/utils/station';
 import { showToast } from '~/utils/toast';
 import { AgentEmptyState } from './AgentEmptyState';
 import { AgentHeader } from './AgentHeader';
@@ -274,9 +275,14 @@ const DestinationAgentScreen = () => {
         .map((id) => byId.get(id))
         .filter((s): s is Station => s != null);
 
+      // 提案側の stationGroupId は untrusted なため、API が返した
+      // 正しい groupId でもう一度同一駅の重複を落とす(熱海のように
+      // 路線ごとに別 stationId を持つ駅が並ぶのを防ぐ)
+      const deduped = dedupeStationsByGroupId(ordered);
+
       setSuggestionStates((prev) => ({
         ...prev,
-        [entryId]: { status: 'loaded', stations: ordered },
+        [entryId]: { status: 'loaded', stations: deduped },
       }));
     },
     [fetchStationsByIds]

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -275,9 +275,10 @@ const DestinationAgentScreen = () => {
         .map((id) => byId.get(id))
         .filter((s): s is Station => s != null);
 
-      // 提案側の stationGroupId は untrusted なため、API が返した
-      // 正しい groupId でもう一度同一駅の重複を落とす(熱海のように
-      // 路線ごとに別 stationId を持つ駅が並ぶのを防ぐ)
+      // 熱海のように 1 つの物理駅が路線ごとに別 stationId を持つケースで
+      // 同じ駅のカードが並ぶのを防ぐ。提案側の stationGroupId は untrusted
+      // (サーバ検証は stationId 突合のみ)なので、間引きは取得前ではなく
+      // ここで API が返した groupId を使って行う
       const deduped = dedupeStationsByGroupId(ordered);
 
       setSuggestionStates((prev) => ({

--- a/src/utils/station.test.ts
+++ b/src/utils/station.test.ts
@@ -1,6 +1,7 @@
 import type { Station, TrainTypeNested } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
 import {
+  dedupeStationsByGroupId,
   getStationLineId,
   getStationPrimaryCode,
   isSameStationShallow,
@@ -294,6 +295,49 @@ describe('getStationLineId', () => {
     });
     // The function uses ?? undefined, so null becomes undefined
     expect(getStationLineId(station)).toBeUndefined();
+  });
+});
+
+describe('dedupeStationsByGroupId', () => {
+  it('returns the same array reference when length <= 1', () => {
+    const empty: Station[] = [];
+    expect(dedupeStationsByGroupId(empty)).toBe(empty);
+
+    const single = [createMockStation({ id: 1, groupId: 1 })];
+    expect(dedupeStationsByGroupId(single)).toBe(single);
+  });
+
+  it('keeps only the first station of each groupId', () => {
+    // 熱海駅を模した重複ケース(路線ごとに別 id・同じ groupId)
+    const stations = [
+      createMockStation({ id: 1131301, groupId: 1131301, name: '熱海' }),
+      createMockStation({ id: 1132401, groupId: 1131301, name: '熱海' }),
+      createMockStation({ id: 1133101, groupId: 1131301, name: '熱海' }),
+      createMockStation({ id: 1121301, groupId: 1121301, name: '鬼怒川温泉' }),
+    ];
+    expect(dedupeStationsByGroupId(stations).map((s) => s.id)).toEqual([
+      1131301, 1121301,
+    ]);
+  });
+
+  it('preserves the original order', () => {
+    const stations = [
+      createMockStation({ id: 3, groupId: 30 }),
+      createMockStation({ id: 1, groupId: 10 }),
+      createMockStation({ id: 2, groupId: 30 }),
+    ];
+    expect(dedupeStationsByGroupId(stations).map((s) => s.id)).toEqual([3, 1]);
+  });
+
+  it('keeps stations without groupId as-is', () => {
+    const stations = [
+      createMockStation({ id: 1, groupId: null }),
+      createMockStation({ id: 2, groupId: null }),
+      createMockStation({ id: 3, groupId: undefined }),
+    ];
+    expect(dedupeStationsByGroupId(stations).map((s) => s.id)).toEqual([
+      1, 2, 3,
+    ]);
   });
 });
 

--- a/src/utils/station.ts
+++ b/src/utils/station.ts
@@ -13,6 +13,28 @@ export const getStationName = (s: Station | undefined): string =>
 export const getStationLineId = (s: Station | undefined): number | undefined =>
   (s?.line as Line | undefined)?.id ?? undefined;
 
+/**
+ * 同じ物理駅が路線ごとに別レコード(別 `id`)として返ってくるケース
+ * (例: 熱海駅の 東海道線 / 東海道本線 / 伊東線)で、同じ駅が並ぶのを
+ * 防ぐため、`groupId` が一致する Station を最初の出現だけ残して間引く。
+ * 元の並び順(呼び出し側が意図した優先順)は保つ。`groupId` が無い駅は
+ * 同一判定ができないためそのまま残す。
+ */
+export const dedupeStationsByGroupId = (stations: Station[]): Station[] => {
+  if (stations.length <= 1) return stations;
+  const seen = new Set<number>();
+  const result: Station[] = [];
+  for (const station of stations) {
+    const groupId = station.groupId;
+    if (groupId != null) {
+      if (seen.has(groupId)) continue;
+      seen.add(groupId);
+    }
+    result.push(station);
+  }
+  return result;
+};
+
 export const isSameStationShallow = (
   a: Station | undefined,
   b: Station | undefined


### PR DESCRIPTION
## 概要

AIチャット（AIに行き先を相談）の提案カードで、同じ駅が繰り返し表示される問題を修正する。熱海のように 1 つの物理駅が路線ごとに別 `stationId` を持つ駅では、サーバーの `suggestions` に同一駅が複数件（東海道線 / 東海道本線 / 伊東線）含まれ、そのまま 3 枚のカードとして並んでいた。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/station.ts`: `groupId` が同じ `Station` を最初の 1 件だけ残す `dedupeStationsByGroupId` を追加。
- `DestinationAgentScreen` の `resolveSuggestions`: `GET_STATIONS_BY_IDS` で駅を再取得した後に `dedupeStationsByGroupId` を適用し、同一物理駅のカードが並ばないようにした。
- `useDestinationAgent`: `dedupeAgentSuggestions` を追加し、同じ `stationId` を指す完全重複の提案だけを受信時に落とす（再取得 ID とスケルトンの React key の重複防止）。
- グループ単位の間引きは**再取得後の API 由来 `groupId` に一本化**している。提案の `stationGroupId` はサーバー側の実在性検証（ツール結果との `stationId` 突合）の対象外＝untrusted で、誤った値が別々の駅に付いていると取得前に落とした駅を `GET_STATIONS_BY_IDS` に渡せず復元できなくなるため（CodeRabbit の指摘を受けて修正）。
- いずれもモデルが提示した優先順（提案順）は保つ。`groupId` を持たない駅は同一判定できないためそのまま残す。
- `docs/spec/ai-agent/architecture.md`: 上記の方針を追記。
- テスト追加: `useDestinationAgent.test.ts`（同一 `stationId` の重複は 1 件に、`stationGroupId` が同じでも `stationId` が違う提案は落とさない）、`station.test.ts`（`dedupeStationsByGroupId` の順序保持・`groupId` なしの扱いなど 4 ケース）。

会話ターンをまたいだ再提案（前のターンで出た駅が次の回答にも出る）は対象外。「その駅について詳しく」といった追問でカードが 0 件になる副作用があるため、必要ならサーバー側（BFF）のプロンプト・検証で扱うのが妥当と判断した。

### リグレッションリスクと緩和

- 影響範囲は AI チャット画面の提案カード表示のみ。提案タップ後のフロー（`useDestinationSelection` → `SelectBoundModal`）には変更なし。
- 重複が無い応答では挙動が変わらないこと、`groupId` が無い駅を落とさないこと、untrusted な `stationGroupId` で候補を失わないことをユニットテストで担保している。
- `dedupeStationsByGroupId` は新規追加のため既存呼び出し元への影響なし。

## テスト

`npm run lint` / `npm test` / `npm run typecheck` をローカルで実行し、いずれも成功（218 suites / 2310 tests パス）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->
