### PR TITLE
ウォークスルーの切り抜き角丸を対象要素の形に合わせて修正

### DIFF
--- a/src/components/WalkthroughOverlay.test.tsx
+++ b/src/components/WalkthroughOverlay.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
-import { Rect } from 'react-native-svg';
+import { Path } from 'react-native-svg';
 import { THEME_PREFERENCE } from '~/models/Theme';
 import { themePreferenceAtom } from '~/store/atoms/theme';
+import { buildRoundedRectPath } from '~/utils/roundedRectPath';
 import WalkthroughOverlay, { type WalkthroughStep } from './WalkthroughOverlay';
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -14,21 +15,22 @@ jest.mock('~/translation', () => ({
 }));
 
 const SPOTLIGHT_BORDER_RADIUS = 12;
+const SPOTLIGHT_RECT = { x: 24, y: 120, width: 320, height: 76 };
 
 const step: WalkthroughStep = {
   id: 'settingsTheme',
   titleKey: 'settingsWalkthroughTitle2',
   descriptionKey: 'settingsWalkthroughDescription2',
   spotlightArea: {
-    x: 24,
-    y: 120,
-    width: 320,
-    height: 76,
+    ...SPOTLIGHT_RECT,
     borderRadius: SPOTLIGHT_BORDER_RADIUS,
   },
 };
 
