### PR TITLE
TTS読み上げ時のみ「JR」を置換してジュニアと誤読されるのを防止

### DIFF
--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -171,6 +171,38 @@ describe('useTTS', () => {
     );
   });
 
+  it('「JR」は読み上げ直前に読みが確定する表記へ置換される', async () => {
+    // TTS エンジンが "Jr."（ジュニア）と誤読するため、日本語はカタカナ、
+    // 英語はアルファベット読みさせる表記へ倒す。sub alias 経由（= 読み仮名側に
+    // 「JR」が残るケース）でも置換されることを確認する。
+    const { useTTSText } = jest.requireMock('./useTTSText') as {
+      useTTSText: jest.Mock;
+    };
+    useTTSText.mockReturnValue({
+      text: [
+        '次は、<sub alias="JRセン">JR線</sub>、お乗り換えです。',
+        'Thank you for using the JR Kobe Line.',
+      ],
+    });
+
+    const store = createStore();
+    store.set(speechState, defaultSpeechState);
+
+    renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+    await flushAsync();
+
+    expect(mockSpeak).toHaveBeenNthCalledWith(
+      1,
+      '次は、ジェーアールセン、お乗り換えです。',
+      expect.objectContaining({ language: 'ja-JP' })
+    );
+    expect(mockSpeak).toHaveBeenNthCalledWith(
+      2,
+      'Thank you for using the J-R Kobe Line.',
+      expect.objectContaining({ language: 'en-US' })
+    );
+  });
+
   it('無効時は読み上げない', async () => {
     const store = createStore();
     store.set(speechState, {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -7,6 +7,7 @@ import { TransportType } from '~/@types/graphql';
 import speechState, { resetFirstSpeechAtom } from '../store/atoms/speech';
 import { arrivedAtom, selectedBoundAtom } from '../store/atoms/station';
 import { computeSuppressionDecision } from '../utils/computeSuppressionDecision';
+import { fixJrReading } from '../utils/jrReading';
 import { selectBestVoiceIdentifier } from '../utils/nativeTtsVoice';
 import {
   containsJapaneseCharacters,
@@ -291,16 +292,25 @@ export const useTTS = (): void => {
         // テンプレートが生成する SSML 断片を OS ネイティブ TTS 用の
         // プレーンテキストへ変換する。英語はテンプレ側に区切りのカンマが
         // 既に含まれるため <break/> は空白へ置き換える。
+        // 「JR」は TTS エンジンが "Jr."（ジュニア）と誤読するため、読み上げ
+        // 直前のこの段でのみ読み方が確定する表記へ置換する（切り詰め判定は
+        // 置換後の長さで行いたいので truncate より前に適用する）。
         const plainJa =
           shouldSpeakJapanese && canSpeakJa
             ? truncateToSpeechLimit(
-                ssmlToPlainText(ja, { breakReplacement: '、' })
+                fixJrReading(
+                  ssmlToPlainText(ja, { breakReplacement: '、' }),
+                  'JA'
+                )
               )
             : '';
         let plainEn =
           shouldSpeakEnglish && canSpeakEn
             ? truncateToSpeechLimit(
-                ssmlToPlainText(en, { breakReplacement: ' ' })
+                fixJrReading(
+                  ssmlToPlainText(en, { breakReplacement: ' ' }),
+                  'EN'
+                )
               )
             : '';
         // nameRoman が欠落した駅データ等では wrapPhoneme のローマ字フォール

--- a/src/utils/jrReading.test.ts
+++ b/src/utils/jrReading.test.ts
@@ -1,0 +1,56 @@
+import { fixJrReading } from './jrReading';
+
+describe('fixJrReading', () => {
+  describe('日本語', () => {
+    it('路線名の「JR」をカタカナ読みへ置換する', () => {
+      expect(fixJrReading('次は、JR神戸線です。', 'JA')).toBe(
+        '次は、ジェーアール神戸線です。'
+      );
+    });
+
+    it('会社名の「JR」もカタカナ読みへ置換する', () => {
+      expect(fixJrReading('今日も、JR東日本をご利用くださいまして', 'JA')).toBe(
+        '今日も、ジェーアール東日本をご利用くださいまして'
+      );
+    });
+
+    it('1文中の複数箇所をすべて置換する', () => {
+      expect(fixJrReading('JR線とJR神戸線', 'JA')).toBe(
+        'ジェーアール線とジェーアール神戸線'
+      );
+    });
+
+    it('全角の「ＪＲ」も置換する', () => {
+      expect(fixJrReading('ＪＲ線', 'JA')).toBe('ジェーアール線');
+    });
+  });
+
+  describe('英語', () => {
+    it('「JR」をアルファベット読みさせる表記へ置換する', () => {
+      expect(fixJrReading('the JR Kobe Line', 'EN')).toBe('the J-R Kobe Line');
+    });
+
+    it('文末など後続文字が英数字でない場合も置換する', () => {
+      expect(fixJrReading('Thank you for using JR.', 'EN')).toBe(
+        'Thank you for using J-R.'
+      );
+    });
+  });
+
+  describe('誤置換の防止', () => {
+    it('前後が英数字の場合は別語の一部とみなして置換しない', () => {
+      expect(fixJrReading('AJRB', 'JA')).toBe('AJRB');
+      expect(fixJrReading('JR2', 'EN')).toBe('JR2');
+    });
+
+    it('小文字の「Jr」は置換しない', () => {
+      expect(fixJrReading('Jr.', 'EN')).toBe('Jr.');
+    });
+
+    it('「JR」を含まないテキストはそのまま返す', () => {
+      expect(fixJrReading('次は、渋谷、渋谷。', 'JA')).toBe(
+        '次は、渋谷、渋谷。'
+      );
+    });
+  });
+});

--- a/src/utils/jrReading.ts
+++ b/src/utils/jrReading.ts
@@ -1,0 +1,39 @@
+// OS ネイティブ TTS は「JR」を英語の略記 "Jr." と解釈し、日本語音声でも
+// 「ジュニア」と読み上げてしまう (例: 「JR神戸線」→「ジュニアこうべせん」)。
+// 路線名・会社名は API 由来のため表記そのものは変えられず、また画面表示は
+// 「JR」のままにしたいので、読み上げ直前のプレーンテキストに対してのみ
+// 読み方が確定する表記へ置換する。
+
+// 日本語音声向け。カタカナへ倒して「ジェーアール」と読ませる。
+const JR_READING_JA = 'ジェーアール';
+// 英語音声向け。ハイフンで区切ることで単語 ("Junior") ではなく
+// アルファベット 1 文字ずつ ("jay are") として読ませる。
+const JR_READING_EN = 'J-R';
+
+// 半角・全角の「JR」。大文字のみを対象にし、`Jr` のような通常の略記
+// (人名の Junior など) は誤置換しない。
+const JR_REGEXP = /JR|ＪＲ/g;
+
+// 「JR」の前後がこの文字種なら別語の一部とみなして置換しない
+// (例: 架空の識別子 `AJRB` / `JR2` を壊さないための保険)。
+const ALPHANUMERIC_REGEXP = /[0-9A-Za-z０-９Ａ-Ｚａ-ｚ]/;
+
+/**
+ * 読み上げ用テキスト内の「JR」を、TTS エンジンが正しく読める表記へ置換する。
+ * 表示用テキストには適用しないこと (TTS 生成時専用)。
+ */
+export const fixJrReading = (text: string, language: 'JA' | 'EN'): string => {
+  const reading = language === 'JA' ? JR_READING_JA : JR_READING_EN;
+
+  return text.replace(JR_REGEXP, (match: string, offset: number) => {
+    const before = text[offset - 1];
+    const after = text[offset + match.length];
+    if (
+      (before && ALPHANUMERIC_REGEXP.test(before)) ||
+      (after && ALPHANUMERIC_REGEXP.test(after))
+    ) {
+      return match;
+    }
+    return reading;
+  });
+};


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

OS ネイティブ TTS が「JR」を英語の略記 "Jr." と解釈し「ジュニア」と読み上げてしまう問題を修正します。読み上げ直前のプレーンテキストに対してのみ「JR」を読みが確定する表記へ置換し、日本語音声では「ジェーアール」と読まれるようにしました。画面表示用のテキストには一切影響しません。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/jrReading.ts` を追加。読み上げ用テキスト内の「JR」を言語別の表記へ置換する `fixJrReading(text, language)` を実装（日本語: `ジェーアール` / 英語: `J-R`）
- `src/hooks/useTTS.ts` で `ssmlToPlainText()` の直後・`truncateToSpeechLimit()` の直前に適用。`Speech.speak()` へ渡す文字列だけが変わる
- 半角・全角（`ＪＲ`）の大文字のみを対象とし、前後が英数字の場合（`AJRB` / `JR2`）や小文字の `Jr.` は置換しない
- Hermes での互換性を考慮し look-behind は使わず、`replace` のコールバック内で前後の文字を判定
- `src/utils/jrReading.test.ts` を追加。`src/hooks/useTTS.test.ts` には sub alias 経由（`<sub alias="JRセン">JR線</sub>`）を含む統合テストを追加

置換を `ssmlToPlainText()` の後段に置いたことで、`nameKatakana` 側に「JR」が残るケース（`src/utils/jr.ts` が生成する JR 統合路線の `JRセン` など）や、`nameKatakana` 欠落で表記がそのまま読まれるケースも同じ経路でカバーされます。

影響範囲とリスク: 変更は `useTTS` の発話直前の 1 箇所のみで、`useTTSText` が生成するテキスト・画面表示・保存データには影響しません。想定される退行は「JR」を含まない語の誤置換ですが、大文字のみ・前後が英数字なら除外という条件で抑止し、ユニットテストで固定しています。英語側の `J-R` は、ハイフン区切りの単独大文字をアルファベット読みする TTS エンジンの挙動に依存するため、実機での英語アナウンス確認が望ましいです。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint` / `npm run typecheck` はエラーなし、`npm test` は 222 suites / 2335 tests すべて成功。実機（iOS / Android）での読み上げ確認は未実施です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01YWJ6Ed93a1i8QNQQmeKCht)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 音声読み上げ時の「JR」「ＪＲ」の発音を改善しました。
  * 日本語では「ジェーアール」、英語では「J-R」として自然に読み上げます。
  * 人名の略称や識別子など、他の英数字の一部は誤って変換されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->