### PR TITLE
App Clipのimport Expoをinternalに揃えてiOSアーカイブの失敗を解消

### DIFF
--- a/docs/ios-app-clip.md
+++ b/docs/ios-app-clip.md
@@ -27,6 +27,21 @@ App Clip の `AppDelegate.swift` は本体アプリの `ios/AppDelegate.swift` �
    `thirdPartyFabricComponents` が空になり、autolink したネイティブ
    コンポーネントが一切登録されない。
 
+## `Expo` は `internal import` で取り込む
+
+`import Expo` ではなく `internal import Expo` と書くこと。CocoaPods が各ターゲット
+向けに生成する `ios/Pods/Target Support Files/Pods-TrainLCD-<Target>/ExpoModulesProvider.swift`
+が `internal import Expo` を書いており、同じモジュール内でアクセスレベルの
+指定有無が混ざると Swift が
+
+```text
+error: ambiguous implicit access level for import of 'Expo'; it is imported as 'internal' elsewhere
+```
+
+を出してアーカイブが失敗する（実例: [Build iOS Canary #31593391309](https://github.com/TrainLCD/MobileApp/actions/runs/31593391309)）。
+本体アプリの `ios/AppDelegate.swift` も同じ理由で `internal import Expo` になっている。
+`ExpoModulesProvider.swift` は生成物なので、揃えるのは常に App Clip 側。
+
 ## 起動 URL（App Clip Invocation URL）の受け取り
 
 App Clip の起動 URL は `application(_:continue:restorationHandler:)` にしか

--- a/ios/CanaryAppClip/AppDelegate.swift
+++ b/ios/CanaryAppClip/AppDelegate.swift
@@ -6,7 +6,11 @@
 //  Copyright © 2025 Facebook. All rights reserved.
 //
 
-import Expo
+// Pods が生成する `ExpoModulesProvider.swift` が同じターゲット内で `internal import Expo`
+// を書いているため、こちらも明示的に `internal` を付ける。素の `import Expo` だと
+// "ambiguous implicit access level for import" でコンパイルが落ちる（本体アプリの
+// ios/AppDelegate.swift も同じ理由で `internal import` にしている）。
+internal import Expo
 import React
 import ReactAppDependencyProvider
 

--- a/ios/ProdAppClip/AppDelegate.swift
+++ b/ios/ProdAppClip/AppDelegate.swift
@@ -6,7 +6,11 @@
 //  Copyright © 2025 Facebook. All rights reserved.
 //
 
-import Expo
+// Pods が生成する `ExpoModulesProvider.swift` が同じターゲット内で `internal import Expo`
+// を書いているため、こちらも明示的に `internal` を付ける。素の `import Expo` だと
+// "ambiguous implicit access level for import" でコンパイルが落ちる（本体アプリの
+// ios/AppDelegate.swift も同じ理由で `internal import` にしている）。
+internal import Expo
 import React
 import ReactAppDependencyProvider
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6672 で App Clip の `AppDelegate` を Swift 化した際、`Expo` の import にアクセスレベルを付けていなかったため、canary の iOS アーカイブが失敗していた（[Build iOS Canary #31593391309](https://github.com/TrainLCD/MobileApp/actions/runs/31593391309/job/94103193222)）。これを解消する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `ios/CanaryAppClip/AppDelegate.swift` / `ios/ProdAppClip/AppDelegate.swift` の `import Expo` を `internal import Expo` へ変更（理由をコメントで併記）
- `docs/ios-app-clip.md` に「`Expo` は `internal import` で取り込む」節を追加

### 失敗の内容

```text
/Users/runner/work/MobileApp/MobileApp/ios/CanaryAppClip/AppDelegate.swift:9:8: error: ambiguous implicit access level for import of 'Expo'; it is imported as 'internal' elsewhere
import Expo
       ^
internal
/Users/runner/work/MobileApp/MobileApp/ios/Pods/Target Support Files/Pods-TrainLCD-CanaryTrainLCD-CanaryAppClip/ExpoModulesProvider.swift:10:1: note: imported 'internal' here
internal import Expo
^
** ARCHIVE FAILED **
```

CocoaPods が各ターゲット向けに生成する `ExpoModulesProvider.swift` が `internal import Expo` と書いているため、同じモジュール内でアクセスレベル指定の有無が混ざると Swift がこのエラーを出す。本体アプリの `ios/AppDelegate.swift` は元から `internal import Expo` なので影響を受けておらず、#6672 で新規追加した App Clip 2 ファイルだけが素の `import Expo` だった。`ExpoModulesProvider.swift` は生成物なので、揃えるのは常に App Clip 側になる。

`ProdAppClip` も同一内容だったため、放置すると本番ビルドでも同じ箇所で失敗する。今回まとめて修正している。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint       Checked 631 files. No fixes applied.
npm test           218 suites / 2310 tests 全て passed
npm run typecheck  エラーなし
```

Swift のコンパイル自体は JS 側のチェックでは検証できないため、最終確認は本 PR を `dev` に取り込んだあとの canary ビルドとなる。

回帰リスクは低い。変更は import 文のアクセスレベル指定のみで、`ExpoAppDelegate` を使ったブートストラップ経路・ディープリンク処理・シンボルの可視性は変わらない（`Expo` の型は `AppDelegate` の内部実装でしか使っておらず、App Clip ターゲットは他モジュールから import されないため `internal` で足りる）。本体アプリのターゲットには一切変更が無い。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6672

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_015p2Vn2rDGfNnYr8hs6dVb2)_