-const renderOverlay = (isLEDTheme: boolean) => {
+const renderOverlay = (
+  isLEDTheme: boolean,
+  spotlightArea: WalkthroughStep['spotlightArea'] = step.spotlightArea
+) => {
   const store = createStore();
   store.set(
     themePreferenceAtom,
@@ -39,7 +41,7 @@ const renderOverlay = (isLEDTheme: boolean) => {
     <Provider store={store}>
       <WalkthroughOverlay
         visible
-        step={step}
+        step={{ ...step, spotlightArea }}
         currentStepIndex={0}
         totalSteps={4}
         onNext={jest.fn()}
@@ -50,9 +52,10 @@ const renderOverlay = (isLEDTheme: boolean) => {
   );
 };
 
-// マスク内の切り抜き矩形は fill="black" の Rect のみ
-const getSpotlightRect = (screen: ReturnType<typeof renderOverlay>) =>
-  screen.UNSAFE_getAllByType(Rect).find((rect) => rect.props.fill === 'black');
+// マスク内の切り抜きは fill="black" の Path のみ
+const getSpotlightPath = (screen: ReturnType<typeof renderOverlay>) =>
+  screen.UNSAFE_getAllByType(Path).find((path) => path.props.fill === 'black')
+    ?.props.d;
 
 describe('WalkthroughOverlay', () => {
   beforeEach(() => {
@@ -66,17 +69,91 @@ describe('WalkthroughOverlay', () => {
   });
 
   it('通常テーマでは指定された角丸で切り抜く', () => {
-    const spotlightRect = getSpotlightRect(renderOverlay(false));
-
-    expect(spotlightRect?.props.rx).toBe(SPOTLIGHT_BORDER_RADIUS);
-    expect(spotlightRect?.props.ry).toBe(SPOTLIGHT_BORDER_RADIUS);
+    expect(getSpotlightPath(renderOverlay(false))).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: SPOTLIGHT_BORDER_RADIUS,
+        topRight: SPOTLIGHT_BORDER_RADIUS,
+        bottomRight: SPOTLIGHT_BORDER_RADIUS,
+        bottomLeft: SPOTLIGHT_BORDER_RADIUS,
+      })
+    );
   });
 
   it('LEDテーマでは角丸なしで切り抜く', () => {
-    const spotlightRect = getSpotlightRect(renderOverlay(true));
+    expect(getSpotlightPath(renderOverlay(true))).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: 0,
+        topRight: 0,
+        bottomRight: 0,
+        bottomLeft: 0,
+      })
+    );
+  });
 
-    expect(spotlightRect?.props.rx).toBe(0);
-    expect(spotlightRect?.props.ry).toBe(0);
+  it('隅ごとの指定があれば対象要素の形に合わせて切り抜く', () => {
+    const path = getSpotlightPath(
+      renderOverlay(false, {
+        ...SPOTLIGHT_RECT,
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        borderBottomLeftRadius: 16,
+        borderBottomRightRadius: 16,
+      })
+    );
+
+    expect(path).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: 0,
+        topRight: 0,
+        bottomRight: 16,
+        bottomLeft: 16,
+      })
+    );
+  });
+
+  it('隅ごとの指定がない隅には borderRadius が使われる', () => {
+    const path = getSpotlightPath(
+      renderOverlay(false, {
+        ...SPOTLIGHT_RECT,
+        borderRadius: SPOTLIGHT_BORDER_RADIUS,
+        borderTopLeftRadius: 0,
+      })
+    );
+
+    expect(path).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: 0,
+        topRight: SPOTLIGHT_BORDER_RADIUS,
+        bottomRight: SPOTLIGHT_BORDER_RADIUS,
+        bottomLeft: SPOTLIGHT_BORDER_RADIUS,
+      })
+    );
+  });
+
+  it('LEDテーマでは隅ごとの指定があっても角丸なしにする', () => {
+    const path = getSpotlightPath(
+      renderOverlay(true, {
+        ...SPOTLIGHT_RECT,
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        borderBottomLeftRadius: 16,
+        borderBottomRightRadius: 16,
+      })
+    );
+
+    expect(path).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: 0,
+        topRight: 0,
+        bottomRight: 0,
+        bottomLeft: 0,
+      })
+    );
   });
 
   it('LEDテーマではツールチップも角丸なしになる', () => {

--- a/src/components/WalkthroughOverlay.test.tsx
+++ b/src/components/WalkthroughOverlay.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import { Rect } from 'react-native-svg';
+import { THEME_PREFERENCE } from '~/models/Theme';
+import { themePreferenceAtom } from '~/store/atoms/theme';
+import WalkthroughOverlay, { type WalkthroughStep } from './WalkthroughOverlay';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+const SPOTLIGHT_BORDER_RADIUS = 12;
+
+const step: WalkthroughStep = {
+  id: 'settingsTheme',
+  titleKey: 'settingsWalkthroughTitle2',
+  descriptionKey: 'settingsWalkthroughDescription2',
+  spotlightArea: {
+    x: 24,
+    y: 120,
+    width: 320,
+    height: 76,
+    borderRadius: SPOTLIGHT_BORDER_RADIUS,
+  },
+};
+
+const renderOverlay = (isLEDTheme: boolean) => {
+  const store = createStore();
+  store.set(
+    themePreferenceAtom,
+    isLEDTheme ? THEME_PREFERENCE.LED : THEME_PREFERENCE.TOKYO_METRO
+  );
+
+  return render(
+    <Provider store={store}>
+      <WalkthroughOverlay
+        visible
+        step={step}
+        currentStepIndex={0}
+        totalSteps={4}
+        onNext={jest.fn()}
+        onGoToStep={jest.fn()}
+        onSkip={jest.fn()}
+      />
+    </Provider>
+  );
+};
+
+// マスク内の切り抜き矩形は fill="black" の Rect のみ
+const getSpotlightRect = (screen: ReturnType<typeof renderOverlay>) =>
+  screen.UNSAFE_getAllByType(Rect).find((rect) => rect.props.fill === 'black');
+
+describe('WalkthroughOverlay', () => {
+  beforeEach(() => {
+    // ツールチップ位置のアニメーションがテスト外で進行しないよう固定する
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('通常テーマでは指定された角丸で切り抜く', () => {
+    const spotlightRect = getSpotlightRect(renderOverlay(false));
+
+    expect(spotlightRect?.props.rx).toBe(SPOTLIGHT_BORDER_RADIUS);
+    expect(spotlightRect?.props.ry).toBe(SPOTLIGHT_BORDER_RADIUS);
+  });
+
+  it('LEDテーマでは角丸なしで切り抜く', () => {
+    const spotlightRect = getSpotlightRect(renderOverlay(true));
+
+    expect(spotlightRect?.props.rx).toBe(0);
+    expect(spotlightRect?.props.ry).toBe(0);
+  });
+
+  it('LEDテーマではツールチップも角丸なしになる', () => {
+    const { getByLabelText } = renderOverlay(true);
+
+    const nextButton = getByLabelText('walkthroughNext');
+
+    expect(nextButton).toHaveStyle({ borderRadius: 0 });
+  });
+});

--- a/src/components/WalkthroughOverlay.test.tsx
+++ b/src/components/WalkthroughOverlay.test.tsx
@@ -15,6 +15,8 @@ jest.mock('~/translation', () => ({
 }));
 
 const SPOTLIGHT_BORDER_RADIUS = 12;
+// 呼び出し側が半径を一切指定しなかった場合の既定値
+const DEFAULT_SPOTLIGHT_BORDER_RADIUS = 8;
 const SPOTLIGHT_RECT = { x: 24, y: 120, width: 320, height: 76 };
 
 const step: WalkthroughStep = {
@@ -76,6 +78,18 @@ describe('WalkthroughOverlay', () => {
         topRight: SPOTLIGHT_BORDER_RADIUS,
         bottomRight: SPOTLIGHT_BORDER_RADIUS,
         bottomLeft: SPOTLIGHT_BORDER_RADIUS,
+      })
+    );
+  });
+
+  it('半径の指定がなければ既定の角丸で切り抜く', () => {
+    expect(getSpotlightPath(renderOverlay(false, SPOTLIGHT_RECT))).toBe(
+      buildRoundedRectPath({
+        ...SPOTLIGHT_RECT,
+        topLeft: DEFAULT_SPOTLIGHT_BORDER_RADIUS,
+        topRight: DEFAULT_SPOTLIGHT_BORDER_RADIUS,
+        bottomRight: DEFAULT_SPOTLIGHT_BORDER_RADIUS,
+        bottomLeft: DEFAULT_SPOTLIGHT_BORDER_RADIUS,
       })
     );
   });

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -9,10 +9,11 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Svg, { Defs, Mask, Rect } from 'react-native-svg';
+import Svg, { Defs, Mask, Path, Rect } from 'react-native-svg';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import { translate } from '../translation';
 import { RFValue } from '../utils/rfValue';
+import { buildRoundedRectPath } from '../utils/roundedRectPath';
 import Typography from './Typography';
 
 export type SpotlightArea = {
@@ -20,7 +21,13 @@ export type SpotlightArea = {
   y: number;
   width: number;
   height: number;
+  /** 4隅共通の角丸。隅ごとの指定がない隅に適用される */
   borderRadius?: number;
+  // 上辺だけ直角のカードなど、対象要素の形に合わせたい場合は隅ごとに指定する
+  borderTopLeftRadius?: number;
+  borderTopRightRadius?: number;
+  borderBottomRightRadius?: number;
+  borderBottomLeftRadius?: number;
 };
 
 export type WalkthroughStepId =
@@ -168,10 +175,27 @@ const WalkthroughOverlay: React.FC<Props> = ({
     };
   }, [overlayOffset.x, overlayOffset.y, spotlightArea]);
 
-  // 切り抜きの角丸は呼び出し側の指定に従うが、LEDテーマでは角丸を使わない
-  const spotlightBorderRadius = isLEDTheme
-    ? 0
-    : (adjustedSpotlightArea?.borderRadius ?? DEFAULT_SPOTLIGHT_BORDER_RADIUS);
+  // 切り抜きの角丸は呼び出し側の指定（隅ごと > 4隅共通）に従うが、LEDテーマでは角丸を使わない
+  const spotlightPath = useMemo(() => {
+    if (!adjustedSpotlightArea) {
+      return null;
+    }
+    const fallbackRadius =
+      adjustedSpotlightArea.borderRadius ?? DEFAULT_SPOTLIGHT_BORDER_RADIUS;
+    const resolveRadius = (cornerRadius: number | undefined) =>
+      isLEDTheme ? 0 : (cornerRadius ?? fallbackRadius);
+
+    return buildRoundedRectPath({
+      x: adjustedSpotlightArea.x,
+      y: adjustedSpotlightArea.y,
+      width: adjustedSpotlightArea.width,
+      height: adjustedSpotlightArea.height,
+      topLeft: resolveRadius(adjustedSpotlightArea.borderTopLeftRadius),
+      topRight: resolveRadius(adjustedSpotlightArea.borderTopRightRadius),
+      bottomRight: resolveRadius(adjustedSpotlightArea.borderBottomRightRadius),
+      bottomLeft: resolveRadius(adjustedSpotlightArea.borderBottomLeftRadius),
+    });
+  }, [adjustedSpotlightArea, isLEDTheme]);
 
   // tooltipPosition === 'top' かつ spotlightArea がある場合は bottom で配置
   const useBottomPositioning =
@@ -253,17 +277,7 @@ const WalkthroughOverlay: React.FC<Props> = ({
                 height={screenHeight}
                 fill="white"
               />
-              {adjustedSpotlightArea && (
-                <Rect
-                  x={adjustedSpotlightArea.x}
-                  y={adjustedSpotlightArea.y}
-                  width={adjustedSpotlightArea.width}
-                  height={adjustedSpotlightArea.height}
-                  rx={spotlightBorderRadius}
-                  ry={spotlightBorderRadius}
-                  fill="black"
-                />
-              )}
+              {spotlightPath && <Path d={spotlightPath} fill="black" />}
             </Mask>
           </Defs>
           <Rect

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -1,3 +1,4 @@
+import { useAtomValue } from 'jotai';
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   Platform,
@@ -9,6 +10,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, { Defs, Mask, Rect } from 'react-native-svg';
+import { isLEDThemeAtom } from '../store/atoms/theme';
 import { translate } from '../translation';
 import { RFValue } from '../utils/rfValue';
 import Typography from './Typography';
@@ -56,6 +58,9 @@ type Props = {
 };
 
 const ANIMATION_DURATION = 300;
+
+// spotlightArea.borderRadius が指定されていない場合の切り抜き半径
+const DEFAULT_SPOTLIGHT_BORDER_RADIUS = 8;
 
 const styles = StyleSheet.create({
   overlay: {
@@ -125,6 +130,10 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
   },
+  // LEDテーマは角丸を使わないため、角丸を持つ要素すべてに重ねて直角化する
+  squareCorners: {
+    borderRadius: 0,
+  },
 });
 
 const WalkthroughOverlay: React.FC<Props> = ({
@@ -137,6 +146,7 @@ const WalkthroughOverlay: React.FC<Props> = ({
   onSkip,
 }) => {
   const insets = useSafeAreaInsets();
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const maskId = useId();
   const overlayRef = useRef<View>(null);
@@ -157,6 +167,11 @@ const WalkthroughOverlay: React.FC<Props> = ({
       y: spotlightArea.y - overlayOffset.y,
     };
   }, [overlayOffset.x, overlayOffset.y, spotlightArea]);
+
+  // 切り抜きの角丸は呼び出し側の指定に従うが、LEDテーマでは角丸を使わない
+  const spotlightBorderRadius = isLEDTheme
+    ? 0
+    : (adjustedSpotlightArea?.borderRadius ?? DEFAULT_SPOTLIGHT_BORDER_RADIUS);
 
   // tooltipPosition === 'top' かつ spotlightArea がある場合は bottom で配置
   const useBottomPositioning =
@@ -244,8 +259,8 @@ const WalkthroughOverlay: React.FC<Props> = ({
                   y={adjustedSpotlightArea.y}
                   width={adjustedSpotlightArea.width}
                   height={adjustedSpotlightArea.height}
-                  rx={adjustedSpotlightArea.borderRadius ?? 8}
-                  ry={adjustedSpotlightArea.borderRadius ?? 8}
+                  rx={spotlightBorderRadius}
+                  ry={spotlightBorderRadius}
                   fill="black"
                 />
               )}
@@ -262,7 +277,13 @@ const WalkthroughOverlay: React.FC<Props> = ({
         </Svg>
       </Pressable>
 
-      <RNAnimated.View style={[styles.tooltipContainer, animatedTooltipStyle]}>
+      <RNAnimated.View
+        style={[
+          styles.tooltipContainer,
+          animatedTooltipStyle,
+          isLEDTheme && styles.squareCorners,
+        ]}
+      >
         <Typography style={styles.title}>{translate(step.titleKey)}</Typography>
         <Typography style={styles.description}>
           {translate(step.descriptionKey)}
@@ -297,6 +318,7 @@ const WalkthroughOverlay: React.FC<Props> = ({
                   style={[
                     styles.dot,
                     index === currentStepIndex && styles.dotActive,
+                    isLEDTheme && styles.squareCorners,
                   ]}
                 />
               </Pressable>
@@ -304,7 +326,7 @@ const WalkthroughOverlay: React.FC<Props> = ({
           </View>
 
           <Pressable
-            style={styles.nextButton}
+            style={[styles.nextButton, isLEDTheme && styles.squareCorners]}
             onPress={onNext}
             accessibilityRole="button"
             accessibilityLabel={

--- a/src/hooks/useSelectLineWalkthrough.test.tsx
+++ b/src/hooks/useSelectLineWalkthrough.test.tsx
@@ -62,12 +62,16 @@ describe('useSelectLineWalkthrough', () => {
       });
     });
 
+    // NowHeader のカードは上辺が直角・下辺のみ角丸なので、切り抜きも同じ形になる
     expect(mockSetSpotlightArea).toHaveBeenCalledWith({
       x: 10,
       y: 20,
       width: 300,
       height: 50,
-      borderRadius: 16,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+      borderBottomLeftRadius: 16,
+      borderBottomRightRadius: 16,
     });
   });
 

--- a/src/hooks/useSelectLineWalkthrough.ts
+++ b/src/hooks/useSelectLineWalkthrough.ts
@@ -44,7 +44,11 @@ export const useSelectLineWalkthrough = () => {
         y: nowHeaderLayout.y,
         width: nowHeaderLayout.width,
         height: nowHeaderLayout.height,
-        borderRadius: 16,
+        // NowHeader のカードは画面上端に密着し下辺のみ角丸なので、切り抜きも同じ形にする
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        borderBottomLeftRadius: 16,
+        borderBottomRightRadius: 16,
       });
     }
   }, [currentStepId, nowHeaderLayout, setSpotlightArea]);

--- a/src/screens/AppSettings.test.tsx
+++ b/src/screens/AppSettings.test.tsx
@@ -1,0 +1,157 @@
+import { render, waitFor } from '@testing-library/react-native';
+import { View } from 'react-native';
+import type {
+  WalkthroughStep,
+  WalkthroughStepId,
+} from '~/components/WalkthroughOverlay';
+import AppSettingsScreen from './AppSettings';
+
+// --- モジュールモック ---
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('react-native-app-clip', () => ({
+  isClip: () => false,
+}));
+
+jest.mock('expo-linear-gradient', () => {
+  const { View: RNView } = require('react-native');
+  return { LinearGradient: RNView };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const { View: RNView } = require('react-native');
+  return { SafeAreaView: RNView };
+});
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+}));
+
+jest.mock('~/components/WalkthroughOverlay', () => () => null);
+
+// ヘッダーはマウント時に onLayout を発火させ、画面側の再計測を起動する
+jest.mock('~/components/SettingsHeader', () => {
+  const { useEffect: useEffectMock } = require('react');
+  return {
+    SettingsHeader: ({
+      onLayout,
+    }: {
+      onLayout: (e: { nativeEvent: { layout: { height: number } } }) => void;
+    }) => {
+      useEffectMock(() => {
+        onLayout({ nativeEvent: { layout: { height: 64 } } });
+      }, [onLayout]);
+      return null;
+    },
+  };
+});
+
+jest.mock('../components/FooterTabBar', () => ({
+  __esModule: true,
+  default: () => null,
+  useFooterHeight: () => 0,
+}));
+
+const mockSetSpotlightArea = jest.fn();
+let mockCurrentStepId: WalkthroughStepId | null = null;
+
+jest.mock('~/hooks/useSettingsWalkthrough', () => ({
+  useSettingsWalkthrough: () => ({
+    isWalkthroughCompleted: false,
+    isWalkthroughActive: true,
+    currentStepIndex: 0,
+    currentStepId: mockCurrentStepId,
+    currentStep: null,
+    totalSteps: 4,
+    nextStep: jest.fn(),
+    goToStep: jest.fn(),
+    skipWalkthrough: jest.fn(),
+    setSpotlightArea: mockSetSpotlightArea,
+  }),
+}));
+
+const MEASURED_RECT = { x: 24, y: 120, width: 320, height: 76 };
+
+const lastSpotlightArea = (): WalkthroughStep['spotlightArea'] => {
+  const lastCall = mockSetSpotlightArea.mock.calls.at(-1);
+  return lastCall?.[0];
+};
+
+// スポットライト対象の項目を持つステップ
+const SPOTLIGHT_STEP_IDS: WalkthroughStepId[] = [
+  'settingsTheme',
+  'settingsTts',
+  'settingsLanguages',
+];
+
+describe('AppSettingsScreen', () => {
+  let measureSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // jest 環境では measureInWindow のコールバックが呼ばれないため、固定の矩形を返す
+    measureSpy = jest
+      .spyOn(
+        View.prototype as unknown as {
+          measureInWindow: (
+            callback: (
+              x: number,
+              y: number,
+              width: number,
+              height: number
+            ) => void
+          ) => void;
+        },
+        'measureInWindow'
+      )
+      .mockImplementation((callback) => {
+        callback(
+          MEASURED_RECT.x,
+          MEASURED_RECT.y,
+          MEASURED_RECT.width,
+          MEASURED_RECT.height
+        );
+      });
+  });
+
+  afterEach(() => {
+    mockCurrentStepId = null;
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('ウォークスルーの切り抜きは全ステップで同一の角丸半径になる', async () => {
+    const radii: (number | undefined)[] = [];
+
+    for (const stepId of SPOTLIGHT_STEP_IDS) {
+      mockCurrentStepId = stepId;
+      mockSetSpotlightArea.mockClear();
+
+      const { unmount } = render(<AppSettingsScreen />);
+
+      await waitFor(() => expect(mockSetSpotlightArea).toHaveBeenCalled());
+      radii.push(lastSpotlightArea()?.borderRadius);
+
+      unmount();
+    }
+
+    expect(radii).toHaveLength(SPOTLIGHT_STEP_IDS.length);
+    // 角丸なしのケースが混ざらないこと
+    expect(radii.every((radius) => typeof radius === 'number')).toBe(true);
+    expect(new Set(radii).size).toBe(1);
+  });
+
+  it('スポットライト対象がないステップでは切り抜きを設定しない', async () => {
+    mockCurrentStepId = 'settingsWelcome';
+    render(<AppSettingsScreen />);
+
+    await waitFor(() => expect(measureSpy).toHaveBeenCalled());
+    expect(mockSetSpotlightArea).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -45,6 +45,9 @@ const SETTING_ITEM_ID_MAP = {
 
 type SettingItemId = keyof typeof SETTING_ITEM_ID_MAP;
 
+// ウォークスルーの切り抜きは対象項目がリストの先頭・中間・末尾のいずれでも同じ角丸にする
+const SPOTLIGHT_BORDER_RADIUS = 12;
+
 type SettingsSectionData = {
   id: SettingItemId;
   title: string;
@@ -252,7 +255,7 @@ const AppSettingsScreen: React.FC = () => {
         y: themeItemLayout.y,
         width: themeItemLayout.width,
         height: themeItemLayout.height,
-        borderRadius: 12,
+        borderRadius: SPOTLIGHT_BORDER_RADIUS,
       });
     }
   }, [currentStepId, themeItemLayout, setSpotlightArea]);
@@ -264,7 +267,7 @@ const AppSettingsScreen: React.FC = () => {
         y: ttsItemLayout.y,
         width: ttsItemLayout.width,
         height: ttsItemLayout.height,
-        borderRadius: 0,
+        borderRadius: SPOTLIGHT_BORDER_RADIUS,
       });
     }
   }, [currentStepId, ttsItemLayout, setSpotlightArea]);
