### PR TITLE
iOSのTTSをgpt-4o-mini-ttsの女性声へ切り替えAndroidは端末内蔵TTSを維持

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 - `utils/`: developer tooling scripts such as GraphQL codegen config.
 - `android/`, `ios/`: native projects.
 
-> The Cloudflare Workers backend (TTS via Azure Speech, feedback triage via Workers AI, review notifiers) has been moved out of this repository into the [TrainLCD/BFF](https://github.com/TrainLCD/BFF) monorepo. The former `functions/` directory no longer lives here.
+> The Cloudflare Workers backend (TTS, session issuance, feedback triage via Workers AI, review notifiers) has been moved out of this repository into [TrainLCD/functions](https://github.com/TrainLCD/functions); the GraphQL BFF lives separately in [TrainLCD/BFF](https://github.com/TrainLCD/BFF). The former `functions/` directory no longer lives here.
 
 ## Tooling & Environment Expectations
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,14 @@ npm run watch:test
 
 ### Backend (Cloudflare Workers)
 
-The backend (feedback triage, review notifiers) now lives in the dedicated [TrainLCD/BFF](https://github.com/TrainLCD/BFF) monorepo and is no longer part of this repository. Voice announcements (TTS) are generated on-device with the OS-native speech synthesizer via `expo-speech`.
+The backend (TTS synthesis, feedback triage, review notifiers) now lives in the dedicated [TrainLCD/BFF](https://github.com/TrainLCD/BFF) monorepo and is no longer part of this repository.
+
+Voice announcements (TTS) use a different engine per platform:
+
+- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped.
+- **Android**: synthesized on-device with the OS-native speech synthesizer via `expo-speech`.
+
+Both paths share the same announcement text pipeline; the SSML fragments emitted by the templates are converted to plain text before reaching either engine (`src/utils/speakableText.ts`), because neither engine interprets SSML.
 
 ## Contributing
 
@@ -226,7 +233,7 @@ TrainLCD is built with:
 - **TypeScript** - Type safety and better developer experience
 - **React Navigation** - Navigation library
 - **Tanstack Query** - Data fetching and caching
-- **Cloudflare Workers** - Backend API (auth, feedback, remote config) with R2/KV storage
+- **Cloudflare Workers** - Backend API (auth, TTS, feedback, remote config) with R2/KV storage
 - **Sentry** - Error tracking and performance monitoring
 - **GraphQL** with Code Generator - Typed queries and operations
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ npm run watch:test
 
 ### Backend (Cloudflare Workers)
 
-The backend (TTS synthesis, feedback triage, review notifiers) now lives in the dedicated [TrainLCD/BFF](https://github.com/TrainLCD/BFF) monorepo and is no longer part of this repository.
+The backend Worker (TTS synthesis, session issuance, feedback triage, review notifiers) lives in [TrainLCD/functions](https://github.com/TrainLCD/functions), and the GraphQL BFF lives in [TrainLCD/BFF](https://github.com/TrainLCD/BFF). Neither is part of this repository.
 
 Voice announcements (TTS) use a different engine per platform:
 
-- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped.
+- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped. **The `/tts` endpoint does not implement this yet** (it is still Azure Speech-only), so iOS currently always takes the fallback path; see [the spec](./docs/spec/tts/remote-tts.md) for the required server-side work.
 - **Android**: synthesized on-device with the OS-native speech synthesizer via `expo-speech`.
 
 Both paths share the same announcement text pipeline; the SSML fragments emitted by the templates are converted to plain text before reaching either engine (`src/utils/speakableText.ts`), because neither engine interprets SSML.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The backend Worker (TTS synthesis, session issuance, feedback triage, review not
 
 Voice announcements (TTS) use a different engine per platform:
 
-- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped. **The `/tts` endpoint does not implement this yet** (it is still Azure Speech-only), so iOS currently always takes the fallback path; see [the spec](./docs/spec/tts/remote-tts.md) for the required server-side work.
+- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped. See [the spec](./docs/spec/tts/remote-tts.md) for the wire contract.
 - **Android**: synthesized on-device with the OS-native speech synthesizer via `expo-speech`.
 
 Both paths share the same announcement text pipeline; the SSML fragments emitted by the templates are converted to plain text before reaching either engine (`src/utils/speakableText.ts`), because neither engine interprets SSML.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@
 - [canary リリース PR でのバージョン更新](./bump-version-on-canary-pr.md)
 - [本番リリース PR でのバージョン更新](./bump-version-on-release-pr.md)
 - [AIエージェント設計書](./spec/ai-agent/architecture.md)
+- [リモートTTS(iOS)設計書](./spec/tts/remote-tts.md)

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -1,0 +1,103 @@
+# リモート TTS (iOS) 設計書
+
+自動アナウンスの読み上げ手段はプラットフォームで異なる。
+
+| プラットフォーム | 合成 | 再生 |
+| --- | --- | --- |
+| iOS | Worker `/tts` 経由の `gpt-4o-mini-tts`（女性声 `nova`） | `expo-audio` |
+| Android | 端末内蔵 TTS (`expo-speech`) | 端末内蔵 TTS |
+
+iOS でリモート合成に失敗した回は、その放送だけ端末内蔵 TTS で読み上げる。圏外・
+トンネル・API 障害でアナウンスが丸ごと欠落しないようにするためのフォールバックで、
+恒久的な切り替えではない（次の放送では再びリモート合成を試みる）。
+
+## 構成
+
+```text
+useTTS ────────────────── 放送タイミング・抑止判定・ダッキング・保留キュー
+  ├─ useRemoteSpeechEngine  iOS: /tts へ合成要求 → expo-audio で再生
+  └─ useNativeSpeechEngine  Android の常用経路 / iOS のフォールバック
+```
+
+両エンジンは `SpeechEngine` (`src/hooks/tts/speechEngine.ts`) を実装する。
+
+- `speak(request, callbacks)` — `onSettled` か `onUnavailable` のどちらかが
+  ちょうど 1 回だけ呼ばれる。
+- `onUnavailable` は「音声を一切生成できず発話しなかった」場合のみ。再生が始まった
+  後の失敗は `onSettled` で終える（途中まで読み上げた放送を頭から読み直さない）。
+- `stop()` — 進行中の発話を中断し、ネイティブ資源を解放する。コールバックは呼ばない。
+
+## テキストの前処理
+
+TTS テンプレートは SSML 断片を生成するが、`gpt-4o-mini-tts` も `expo-speech` も
+SSML を解釈せずタグをそのまま読み上げる。そのため双方のエンジンが
+`toSpeakableText()` (`src/utils/speakableText.ts`) でプレーンテキストへ変換してから
+合成へ渡す。
+
+- `<sub alias="ヨミ">表記</sub>` → 読み (`ヨミ`)
+- `<break/>` → 日本語は `、`、英語は半角スペース
+- 「JR」→ 日本語 `ジェーアール` / 英語 `J-R`（`Jr.` = ジュニアとの誤読を防ぐ）
+- 英語文に混入した日本語は除去する
+
+`gpt-4o-mini-tts` は SSML の代わりに `instructions` で読み方を指示するため、声色・
+速度・間の取り方は `src/constants/tts.ts` の定数で渡す。
+
+## Worker `/tts` の契約
+
+アプリ側は以下を送受信する。Worker 側の実装は
+[TrainLCD/BFF](https://github.com/TrainLCD/BFF) にある。
+
+### リクエスト
+
+`POST /tts` / `Authorization: Bearer <セッショントークン>`
+
+```json
+{
+  "data": {
+    "textJa": "次は、オオサキです",
+    "textEn": "The next station is Osaki, J Y 24.",
+    "model": "gpt-4o-mini-tts",
+    "jaVoiceName": "nova",
+    "enVoiceName": "nova",
+    "instructionsJa": "鉄道の車内自動放送のアナウンサーとして…",
+    "instructionsEn": "Read this as an automated train announcement…"
+  }
+}
+```
+
+合成は文字数課金のため、**ユーザーが無効にしている言語のフィールドは送らない**。
+`textJa` のみ・`textEn` のみのリクエストが正常系として発生するので、Worker は
+届いた言語だけを合成すること。
+
+### レスポンス
+
+```json
+{
+  "result": {
+    "id": "一意なID（キャッシュファイル名に使う）",
+    "jaAudioContent": "<base64>",
+    "enAudioContent": "<base64>",
+    "jaAudioMimeType": "audio/mpeg",
+    "enAudioMimeType": "audio/mpeg"
+  }
+}
+```
+
+- 要求した言語の音声が欠けている応答は失敗として扱い、端末内蔵 TTS へフォールバック
+  する。要求していない言語のフィールドは省略してよい。
+- MIME タイプは省略可。省略時はアプリ側が先頭バイトから MP3 / WAV を判定し、どちらとも
+  判定できない場合のみ生 PCM (16bit LE / 24kHz) とみなして WAV ヘッダーを付与する。
+  誤判定を避けるため、可能な限り MIME タイプを返すこと。
+
+## 停止スイッチ
+
+Remote Config の `tts_enabled_ios` / `tts_enabled_android` が既存のキルスイッチで、
+プラットフォーム単位で TTS 機能ごと停止できる（`useTTSFeatureEnabled`）。リモート
+合成のコストや障害で iOS の読み上げを止めたい場合は `tts_enabled_ios` を `false` に
+する。リモート合成だけを止めて端末内蔵 TTS へ倒す専用スイッチは現時点では持たない。
+
+## キャッシュ
+
+`fetchSpeechAudio` はテキスト・モデル・音声名をキーに合成結果のファイルパスを
+メモリへ保持する（上限 `MAX_FETCH_CACHE_SIZE` 件、超過時は最古から破棄）。同一文面の
+再放送では再合成しないため、折り返し運転や同じ駅を繰り返し通る経路で課金が膨らまない。

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -48,9 +48,6 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
 [TrainLCD/functions](https://github.com/TrainLCD/functions) の
 `src/routes/tts.ts` にある（GraphQL BFF とは別リポジトリ）。
 
-> **未対応**: 現行の `/tts` は Azure Speech 専用で、この契約をまだ満たしていない。
-> 詳細と必要な作業は「[現行 `/tts` との差分](#現行-tts-との差分)」を参照。
-
 ### リクエスト
 
 `POST /tts` / `Authorization: Bearer <セッショントークン>`
@@ -93,40 +90,22 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
   判定できない場合のみ生 PCM (16bit LE / 24kHz) とみなして WAV ヘッダーを付与する。
   誤判定を避けるため、可能な限り MIME タイプを返すこと。
 
-## 現行 `/tts` との差分
+### サーバー側の実装メモ
 
-現行の [TrainLCD/functions](https://github.com/TrainLCD/functions)
-`src/routes/tts.ts` は **Azure Speech 専用**で、上記の契約とは以下が食い違う。
-そのため gpt-4o-mini-tts での合成にはサーバー側の実装が必要で、それまで iOS は
-毎回フォールバックして端末内蔵 TTS で読み上げる（クラッシュも無音も起きないが、
-女性声 TTS にはならない）。
+Azure Speech 版から全面移行済み（Azure 関連のコード・環境変数・シークレットは
+削除された）。アプリ側と対応が取れている前提は以下のとおり。
 
-| 項目 | 現行 `/tts` | 本設計が要求するもの |
-| --- | --- | --- |
-| 合成エンジン | Azure Speech | OpenAI `gpt-4o-mini-tts` |
-| 入力 | `ssmlJa` / `ssmlEn`（両方必須・SSML） | `textJa` / `textEn`（プレーンテキスト・片方のみ可） |
-| 声の指定 | Azure ボイス名（`<locale>-<Name>Neural` 形式のみ受理） | `nova` などの OpenAI ボイス名 |
-| 読み方の指示 | `mstts:express-as` / `prosody`（env 経由） | `instructions` |
-| モデル指定 | なし | `model` |
-
-変わらないもの:
-
-- 認証（`Authorization: Bearer <セッショントークン>`）と callable 互換の
-  ワイヤ形式（`{ data: … }` / `{ result: … }` / `{ error: { message, status } }`）
-- レスポンスの `id` / `*AudioContent` / `*AudioMimeType`
-- KV/R2 による合成結果キャッシュの考え方（キーに `model` と `voice`、
-  `instructions` を含める必要がある点だけ追加）
-
-サーバー側実装時の注意:
-
-- `OPENAI_API_KEY` は `Env` に既にある（AI エージェントが使用）ため、
-  新たなシークレット追加は不要。
-- 現行の入力上限は可視テキスト 4000 バイト・生 SSML 10000 バイト。プレーン
-  テキスト化で同等のバイト数ガードを維持すること（アプリ側は文字数ベースで
-  `REMOTE_TTS_MAX_INPUT_LENGTH` に丸めるだけなので、バイト数の防衛は
-  サーバー側が担う）。
-- 片言語のみのリクエストが正常系として来る。両方必須のバリデーションは外し、
-  届いた言語だけ合成して対応する `*AudioContent` を返す。
+- ボイス名とモデルは Worker 側で許可制。未知の値はリクエスト → KV(`config:tts`)
+  → `TTS_*` 環境変数の順にフォールバックするため、アプリが古いボイス名を送っても
+  400 にはならず既定の女性声で合成される。
+- 入力上限は Worker 側が UTF-8 **バイト**で検証する（4000 バイト）。アプリ側も
+  同じバイト数で丸める（`REMOTE_TTS_MAX_INPUT_BYTES`）ので、文字数と
+  バイト数の食い違いで無用なフォールバックが起きない。
+- Worker は受け取ったテキストにも `stripSsml` をかける。タグが紛れ込んでも
+  読み上げさせないための二重防御で、プレーンテキストには作用しない。
+- 英語は Worker 側で `normalizeRomanText`（全角記号・略記・長音符の吸収）を
+  通す。アプリが確定させた `J-R` を崩さないよう、ハイフン区切りの頭字語は
+  そのまま残す。
 
 ## 停止スイッチ
 

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -45,7 +45,11 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
 ## Worker `/tts` の契約
 
 アプリ側は以下を送受信する。Worker 側の実装は
-[TrainLCD/BFF](https://github.com/TrainLCD/BFF) にある。
+[TrainLCD/functions](https://github.com/TrainLCD/functions) の
+`src/routes/tts.ts` にある（GraphQL BFF とは別リポジトリ）。
+
+> **未対応**: 現行の `/tts` は Azure Speech 専用で、この契約をまだ満たしていない。
+> 詳細と必要な作業は「[現行 `/tts` との差分](#現行-tts-との差分)」を参照。
 
 ### リクエスト
 
@@ -88,6 +92,41 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
 - MIME タイプは省略可。省略時はアプリ側が先頭バイトから MP3 / WAV を判定し、どちらとも
   判定できない場合のみ生 PCM (16bit LE / 24kHz) とみなして WAV ヘッダーを付与する。
   誤判定を避けるため、可能な限り MIME タイプを返すこと。
+
+## 現行 `/tts` との差分
+
+現行の [TrainLCD/functions](https://github.com/TrainLCD/functions)
+`src/routes/tts.ts` は **Azure Speech 専用**で、上記の契約とは以下が食い違う。
+そのため gpt-4o-mini-tts での合成にはサーバー側の実装が必要で、それまで iOS は
+毎回フォールバックして端末内蔵 TTS で読み上げる（クラッシュも無音も起きないが、
+女性声 TTS にはならない）。
+
+| 項目 | 現行 `/tts` | 本設計が要求するもの |
+| --- | --- | --- |
+| 合成エンジン | Azure Speech | OpenAI `gpt-4o-mini-tts` |
+| 入力 | `ssmlJa` / `ssmlEn`（両方必須・SSML） | `textJa` / `textEn`（プレーンテキスト・片方のみ可） |
+| 声の指定 | Azure ボイス名（`<locale>-<Name>Neural` 形式のみ受理） | `nova` などの OpenAI ボイス名 |
+| 読み方の指示 | `mstts:express-as` / `prosody`（env 経由） | `instructions` |
+| モデル指定 | なし | `model` |
+
+変わらないもの:
+
+- 認証（`Authorization: Bearer <セッショントークン>`）と callable 互換の
+  ワイヤ形式（`{ data: … }` / `{ result: … }` / `{ error: { message, status } }`）
+- レスポンスの `id` / `*AudioContent` / `*AudioMimeType`
+- KV/R2 による合成結果キャッシュの考え方（キーに `model` と `voice`、
+  `instructions` を含める必要がある点だけ追加）
+
+サーバー側実装時の注意:
+
+- `OPENAI_API_KEY` は `Env` に既にある（AI エージェントが使用）ため、
+  新たなシークレット追加は不要。
+- 現行の入力上限は可視テキスト 4000 バイト・生 SSML 10000 バイト。プレーン
+  テキスト化で同等のバイト数ガードを維持すること（アプリ側は文字数ベースで
+  `REMOTE_TTS_MAX_INPUT_LENGTH` に丸めるだけなので、バイト数の防衛は
+  サーバー側が担う）。
+- 片言語のみのリクエストが正常系として来る。両方必須のバリデーションは外し、
+  届いた言語だけ合成して対応する `*AudioContent` を返す。
 
 ## 停止スイッチ
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,4 +16,5 @@ export * from './station';
 export * from './storage';
 export * from './theme';
 export * from './threshold';
+export * from './tts';
 export * from './url';

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -1,0 +1,26 @@
+// iOS のリモート TTS (Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用) の既定値。
+// Android は端末内蔵の TTS (expo-speech) を使い続けるため、これらは参照されない。
+
+// 合成に使うモデル。Worker 側が別モデルへ切り替える場合もリクエストで明示するため、
+// アプリ側の期待するモデルをここで固定する。
+export const REMOTE_TTS_MODEL = 'gpt-4o-mini-tts';
+
+// 車内放送に使う女性声。gpt-4o-mini-tts の音声は多言語対応のため、日英で同一の
+// 声を指定して一人のアナウンサーが読み上げている印象を保つ。
+export const REMOTE_TTS_VOICE = 'nova';
+
+// gpt-4o-mini-tts は SSML を解釈せず、代わりに instructions で読み方を指示する。
+// 駅名・路線名の固有名詞が続くため、速度と間の取り方を明示して聞き取りやすくする。
+export const REMOTE_TTS_INSTRUCTIONS_JA =
+  '鉄道の車内自動放送のアナウンサーとして、落ち着いた丁寧な女性の声で読み上げてください。' +
+  '一定の速さを保ち、句読点では短く間を取ります。駅名や路線名は一語ずつ明瞭に発音し、' +
+  '感情を込めすぎず、事務的で聞き取りやすい調子にしてください。';
+
+export const REMOTE_TTS_INSTRUCTIONS_EN =
+  'Read this as an automated train announcement in a calm, polite female voice. ' +
+  'Keep a steady pace, pause briefly at commas, and pronounce station and line names ' +
+  'clearly. Stay neutral and business-like rather than expressive.';
+
+// gpt-4o-mini-tts の入力上限は 4096 文字。超過すると合成自体が失敗するため、
+// 送信前に切り詰める。通常のアナウンス文はこの上限に達しない。
+export const REMOTE_TTS_MAX_INPUT_LENGTH = 4096;

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -21,6 +21,7 @@ export const REMOTE_TTS_INSTRUCTIONS_EN =
   'Keep a steady pace, pause briefly at commas, and pronounce station and line names ' +
   'clearly. Stay neutral and business-like rather than expressive.';
 
-// gpt-4o-mini-tts の入力上限は 4096 文字。超過すると合成自体が失敗するため、
-// 送信前に切り詰める。通常のアナウンス文はこの上限に達しない。
-export const REMOTE_TTS_MAX_INPUT_LENGTH = 4096;
+// Worker(/tts) が受け付ける読み上げテキストの上限(UTF-8 バイト)。超過すると
+// 400 で弾かれて無用なフォールバックを招くため、送信前に切り詰める。
+// Worker 側の TEXT_BYTE_LIMIT と一致させること。通常のアナウンス文は達しない。
+export const REMOTE_TTS_MAX_INPUT_BYTES = 4000;

--- a/src/hooks/tts/speechEngine.ts
+++ b/src/hooks/tts/speechEngine.ts
@@ -1,0 +1,32 @@
+// 自動アナウンスの読み上げ手段を差し替えられるようにするための共通インターフェース。
+// Android は端末内蔵 TTS (useNativeSpeechEngine)、iOS は Worker 経由の
+// gpt-4o-mini-tts (useRemoteSpeechEngine) を使い、リモートが使えないときは
+// useTTS がその回だけ内蔵 TTS へフォールバックする。
+
+export interface SpeechEngineRequest {
+  // テンプレートが生成した SSML 断片。プレーンテキストへの変換はエンジン側で行う。
+  ssmlJa: string;
+  ssmlEn: string;
+  speakJa: boolean;
+  speakEn: boolean;
+}
+
+export interface SpeechEngineCallbacks {
+  // 実際に音声を出し始めた。初回放送フラグの確定に使う。
+  onSpeechStarted?: () => void;
+  // 発話が完了・失敗して発話パイプラインを解放してよい状態になった。
+  // onUnavailable と合わせて、1 回の speak につきどちらか一方だけが 1 度呼ばれる。
+  onSettled: () => void;
+  // 音声を一切生成できず発話しなかった（リモート取得失敗など）。
+  // 未指定のエンジンは代わりに onSettled を呼ぶ。
+  onUnavailable?: () => void;
+}
+
+export interface SpeechEngine {
+  speak: (
+    request: SpeechEngineRequest,
+    callbacks: SpeechEngineCallbacks
+  ) => void;
+  // 進行中の発話を中断し、ネイティブ資源を解放する。コールバックは呼ばれない。
+  stop: () => void;
+}

--- a/src/hooks/tts/useNativeSpeechEngine.ts
+++ b/src/hooks/tts/useNativeSpeechEngine.ts
@@ -1,0 +1,230 @@
+import * as Speech from 'expo-speech';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
+import { selectBestVoiceIdentifier } from '../../utils/nativeTtsVoice';
+import {
+  toSpeakableText,
+  truncateToSpeechLimit,
+} from '../../utils/speakableText';
+import type {
+  SpeechEngine,
+  SpeechEngineCallbacks,
+  SpeechEngineRequest,
+} from './speechEngine';
+
+const JA_SPEECH_LANGUAGE = 'ja-JP';
+const EN_SPEECH_LANGUAGE = 'en-US';
+
+// expo-speech は volume 未指定時の既定値が機種・OSバージョンにより最大音量
+// より低くなることがあるため、常に最大値を明示指定して音量が下がる余地を無くす。
+const MAX_SPEECH_VOLUME = 1.0;
+
+// 発話開始前に音声選択（getAvailableVoicesAsync）の完了を待つ上限（ミリ秒）。
+// Android の TTS エンジン初期化がハングした場合でも、この時間を超えたら
+// 音声未指定のまま発話へ進み、アナウンス全体が止まらないようにする。
+const VOICES_READY_TIMEOUT_MS = 5_000;
+
+/**
+ * 端末内蔵の TTS (expo-speech) で読み上げるエンジン。
+ * Android の常用経路であり、iOS ではリモート TTS が使えないときの
+ * フォールバックとして使う。
+ */
+export const useNativeSpeechEngine = (): SpeechEngine => {
+  // 発話ごとに採番する世代 ID。停止や新規発話で無効化された古い発話の
+  // コールバックが、後続の発話の再生状態を壊すのを防ぐ。
+  const runIdRef = useRef(0);
+
+  // 言語ごとに端末の最高品質音声（premium / enhanced）を明示指定するための識別子。
+  // 見つからない場合は undefined のままシステム既定音声に任せる。
+  const jaVoiceIdRef = useRef<string | undefined>(undefined);
+  const enVoiceIdRef = useRef<string | undefined>(undefined);
+  // Android で音声一覧の取得に成功した（=言語ごとの音声有無を判定できる）か。
+  // expo-speech の Android 実装は対象言語の音声データが端末に無いと setLanguage
+  // が LANG_MISSING_DATA となり端末既定言語にフォールバックするため、音声が
+  // 見つからなかった言語の発話はスキップする判断に使う。
+  const androidVoicesLoadedRef = useRef(false);
+
+  // 初回発話が音声選択の完了前に走ると voice 未指定で合成されてしまうため、
+  // 発話側が選択完了を待てるよう Promise を保持する（常に resolve する）。
+  const voicesReadyRef = useRef<Promise<void> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    voicesReadyRef.current = (async () => {
+      try {
+        const voices = await Speech.getAvailableVoicesAsync();
+        if (cancelled) {
+          return;
+        }
+        // Android は voice 未指定だと言語フォールバック不備の影響を受けるため、
+        // 高品質音声が無くても既定品質のローカル音声を明示指定する
+        const options = { allowDefaultQuality: Platform.OS === 'android' };
+        jaVoiceIdRef.current = selectBestVoiceIdentifier(
+          voices,
+          JA_SPEECH_LANGUAGE,
+          options
+        );
+        enVoiceIdRef.current = selectBestVoiceIdentifier(
+          voices,
+          EN_SPEECH_LANGUAGE,
+          options
+        );
+        if (Platform.OS === 'android' && voices.length > 0) {
+          androidVoicesLoadedRef.current = true;
+          if (!jaVoiceIdRef.current) {
+            console.warn(
+              '[useNativeSpeechEngine] No Japanese voice found on this device; Japanese announcements will be skipped'
+            );
+          }
+          if (!enVoiceIdRef.current) {
+            console.warn(
+              '[useNativeSpeechEngine] No English voice found on this device; English announcements will be skipped'
+            );
+          }
+        }
+      } catch (e) {
+        console.warn(
+          '[useNativeSpeechEngine] getAvailableVoicesAsync failed:',
+          e
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 音声選択の完了を待つ。取得がハングしても発話全体が止まらないよう上限付き
+  const waitForVoicesReady = useCallback(async () => {
+    const ready = voicesReadyRef.current;
+    if (!ready) {
+      return;
+    }
+    await Promise.race([
+      ready,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, VOICES_READY_TIMEOUT_MS);
+      }),
+    ]);
+  }, []);
+
+  const stop = useCallback(() => {
+    // 世代を進めて残存コールバックを無効化してから読み上げを停止する
+    runIdRef.current += 1;
+    try {
+      Speech.stop();
+    } catch {}
+  }, []);
+
+  const speak = useCallback(
+    (request: SpeechEngineRequest, callbacks: SpeechEngineCallbacks) => {
+      const runId = runIdRef.current + 1;
+      runIdRef.current = runId;
+      const isStaleRun = () => runIdRef.current !== runId;
+
+      void (async () => {
+        // 初回アナウンスが音声選択の完了前に走ると voice 未指定で合成され、
+        // Android では言語フォールバック不備により端末既定言語（日本語）で
+        // 英語文が読まれうる。選択完了を待ってから発話する
+        await waitForVoicesReady();
+        if (isStaleRun()) {
+          return;
+        }
+
+        // Android で端末に対象言語の音声が1つも無い場合、expo-speech の
+        // setLanguage が LANG_MISSING_DATA で端末既定言語にフォールバックし、
+        // 英語文が日本語音声で合成されてしまう。誤った言語の音声で読み上げる
+        // より、その言語の発話をスキップする方がマシなため発話対象から外す。
+        const voicesKnown = androidVoicesLoadedRef.current;
+        const canSpeakJa = !voicesKnown || Boolean(jaVoiceIdRef.current);
+        const canSpeakEn = !voicesKnown || Boolean(enVoiceIdRef.current);
+
+        const limit = Speech.maxSpeechInputLength;
+        const plainJa =
+          request.speakJa && canSpeakJa
+            ? truncateToSpeechLimit(
+                toSpeakableText(request.ssmlJa, 'JA'),
+                limit
+              )
+            : '';
+        const plainEn =
+          request.speakEn && canSpeakEn
+            ? truncateToSpeechLimit(
+                toSpeakableText(request.ssmlEn, 'EN'),
+                limit
+              )
+            : '';
+
+        const utterances = [
+          plainJa
+            ? {
+                text: plainJa,
+                language: JA_SPEECH_LANGUAGE,
+                voice: jaVoiceIdRef.current,
+              }
+            : null,
+          plainEn
+            ? {
+                text: plainEn,
+                language: EN_SPEECH_LANGUAGE,
+                voice: enVoiceIdRef.current,
+              }
+            : null,
+        ].filter(
+          (
+            u
+          ): u is {
+            text: string;
+            language: string;
+            voice: string | undefined;
+          } => u !== null
+        );
+
+        if (!utterances.length) {
+          callbacks.onSettled();
+          return;
+        }
+
+        callbacks.onSpeechStarted?.();
+
+        // JA→EN を一括で OS の読み上げキューへ積む。Android の TextToSpeech は
+        // speak() 呼び出し時点の言語・音声設定を発話リクエストごとにスナップ
+        // ショットする（setVoice / setLanguage は mParams に保存され speak() が
+        // 要求ごとに複製する）ため、発話ごとに異なる音声を安全に指定できる。
+        // iOS の AVSpeechUtterance も発話単位で音声を保持する。一括で積むことで
+        // エンジンが前の発話の再生中に次の合成を先行でき、発話間の無音
+        // （合成待ちのラグ）を最小化する。完了・エラー・停止のいずれかが全発話
+        // 分そろった時点でパイプラインを解放する。停止や新規発話で世代が
+        // 進んでいたら、古いコールバックは無視する
+        let remaining = utterances.length;
+        const settle = () => {
+          if (isStaleRun()) {
+            return;
+          }
+          remaining -= 1;
+          if (remaining <= 0) {
+            callbacks.onSettled();
+          }
+        };
+        for (const utterance of utterances) {
+          Speech.speak(utterance.text, {
+            language: utterance.language,
+            volume: MAX_SPEECH_VOLUME,
+            ...(utterance.voice ? { voice: utterance.voice } : {}),
+            onDone: settle,
+            onStopped: settle,
+            onError: (error) => {
+              console.warn('[useNativeSpeechEngine] speech error:', error);
+              settle();
+            },
+          });
+        }
+      })();
+    },
+    [waitForVoicesReady]
+  );
+
+  useEffect(() => stop, [stop]);
+
+  return useMemo(() => ({ speak, stop }), [speak, stop]);
+};

--- a/src/hooks/tts/useRemoteSpeechEngine.test.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.test.ts
@@ -71,6 +71,10 @@ describe('useRemoteSpeechEngine', () => {
     });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('SSML をプレーンテキストへ変換し、モデル・女性声・読み方指示を添えて要求する', async () => {
     const { result } = renderEngine();
 

--- a/src/hooks/tts/useRemoteSpeechEngine.test.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.test.ts
@@ -1,0 +1,311 @@
+import { act, renderHook } from '@testing-library/react-native';
+import {
+  REMOTE_TTS_INSTRUCTIONS_EN,
+  REMOTE_TTS_INSTRUCTIONS_JA,
+  REMOTE_TTS_MODEL,
+  REMOTE_TTS_VOICE,
+} from '~/constants';
+import type { SpeechEngineRequest } from './speechEngine';
+import { useRemoteSpeechEngine } from './useRemoteSpeechEngine';
+
+const mockGetSessionToken = jest.fn();
+jest.mock('~/lib/session', () => ({
+  getSessionToken: () => mockGetSessionToken(),
+}));
+
+jest.mock('~/lib/workerApi', () => ({
+  workerUrl: (path: string) => `https://worker.example.com${path}`,
+}));
+
+const mockFetchSpeechAudio = jest.fn();
+jest.mock('~/utils/ttsSpeechFetcher', () => ({
+  fetchSpeechAudio: (...args: unknown[]) => mockFetchSpeechAudio(...args),
+}));
+
+type PlayAudioOptions = {
+  uri: string;
+  onFinish: () => void;
+  onError: (error: unknown) => void;
+};
+
+const playAudioCalls: PlayAudioOptions[] = [];
+const mockPlayAudio = jest.fn((options: PlayAudioOptions) => {
+  playAudioCalls.push(options);
+  return { player: { uri: options.uri }, listener: { remove: jest.fn() } };
+});
+
+jest.mock('~/utils/ttsAudioPlayer', () => ({
+  playAudio: (options: PlayAudioOptions) => mockPlayAudio(options),
+  safeRemoveListener: jest.fn(),
+  safeRemovePlayer: jest.fn(),
+}));
+
+const defaultRequest: SpeechEngineRequest = {
+  ssmlJa: '次は<sub alias="オオサキ">大崎</sub>です',
+  ssmlEn: 'The next station is Osaki,<break time="200ms"/> J Y 24.',
+  speakJa: true,
+  speakEn: true,
+};
+
+// 発話開始は getSessionToken と fetchSpeechAudio の解決を待つため非同期。
+// マイクロタスクを数回進めて再生開始まで到達させる。
+const flushAsync = async () => {
+  await act(async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+  });
+};
+
+const renderEngine = () => renderHook(() => useRemoteSpeechEngine());
+
+describe('useRemoteSpeechEngine', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    playAudioCalls.length = 0;
+    mockGetSessionToken.mockResolvedValue('test-token');
+    mockFetchSpeechAudio.mockResolvedValue({
+      id: 'tts-1',
+      pathJa: '/cache/tts-1_ja.mp3',
+      pathEn: '/cache/tts-1_en.mp3',
+    });
+  });
+
+  it('SSML をプレーンテキストへ変換し、モデル・女性声・読み方指示を添えて要求する', async () => {
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled: jest.fn() });
+    await flushAsync();
+
+    expect(mockFetchSpeechAudio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // SSML タグは読み上げられてしまうため、変換後のテキストを送る
+        textJa: '次はオオサキです',
+        textEn: 'The next station is Osaki, J Y 24.',
+        apiUrl: 'https://worker.example.com/tts',
+        idToken: 'test-token',
+        model: REMOTE_TTS_MODEL,
+        jaVoiceName: REMOTE_TTS_VOICE,
+        enVoiceName: REMOTE_TTS_VOICE,
+        instructionsJa: REMOTE_TTS_INSTRUCTIONS_JA,
+        instructionsEn: REMOTE_TTS_INSTRUCTIONS_EN,
+      })
+    );
+  });
+
+  it('日本語を再生し終えてから英語を再生し、両方の完了で onSettled を呼ぶ', async () => {
+    const onSettled = jest.fn();
+    const onSpeechStarted = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled, onSpeechStarted });
+    await flushAsync();
+
+    expect(onSpeechStarted).toHaveBeenCalledTimes(1);
+    expect(playAudioCalls).toHaveLength(1);
+    expect(playAudioCalls[0].uri).toBe('/cache/tts-1_ja.mp3');
+    expect(onSettled).not.toHaveBeenCalled();
+
+    // 日本語の再生完了で英語へ進む
+    act(() => {
+      playAudioCalls[0].onFinish();
+    });
+    expect(playAudioCalls).toHaveLength(2);
+    expect(playAudioCalls[1].uri).toBe('/cache/tts-1_en.mp3');
+    expect(onSettled).not.toHaveBeenCalled();
+
+    act(() => {
+      playAudioCalls[1].onFinish();
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('日本語の再生に失敗しても英語へ進み、最後に onSettled を呼ぶ', async () => {
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled });
+    await flushAsync();
+
+    act(() => {
+      playAudioCalls[0].onError(new Error('playback failed'));
+    });
+    expect(playAudioCalls[1].uri).toBe('/cache/tts-1_en.mp3');
+
+    act(() => {
+      playAudioCalls[1].onError(new Error('playback failed'));
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('日本語のみ有効な場合は英語テキストを要求せず日本語だけ再生する', async () => {
+    // 合成は文字数課金のため、無効な言語は要求しない
+    mockFetchSpeechAudio.mockResolvedValue({
+      id: 'tts-2',
+      pathJa: '/cache/tts-2_ja.mp3',
+      pathEn: null,
+    });
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak({ ...defaultRequest, speakEn: false }, { onSettled });
+    await flushAsync();
+
+    expect(mockFetchSpeechAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ textEn: '' })
+    );
+    expect(playAudioCalls).toHaveLength(1);
+    expect(playAudioCalls[0].uri).toBe('/cache/tts-2_ja.mp3');
+
+    act(() => {
+      playAudioCalls[0].onFinish();
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('英語のみ有効な場合は英語だけ再生する', async () => {
+    mockFetchSpeechAudio.mockResolvedValue({
+      id: 'tts-3',
+      pathJa: null,
+      pathEn: '/cache/tts-3_en.mp3',
+    });
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak({ ...defaultRequest, speakJa: false }, { onSettled });
+    await flushAsync();
+
+    expect(mockFetchSpeechAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ textJa: '' })
+    );
+    expect(playAudioCalls).toHaveLength(1);
+    expect(playAudioCalls[0].uri).toBe('/cache/tts-3_en.mp3');
+
+    act(() => {
+      playAudioCalls[0].onFinish();
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('両方の言語が無効な場合は要求せず onSettled で終える', async () => {
+    const onSettled = jest.fn();
+    const onUnavailable = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(
+      { ...defaultRequest, speakJa: false, speakEn: false },
+      { onSettled, onUnavailable }
+    );
+    await flushAsync();
+
+    expect(mockFetchSpeechAudio).not.toHaveBeenCalled();
+    // 読み上げるものが無いだけなのでフォールバックは不要
+    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('セッショントークンが取れない場合は onUnavailable を呼ぶ', async () => {
+    mockGetSessionToken.mockResolvedValue(null);
+    const onSettled = jest.fn();
+    const onUnavailable = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled, onUnavailable });
+    await flushAsync();
+
+    expect(mockFetchSpeechAudio).not.toHaveBeenCalled();
+    expect(onUnavailable).toHaveBeenCalledTimes(1);
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it('音声の取得に失敗した場合は onUnavailable を呼ぶ', async () => {
+    // 圏外・トンネル・API 障害。呼び出し側が端末内蔵 TTS へフォールバックする
+    mockFetchSpeechAudio.mockResolvedValue(null);
+    const onSettled = jest.fn();
+    const onUnavailable = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled, onUnavailable });
+    await flushAsync();
+
+    expect(onUnavailable).toHaveBeenCalledTimes(1);
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(playAudioCalls).toHaveLength(0);
+  });
+
+  it('取得中に例外が出た場合も onUnavailable を呼ぶ', async () => {
+    mockFetchSpeechAudio.mockRejectedValue(new Error('boom'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const onSettled = jest.fn();
+    const onUnavailable = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled, onUnavailable });
+    await flushAsync();
+
+    expect(onUnavailable).toHaveBeenCalledTimes(1);
+    expect(onSettled).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('onUnavailable 未指定の場合は onSettled で代替する', async () => {
+    mockFetchSpeechAudio.mockResolvedValue(null);
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled });
+    await flushAsync();
+
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop 後は取得が完了してもコールバックを呼ばず再生もしない', async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    mockFetchSpeechAudio.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    const onSettled = jest.fn();
+    const onUnavailable = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled, onUnavailable });
+    act(() => {
+      result.current.stop();
+    });
+
+    await act(async () => {
+      resolveFetch({
+        id: 'tts-4',
+        pathJa: '/cache/tts-4_ja.mp3',
+        pathEn: '/cache/tts-4_en.mp3',
+      });
+      await Promise.resolve();
+    });
+    await flushAsync();
+
+    expect(playAudioCalls).toHaveLength(0);
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(onUnavailable).not.toHaveBeenCalled();
+  });
+
+  it('再生中に stop されたら残りのコールバックを無視する', async () => {
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled });
+    await flushAsync();
+
+    act(() => {
+      result.current.stop();
+    });
+    // 停止済みのプレイヤーから遅れて完了通知が届いても発話は進めない
+    act(() => {
+      playAudioCalls[0].onFinish();
+    });
+
+    expect(playAudioCalls).toHaveLength(1);
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/tts/useRemoteSpeechEngine.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.ts
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  REMOTE_TTS_INSTRUCTIONS_EN,
+  REMOTE_TTS_INSTRUCTIONS_JA,
+  REMOTE_TTS_MAX_INPUT_LENGTH,
+  REMOTE_TTS_MODEL,
+  REMOTE_TTS_VOICE,
+} from '../../constants';
+import { getSessionToken } from '../../lib/session';
+import { workerUrl } from '../../lib/workerApi';
+import {
+  toSpeakableText,
+  truncateToSpeechLimit,
+} from '../../utils/speakableText';
+import {
+  type PlayAudioHandle,
+  playAudio,
+  safeRemoveListener,
+  safeRemovePlayer,
+} from '../../utils/ttsAudioPlayer';
+import { fetchSpeechAudio } from '../../utils/ttsSpeechFetcher';
+import type {
+  SpeechEngine,
+  SpeechEngineCallbacks,
+  SpeechEngineRequest,
+} from './speechEngine';
+
+/**
+ * Worker の /tts 経由で gpt-4o-mini-tts に合成させ、expo-audio で再生するエンジン。
+ * iOS 専用。合成に失敗した場合は onUnavailable を呼び、呼び出し側 (useTTS) が
+ * その回だけ端末内蔵 TTS へフォールバックする。
+ */
+export const useRemoteSpeechEngine = (): SpeechEngine => {
+  // 発話ごとに採番する世代 ID。停止や新規発話で古い fetch 継続を破棄し、
+  // 解決の遅れた音声が後から割り込んで再生されるのを防ぐ。
+  const runIdRef = useRef(0);
+  const jaHandleRef = useRef<PlayAudioHandle | null>(null);
+  const enHandleRef = useRef<PlayAudioHandle | null>(null);
+
+  // iOS は replace() によるプレイヤー再利用がバックグラウンド再生を壊すため、
+  // 発話ごとに生成し、終了時にネイティブごと解放する。
+  const releaseJaPlayer = useCallback(() => {
+    safeRemoveListener(jaHandleRef.current?.listener ?? null);
+    safeRemovePlayer(jaHandleRef.current?.player ?? null);
+    jaHandleRef.current = null;
+  }, []);
+
+  const releaseEnPlayer = useCallback(() => {
+    safeRemoveListener(enHandleRef.current?.listener ?? null);
+    safeRemovePlayer(enHandleRef.current?.player ?? null);
+    enHandleRef.current = null;
+  }, []);
+
+  const stop = useCallback(() => {
+    runIdRef.current += 1;
+    releaseJaPlayer();
+    releaseEnPlayer();
+  }, [releaseJaPlayer, releaseEnPlayer]);
+
+  // 取得済みの音声を JA → EN の順に再生する。どの経路を通っても
+  // onSettled がちょうど 1 回だけ呼ばれるようにする。
+  const playFetched = useCallback(
+    (
+      pathJa: string | null,
+      pathEn: string | null,
+      callbacks: SpeechEngineCallbacks,
+      isStaleRun: () => boolean
+    ) => {
+      callbacks.onSpeechStarted?.();
+
+      const settle = () => {
+        if (isStaleRun()) {
+          return;
+        }
+        callbacks.onSettled();
+      };
+
+      const playEnglish = () => {
+        if (!pathEn) {
+          settle();
+          return;
+        }
+        const finish = () => {
+          releaseEnPlayer();
+          settle();
+        };
+        // playAudio が生成・再生開始に失敗しても必ず完了へ到達させる
+        try {
+          enHandleRef.current = playAudio({
+            uri: pathEn,
+            onFinish: finish,
+            onError: finish,
+          });
+        } catch (e) {
+          console.warn(
+            '[useRemoteSpeechEngine] EN playback failed to start:',
+            e
+          );
+          finish();
+        }
+      };
+
+      if (!pathJa) {
+        playEnglish();
+        return;
+      }
+
+      const finishJa = () => {
+        releaseJaPlayer();
+        if (isStaleRun()) {
+          return;
+        }
+        playEnglish();
+      };
+
+      try {
+        jaHandleRef.current = playAudio({
+          uri: pathJa,
+          onFinish: finishJa,
+          onError: finishJa,
+        });
+      } catch (e) {
+        console.warn('[useRemoteSpeechEngine] JA playback failed to start:', e);
+        finishJa();
+      }
+    },
+    [releaseJaPlayer, releaseEnPlayer]
+  );
+
+  const speak = useCallback(
+    (request: SpeechEngineRequest, callbacks: SpeechEngineCallbacks) => {
+      const runId = runIdRef.current + 1;
+      runIdRef.current = runId;
+      const isStaleRun = () => runIdRef.current !== runId;
+      // 合成できなかったときの通知。onUnavailable 未指定なら通常の完了として扱う。
+      const reportUnavailable = () => {
+        if (callbacks.onUnavailable) {
+          callbacks.onUnavailable();
+          return;
+        }
+        callbacks.onSettled();
+      };
+
+      void (async () => {
+        if (!request.speakJa && !request.speakEn) {
+          callbacks.onSettled();
+          return;
+        }
+
+        try {
+          const idToken = await getSessionToken();
+          if (isStaleRun()) {
+            return;
+          }
+          if (!idToken) {
+            console.warn(
+              '[useRemoteSpeechEngine] session token is missing, skipping fetch'
+            );
+            reportUnavailable();
+            return;
+          }
+
+          // 合成は文字数課金のため、無効な言語のテキストは送らない
+          const textJa = request.speakJa
+            ? truncateToSpeechLimit(
+                toSpeakableText(request.ssmlJa, 'JA'),
+                REMOTE_TTS_MAX_INPUT_LENGTH
+              )
+            : '';
+          const textEn = request.speakEn
+            ? truncateToSpeechLimit(
+                toSpeakableText(request.ssmlEn, 'EN'),
+                REMOTE_TTS_MAX_INPUT_LENGTH
+              )
+            : '';
+
+          const fetched = await fetchSpeechAudio({
+            textJa,
+            textEn,
+            apiUrl: workerUrl('/tts'),
+            idToken,
+            model: REMOTE_TTS_MODEL,
+            jaVoiceName: REMOTE_TTS_VOICE,
+            enVoiceName: REMOTE_TTS_VOICE,
+            instructionsJa: REMOTE_TTS_INSTRUCTIONS_JA,
+            instructionsEn: REMOTE_TTS_INSTRUCTIONS_EN,
+          });
+
+          if (isStaleRun()) {
+            return;
+          }
+          if (!fetched || (!fetched.pathJa && !fetched.pathEn)) {
+            console.warn(
+              '[useRemoteSpeechEngine] failed to fetch speech audio'
+            );
+            reportUnavailable();
+            return;
+          }
+
+          playFetched(fetched.pathJa, fetched.pathEn, callbacks, isStaleRun);
+        } catch (error) {
+          if (isStaleRun()) {
+            return;
+          }
+          console.error('[useRemoteSpeechEngine] speech error:', error);
+          reportUnavailable();
+        }
+      })();
+    },
+    [playFetched]
+  );
+
+  useEffect(() => stop, [stop]);
+
+  return useMemo(() => ({ speak, stop }), [speak, stop]);
+};

--- a/src/hooks/tts/useRemoteSpeechEngine.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   REMOTE_TTS_INSTRUCTIONS_EN,
   REMOTE_TTS_INSTRUCTIONS_JA,
-  REMOTE_TTS_MAX_INPUT_LENGTH,
+  REMOTE_TTS_MAX_INPUT_BYTES,
   REMOTE_TTS_MODEL,
   REMOTE_TTS_VOICE,
 } from '../../constants';
@@ -10,7 +10,7 @@ import { getSessionToken } from '../../lib/session';
 import { workerUrl } from '../../lib/workerApi';
 import {
   toSpeakableText,
-  truncateToSpeechLimit,
+  truncateToByteLimit,
 } from '../../utils/speakableText';
 import {
   type PlayAudioHandle,
@@ -162,15 +162,15 @@ export const useRemoteSpeechEngine = (): SpeechEngine => {
 
           // 合成は文字数課金のため、無効な言語のテキストは送らない
           const textJa = request.speakJa
-            ? truncateToSpeechLimit(
+            ? truncateToByteLimit(
                 toSpeakableText(request.ssmlJa, 'JA'),
-                REMOTE_TTS_MAX_INPUT_LENGTH
+                REMOTE_TTS_MAX_INPUT_BYTES
               )
             : '';
           const textEn = request.speakEn
-            ? truncateToSpeechLimit(
+            ? truncateToByteLimit(
                 toSpeakableText(request.ssmlEn, 'EN'),
-                REMOTE_TTS_MAX_INPUT_LENGTH
+                REMOTE_TTS_MAX_INPUT_BYTES
               )
             : '';
 

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -27,6 +27,32 @@ jest.mock('expo-audio', () => ({
   setAudioModeAsync: (...args: unknown[]) => mockSetAudioModeAsync(...args),
 }));
 
+// このファイルは「端末内蔵 TTS で読み上げるまで」を検証する。リモート TTS の
+// 実装そのもの（/tts への送信内容や音声再生）は useRemoteSpeechEngine.test.ts で
+// 検証するため、ここではエンジンを差し替えて挙動を固定する。
+// 既定はリモート合成が使えない状態とし、iOS でも端末内蔵 TTS へフォールバック
+// してくる経路を通す（jest-expo の既定 Platform.OS は 'ios'）。
+const remoteSpeakUnavailable = (
+  _request: unknown,
+  callbacks: { onUnavailable?: () => void; onSettled: () => void }
+) => {
+  (callbacks.onUnavailable ?? callbacks.onSettled)();
+};
+const mockRemoteSpeak = jest.fn(remoteSpeakUnavailable);
+const mockRemoteStop = jest.fn();
+
+// 本物の useRemoteSpeechEngine と同じく、レンダーをまたいで同一のオブジェクトを
+// 返す（毎レンダー新しい参照を返すと useTTS 側の依存が無用に変化してしまう）。
+const mockRemoteEngine = {
+  speak: (...args: unknown[]) =>
+    (mockRemoteSpeak as unknown as (...a: unknown[]) => void)(...args),
+  stop: (...args: unknown[]) => mockRemoteStop(...args),
+};
+
+jest.mock('./tts/useRemoteSpeechEngine', () => ({
+  useRemoteSpeechEngine: () => mockRemoteEngine,
+}));
+
 jest.mock('./useCurrentLine', () => ({
   useCurrentLine: jest.fn(() => undefined),
 }));
@@ -99,6 +125,8 @@ describe('useTTS', () => {
     jest.clearAllMocks();
     settledSpeakCallCount = 0;
     mockGetAvailableVoicesAsync.mockResolvedValue([]);
+    // 個別テストで差し替えたリモートエンジンの挙動を既定へ戻す
+    mockRemoteSpeak.mockImplementation(remoteSpeakUnavailable);
     // テスト間で useTTSText の mock を復元
     const { useTTSText } = jest.requireMock('./useTTSText') as {
       useTTSText: jest.Mock;
@@ -270,7 +298,7 @@ describe('useTTS', () => {
       expect.objectContaining({ language: 'en-US' })
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      '[useTTS] English text contains Japanese characters, stripping:',
+      '[speakableText] English text contains Japanese characters, stripping:',
       'Arriving at あかさか K 7.'
     );
 
@@ -811,5 +839,101 @@ describe('useTTS', () => {
     expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
       expect.objectContaining({ interruptionMode: 'mixWithOthers' })
     );
+  });
+
+  describe('プラットフォーム別の読み上げ経路', () => {
+    it('[iOS] リモートTTSで読み上げ、端末内蔵TTSは使わない', async () => {
+      mockRemoteSpeak.mockImplementation(
+        (
+          _request: unknown,
+          callbacks: {
+            onSpeechStarted?: () => void;
+            onSettled: () => void;
+          }
+        ) => {
+          callbacks.onSpeechStarted?.();
+          callbacks.onSettled();
+        }
+      );
+
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).toHaveBeenCalledTimes(1);
+      expect(mockRemoteSpeak).toHaveBeenCalledWith(
+        {
+          ssmlJa: 'ja text',
+          ssmlEn: 'en text',
+          speakJa: true,
+          speakEn: true,
+        },
+        expect.any(Object)
+      );
+      expect(mockSpeak).not.toHaveBeenCalled();
+    });
+
+    it('[iOS] リモートTTSが使えない回は端末内蔵TTSへフォールバックする', async () => {
+      // 圏外・トンネル・API障害で合成できなくてもアナウンスを欠落させない
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).toHaveBeenCalledTimes(1);
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        1,
+        'ja text',
+        expect.objectContaining({ language: 'ja-JP' })
+      );
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        2,
+        'en text',
+        expect.objectContaining({ language: 'en-US' })
+      );
+    });
+
+    it('[iOS] フォールバックした発話の完了でも再生パイプラインが解放される', async () => {
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      mockSetAudioModeAsync.mockClear();
+      await act(async () => {
+        finishAllUtterances();
+      });
+
+      // ダッキングが解除される = playingRef が解放されている
+      expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ interruptionMode: 'mixWithOthers' })
+      );
+    });
+
+    it('[Android] リモートTTSを呼ばず端末内蔵TTSで読み上げる', async () => {
+      setPlatformOS('android');
+
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).not.toHaveBeenCalled();
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        1,
+        'ja text',
+        expect.objectContaining({ language: 'ja-JP' })
+      );
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        2,
+        'en text',
+        expect.objectContaining({ language: 'en-US' })
+      );
+    });
   });
 });

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,5 +1,4 @@
 import { setAudioModeAsync } from 'expo-audio';
-import * as Speech from 'expo-speech';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef } from 'react';
 import { Platform } from 'react-native';
@@ -7,46 +6,25 @@ import { TransportType } from '~/@types/graphql';
 import speechState, { resetFirstSpeechAtom } from '../store/atoms/speech';
 import { arrivedAtom, selectedBoundAtom } from '../store/atoms/station';
 import { computeSuppressionDecision } from '../utils/computeSuppressionDecision';
-import { fixJrReading } from '../utils/jrReading';
-import { selectBestVoiceIdentifier } from '../utils/nativeTtsVoice';
-import {
-  containsJapaneseCharacters,
-  stripJapaneseCharacters,
-} from '../utils/phoneme';
-import { ssmlToPlainText } from '../utils/ssmlToPlainText';
+import type { SpeechEngineRequest } from './tts/speechEngine';
+import { useNativeSpeechEngine } from './tts/useNativeSpeechEngine';
+import { useRemoteSpeechEngine } from './tts/useRemoteSpeechEngine';
 import { useCurrentLine } from './useCurrentLine';
 import { usePrevious } from './usePrevious';
 import { useStoppingState } from './useStoppingState';
 import { useTTSText } from './useTTSText';
 
-// 発話開始後に onDone / onError / onStopped が一切届かない場合の安全タイムアウト（ミリ秒）。
-// Android の TTS エンジンは音声フォーカス喪失や中断時にコールバックを落とすことがあり、
-// その場合に playingRef が解放されず以降の TTS 全体が停止するのを防ぐ。
-// 正常な発話（日英合わせても数十秒程度）はこの時間内に必ず完了する。
+// 発話開始後に完了・失敗の通知が一切届かない場合の安全タイムアウト（ミリ秒）。
+// 端末内蔵の TTS エンジンは音声フォーカス喪失や中断時にコールバックを落とすこと
+// があり、リモート TTS も取得と再生の双方でハングしうる。その場合に playingRef が
+// 解放されず以降の TTS 全体が停止するのを防ぐ。正常な発話（日英合わせても数十秒
+// 程度、リモートは取得時間を含めても十分収まる）はこの時間内に必ず完了する。
 const PLAYBACK_TIMEOUT_MS = 300_000;
 
-const JA_SPEECH_LANGUAGE = 'ja-JP';
-const EN_SPEECH_LANGUAGE = 'en-US';
-
-// expo-speech は volume 未指定時の既定値が機種・OSバージョンにより最大音量
-// より低くなることがあるため、常に最大値を明示指定して音量が下がる余地を無くす。
-const MAX_SPEECH_VOLUME = 1.0;
-
-// 発話開始前に音声選択（getAvailableVoicesAsync）の完了を待つ上限（ミリ秒）。
-// Android の TTS エンジン初期化がハングした場合でも、この時間を超えたら
-// 音声未指定のまま発話へ進み、アナウンス全体が止まらないようにする。
-const VOICES_READY_TIMEOUT_MS = 5_000;
-
-// Android の TextToSpeech は入力長上限 (通常 4000 文字) を超えると発話自体が
-// 失敗する。通常のアナウンス文はこの上限に達しないが、超過時は静かに失敗する
-// より切り詰めて読み上げる方がマシなため防衛的に丸める。
-const truncateToSpeechLimit = (text: string): string => {
-  const limit = Speech.maxSpeechInputLength;
-  if (typeof limit === 'number' && limit > 0 && text.length > limit) {
-    return text.slice(0, limit);
-  }
-  return text;
-};
+// iOS のみ Worker 経由の gpt-4o-mini-tts（女性声）で読み上げる。Android は
+// 端末内蔵 TTS のまま据え置き。iOS でもリモート合成に失敗した回は端末内蔵 TTS へ
+// フォールバックするため、圏外・トンネル・API 障害でもアナウンスは途切れない。
+const shouldUseRemoteTTS = (): boolean => Platform.OS === 'ios';
 
 export const useTTS = (): void => {
   const { enabled, backgroundEnabled, ttsEnabledLanguages } =
@@ -90,81 +68,27 @@ export const useTTS = (): void => {
 
   const playingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 言語ごとに端末の最高品質音声（premium / enhanced）を明示指定するための識別子。
-  // 見つからない場合は undefined のままシステム既定音声に任せる。
-  const jaVoiceIdRef = useRef<string | undefined>(undefined);
-  const enVoiceIdRef = useRef<string | undefined>(undefined);
-  // Android で音声一覧の取得に成功した（=言語ごとの音声有無を判定できる）か。
-  // expo-speech の Android 実装は対象言語の音声データが端末に無いと setLanguage
-  // が LANG_MISSING_DATA となり端末既定言語にフォールバックするため、音声が
-  // 見つからなかった言語の発話はスキップする判断に使う。
-  const androidVoicesLoadedRef = useRef(false);
+  // 端末内蔵 TTS は Android の常用経路であり、iOS ではリモート合成が使えない
+  // ときのフォールバックも担うため、どちらのプラットフォームでも用意しておく。
+  const nativeEngine = useNativeSpeechEngine();
+  const remoteEngine = useRemoteSpeechEngine();
 
-  // 初回発話が音声選択の完了前に走ると voice 未指定で合成されてしまうため、
-  // 発話側が選択完了を待てるよう Promise を保持する（常に resolve する）。
-  const voicesReadyRef = useRef<Promise<void> | null>(null);
+  const stopAllEngines = useCallback(() => {
+    remoteEngine.stop();
+    nativeEngine.stop();
+  }, [nativeEngine, remoteEngine]);
 
-  useEffect(() => {
-    let cancelled = false;
-    voicesReadyRef.current = (async () => {
-      try {
-        const voices = await Speech.getAvailableVoicesAsync();
-        if (cancelled) {
-          return;
-        }
-        // Android は voice 未指定だと言語フォールバック不備の影響を受けるため、
-        // 高品質音声が無くても既定品質のローカル音声を明示指定する
-        const options = { allowDefaultQuality: Platform.OS === 'android' };
-        jaVoiceIdRef.current = selectBestVoiceIdentifier(
-          voices,
-          JA_SPEECH_LANGUAGE,
-          options
-        );
-        enVoiceIdRef.current = selectBestVoiceIdentifier(
-          voices,
-          EN_SPEECH_LANGUAGE,
-          options
-        );
-        if (Platform.OS === 'android' && voices.length > 0) {
-          androidVoicesLoadedRef.current = true;
-          if (!jaVoiceIdRef.current) {
-            console.warn(
-              '[useTTS] No Japanese voice found on this device; Japanese announcements will be skipped'
-            );
-          }
-          if (!enVoiceIdRef.current) {
-            console.warn(
-              '[useTTS] No English voice found on this device; English announcements will be skipped'
-            );
-          }
-        }
-      } catch (e) {
-        console.warn('[useTTS] getAvailableVoicesAsync failed:', e);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // 音声選択の完了を待つ。取得がハングしても発話全体が止まらないよう上限付き
-  const waitForVoicesReady = useCallback(async () => {
-    const ready = voicesReadyRef.current;
-    if (!ready) {
-      return;
-    }
-    await Promise.race([
-      ready,
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, VOICES_READY_TIMEOUT_MS);
-      }),
-    ]);
-  }, []);
+  // アンマウント時のクリーンアップから参照する。エンジンの識別子を effect の
+  // 依存に入れると、識別子が変わっただけでクリーンアップが走って発話中の
+  // アナウンスを打ち切ってしまうため、ref 経由で最新の実装を呼ぶ。
+  const stopAllEnginesRef = useRef(stopAllEngines);
+  stopAllEnginesRef.current = stopAllEngines;
 
   // OS ネイティブ TTS は expo-audio のプレイヤーを使わないが、iOS の
   // AVSpeechSynthesizer はアプリの音声セッションを共有するため、
   // サイレントスイッチ中の読み上げ・バックグラウンド再生はここで設定した
-  // audio mode に従う。他アプリ音声のダッキングは発話開始直前にのみ有効化し
+  // audio mode に従う。リモート TTS の再生（expo-audio）も同じセッションを使う。
+  // 他アプリ音声のダッキングは発話開始直前にのみ有効化し
   // （setDuckingActiveAsync 参照）、ここでは非ダッキング状態を既定にする。
   const backgroundEnabledRef = useRef(backgroundEnabled);
   backgroundEnabledRef.current = backgroundEnabled;
@@ -226,9 +150,9 @@ export const useTTS = (): void => {
     }
   }, [setDuckingActiveAsync]);
 
-  // 発話開始時に安全タイムアウトを張る。OS の TTS エンジンから完了・エラー・
-  // 停止のいずれのコールバックも届かないままハングした場合でも、playingRef を
-  // 確実に解放して以降の発話が詰まらないようにする。
+  // 発話開始時に安全タイムアウトを張る。TTS エンジンから完了・エラー・停止の
+  // いずれの通知も届かないままハングした場合でも、playingRef を確実に解放して
+  // 以降の発話が詰まらないようにする。
   const armPlaybackWatchdog = useCallback(
     (runId: number) => {
       if (playingTimeoutRef.current) {
@@ -244,13 +168,11 @@ export const useTTS = (): void => {
         // 世代を進めて、強制リセット後に古い発話のコールバックが
         // 再生状態へ割り込むのを無効化する
         speechRunIdRef.current += 1;
-        try {
-          Speech.stop();
-        } catch {}
+        stopAllEngines();
         finishPlaying();
       }, PLAYBACK_TIMEOUT_MS);
     },
-    [finishPlaying]
+    [finishPlaying, stopAllEngines]
   );
 
   const speechWithText = useCallback(
@@ -260,7 +182,7 @@ export const useTTS = (): void => {
       }
 
       // 発話の世代IDを同期的に採番して再生中フラグを立てる。ここを非同期に
-      // すると同一テキストで二重に発話が走りうる。音声選択の完了待ちなどの
+      // すると同一テキストで二重に発話が走りうる。音声セッション設定などの
       // 非同期処理後は isStaleRun で世代を確認し、古い継続を破棄する
       const runId = speechRunIdRef.current + 1;
       speechRunIdRef.current = runId;
@@ -272,89 +194,28 @@ export const useTTS = (): void => {
         !playingRef.current ||
         !isLoadableRef.current;
 
-      void (async () => {
-        // 初回アナウンスが音声選択の完了前に走ると voice 未指定で合成され、
-        // Android では言語フォールバック不備により端末既定言語（日本語）で
-        // 英語文が読まれうる。選択完了を待ってから発話する
-        await waitForVoicesReady();
+      const request: SpeechEngineRequest = {
+        ssmlJa: ja,
+        ssmlEn: en,
+        speakJa: shouldSpeakJapanese,
+        speakEn: shouldSpeakEnglish,
+      };
+
+      const onSpeechStarted = () => {
+        if (firstSpeechRef.current) {
+          firstSpeechRef.current = false;
+          suppressPostFirstSpeechRef.current = true;
+        }
+      };
+
+      const onSettled = () => {
         if (isStaleRun()) {
           return;
         }
+        finishPlaying();
+      };
 
-        // Android で端末に対象言語の音声が1つも無い場合、expo-speech の
-        // setLanguage が LANG_MISSING_DATA で端末既定言語にフォールバックし、
-        // 英語文が日本語音声で合成されてしまう。誤った言語の音声で読み上げる
-        // より、その言語の発話をスキップする方がマシなため発話対象から外す。
-        const voicesKnown = androidVoicesLoadedRef.current;
-        const canSpeakJa = !voicesKnown || Boolean(jaVoiceIdRef.current);
-        const canSpeakEn = !voicesKnown || Boolean(enVoiceIdRef.current);
-
-        // テンプレートが生成する SSML 断片を OS ネイティブ TTS 用の
-        // プレーンテキストへ変換する。英語はテンプレ側に区切りのカンマが
-        // 既に含まれるため <break/> は空白へ置き換える。
-        // 「JR」は TTS エンジンが "Jr."（ジュニア）と誤読するため、読み上げ
-        // 直前のこの段でのみ読み方が確定する表記へ置換する（切り詰め判定は
-        // 置換後の長さで行いたいので truncate より前に適用する）。
-        const plainJa =
-          shouldSpeakJapanese && canSpeakJa
-            ? truncateToSpeechLimit(
-                fixJrReading(
-                  ssmlToPlainText(ja, { breakReplacement: '、' }),
-                  'JA'
-                )
-              )
-            : '';
-        let plainEn =
-          shouldSpeakEnglish && canSpeakEn
-            ? truncateToSpeechLimit(
-                fixJrReading(
-                  ssmlToPlainText(en, { breakReplacement: ' ' }),
-                  'EN'
-                )
-              )
-            : '';
-        // nameRoman が欠落した駅データ等では wrapPhoneme のローマ字フォール
-        // バックが効かず、英語文に日本語が残ることがある。日本語が混じった
-        // 英語文は voice を明示指定していても TTS エンジンが言語を誤判定して
-        // 全文を日本語音声で合成してしまうため、最終防衛線として除去する
-        if (containsJapaneseCharacters(plainEn)) {
-          console.warn(
-            '[useTTS] English text contains Japanese characters, stripping:',
-            plainEn
-          );
-          plainEn = stripJapaneseCharacters(plainEn);
-        }
-
-        const utterances = [
-          plainJa
-            ? {
-                text: plainJa,
-                language: JA_SPEECH_LANGUAGE,
-                voice: jaVoiceIdRef.current,
-              }
-            : null,
-          plainEn
-            ? {
-                text: plainEn,
-                language: EN_SPEECH_LANGUAGE,
-                voice: enVoiceIdRef.current,
-              }
-            : null,
-        ].filter(
-          (
-            u
-          ): u is {
-            text: string;
-            language: string;
-            voice: string | undefined;
-          } => u !== null
-        );
-
-        if (!utterances.length) {
-          finishPlaying();
-          return;
-        }
-
+      void (async () => {
         // 実際に読み上げる直前にのみ他アプリ音声のダッキングを有効化する
         await setDuckingActiveAsync(true);
         if (isStaleRun()) {
@@ -364,52 +225,36 @@ export const useTTS = (): void => {
           return;
         }
 
-        if (firstSpeechRef.current) {
-          firstSpeechRef.current = false;
-          suppressPostFirstSpeechRef.current = true;
+        if (!shouldUseRemoteTTS()) {
+          nativeEngine.speak(request, { onSpeechStarted, onSettled });
+          return;
         }
 
-        // JA→EN を一括で OS の読み上げキューへ積む。Android の TextToSpeech は
-        // speak() 呼び出し時点の言語・音声設定を発話リクエストごとにスナップ
-        // ショットする（setVoice / setLanguage は mParams に保存され speak() が
-        // 要求ごとに複製する）ため、発話ごとに異なる音声を安全に指定できる。
-        // iOS の AVSpeechUtterance も発話単位で音声を保持する。一括で積むことで
-        // エンジンが前の発話の再生中に次の合成を先行でき、発話間の無音
-        // （合成待ちのラグ）を最小化する。完了・エラー・停止のいずれかが全発話
-        // 分そろった時点でパイプラインを解放する。タイムアウトや新規発話で
-        // 世代が進んでいたら、古いコールバックは無視する
-        let remaining = utterances.length;
-        const settle = () => {
-          if (isStaleRun()) {
-            return;
-          }
-          remaining -= 1;
-          if (remaining <= 0) {
-            finishPlaying();
-          }
-        };
-        for (const utterance of utterances) {
-          Speech.speak(utterance.text, {
-            language: utterance.language,
-            volume: MAX_SPEECH_VOLUME,
-            ...(utterance.voice ? { voice: utterance.voice } : {}),
-            onDone: settle,
-            onStopped: settle,
-            onError: (error) => {
-              console.warn('[useTTS] speech error:', error);
-              settle();
-            },
-          });
-        }
+        remoteEngine.speak(request, {
+          onSpeechStarted,
+          onSettled,
+          // 圏外・トンネル・API 障害で合成できなかった回は、その放送だけ
+          // 端末内蔵 TTS で読み上げてアナウンスの欠落を防ぐ
+          onUnavailable: () => {
+            if (isStaleRun()) {
+              return;
+            }
+            console.warn(
+              '[useTTS] Remote TTS unavailable, falling back to on-device TTS'
+            );
+            nativeEngine.speak(request, { onSpeechStarted, onSettled });
+          },
+        });
       })();
     },
     [
       armPlaybackWatchdog,
       finishPlaying,
+      nativeEngine,
+      remoteEngine,
       setDuckingActiveAsync,
       shouldSpeakEnglish,
       shouldSpeakJapanese,
-      waitForVoicesReady,
     ]
   );
 
@@ -482,9 +327,7 @@ export const useTTS = (): void => {
       }
       // 世代を進めて残存コールバックを無効化してから読み上げを停止する
       speechRunIdRef.current += 1;
-      try {
-        Speech.stop();
-      } catch {}
+      stopAllEnginesRef.current();
       playingRef.current = false;
       // 発話中にアンマウントされた場合、ダッキングが張られたまま残るのを防ぐ
       void setDuckingActiveAsync(false);

--- a/src/utils/base64ToUint8Array.test.ts
+++ b/src/utils/base64ToUint8Array.test.ts
@@ -1,0 +1,47 @@
+import { base64ToUint8Array } from './base64ToUint8Array';
+
+describe('base64ToUint8Array', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('既知文字列をデコードできる', () => {
+    // "Hello" = SGVsbG8=
+    const result = base64ToUint8Array('SGVsbG8=');
+    expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]));
+  });
+
+  it('パディングなしの文字列をデコードできる', () => {
+    // "abc" = YWJj (no padding)
+    const result = base64ToUint8Array('YWJj');
+    expect(result).toEqual(new Uint8Array([97, 98, 99]));
+  });
+
+  it('パディング1つの文字列をデコードできる', () => {
+    // "ab" = YWI=
+    const result = base64ToUint8Array('YWI=');
+    expect(result).toEqual(new Uint8Array([97, 98]));
+  });
+
+  it('パディング2つの文字列をデコードできる', () => {
+    // "a" = YQ==
+    const result = base64ToUint8Array('YQ==');
+    expect(result).toEqual(new Uint8Array([97]));
+  });
+
+  it('空文字列を渡すと空のUint8Arrayを返す', () => {
+    const result = base64ToUint8Array('');
+    expect(result).toEqual(new Uint8Array(0));
+  });
+
+  it('改行やスペースを含むbase64をデコードできる', () => {
+    const result = base64ToUint8Array('SGVs\nbG8=');
+    expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]));
+  });
+
+  it('単一バイト QQ== をデコードできる', () => {
+    // "A" = QQ==
+    const result = base64ToUint8Array('QQ==');
+    expect(result).toEqual(new Uint8Array([65]));
+  });
+});

--- a/src/utils/base64ToUint8Array.test.ts
+++ b/src/utils/base64ToUint8Array.test.ts
@@ -44,4 +44,20 @@ describe('base64ToUint8Array', () => {
     const result = base64ToUint8Array('QQ==');
     expect(result).toEqual(new Uint8Array([65]));
   });
+
+  it('パディング無しで長さが4の倍数でない入力も復号できる', () => {
+    // 非整数長を new Uint8Array へ渡すと RangeError で落ちるため
+    expect(Array.from(base64ToUint8Array('QQ'))).toEqual([0x41]);
+    expect(Array.from(base64ToUint8Array('YWI'))).toEqual([0x61, 0x62]);
+    expect(Array.from(base64ToUint8Array('YWJj'))).toEqual([0x61, 0x62, 0x63]);
+  });
+
+  it('パディングの有無で同じ結果になる', () => {
+    expect(Array.from(base64ToUint8Array('QQ'))).toEqual(
+      Array.from(base64ToUint8Array('QQ=='))
+    );
+    expect(Array.from(base64ToUint8Array('YWI'))).toEqual(
+      Array.from(base64ToUint8Array('YWI='))
+    );
+  });
 });

--- a/src/utils/base64ToUint8Array.ts
+++ b/src/utils/base64ToUint8Array.ts
@@ -1,0 +1,40 @@
+const BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+export const base64ToUint8Array = (input: string): Uint8Array => {
+  const sanitized = input.replace(/[^A-Za-z0-9+/=]/g, '');
+  const length =
+    (sanitized.length * 3) / 4 -
+    (sanitized.endsWith('==') ? 2 : sanitized.endsWith('=') ? 1 : 0);
+  const bytes = new Uint8Array(length);
+
+  let byteIndex = 0;
+  const decodeChar = (char: string): number => {
+    if (char === '=') {
+      return 0;
+    }
+    const index = BASE64_ALPHABET.indexOf(char);
+    if (index === -1) {
+      throw new Error('Invalid base64 character.');
+    }
+    return index;
+  };
+
+  for (let i = 0; i < sanitized.length; i += 4) {
+    const chunk =
+      (decodeChar(sanitized[i]) << 18) |
+      (decodeChar(sanitized[i + 1]) << 12) |
+      (decodeChar(sanitized[i + 2]) << 6) |
+      decodeChar(sanitized[i + 3]);
+
+    bytes[byteIndex++] = (chunk >> 16) & 0xff;
+    if (sanitized[i + 2] !== '=') {
+      bytes[byteIndex++] = (chunk >> 8) & 0xff;
+    }
+    if (sanitized[i + 3] !== '=') {
+      bytes[byteIndex++] = chunk & 0xff;
+    }
+  }
+
+  return bytes;
+};

--- a/src/utils/base64ToUint8Array.ts
+++ b/src/utils/base64ToUint8Array.ts
@@ -3,14 +3,24 @@ const BASE64_ALPHABET =
 
 export const base64ToUint8Array = (input: string): Uint8Array => {
   const sanitized = input.replace(/[^A-Za-z0-9+/=]/g, '');
+  // パディング無し（長さが 4 の倍数でない）入力でも整数長になるよう計算する。
+  // 非整数を new Uint8Array へ渡すと RangeError で落ちるため。
+  const remainder = sanitized.length % 4;
+  const padding = sanitized.endsWith('==')
+    ? 2
+    : sanitized.endsWith('=')
+      ? 1
+      : 0;
   const length =
-    (sanitized.length * 3) / 4 -
-    (sanitized.endsWith('==') ? 2 : sanitized.endsWith('=') ? 1 : 0);
+    Math.floor(sanitized.length / 4) * 3 -
+    padding +
+    (remainder === 2 ? 1 : remainder === 3 ? 2 : 0);
   const bytes = new Uint8Array(length);
 
   let byteIndex = 0;
-  const decodeChar = (char: string): number => {
-    if (char === '=') {
+  // 末尾チャンクが 4 文字未満だと undefined が渡るため、パディングと同じ 0 として扱う
+  const decodeChar = (char: string | undefined): number => {
+    if (char === undefined || char === '=') {
       return 0;
     }
     const index = BASE64_ALPHABET.indexOf(char);
@@ -21,17 +31,19 @@ export const base64ToUint8Array = (input: string): Uint8Array => {
   };
 
   for (let i = 0; i < sanitized.length; i += 4) {
+    const third = sanitized[i + 2];
+    const fourth = sanitized[i + 3];
     const chunk =
       (decodeChar(sanitized[i]) << 18) |
       (decodeChar(sanitized[i + 1]) << 12) |
-      (decodeChar(sanitized[i + 2]) << 6) |
-      decodeChar(sanitized[i + 3]);
+      (decodeChar(third) << 6) |
+      decodeChar(fourth);
 
     bytes[byteIndex++] = (chunk >> 16) & 0xff;
-    if (sanitized[i + 2] !== '=') {
+    if (third !== undefined && third !== '=') {
       bytes[byteIndex++] = (chunk >> 8) & 0xff;
     }
-    if (sanitized[i + 3] !== '=') {
+    if (fourth !== undefined && fourth !== '=') {
       bytes[byteIndex++] = chunk & 0xff;
     }
   }

--- a/src/utils/speakableText.test.ts
+++ b/src/utils/speakableText.test.ts
@@ -1,4 +1,8 @@
-import { toSpeakableText, truncateToSpeechLimit } from './speakableText';
+import {
+  toSpeakableText,
+  truncateToByteLimit,
+  truncateToSpeechLimit,
+} from './speakableText';
 
 describe('toSpeakableText', () => {
   afterEach(() => {
@@ -52,6 +56,34 @@ describe('toSpeakableText', () => {
     expect(toSpeakableText('つぎはあかさかです', 'JA')).toBe(
       'つぎはあかさかです'
     );
+  });
+});
+
+describe('truncateToByteLimit', () => {
+  it('UTF-8 バイト数で切り詰める', () => {
+    // 日本語1文字=3バイトなので、10バイト上限では3文字まで
+    expect(truncateToByteLimit('あいうえお', 10)).toBe('あいう');
+  });
+
+  it('上限以内ならそのまま返す', () => {
+    expect(truncateToByteLimit('あいう', 9)).toBe('あいう');
+    expect(truncateToByteLimit('abc', 10)).toBe('abc');
+  });
+
+  it('文字の途中では切らない', () => {
+    // 8バイト上限でも4バイト目の途中で切って壊れた文字を作らない
+    expect(truncateToByteLimit('あいうえお', 8)).toBe('あい');
+  });
+
+  it('サロゲートペアを割らない', () => {
+    // 絵文字は4バイト。5バイト上限なら1文字だけ入る
+    expect(truncateToByteLimit('🚃🚃', 5)).toBe('🚃');
+    expect(truncateToByteLimit('🚃🚃', 3)).toBe('');
+  });
+
+  it('上限が0以下なら切り詰めない', () => {
+    expect(truncateToByteLimit('あいうえお', 0)).toBe('あいうえお');
+    expect(truncateToByteLimit('あいうえお', -1)).toBe('あいうえお');
   });
 });
 

--- a/src/utils/speakableText.test.ts
+++ b/src/utils/speakableText.test.ts
@@ -1,0 +1,72 @@
+import { toSpeakableText, truncateToSpeechLimit } from './speakableText';
+
+describe('toSpeakableText', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('SSML タグを除去し、sub は読み仮名を採用する', () => {
+    expect(
+      toSpeakableText('次は<sub alias="オオサキ">大崎</sub>です', 'JA')
+    ).toBe('次はオオサキです');
+  });
+
+  it('日本語の break は読点へ置き換える', () => {
+    expect(toSpeakableText('次は<break time="250ms"/>大崎です', 'JA')).toBe(
+      '次は、大崎です'
+    );
+  });
+
+  it('英語の break は半角スペースへ置き換える', () => {
+    // 英語テンプレートは区切りのカンマを自前で持つため読点を足さない
+    expect(
+      toSpeakableText(
+        'The next station is Osaki,<break time="200ms"/> J Y 24.',
+        'EN'
+      )
+    ).toBe('The next station is Osaki, J Y 24.');
+  });
+
+  it('「JR」を言語ごとの読み方が確定する表記へ置換する', () => {
+    expect(toSpeakableText('<sub alias="JRセン">JR線</sub>', 'JA')).toBe(
+      'ジェーアールセン'
+    );
+    expect(toSpeakableText('the JR Kobe Line', 'EN')).toBe('the J-R Kobe Line');
+  });
+
+  it('英語文に混入した日本語を除去する', () => {
+    // nameRoman 欠落データ等で英語文に日本語が残ると、エンジンが言語を誤判定して
+    // 全文を日本語音声で読んでしまうため最終防衛線として除去する
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    expect(toSpeakableText('Arriving at あかさか K 7.', 'EN')).toBe(
+      'Arriving at K 7.'
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[speakableText] English text contains Japanese characters, stripping:',
+      'Arriving at あかさか K 7.'
+    );
+  });
+
+  it('日本語文の日本語は当然除去しない', () => {
+    expect(toSpeakableText('つぎはあかさかです', 'JA')).toBe(
+      'つぎはあかさかです'
+    );
+  });
+});
+
+describe('truncateToSpeechLimit', () => {
+  it('上限を超えたら切り詰める', () => {
+    expect(truncateToSpeechLimit('abcdef', 3)).toBe('abc');
+  });
+
+  it('上限以内ならそのまま返す', () => {
+    expect(truncateToSpeechLimit('abc', 10)).toBe('abc');
+  });
+
+  it('上限が未定義・0・負値なら切り詰めない', () => {
+    expect(truncateToSpeechLimit('abcdef', undefined)).toBe('abcdef');
+    expect(truncateToSpeechLimit('abcdef', 0)).toBe('abcdef');
+    expect(truncateToSpeechLimit('abcdef', -1)).toBe('abcdef');
+  });
+});

--- a/src/utils/speakableText.ts
+++ b/src/utils/speakableText.ts
@@ -1,0 +1,56 @@
+import { fixJrReading } from './jrReading';
+import { containsJapaneseCharacters, stripJapaneseCharacters } from './phoneme';
+import { ssmlToPlainText } from './ssmlToPlainText';
+
+// TTS テンプレートが生成する SSML 断片を、読み上げエンジンへ渡せるプレーン
+// テキストへ変換する。端末内蔵 TTS (expo-speech) も iOS のリモート TTS
+// (gpt-4o-mini-tts) も SSML を解釈せずタグをそのまま読み上げてしまうため、
+// どちらの経路でもこの変換を通す。
+
+/**
+ * SSML 断片を読み上げ用のプレーンテキストへ変換する。
+ *
+ * - `<break/>` は日本語では「、」、英語ではテンプレ側に区切りのカンマが既に
+ *   含まれるため半角スペースへ置き換える。
+ * - 「JR」は TTS エンジンが "Jr."（ジュニア）と誤読するため、読み方が確定する
+ *   表記へ置換する。
+ * - 英語文に日本語が残っている場合は除去する。nameRoman が欠落した駅データ等では
+ *   wrapPhoneme のローマ字フォールバックが効かず英語文に日本語が混ざることがあり、
+ *   その場合エンジンが言語を誤判定して全文を日本語音声で合成してしまうため。
+ */
+export const toSpeakableText = (
+  ssml: string,
+  language: 'JA' | 'EN'
+): string => {
+  const plain = fixJrReading(
+    ssmlToPlainText(ssml, {
+      breakReplacement: language === 'JA' ? '、' : ' ',
+    }),
+    language
+  );
+
+  if (language === 'EN' && containsJapaneseCharacters(plain)) {
+    console.warn(
+      '[speakableText] English text contains Japanese characters, stripping:',
+      plain
+    );
+    return stripJapaneseCharacters(plain);
+  }
+
+  return plain;
+};
+
+/**
+ * エンジンの入力長上限に合わせて切り詰める。上限を超えると発話自体が失敗する
+ * エンジンがあるため、静かに失敗するより切り詰めて読み上げる方がマシとして
+ * 防衛的に丸める。通常のアナウンス文は上限に達しない。
+ */
+export const truncateToSpeechLimit = (
+  text: string,
+  limit: number | undefined
+): string => {
+  if (typeof limit === 'number' && limit > 0 && text.length > limit) {
+    return text.slice(0, limit);
+  }
+  return text;
+};

--- a/src/utils/speakableText.ts
+++ b/src/utils/speakableText.ts
@@ -1,6 +1,7 @@
 import { fixJrReading } from './jrReading';
 import { containsJapaneseCharacters, stripJapaneseCharacters } from './phoneme';
 import { ssmlToPlainText } from './ssmlToPlainText';
+import getStringBytes from './stringBytes';
 
 // TTS テンプレートが生成する SSML 断片を、読み上げエンジンへ渡せるプレーン
 // テキストへ変換する。端末内蔵 TTS (expo-speech) も iOS のリモート TTS
@@ -53,4 +54,27 @@ export const truncateToSpeechLimit = (
     return text.slice(0, limit);
   }
   return text;
+};
+
+/**
+ * UTF-8 バイト数の上限に合わせて切り詰める。リモート TTS の Worker は入力長を
+ * バイトで検証するため、文字数で丸めると日本語の長文が 400 で弾かれ、無用な
+ * フォールバックを招く。文字の途中で切らないようコードポイント単位で積む。
+ */
+export const truncateToByteLimit = (text: string, limit: number): string => {
+  if (limit <= 0 || getStringBytes(text) <= limit) {
+    return text;
+  }
+
+  let bytes = 0;
+  let truncated = '';
+  for (const char of text) {
+    const charBytes = getStringBytes(char);
+    if (bytes + charBytes > limit) {
+      break;
+    }
+    bytes += charBytes;
+    truncated += char;
+  }
+  return truncated;
 };

--- a/src/utils/test/ttsMocks.ts
+++ b/src/utils/test/ttsMocks.ts
@@ -1,0 +1,18 @@
+export const mockFetch = jest.fn();
+
+jest.mock('expo/fetch', () => ({
+  fetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+jest.mock('expo-file-system', () => ({
+  Paths: { cache: '/tmp' },
+  File: class {
+    public uri: string;
+
+    constructor(basePath: string, name: string) {
+      this.uri = `${basePath}/${name}`;
+    }
+
+    write() {}
+  },
+}));

--- a/src/utils/test/ttsMocks.ts
+++ b/src/utils/test/ttsMocks.ts
@@ -1,5 +1,9 @@
 export const mockFetch = jest.fn();
 
+// 退避・クリア時に削除された音声ファイルの uri を受け取る。
+// jest.mock のファクトリから参照するため、名前は `mock` 始まりにする必要がある。
+export const mockFileDelete = jest.fn();
+
 jest.mock('expo/fetch', () => ({
   fetch: (...args: unknown[]) => mockFetch(...args),
 }));
@@ -9,10 +13,16 @@ jest.mock('expo-file-system', () => ({
   File: class {
     public uri: string;
 
-    constructor(basePath: string, name: string) {
-      this.uri = `${basePath}/${name}`;
+    // `new File(basePath, name)` と `new File(uri)` の両方の呼ばれ方をする
+    constructor(basePathOrUri: string, name?: string) {
+      this.uri =
+        name === undefined ? basePathOrUri : `${basePathOrUri}/${name}`;
     }
 
     write() {}
+
+    delete() {
+      mockFileDelete(this.uri);
+    }
   },
 }));

--- a/src/utils/ttsAudioPlayer.test.ts
+++ b/src/utils/ttsAudioPlayer.test.ts
@@ -1,0 +1,474 @@
+import {
+  FINISH_END_EPSILON_SEC,
+  MAX_RESUME_ATTEMPTS,
+  playAudio,
+  STALL_CHECK_INTERVAL_MS,
+  STALL_TIMEOUT_MS,
+  safeRemoveListener,
+  safeRemovePlayer,
+} from './ttsAudioPlayer';
+
+const mockCreateAudioPlayer = jest.fn();
+
+jest.mock('expo-audio', () => ({
+  createAudioPlayer: (...args: unknown[]) => mockCreateAudioPlayer(...args),
+}));
+
+type EmittedStatus = {
+  didJustFinish?: boolean;
+  error?: string;
+  currentTime?: number;
+  duration?: number;
+  playbackState?: string;
+  reasonForWaitingToPlay?: string;
+};
+
+type StatusCallback = (status: EmittedStatus) => void;
+
+const createMockPlayer = (opts?: { playing?: boolean; duration?: number }) => {
+  let statusCallback: StatusCallback | null = null;
+  const listenerRemove = jest.fn();
+  const player = {
+    playing: opts?.playing ?? false,
+    currentTime: 0,
+    duration: opts?.duration ?? 0,
+    addListener: jest.fn((_event: string, callback: StatusCallback) => {
+      statusCallback = callback;
+      return { remove: listenerRemove };
+    }),
+    play: jest.fn(),
+    pause: jest.fn(),
+    remove: jest.fn(),
+    replace: jest.fn(),
+    seekTo: jest.fn().mockResolvedValue(undefined),
+  };
+  return {
+    player,
+    listenerRemove,
+    emitStatus: (status: EmittedStatus) => {
+      statusCallback?.(status);
+    },
+  };
+};
+
+describe('safeRemoveListener', () => {
+  it('null を渡しても例外にならない', () => {
+    expect(() => safeRemoveListener(null)).not.toThrow();
+  });
+
+  it('listener の remove を呼ぶ', () => {
+    const remove = jest.fn();
+    safeRemoveListener({ remove });
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('remove が例外を投げても安全', () => {
+    const remove = jest.fn(() => {
+      throw new Error('already removed');
+    });
+    expect(() => safeRemoveListener({ remove })).not.toThrow();
+  });
+});
+
+describe('safeRemovePlayer', () => {
+  it('null を渡しても例外にならない', () => {
+    expect(() => safeRemovePlayer(null)).not.toThrow();
+  });
+
+  it('player の pause と remove を呼ぶ', () => {
+    const player = {
+      pause: jest.fn(),
+      remove: jest.fn(),
+    } as unknown as Parameters<typeof safeRemovePlayer>[0];
+    safeRemovePlayer(player);
+    expect(
+      (player as unknown as { pause: jest.Mock }).pause
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      (player as unknown as { remove: jest.Mock }).remove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause/remove が例外を投げても安全', () => {
+    const player = {
+      pause: jest.fn(() => {
+        throw new Error('fail');
+      }),
+      remove: jest.fn(),
+    } as unknown as Parameters<typeof safeRemovePlayer>[0];
+    expect(() => safeRemovePlayer(player)).not.toThrow();
+  });
+});
+
+describe('playAudio', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('再生完了時に onFinish を呼ぶ', () => {
+    const mock = createMockPlayer();
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'test.mp3', onFinish, onError });
+
+    expect(mock.player.play).toHaveBeenCalledTimes(1);
+
+    mock.emitStatus({ didJustFinish: true });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('再生エラー時に onError を呼ぶ', () => {
+    const mock = createMockPlayer();
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'test.mp3', onFinish, onError });
+
+    mock.emitStatus({ error: 'decode error' });
+
+    expect(onError).toHaveBeenCalledWith('decode error');
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('play() が例外を投げた場合に onError を呼ぶ', () => {
+    const mock = createMockPlayer();
+    const playError = new Error('play failed');
+    mock.player.play.mockImplementation(() => {
+      throw playError;
+    });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'test.mp3', onFinish, onError });
+
+    expect(onError).toHaveBeenCalledWith(playError);
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('PlayAudioHandle の player と listener を返す', () => {
+    const mock = createMockPlayer();
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const handle = playAudio({
+      uri: 'test.mp3',
+      onFinish: jest.fn(),
+      onError: jest.fn(),
+    });
+
+    expect(handle.player).toBe(mock.player);
+    expect(handle.listener).toEqual({ remove: expect.any(Function) });
+  });
+
+  it('指定した uri でプレイヤーを作成する', () => {
+    const mock = createMockPlayer();
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    playAudio({
+      uri: '/path/to/audio.mp3',
+      onFinish: jest.fn(),
+      onError: jest.fn(),
+    });
+
+    expect(mockCreateAudioPlayer).toHaveBeenCalledWith({
+      uri: '/path/to/audio.mp3',
+    });
+  });
+
+  it('発話ごとにプレイヤーを新規生成する', () => {
+    // iOS は replace() による使い回しがバックグラウンド再生を壊すため、
+    // 音源ごとに生成して終了時にネイティブごと解放する
+    const mock = createMockPlayer();
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const handle = playAudio({
+      uri: '/path/to/next.mp3',
+      onFinish: jest.fn(),
+      onError: jest.fn(),
+    });
+
+    expect(mockCreateAudioPlayer).toHaveBeenCalledTimes(1);
+    expect(handle.player).toBe(mock.player);
+    expect(mock.player.replace).not.toHaveBeenCalled();
+    expect(mock.player.play).toHaveBeenCalledTimes(1);
+  });
+
+  it('再生位置が進まないままの場合はストールとして onError を呼ぶ', () => {
+    // Androidではネイティブエラーや音声フォーカス喪失でプレイヤーが
+    // 停止してもイベントが届かないため、ウォッチドッグで検知する
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'stalled.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS + STALL_CHECK_INTERVAL_MS);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ttsAudioPlayer] playback stalled, aborting:',
+      'stalled.mp3'
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('playing=true の間はストール扱いしない', () => {
+    const mock = createMockPlayer({ playing: true });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'long.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('currentTime が進んでいる間はストール扱いしない', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'progressing.mp3', onFinish, onError });
+
+    // ポーリングごとに再生位置を進める
+    for (let i = 0; i < (STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS) * 3; i++) {
+      mock.player.currentTime += 1;
+      jest.advanceTimersByTime(STALL_CHECK_INTERVAL_MS);
+    }
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('再生完了後はウォッチドッグが停止する', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'finished.mp3', onFinish, onError });
+
+    mock.emitStatus({ didJustFinish: true });
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('終端付近の didJustFinish は正常完了として扱う', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'complete.mp3', onFinish, onError });
+
+    // 終端(30s)付近で完了 → そのまま完了扱い
+    mock.emitStatus({ didJustFinish: true, currentTime: 29.9, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+  });
+
+  it('完了通知が位置を終端で上書きしても直前の実位置から再開する', async () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'ios-early-finish.mp3', onFinish, onError });
+
+    // iOS は早期終了前の実位置を通常更新で通知した後、完了イベントだけ
+    // currentTime=duration に上書きする。この終端値を信用すると英語へ進んでしまう。
+    mock.emitStatus({ currentTime: 10, duration: 30 });
+    mock.player.currentTime = 10;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(mock.player.play).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
+  it('プレイヤー位置が0にリセットされた場合は直前の状態位置から再開する', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    const handle = playAudio({
+      uri: 'ios-reset-early-finish.mp3',
+      onFinish,
+      onError,
+    });
+
+    mock.emitStatus({ currentTime: 10, duration: 30 });
+    mock.player.currentTime = 0;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    handle.listener.remove();
+    warnSpy.mockRestore();
+  });
+
+  it('直前の実位置が終端付近なら上書きされた完了通知を受理する', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'ios-complete.mp3', onFinish, onError });
+
+    mock.emitStatus({ currentTime: 29.9, duration: 30 });
+    mock.player.currentTime = 30;
+    mock.emitStatus({ didJustFinish: true, currentTime: 30, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+  });
+
+  it('終端手前の didJustFinish は早期完了とみなしその位置から再開する', async () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'long.mp3', onFinish, onError });
+
+    // 本来30sあるのに10sで完了報告（iOSの早期 didJustFinish 誤報を再現）
+    mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+
+    // 完了扱いせず、10sの位置へ seek してから再生を継続する
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledWith(10);
+
+    // seekTo の Promise チェーン（.catch → .finally → play）を消化する
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+
+    // seek 完了後に再開の play() が呼ばれる（初回 play と合わせて 2 回）
+    expect(mock.player.play).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
+  it('位置が0の早期 didJustFinish は再開せず完了として扱う', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'reset.mp3', onFinish, onError });
+
+    // 位置が0にリセットされて報告された場合は頭から再生し直しを避け、完了として進む
+    mock.emitStatus({ didJustFinish: true, currentTime: 0, duration: 30 });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(mock.player.seekTo).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('早期 didJustFinish が続いても最大回数で完了として打ち切る', () => {
+    const mock = createMockPlayer({ playing: true, duration: 30 });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'stuck.mp3', onFinish, onError });
+
+    // 上限回数までは再開を試み、それを超えたら完了として進む（無限ループ防止）
+    for (let i = 0; i < MAX_RESUME_ATTEMPTS; i++) {
+      mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+    }
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.player.seekTo).toHaveBeenCalledTimes(MAX_RESUME_ATTEMPTS);
+
+    // 上限超過の早期完了は通常完了として扱う
+    mock.emitStatus({ didJustFinish: true, currentTime: 10, duration: 30 });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('FINISH_END_EPSILON_SEC は正の有限値', () => {
+    expect(Number.isFinite(FINISH_END_EPSILON_SEC)).toBe(true);
+    expect(FINISH_END_EPSILON_SEC).toBeGreaterThan(0);
+  });
+
+  it('listener.remove() 後はウォッチドッグが停止する', () => {
+    const mock = createMockPlayer({ playing: false });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    const handle = playAudio({ uri: 'removed.mp3', onFinish, onError });
+
+    handle.listener.remove();
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(mock.listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('プレイヤーのプロパティ参照が例外を投げた場合は onError で復帰する', () => {
+    const mock = createMockPlayer();
+    Object.defineProperty(mock.player, 'playing', {
+      get: () => {
+        throw new Error('player released');
+      },
+    });
+    mockCreateAudioPlayer.mockReturnValue(mock.player);
+
+    const onFinish = jest.fn();
+    const onError = jest.fn();
+    playAudio({ uri: 'released.mp3', onFinish, onError });
+
+    jest.advanceTimersByTime(STALL_CHECK_INTERVAL_MS);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -1,0 +1,184 @@
+import type { AudioPlayer } from 'expo-audio';
+import { createAudioPlayer } from 'expo-audio';
+
+// このプレイヤーは iOS のリモート TTS 再生専用。Android は端末内蔵の TTS
+// (expo-speech) で読み上げるため、ここを通らない。かつて Android 対応のために
+// あった「プレイヤーを replace() で使い回す」経路は、iOS ではバックグラウンド
+// 再生を壊すため使っておらず、iOS 専用化に伴い削除した。
+
+// 再生位置が進まない状態がこの時間続いたらストールとみなして打ち切る。
+// 再生エラーや音声フォーカス喪失で停止しても JS へ error イベントも
+// didJustFinish も届かないことがあるため、ポーリングで検知して再生
+// パイプラインをデッドロックから復帰させる。
+export const STALL_TIMEOUT_MS = 10_000;
+// ストール監視のポーリング間隔
+export const STALL_CHECK_INTERVAL_MS = 1_000;
+
+// didJustFinish 受信時、再生位置がこの秒数以内まで終端へ達していれば正常終了とみなす。
+// iOS は長尺音声で、音声セッションの一時中断やデコード境界などにより本来の終端より
+// 手前で didJustFinish を誤報することがある。これをそのまま「完了」と扱うと、日本語
+// アナウンスが途中で打ち切られて次（英語）へ飛んでしまうため、終端付近に達していない
+// 完了報告は早期完了とみなして再生を継続する。
+export const FINISH_END_EPSILON_SEC = 0.5;
+// 早期 didJustFinish からの再開を試みる最大回数（誤検知時の無限ループを防ぐ安全弁）
+export const MAX_RESUME_ATTEMPTS = 5;
+
+export const safeRemoveListener = (
+  listener: { remove: () => void } | null
+): void => {
+  try {
+    listener?.remove();
+  } catch {}
+};
+
+export const safeRemovePlayer = (player: AudioPlayer | null): void => {
+  try {
+    player?.pause();
+    player?.remove();
+  } catch {}
+};
+
+export interface PlayAudioHandle {
+  player: AudioPlayer;
+  listener: { remove: () => void };
+}
+
+export const playAudio = (options: {
+  uri: string;
+  onFinish: () => void;
+  onError: (error: unknown) => void;
+}): PlayAudioHandle => {
+  const { uri, onFinish, onError } = options;
+  const player = createAudioPlayer({ uri });
+
+  let settled = false;
+  let stalledTicks = 0;
+  let lastCurrentTime = -1;
+  let lastStatusPosition = 0;
+  let resumeAttempts = 0;
+  const maxStalledTicks = Math.ceil(STALL_TIMEOUT_MS / STALL_CHECK_INTERVAL_MS);
+
+  // 終端付近に達していない didJustFinish（iOS の早期完了誤報）を「正常終了」と
+  // 扱わないためのガード。位置が取れる場合はその位置から再開して打ち切りを防ぎ、
+  // 位置が取れない/終端付近の場合は従来どおり完了として進む（=最悪でも現状維持）。
+  const handleDidJustFinish = (status: {
+    currentTime?: number;
+    duration?: number;
+    playbackState?: string;
+    reasonForWaitingToPlay?: string;
+  }) => {
+    const duration = status.duration || player.duration || 0;
+    const reportedPosition = status.currentTime ?? player.currentTime ?? 0;
+    // expo-audio (iOS) は AVPlayerItemDidPlayToEndTime を受けると、実際の
+    // 停止位置にかかわらず完了イベントの currentTime を duration で上書きする。
+    // player.currentTime 自体は AVPlayer の実位置を返すため、まずそちらを参照し、
+    // 0 にリセット済みなら通常の状態更新で最後に観測した実再生位置を使う。
+    const playerPosition = player.currentTime ?? 0;
+    const position =
+      playerPosition > 0
+        ? playerPosition
+        : lastStatusPosition > 0 &&
+            duration > 0 &&
+            reportedPosition >= duration - FINISH_END_EPSILON_SEC
+          ? lastStatusPosition
+          : reportedPosition;
+    const reachedEnd =
+      duration <= 0 || position >= duration - FINISH_END_EPSILON_SEC;
+
+    if (!reachedEnd) {
+      // 早期完了の実測値をログに残す（実機での原因特定と再開判定の検証用）
+      console.warn(
+        `[ttsAudioPlayer] early didJustFinish at ${position.toFixed(2)}/${duration.toFixed(2)}s ` +
+          `(state=${status.playbackState ?? 'n/a'}, waiting=${status.reasonForWaitingToPlay ?? 'n/a'}):`,
+        uri
+      );
+      // 位置が取れていれば、その位置から再開して途中打ち切りを防ぐ。
+      // 位置が 0（=リセット報告）だと頭から再生し直しになるため再開しない。
+      if (position > 0 && resumeAttempts < MAX_RESUME_ATTEMPTS) {
+        resumeAttempts += 1;
+        // 再開直後はストール監視を誤発火させないようカウンタを戻す
+        stalledTicks = 0;
+        lastCurrentTime = -1;
+        try {
+          // didJustFinish で位置が末尾/0 へ移動する実装に備え、明示的に戻してから再生。
+          // seekTo は非同期のため、完了を待ってから play() しないと古い位置から
+          // 再生が始まりうる。エラー時も含め確実に再生を開始する。
+          player
+            .seekTo(position)
+            .catch(() => {})
+            .finally(() => {
+              try {
+                player.play();
+              } catch (e) {
+                settle(() => onError(e));
+              }
+            });
+        } catch (e) {
+          settle(() => onError(e));
+        }
+        return;
+      }
+    }
+    settle(onFinish);
+  };
+
+  const statusListener = player.addListener(
+    'playbackStatusUpdate',
+    (status) => {
+      if (status.didJustFinish) {
+        handleDidJustFinish(status);
+      } else if ('error' in status && status.error) {
+        console.warn('[ttsAudioPlayer] playback error:', status.error);
+        settle(() => onError(status.error));
+      } else if (
+        Number.isFinite(status.currentTime) &&
+        status.currentTime >= 0
+      ) {
+        lastStatusPosition = status.currentTime;
+      }
+    }
+  );
+
+  const dispose = () => {
+    clearInterval(watchdog);
+    safeRemoveListener(statusListener);
+  };
+
+  const settle = (callback: () => void) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    dispose();
+    callback();
+  };
+
+  // didJustFinishが届かないままプレイヤーが停止した場合の検知
+  // （ネイティブエラー・音声フォーカス喪失・バックグラウンド遷移など）
+  const watchdog = setInterval(() => {
+    try {
+      const playing = player.playing;
+      const currentTime = player.currentTime;
+      if (playing || currentTime !== lastCurrentTime) {
+        lastCurrentTime = currentTime;
+        stalledTicks = 0;
+        return;
+      }
+      stalledTicks += 1;
+      if (stalledTicks >= maxStalledTicks) {
+        console.warn('[ttsAudioPlayer] playback stalled, aborting:', uri);
+        settle(() => onError(new Error('Playback stalled')));
+      }
+    } catch (e) {
+      settle(() => onError(e));
+    }
+  }, STALL_CHECK_INTERVAL_MS);
+
+  try {
+    player.play();
+  } catch (e) {
+    settle(() => onError(e));
+  }
+
+  return { player, listener: { remove: dispose } };
+};

--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -1,4 +1,4 @@
-import { mockFetch } from '~/utils/test/ttsMocks';
+import { mockFetch, mockFileDelete } from '~/utils/test/ttsMocks';
 import {
   clearFetchCache,
   fetchSpeechAudio,
@@ -25,6 +25,8 @@ describe('fetchSpeechAudio', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     clearFetchCache();
+    // clearFetchCache 自体の削除呼び出しを次のテストへ持ち越さない
+    mockFileDelete.mockClear();
   });
 
   afterEach(() => {
@@ -335,6 +337,56 @@ describe('fetchSpeechAudio', () => {
     await fetchSpeechAudio({ ...defaultOptions, textJa: 'あふれさせる' });
     await fetchSpeechAudio({ ...defaultOptions, textJa: 'テキスト0' });
     expect(mockFetch).toHaveBeenCalledTimes(MAX_FETCH_CACHE_SIZE + 2);
+  });
+
+  it('退避したエントリの音声ファイルを削除する', async () => {
+    // Map から捨てるだけだとキャッシュディレクトリに実ファイルが残り続ける
+    mockFetch.mockImplementation(async () =>
+      okResponse({
+        id: 'tts-evict',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    for (let i = 0; i <= MAX_FETCH_CACHE_SIZE; i += 1) {
+      await fetchSpeechAudio({ ...defaultOptions, textJa: `テキスト${i}` });
+    }
+
+    expect(mockFileDelete.mock.calls.map(([uri]) => uri)).toEqual([
+      '/tmp/tts-evict_ja.wav',
+      '/tmp/tts-evict_en.wav',
+    ]);
+  });
+
+  it('キャッシュクリア時に保持している音声ファイルを削除する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-clear',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    await fetchSpeechAudio(defaultOptions);
+    expect(mockFileDelete).not.toHaveBeenCalled();
+
+    clearFetchCache();
+    expect(mockFileDelete.mock.calls.map(([uri]) => uri)).toEqual([
+      '/tmp/tts-clear_ja.wav',
+      '/tmp/tts-clear_en.wav',
+    ]);
+  });
+
+  it('id がファイル名として安全でない場合は null を返す', async () => {
+    // パス区切りや .. を含む id をそのまま連結するとキャッシュ外へ書き込みうる
+    for (const id of ['../evil', 'a/b', 'a\\b', '']) {
+      clearFetchCache();
+      mockFetch.mockResolvedValue(
+        okResponse({ id, jaAudioContent: 'QQ==', enAudioContent: 'QQ==' })
+      );
+      expect(await fetchSpeechAudio(defaultOptions)).toBeNull();
+    }
   });
 
   it('PCM MIME の場合は WAV として保存する', async () => {

--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -1,0 +1,438 @@
+import { mockFetch } from '~/utils/test/ttsMocks';
+import {
+  clearFetchCache,
+  fetchSpeechAudio,
+  MAX_FETCH_CACHE_SIZE,
+  TTS_FETCH_TIMEOUT_MS,
+} from './ttsSpeechFetcher';
+
+const defaultOptions = {
+  textJa: 'こんにちは',
+  textEn: 'Hello',
+  apiUrl: 'https://api.example.com/tts',
+  idToken: 'test-token',
+};
+
+const okResponse = (result: Record<string, unknown>) => ({
+  ok: true,
+  json: async () => ({ result }),
+});
+
+const parseRequestBody = (callIndex = 0) =>
+  JSON.parse(mockFetch.mock.calls[callIndex][1].body);
+
+describe('fetchSpeechAudio', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearFetchCache();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('成功レスポンスでファイルパスを返す', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-123',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-123',
+      pathJa: '/tmp/tts-123_ja.wav',
+      pathEn: '/tmp/tts-123_en.wav',
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/tts',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      })
+    );
+  });
+
+  it('プレーンテキストをそのまま送信する（SSML でラップしない）', async () => {
+    // gpt-4o-mini-tts は SSML を解釈せずタグをそのまま読み上げてしまうため、
+    // 呼び出し側が変換済みのプレーンテキストを送る契約になっている
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-123',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      textJa: '  テスト  ',
+      textEn: '  test  ',
+    });
+
+    const body = parseRequestBody();
+    expect(body.data.textJa).toBe('テスト');
+    expect(body.data.textEn).toBe('test');
+    expect(body.data.ssmlJa).toBeUndefined();
+    expect(body.data.ssmlEn).toBeUndefined();
+  });
+
+  it('モデル・音声・読み方指示をリクエストに含める', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-130',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      model: 'gpt-4o-mini-tts',
+      jaVoiceName: 'nova',
+      enVoiceName: 'nova',
+      instructionsJa: '落ち着いた女性の声で',
+      instructionsEn: 'calm female voice',
+    });
+
+    const body = parseRequestBody();
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        model: 'gpt-4o-mini-tts',
+        jaVoiceName: 'nova',
+        enVoiceName: 'nova',
+        instructionsJa: '落ち着いた女性の声で',
+        instructionsEn: 'calm female voice',
+      })
+    );
+  });
+
+  it('日本語のみ要求した場合は英語を送らず英語パスも返さない', async () => {
+    // 合成は文字数課金のため、無効な言語を要求しないことを保証する
+    mockFetch.mockResolvedValue(
+      okResponse({ id: 'tts-131', jaAudioContent: 'QQ==' })
+    );
+
+    const result = await fetchSpeechAudio({ ...defaultOptions, textEn: '' });
+
+    const body = parseRequestBody();
+    expect(body.data.textJa).toBe('こんにちは');
+    expect(body.data).not.toHaveProperty('textEn');
+    expect(result).toEqual({
+      id: 'tts-131',
+      pathJa: '/tmp/tts-131_ja.wav',
+      pathEn: null,
+    });
+  });
+
+  it('英語のみ要求した場合は日本語を送らず日本語パスも返さない', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({ id: 'tts-132', enAudioContent: 'QQ==' })
+    );
+
+    const result = await fetchSpeechAudio({ ...defaultOptions, textJa: '' });
+
+    const body = parseRequestBody();
+    expect(body.data.textEn).toBe('Hello');
+    expect(body.data).not.toHaveProperty('textJa');
+    expect(result).toEqual({
+      id: 'tts-132',
+      pathJa: null,
+      pathEn: '/tmp/tts-132_en.wav',
+    });
+  });
+
+  it('日本語・英語ともに空の場合は null を返す', async () => {
+    const result = await fetchSpeechAudio({
+      ...defaultOptions,
+      textJa: '',
+      textEn: '',
+    });
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('HTTP エラー時に null を返す', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    const result = await fetchSpeechAudio(defaultOptions);
+    expect(result).toBeNull();
+  });
+
+  it('レスポンスに result.id がない場合は null を返す', async () => {
+    mockFetch.mockResolvedValue(okResponse({}));
+
+    const result = await fetchSpeechAudio(defaultOptions);
+    expect(result).toBeNull();
+  });
+
+  it('要求した言語のオーディオが欠けている場合は null を返す', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-123',
+        jaAudioContent: 'QQ==',
+        enAudioContent: null,
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+    expect(result).toBeNull();
+  });
+
+  it('ネットワーク例外時に null を返す', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const result = await fetchSpeechAudio(defaultOptions);
+    expect(result).toBeNull();
+  });
+
+  it('リクエストがハングした場合はタイムアウトで中断して null を返す', async () => {
+    jest.useFakeTimers();
+    try {
+      let capturedSignal: AbortSignal | undefined;
+      // 応答もエラーも返さないリクエストを再現し、abort されたら reject する
+      mockFetch.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new Error('Aborted'));
+            });
+          });
+        }
+      );
+
+      const promise = fetchSpeechAudio({ ...defaultOptions, timeoutMs: 1000 });
+      await jest.advanceTimersByTimeAsync(1000);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(capturedSignal?.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('timeoutMs に不正値が渡されてもデフォルトのタイムアウトに正規化する', async () => {
+    jest.useFakeTimers();
+    try {
+      let capturedSignal: AbortSignal | undefined;
+      mockFetch.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new Error('Aborted'));
+            });
+          });
+        }
+      );
+
+      // timeoutMs: 0 は無効値。即座に abort せず既定値まで待つことを検証する
+      const promise = fetchSpeechAudio({ ...defaultOptions, timeoutMs: 0 });
+      await jest.advanceTimersByTimeAsync(0);
+      expect(capturedSignal?.aborted).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(TTS_FETCH_TIMEOUT_MS);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(capturedSignal?.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('英語テキストからマクロンを除去して送信する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-127',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Kiryū and Ōhirashita',
+    });
+
+    const body = parseRequestBody();
+    expect(body.data.textEn).toBe('Kiryu and Ohirashita');
+  });
+
+  it('マクロン有無で同じキャッシュを共有する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-129',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    const first = await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Tōkyō',
+    });
+    const second = await fetchSpeechAudio({
+      ...defaultOptions,
+      textEn: 'Tokyo',
+    });
+
+    expect(first).toEqual(second);
+    // 2 回目はキャッシュヒットで fetch は 1 回だけ
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('音声が異なればキャッシュを共有しない', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-133',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    await fetchSpeechAudio({ ...defaultOptions, jaVoiceName: 'nova' });
+    await fetchSpeechAudio({ ...defaultOptions, jaVoiceName: 'shimmer' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('キャッシュは上限を超えたら最古のエントリから捨てる', async () => {
+    mockFetch.mockImplementation(async () =>
+      okResponse({
+        id: 'tts-lru',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+      })
+    );
+
+    // 上限ぴったりまで別テキストで埋める
+    for (let i = 0; i < MAX_FETCH_CACHE_SIZE; i += 1) {
+      await fetchSpeechAudio({ ...defaultOptions, textJa: `テキスト${i}` });
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(MAX_FETCH_CACHE_SIZE);
+
+    // 直近のエントリはキャッシュに残っている
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      textJa: `テキスト${MAX_FETCH_CACHE_SIZE - 1}`,
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(MAX_FETCH_CACHE_SIZE);
+
+    // 上限を 1 つ超えさせると最古のエントリが押し出され、再取得が走る
+    await fetchSpeechAudio({ ...defaultOptions, textJa: 'あふれさせる' });
+    await fetchSpeechAudio({ ...defaultOptions, textJa: 'テキスト0' });
+    expect(mockFetch).toHaveBeenCalledTimes(MAX_FETCH_CACHE_SIZE + 2);
+  });
+
+  it('PCM MIME の場合は WAV として保存する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-124',
+        jaAudioContent: 'AAECAw==',
+        enAudioContent: 'AAECAw==',
+        jaAudioMimeType: 'audio/pcm;rate=24000',
+        enAudioMimeType: 'audio/L16;rate=24000',
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-124',
+      pathJa: '/tmp/tts-124_ja.wav',
+      pathEn: '/tmp/tts-124_en.wav',
+    });
+  });
+
+  it('MP3 MIME の場合は MP3 として保存する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-125',
+        jaAudioContent: 'QQ==',
+        enAudioContent: 'QQ==',
+        jaAudioMimeType: 'audio/mpeg',
+        enAudioMimeType: 'audio/mp3',
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-125',
+      pathJa: '/tmp/tts-125_ja.mp3',
+      pathEn: '/tmp/tts-125_en.mp3',
+    });
+  });
+
+  it('MIME 不明でも中身が MP3 なら MP3 として保存する', async () => {
+    // gpt-4o-mini-tts の既定応答は MP3。MIME 欠落時に PCM 扱いして WAV ヘッダーを
+    // 被せると再生できなくなるため、先頭バイトで判定する
+    // 'SUQz...' = "ID3" タグ、'/+AA' = 0xFF 0xE0 のフレーム同期
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-134',
+        jaAudioContent: 'SUQzAAA=',
+        enAudioContent: '/+AAAA==',
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-134',
+      pathJa: '/tmp/tts-134_ja.mp3',
+      pathEn: '/tmp/tts-134_en.mp3',
+    });
+  });
+
+  it('MIME 不明で中身が WAV なら WAV として保存する', async () => {
+    // "RIFF....WAVE"
+    const riffWave = 'UklGRgAAAABXQVZF';
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-135',
+        jaAudioContent: riffWave,
+        enAudioContent: riffWave,
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-135',
+      pathJa: '/tmp/tts-135_ja.wav',
+      pathEn: '/tmp/tts-135_en.wav',
+    });
+  });
+
+  it('MIME 不明で形式も判別できない場合は PCM とみなして WAV 化する', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: 'tts-126',
+        jaAudioContent: 'AAECAw==',
+        enAudioContent: 'AAECAw==',
+      })
+    );
+
+    const result = await fetchSpeechAudio(defaultOptions);
+
+    expect(result).toEqual({
+      id: 'tts-126',
+      pathJa: '/tmp/tts-126_ja.wav',
+      pathEn: '/tmp/tts-126_en.wav',
+    });
+  });
+});

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -1,0 +1,363 @@
+import { fetch } from 'expo/fetch';
+import { File, Paths } from 'expo-file-system';
+import { base64ToUint8Array } from './base64ToUint8Array';
+
+// ネットワーク切り替えやドーズ状態に入るとリクエストが応答もエラーも返さず
+// 永久にハングすることがある。その場合に呼び出し側の再生パイプラインが
+// 解放されず TTS 全体が停止してしまうため、AbortController で上限時間を設ける。
+export const TTS_FETCH_TIMEOUT_MS = 20_000;
+
+// 合成済み音声のパスを保持する上限。1 回の乗車で数十件のアナウンスが生成される
+// ため、無制限に持つとキャッシュディレクトリと Map が膨らみ続ける。
+export const MAX_FETCH_CACHE_SIZE = 50;
+
+export interface FetchSpeechOptions {
+  // 読み上げるプレーンテキスト。gpt-4o-mini-tts は SSML を解釈せずタグを
+  // そのまま読み上げてしまうため、呼び出し側で変換済みのものを渡すこと。
+  // 合成は文字数課金のため、ユーザーが無効にしている言語は空/未指定にして
+  // 送信対象から外す（両方空なら何も要求しない）。
+  textJa?: string;
+  textEn?: string;
+  apiUrl: string;
+  idToken: string;
+  model?: string;
+  jaVoiceName?: string;
+  enVoiceName?: string;
+  // 読み方の指示 (gpt-4o-mini-tts の instructions)。SSML の代替として声色・
+  // 速度・間の取り方を指定する。
+  instructionsJa?: string;
+  instructionsEn?: string;
+  timeoutMs?: number;
+}
+
+export interface FetchedSpeech {
+  id: string;
+  // 要求しなかった言語は null。要求した言語は必ず非 null（欠けた応答は失敗扱い）。
+  pathJa: string | null;
+  pathEn: string | null;
+}
+
+const getSampleRateFromMimeType = (mimeType: string): number => {
+  const rate = mimeType.match(/rate=(\d+)/i)?.[1];
+  const parsed = rate ? Number.parseInt(rate, 10) : Number.NaN;
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return 24000;
+};
+
+const wrapPcm16LeToWav = (
+  pcmData: Uint8Array,
+  sampleRate: number
+): Uint8Array => {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = pcmData.length;
+  const fileSize = 36 + dataSize;
+  const out = new Uint8Array(44 + dataSize);
+  const view = new DataView(out.buffer);
+
+  // RIFF header
+  out.set([0x52, 0x49, 0x46, 0x46], 0); // RIFF
+  view.setUint32(4, fileSize, true);
+  out.set([0x57, 0x41, 0x56, 0x45], 8); // WAVE
+
+  // fmt chunk
+  out.set([0x66, 0x6d, 0x74, 0x20], 12); // fmt
+  view.setUint32(16, 16, true); // PCM chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+
+  // data chunk
+  out.set([0x64, 0x61, 0x74, 0x61], 36); // data
+  view.setUint32(40, dataSize, true);
+  out.set(pcmData, 44);
+
+  return out;
+};
+
+// MIME が欠落・不明なときに先頭バイトから形式を判定する。gpt-4o-mini-tts の
+// 既定応答は MP3 で、生 PCM が返るのは response_format を明示した場合に限られる
+// ため、判定できないバイト列を無条件に PCM 扱いすると MP3 を WAV ヘッダーで
+// 包んで再生不能にしてしまう。
+const sniffAudioFormat = (bytes: Uint8Array): 'mp3' | 'wav' | 'unknown' => {
+  // "RIFF" .... "WAVE"
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x41 &&
+    bytes[10] === 0x56 &&
+    bytes[11] === 0x45
+  ) {
+    return 'wav';
+  }
+  // "ID3" タグ付き MP3
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0x49 &&
+    bytes[1] === 0x44 &&
+    bytes[2] === 0x33
+  ) {
+    return 'mp3';
+  }
+  // MPEG フレーム同期 (11 bit すべて 1)
+  if (bytes.length >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0) {
+    return 'mp3';
+  }
+  return 'unknown';
+};
+
+const normalizeAudioForFile = (
+  base64Audio: string,
+  mimeType?: string
+): { bytes: Uint8Array; ext: 'mp3' | 'wav' } => {
+  const normalizedMime = mimeType?.toLowerCase() ?? '';
+  const bytes = base64ToUint8Array(base64Audio);
+
+  if (normalizedMime.includes('mpeg') || normalizedMime.includes('mp3')) {
+    return { bytes, ext: 'mp3' };
+  }
+
+  if (normalizedMime.includes('wav')) {
+    return { bytes, ext: 'wav' };
+  }
+
+  if (
+    normalizedMime.includes('pcm') ||
+    normalizedMime.includes('l16') ||
+    normalizedMime.includes('linear16')
+  ) {
+    const sampleRate = getSampleRateFromMimeType(normalizedMime);
+    return {
+      bytes: wrapPcm16LeToWav(bytes, sampleRate),
+      ext: 'wav',
+    };
+  }
+
+  // MIME 不明時は中身から判定する。どちらとも判定できなければ生 PCM とみなして
+  // WAV 化する（旧 API の既定挙動に合わせたフォールバック）。
+  const sniffed = sniffAudioFormat(bytes);
+  if (sniffed !== 'unknown') {
+    return { bytes, ext: sniffed };
+  }
+  return {
+    bytes: wrapPcm16LeToWav(bytes, 24000),
+    ext: 'wav',
+  };
+};
+
+const fetchCache = new Map<string, FetchedSpeech>();
+
+// 同一テキストの再放送でリクエストを重ねないためのキャッシュ。Map は挿入順を
+// 保つため、上限超過時に最古のエントリから捨てる。
+const storeInFetchCache = (key: string, value: FetchedSpeech): void => {
+  fetchCache.set(key, value);
+  while (fetchCache.size > MAX_FETCH_CACHE_SIZE) {
+    const oldestKey = fetchCache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    fetchCache.delete(oldestKey);
+  }
+};
+
+const normalizeOptional = (val: string | undefined): string => {
+  const trimmed = (val ?? '').trim();
+  return trimmed.length > 0 ? trimmed : '';
+};
+
+// ヘボン式ローマ字の長音符（マクロン: Ā ā Ē ē Ī ī Ō ō Ū ū）を素の母音へ落とす。
+// NFD で母音と結合マクロン（U+0304）へ分解し、マクロンだけ取り除いて NFC に戻す。
+// 既存の useIsDifferentStationName と同じ手法。
+const COMBINING_MACRON = String.fromCharCode(0x0304);
+const stripMacrons = (text: string): string =>
+  text.normalize('NFD').replaceAll(COMBINING_MACRON, '').normalize('NFC');
+
+const buildCacheKey = (opts: {
+  textJa: string;
+  textEn: string;
+  model?: string;
+  jaVoiceName?: string;
+  enVoiceName?: string;
+}): string =>
+  [
+    // 空文字は「その言語を要求しない」を意味するため、両方をキーに含めることで
+    // 日本語のみ・英語のみ・両方のリクエストが別エントリとして区別される
+    opts.textJa,
+    opts.textEn,
+    normalizeOptional(opts.model),
+    normalizeOptional(opts.jaVoiceName),
+    normalizeOptional(opts.enVoiceName),
+  ].join('\0');
+
+export const clearFetchCache = (): void => {
+  fetchCache.clear();
+};
+
+export const fetchSpeechAudio = async (
+  options: FetchSpeechOptions
+): Promise<FetchedSpeech | null> => {
+  const {
+    textJa,
+    textEn,
+    apiUrl,
+    idToken,
+    model,
+    jaVoiceName,
+    enVoiceName,
+    instructionsJa,
+    instructionsEn,
+    timeoutMs = TTS_FETCH_TIMEOUT_MS,
+  } = options;
+  // 0・負値・NaN・Infinity が明示的に渡された場合もタイムアウト保護が
+  // 効くよう、正の有限値に正規化する
+  const effectiveTimeoutMs =
+    Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : TTS_FETCH_TIMEOUT_MS;
+
+  const trimmedTextJa = (textJa ?? '').trim();
+  // 英語駅名のマクロンは ASCII 母音に落としても読みは変わらない一方、モデルに
+  // よって扱いが揺れるため、送信前に正規化しておく（日本語側は元々含まない）。
+  const sanitizedTextEn = stripMacrons((textEn ?? '').trim());
+
+  const wantsJa = trimmedTextJa.length > 0;
+  const wantsEn = sanitizedTextEn.length > 0;
+  if (!wantsJa && !wantsEn) {
+    return null;
+  }
+
+  const normalizedModel = normalizeOptional(model);
+  const normalizedJaVoiceName = normalizeOptional(jaVoiceName);
+  const normalizedEnVoiceName = normalizeOptional(enVoiceName);
+
+  const cacheKey = buildCacheKey({
+    textJa: trimmedTextJa,
+    textEn: sanitizedTextEn,
+    model: normalizedModel,
+    jaVoiceName: normalizedJaVoiceName,
+    enVoiceName: normalizedEnVoiceName,
+  });
+  const cached = fetchCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const normalizedInstructionsJa = normalizeOptional(instructionsJa);
+  const normalizedInstructionsEn = normalizeOptional(instructionsEn);
+
+  // 要求しない言語のフィールドは送らない。Worker 側は届いた言語だけを合成する。
+  const reqBody = {
+    data: {
+      ...(wantsJa
+        ? {
+            textJa: trimmedTextJa,
+            ...(normalizedJaVoiceName
+              ? { jaVoiceName: normalizedJaVoiceName }
+              : {}),
+            ...(normalizedInstructionsJa
+              ? { instructionsJa: normalizedInstructionsJa }
+              : {}),
+          }
+        : {}),
+      ...(wantsEn
+        ? {
+            textEn: sanitizedTextEn,
+            ...(normalizedEnVoiceName
+              ? { enVoiceName: normalizedEnVoiceName }
+              : {}),
+            ...(normalizedInstructionsEn
+              ? { instructionsEn: normalizedInstructionsEn }
+              : {}),
+          }
+        : {}),
+      ...(normalizedModel ? { model: normalizedModel } : {}),
+    },
+  };
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), effectiveTimeoutMs);
+
+  try {
+    const response = await fetch(apiUrl, {
+      headers: {
+        'content-type': 'application/json; charset=UTF-8',
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: JSON.stringify(reqBody),
+      method: 'POST',
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `[ttsSpeechFetcher] TTS API returned ${response.status}: ${response.statusText}`
+      );
+      return null;
+    }
+
+    const ttsJson = await response.json();
+
+    if (!ttsJson?.result?.id) {
+      console.warn(
+        '[ttsSpeechFetcher] Invalid TTS response: missing result.id'
+      );
+      return null;
+    }
+
+    const {
+      jaAudioContent,
+      enAudioContent,
+      id,
+      jaAudioMimeType,
+      enAudioMimeType,
+    } = ttsJson.result;
+
+    // 要求した言語の音声が欠けている応答は不完全なため失敗として扱い、
+    // 呼び出し側のフォールバック（端末内蔵 TTS）へ委ねる。
+    if ((wantsJa && !jaAudioContent) || (wantsEn && !enAudioContent)) {
+      console.warn(
+        '[ttsSpeechFetcher] Missing audio content in TTS response, skipping file write'
+      );
+      return null;
+    }
+
+    const writeAudio = (
+      base64Audio: string,
+      mimeType: string | undefined,
+      suffix: 'ja' | 'en'
+    ): string => {
+      const normalized = normalizeAudioForFile(base64Audio, mimeType);
+      const file = new File(Paths.cache, `${id}_${suffix}.${normalized.ext}`);
+      file.write(normalized.bytes);
+      return file.uri;
+    };
+
+    const result: FetchedSpeech = {
+      id,
+      pathJa: wantsJa
+        ? writeAudio(jaAudioContent, jaAudioMimeType, 'ja')
+        : null,
+      pathEn: wantsEn
+        ? writeAudio(enAudioContent, enAudioMimeType, 'en')
+        : null,
+    };
+    storeInFetchCache(cacheKey, result);
+    return result;
+  } catch (error) {
+    console.error('[ttsSpeechFetcher] fetchSpeech error:', error);
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -7,6 +7,9 @@ import { base64ToUint8Array } from './base64ToUint8Array';
 // 解放されず TTS 全体が停止してしまうため、AbortController で上限時間を設ける。
 export const TTS_FETCH_TIMEOUT_MS = 20_000;
 
+// キャッシュファイル名に使える id の文字種（Worker は sha256 の16進文字列を返す）
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
 // 合成済み音声のパスを保持する上限。1 回の乗車で数十件のアナウンスが生成される
 // ため、無制限に持つとキャッシュディレクトリと Map が膨らみ続ける。
 export const MAX_FETCH_CACHE_SIZE = 50;
@@ -158,16 +161,34 @@ const normalizeAudioForFile = (
 
 const fetchCache = new Map<string, FetchedSpeech>();
 
+// 参照されなくなった音声ファイルを削除する。Map から捨てるだけだと
+// キャッシュディレクトリに実ファイルが残り続けるため、退避と同時に消す。
+// 削除できなくても（既に OS に掃除された等）キャッシュ整理は続ける。
+const deleteCachedAudio = (speech: FetchedSpeech): void => {
+  for (const path of [speech.pathJa, speech.pathEn]) {
+    if (!path) {
+      continue;
+    }
+    try {
+      new File(path).delete();
+    } catch (e) {
+      console.warn('[ttsSpeechFetcher] failed to delete cached audio:', e);
+    }
+  }
+};
+
 // 同一テキストの再放送でリクエストを重ねないためのキャッシュ。Map は挿入順を
 // 保つため、上限超過時に最古のエントリから捨てる。
 const storeInFetchCache = (key: string, value: FetchedSpeech): void => {
   fetchCache.set(key, value);
   while (fetchCache.size > MAX_FETCH_CACHE_SIZE) {
-    const oldestKey = fetchCache.keys().next().value;
-    if (oldestKey === undefined) {
+    const oldest = fetchCache.entries().next().value;
+    if (oldest === undefined) {
       break;
     }
+    const [oldestKey, oldestValue] = oldest;
     fetchCache.delete(oldestKey);
+    deleteCachedAudio(oldestValue);
   }
 };
 
@@ -201,6 +222,9 @@ const buildCacheKey = (opts: {
   ].join('\0');
 
 export const clearFetchCache = (): void => {
+  for (const speech of fetchCache.values()) {
+    deleteCachedAudio(speech);
+  }
   fetchCache.clear();
 };
 
@@ -308,9 +332,12 @@ export const fetchSpeechAudio = async (
 
     const ttsJson = await response.json();
 
-    if (!ttsJson?.result?.id) {
+    // id はキャッシュファイル名に連結するため、パス区切りや `..` が混ざると
+    // キャッシュディレクトリの外へ書き込みうる。応答元は認証済みの自前 Worker
+    // だが、防御としてファイル名に使える文字だけを受理する。
+    if (!ttsJson?.result?.id || !SAFE_ID_PATTERN.test(ttsJson.result.id)) {
       console.warn(
-        '[ttsSpeechFetcher] Invalid TTS response: missing result.id'
+        '[ttsSpeechFetcher] Invalid TTS response: missing or malformed result.id'
       );
       return null;
     }


### PR DESCRIPTION
## 概要

iOS の自動アナウンスを Worker の `/tts` 経由で OpenAI `gpt-4o-mini-tts`（女性声 `nova`）に読み上げさせるようにしました。Android は現状どおり端末内蔵 TTS（`expo-speech`）のままです。

iOS でも合成に失敗した回は、その放送だけ端末内蔵 TTS で読み上げます。圏外・トンネル・API 障害でアナウンスが丸ごと欠落しないためのフォールバックで、恒久的な切り替えではありません（次の放送では再びリモート合成を試みます）。

サーバー側は TrainLCD/functions#2 で対応済みです。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 発話エンジンの抽象化

読み上げ手段を `SpeechEngine` インターフェース（`src/hooks/tts/speechEngine.ts`）で差し替え可能にし、`useTTS` はタイミング制御（抑止判定・ダッキング・保留キュー・安全タイムアウト）に専念する構成へ整理しました。

```text
useTTS ────────────────── 放送タイミング・抑止判定・ダッキング・保留キュー
  ├─ useRemoteSpeechEngine  iOS: /tts へ合成要求 → expo-audio で再生
  └─ useNativeSpeechEngine  Android の常用経路 / iOS のフォールバック
```

`speak()` は `onSettled` か `onUnavailable` のどちらかがちょうど 1 回だけ呼ばれる契約です。`onUnavailable` は「音声を一切生成できず発話しなかった」場合のみで、再生が始まった後の失敗は `onSettled` で終えます（途中まで読み上げた放送を頭から読み直さないため）。

既存の `expo-speech` 実装は挙動を変えずそのまま `useNativeSpeechEngine` へ抽出しています。

### リモート TTS

PR #6453 で削除された外部 TTS 実装を git 履歴から復元し、音声プレイヤー（`ttsAudioPlayer`）と base64 デコーダを再利用しました。プレイヤーは iOS 専用化に伴い、Android 向けだった `replace()` によるプレイヤー再利用経路を落としています（iOS ではバックグラウンド再生を壊すため元々使っていませんでした）。

- `gpt-4o-mini-tts` は SSML 非対応なので、テンプレートの SSML 断片は `toSpeakableText`（新規・両エンジン共通）でプレーンテキストへ変換してから渡します。声色の指示は `instructions` パラメータへ移しました
- 合成は文字数課金のため、ユーザーが無効にしている言語は `/tts` へ送りません。日本語のみ利用者の英語合成コストがまるごと不要になります
- 合成結果は上限付きキャッシュ（`MAX_FETCH_CACHE_SIZE`）で再放送時の再合成を回避します
- MIME 欠落時は先頭バイトで MP3 / WAV を判定します。旧実装のまま無条件に PCM 扱いすると、既定が MP3 の `gpt-4o-mini-tts` の応答を WAV ヘッダーで包んで再生不能にするためです
- 入力長は Worker と同じ UTF-8 バイト基準（`REMOTE_TTS_MAX_INPUT_BYTES` = 4000）で丸めます。文字数で丸めると日本語の長文が 400 で弾かれ、無用にフォールバックしていました

### 付随する不具合修正

アンマウント用クリーンアップ effect が `stopAllEngines` を依存に持っていたため、エンジンの識別子が変わるだけでクリーンアップが走り、**発話中のアナウンスを打ち切っていました**。ref 経由の参照に変えて解消しています（テストで再現・検証済み）。

### ドキュメント

- `docs/spec/tts/remote-tts.md` を新規追加（構成・テキスト前処理・`/tts` の契約・停止スイッチ・キャッシュ）
- README / AGENTS.md のバックエンド参照先を修正。TTS を含む Worker は TrainLCD/BFF ではなく TrainLCD/functions にあります

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（227 suites / 2419 tests）
- [x] `npm run typecheck` が通ること

```bash
npm run lint && npm test && npm run typecheck
```

追加・更新したテスト:

- `src/hooks/useTTS.test.ts` — プラットフォーム分岐（iOS はリモート／Android はリモートを呼ばない）、リモート失敗時のフォールバック、フォールバック後の再生パイプライン解放を追加。リモートエンジンをモックして既存の全ケースを決定的に保っています
- `src/hooks/tts/useRemoteSpeechEngine.test.ts` — 送信内容（プレーンテキスト・モデル・声・`instructions`）、JA→EN の順次再生、片言語のみ、トークン欠落・取得失敗・例外での `onUnavailable`、`stop()` 後のコールバック無視
- `src/utils/speakableText.test.ts` — SSML 除去・`<sub>` の読み採用・`break` の言語別置換・「JR」の置換・英語文からの日本語除去・バイト単位の切り詰め（サロゲートペア非分割）
- `src/utils/ttsSpeechFetcher.test.ts` — プレーンテキスト契約、片言語リクエスト、MIME 判定（明示・バイト判定・不明）、キャッシュの共有と LRU 破棄
- `src/utils/ttsAudioPlayer.test.ts` / `src/utils/base64ToUint8Array.test.ts` — 復元（プレイヤー再利用のケースのみ新規生成の検証へ差し替え）
- `src/lib/ttsCache.test.ts` 相当はサーバー側 PR に含まれます

**実機・シミュレータでの音声確認は未実施です。** UI 変更はないためスクリーンショットはありません。

## 回帰リスクと緩和

- **Android は無影響**: `Platform.OS === 'ios'` のときだけリモート経路に入ります。`useNativeSpeechEngine` は既存実装の抽出で、発話の組み立て・音声選択・言語スキップ判定を変えていません
- **iOS の失敗時**: 合成できなかった回は端末内蔵 TTS へフォールバックするため、無音やクラッシュにはなりません
- **緊急停止**: 既存の Remote Config `tts_enabled_ios` で iOS の TTS ごと停止できます。リモート合成だけを止めて端末内蔵へ倒す専用スイッチは今回追加していません
- **コスト**: OpenAI の従量課金が発生します。無効言語を送らない・同一文面をキャッシュする、の 2 点で無駄打ちを抑えています
- **バックグラウンド再生**: `expo-audio` を使うため `UIBackgroundModes` に `audio` が必要ですが、Info.plist（Dev / Prod）に既に宣言済みであることを確認しました

## 関連Issue

- サーバー側: TrainLCD/functions#2

## スクリーンショット（任意）

UI 変更なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcdvZQGwmY3iKziFjgLos5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOSでリモート音声合成を利用した読み上げに対応しました。
  * リモート音声合成が利用できない場合は、端末内蔵の読み上げへ自動的に切り替えます。
  * Androidでは端末内蔵の読み上げを使用します。
  * 日本語・英語のSSMLを読み上げ用テキストへ変換し、音声の取得・再生・停止を安定して処理します。
  * 音声データのキャッシュに対応しました。

* **ドキュメント**
  * リモート音声合成の構成、設定、フォールバック動作を説明する設計資料を追加しました。
  * システム構成とバックエンドの役割に関する説明を更新しました。

* **テスト**
  * 音声合成、再生、変換、キャッシュ、エラー処理のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->