@@ -276,7 +279,7 @@ const AppSettingsScreen: React.FC = () => {
         y: languagesItemLayout.y,
         width: languagesItemLayout.width,
         height: languagesItemLayout.height,
-        borderRadius: 12,
+        borderRadius: SPOTLIGHT_BORDER_RADIUS,
       });
     }
   }, [currentStepId, languagesItemLayout, setSpotlightArea]);

--- a/src/utils/roundedRectPath.test.ts
+++ b/src/utils/roundedRectPath.test.ts
@@ -1,0 +1,93 @@
+import { buildRoundedRectPath } from './roundedRectPath';
+
+const BASE = { x: 10, y: 20, width: 100, height: 40 };
+
+describe('buildRoundedRectPath', () => {
+  it('4隅とも同じ半径のパスを生成する', () => {
+    const path = buildRoundedRectPath({
+      ...BASE,
+      topLeft: 8,
+      topRight: 8,
+      bottomRight: 8,
+      bottomLeft: 8,
+    });
+
+    expect(path).toBe(
+      'M 18 20 H 102 A 8 8 0 0 1 110 28 V 52 A 8 8 0 0 1 102 60 H 18 A 8 8 0 0 1 10 52 V 28 A 8 8 0 0 1 18 20 Z'
+    );
+  });
+
+  it('隅ごとに異なる半径を反映する', () => {
+    const path = buildRoundedRectPath({
+      ...BASE,
+      topLeft: 0,
+      topRight: 0,
+      bottomRight: 16,
+      bottomLeft: 16,
+    });
+
+    // 上辺は直角（半径0）、下辺のみ角丸になる
+    expect(path).toBe(
+      'M 10 20 H 110 A 0 0 0 0 1 110 20 V 44 A 16 16 0 0 1 94 60 H 26 A 16 16 0 0 1 10 44 V 20 A 0 0 0 0 1 10 20 Z'
+    );
+  });
+
+  it('全隅が0のときは直角の矩形になる', () => {
+    const path = buildRoundedRectPath({
+      ...BASE,
+      topLeft: 0,
+      topRight: 0,
+      bottomRight: 0,
+      bottomLeft: 0,
+    });
+
+    expect(path).toBe(
+      'M 10 20 H 110 A 0 0 0 0 1 110 20 V 60 A 0 0 0 0 1 110 60 H 10 A 0 0 0 0 1 10 60 V 20 A 0 0 0 0 1 10 20 Z'
+    );
+  });
+
+  it('短辺の半分を超える半径は頭打ちにする', () => {
+    const path = buildRoundedRectPath({
+      ...BASE,
+      topLeft: 999,
+      topRight: 999,
+      bottomRight: 999,
+      bottomLeft: 999,
+    });
+
+    // height 40 なので半径は 20 に丸められる
+    expect(path).toContain('A 20 20 0 0 1');
+    expect(path).not.toContain('999');
+  });
+
+  it('負の半径は0として扱う', () => {
+    const path = buildRoundedRectPath({
+      ...BASE,
+      topLeft: -8,
+      topRight: 4,
+      bottomRight: 4,
+      bottomLeft: 4,
+    });
+
+    expect(path).toBe(
+      'M 10 20 H 106 A 4 4 0 0 1 110 24 V 56 A 4 4 0 0 1 106 60 H 14 A 4 4 0 0 1 10 56 V 20 A 0 0 0 0 1 10 20 Z'
+    );
+  });
+
+  it('サイズが0でも不正なパスにならない', () => {
+    const path = buildRoundedRectPath({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      topLeft: 12,
+      topRight: 12,
+      bottomRight: 12,
+      bottomLeft: 12,
+    });
+
+    expect(path).toBe(
+      'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 0 0 Z'
+    );
+  });
+});

--- a/src/utils/roundedRectPath.ts
+++ b/src/utils/roundedRectPath.ts
@@ -1,0 +1,53 @@
+export type RoundedRectPathParams = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  topLeft: number;
+  topRight: number;
+  bottomRight: number;
+  bottomLeft: number;
+};
+
+/**
+ * 隅ごとに半径の異なる角丸矩形の SVG パスを生成する。
+ * SVG の `<Rect rx ry>` は4隅共通の半径しか表現できないため、
+ * 上辺だけ直角のカードなど対象要素の形へ追従させるにはパスが必要になる。
+ */
+export const buildRoundedRectPath = ({
+  x,
+  y,
+  width,
+  height,
+  topLeft,
+  topRight,
+  bottomRight,
+  bottomLeft,
+}: RoundedRectPathParams): string => {
+  // 半径が矩形からはみ出さないよう短辺の半分で頭打ちにする
+  const maxRadius = Math.max(Math.min(width, height) / 2, 0);
+  const clamp = (radius: number) =>
+    Math.min(Math.max(Number.isFinite(radius) ? radius : 0, 0), maxRadius);
+
+  const tl = clamp(topLeft);
+  const tr = clamp(topRight);
+  const br = clamp(bottomRight);
+  const bl = clamp(bottomLeft);
+
+  const right = x + width;
+  const bottom = y + height;
+
+  // 半径0の円弧は SVG 仕様上「直線」として扱われるため、直角の隅も同じ形で書ける
+  return [
+    `M ${x + tl} ${y}`,
+    `H ${right - tr}`,
+    `A ${tr} ${tr} 0 0 1 ${right} ${y + tr}`,
+    `V ${bottom - br}`,
+    `A ${br} ${br} 0 0 1 ${right - br} ${bottom}`,
+    `H ${x + bl}`,
+    `A ${bl} ${bl} 0 0 1 ${x} ${bottom - bl}`,
+    `V ${y + tl}`,
+    `A ${tl} ${tl} 0 0 1 ${x + tl} ${y}`,
+    'Z',
+  ].join(' ');
+};


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ウォークスルー（オンボーディング）のスポットライト切り抜きに 3 つの角丸不整合があったため修正しました。設定画面で TTS のステップだけ角丸なしになっていた不具合を起点に、LED テーマで角丸が残っていた問題と、対象要素の形に追従できていなかった問題まで併せて解消しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 設定画面のウォークスルーで、TTS のステップだけ `borderRadius: 0` となり切り抜きが角丸にならなかった不具合を修正。半径を `SPOTLIGHT_BORDER_RADIUS` として定数化し、テーマ・TTS・表示言語の 3 ステップで統一した（`src/screens/AppSettings.tsx`）。
- LED テーマでは角丸を使わないルールに合わせ、`WalkthroughOverlay` 側で切り抜き・ツールチップカード・「次へ」ボタン・ページネーションのドットをすべて直角化。全ウォークスルー（設定・路線選択・経路検索）に一括で適用され、今後追加されるステップにも自動で効く。
- スポットライトを隅ごとの角丸に対応（`borderTopLeftRadius` などを `SpotlightArea` に追加）。SVG の `<Rect rx ry>` は 4 隅共通の半径しか表現できないため、マスクの描画を `<Path>` に変更した。隅ごとの指定がない隅は従来どおり `borderRadius` にフォールバックするため、既存の呼び出し箇所は変更不要。
- 隅ごとに半径の異なる角丸矩形の SVG パスを生成する `buildRoundedRectPath` を追加（`src/utils/roundedRectPath.ts`）。短辺の半分での頭打ち、負値・サイズ 0 の防御込み。
- 路線選択の `changeLocation` ステップを NowHeader カードの実形状（上辺 0 / 下辺 16）に合わせた（`src/hooks/useSelectLineWalkthrough.ts`）。

補足: 領域全体を囲む 3 ステップ（路線一覧・プリセット・検索結果）は単一の対象形状が存在しないため既存の半径のままです。検索バー・AI バナー・フッターボタンは元から実形状と一致していたため変更していません。

### リグレッションリスクと緩和策

- 切り抜きの描画方法を `<Rect>` から `<Path>` へ変更しているため、全ウォークスルーの表示に影響します。パス生成は純粋関数として切り出し、単体テスト 6 件（通常・隅ごと・全隅0・頭打ち・負値・サイズ0）でカバーしました。
- `SpotlightArea` の変更は追加プロパティのみで、既存の `borderRadius` 指定はフォールバックとして従来どおり機能します（型・呼び出し箇所の互換性は `npm run typecheck` で確認）。
- LED テーマの直角化は `WalkthroughOverlay` の 1 箇所に集約したため、画面ごとの実装漏れが起きない構造にしています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行コマンドと結果:

- `npm run lint` → 635 ファイル、指摘なし
- `npm run typecheck` → エラーなし
- `npm test` → 221 suites / 2324 tests すべて成功

追加・更新したテスト:

- `src/utils/roundedRectPath.test.ts`（新規 6 件）
- `src/components/WalkthroughOverlay.test.tsx`（新規 6 件。通常テーマ / LED / 隅ごと指定 / フォールバック / LED × 隅ごと指定 / ツールチップの角丸）
- `src/screens/AppSettings.test.tsx`（新規 2 件。全ステップで切り抜き半径が同一になること）
- `src/hooks/useSelectLineWalkthrough.test.tsx`（既存アサーションを NowHeader の実形状に更新）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

実行環境にシミュレータ・エミュレータが無いため未取得です。UI 変更を含むため、レビュー前に実機またはシミュレータでの確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_014Ld3Fk2RBtbRNa4BaNqAXV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - ウォークスルーのスポットライトで、四隅ごとに角丸を調整できるようになりました。
  - 設定画面では、テーマ・音声読み上げ・言語項目を統一した角丸で強調します。
  - ヘッダーなど一部の案内では、上辺を直角、下辺のみ角丸にして対象範囲を正確に示します。
  - LEDテーマでは、スポットライトやツールチップの角丸をなくし、シャープな表示に変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->