### PR TITLE
Remote ConfigでAndroidもリモートTTSを参照できるようプラットフォーム別スイッチを追加

### DIFF
--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -1,23 +1,32 @@
-# リモート TTS (iOS) 設計書
+# リモート TTS 設計書
 
-自動アナウンスの読み上げ手段はプラットフォームで異なる。
+自動アナウンスの読み上げ手段は 2 つあり、どちらを使うかは Remote Config の
+`remote_tts_enabled_ios` / `remote_tts_enabled_android` が決める（[停止スイッチ](#停止スイッチ)）。
 
-| プラットフォーム | 合成 | 再生 |
+| 読み上げ手段 | 合成 | 再生 |
 | --- | --- | --- |
-| iOS | Worker `/tts` 経由の `gpt-4o-mini-tts`（女性声 `nova`） | `expo-audio` |
-| Android | 端末内蔵 TTS (`expo-speech`) | 端末内蔵 TTS |
+| リモート TTS | Worker `/tts` 経由の `gpt-4o-mini-tts`（女性声 `nova`） | `expo-audio` |
+| 端末内蔵 TTS | 端末内蔵 TTS (`expo-speech`) | 端末内蔵 TTS |
 
-iOS でリモート合成に失敗した回は、その放送だけ端末内蔵 TTS で読み上げる。圏外・
-トンネル・API 障害でアナウンスが丸ごと欠落しないようにするためのフォールバックで、
-恒久的な切り替えではない（次の放送では再びリモート合成を試みる）。
+キー未配信・取得失敗時のフォールバックは **iOS = リモート TTS / Android = 端末内蔵 TTS**
+で、これは Remote Config を一切配信しなかった場合の既定動作でもある。Android は文字数
+課金が発生するため、`remote_tts_enabled_android` を `true` で配信したときにだけ `/tts` を
+参照する。
+
+リモート合成に失敗した回は、その放送だけ端末内蔵 TTS で読み上げる。圏外・トンネル・
+API 障害でアナウンスが丸ごと欠落しないようにするためのフォールバックで、恒久的な
+切り替えではない（次の放送では再びリモート合成を試みる）。
 
 ## 構成
 
 ```text
 useTTS ────────────────── 放送タイミング・抑止判定・ダッキング・保留キュー
-  ├─ useRemoteSpeechEngine  iOS: /tts へ合成要求 → expo-audio で再生
-  └─ useNativeSpeechEngine  Android の常用経路 / iOS のフォールバック
+  ├─ useRemoteSpeechEngine  /tts へ合成要求 → expo-audio で再生
+  └─ useNativeSpeechEngine  リモートを使わない構成の常用経路 / リモートのフォールバック
 ```
+
+エンジンの選択は放送直前に `isRemoteTTSEnabled()`（`src/lib/remoteConfig.ts`）を引いて
+決めるため、起動後に Remote Config が届いた場合も次の放送から反映される。
 
 両エンジンは `SpeechEngine` (`src/hooks/tts/speechEngine.ts`) を実装する。
 
@@ -109,10 +118,25 @@ Azure Speech 版から全面移行済み（Azure 関連のコード・環境変�
 
 ## 停止スイッチ
 
-Remote Config の `tts_enabled_ios` / `tts_enabled_android` が既存のキルスイッチで、
-プラットフォーム単位で TTS 機能ごと停止できる（`useTTSFeatureEnabled`）。リモート
-合成のコストや障害で iOS の読み上げを止めたい場合は `tts_enabled_ios` を `false` に
-する。リモート合成だけを止めて端末内蔵 TTS へ倒す専用スイッチは現時点では持たない。
+Remote Config のキーは 2 系統あり、役割が異なる。
+
+- `tts_enabled_ios` / `tts_enabled_android` — TTS 機能自体のキルスイッチ
+  （`useTTSFeatureEnabled`）。`false` のときは読み上げを行わず、設定画面のトグルも
+  無効化する。フォールバックは `true`（提供する）。
+- `remote_tts_enabled_ios` / `remote_tts_enabled_android` — 読み上げエンジンの選択
+  （`isRemoteTTSEnabled`）。`true` でリモート合成、`false` で端末内蔵 TTS。
+  フォールバックは iOS が `true`、Android が `false`。
+
+両者は独立しているため、次のような運用ができる。
+
+- **Android でもリモート合成を使う**: `remote_tts_enabled_android` を `true` にする。
+  段階的に開放したい場合はこのキーだけで切り戻せる。
+- **リモート合成のコスト・障害から退避する**: `remote_tts_enabled_*` を `false` にすると、
+  TTS 機能は維持したまま端末内蔵 TTS へ倒れる。読み上げごと止めたい場合のみ
+  `tts_enabled_*` を `false` にする。
+
+iOS / Android 以外（web など）はリモート再生経路を持たないため、`isRemoteTTSEnabled()`
+は常に `false` を返す。
 
 ## キャッシュ
 

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -1,5 +1,7 @@
-// iOS のリモート TTS (Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用) の既定値。
-// Android は端末内蔵の TTS (expo-speech) を使い続けるため、これらは参照されない。
+// リモート TTS (Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用) の既定値。
+// リモート合成を使うかどうかは Remote Config (remote_tts_enabled_ios /
+// remote_tts_enabled_android) が決めるため、端末内蔵 TTS (expo-speech) で読み上げる
+// 構成では参照されない。
 
 // 合成に使うモデル。Worker 側が別モデルへ切り替える場合もリクエストで明示するため、
 // アプリ側の期待するモデルをここで固定する。

--- a/src/hooks/tts/speechEngine.ts
+++ b/src/hooks/tts/speechEngine.ts
@@ -1,7 +1,8 @@
 // 自動アナウンスの読み上げ手段を差し替えられるようにするための共通インターフェース。
-// Android は端末内蔵 TTS (useNativeSpeechEngine)、iOS は Worker 経由の
-// gpt-4o-mini-tts (useRemoteSpeechEngine) を使い、リモートが使えないときは
-// useTTS がその回だけ内蔵 TTS へフォールバックする。
+// Worker 経由の gpt-4o-mini-tts (useRemoteSpeechEngine) と端末内蔵 TTS
+// (useNativeSpeechEngine) のどちらを使うかは Remote Config
+// (remote_tts_enabled_ios / remote_tts_enabled_android) が決め、リモートが
+// 使えないときは useTTS がその回だけ内蔵 TTS へフォールバックする。
 
 export interface SpeechEngineRequest {
   // テンプレートが生成した SSML 断片。プレーンテキストへの変換はエンジン側で行う。

--- a/src/hooks/tts/useRemoteSpeechEngine.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.ts
@@ -27,8 +27,9 @@ import type {
 
 /**
  * Worker の /tts 経由で gpt-4o-mini-tts に合成させ、expo-audio で再生するエンジン。
- * iOS 専用。合成に失敗した場合は onUnavailable を呼び、呼び出し側 (useTTS) が
- * その回だけ端末内蔵 TTS へフォールバックする。
+ * 使用するかどうかは Remote Config (remote_tts_enabled_ios /
+ * remote_tts_enabled_android) が決める。合成に失敗した場合は onUnavailable を呼び、
+ * 呼び出し側 (useTTS) がその回だけ端末内蔵 TTS へフォールバックする。
  */
 export const useRemoteSpeechEngine = (): SpeechEngine => {
   // 発話ごとに採番する世代 ID。停止や新規発話で古い fetch 継続を破棄し、

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -2,12 +2,20 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import React from 'react';
 import { Platform } from 'react-native';
+import { isRemoteTTSEnabled } from '~/lib/remoteConfig';
 import speechState, { resetFirstSpeechAtom } from '~/store/atoms/speech';
 import { useTTS } from './useTTS';
 
 jest.mock('~/utils/isDevApp', () => ({
   isDevApp: false,
 }));
+
+// リモートTTSを使うかは Remote Config が決める。既定の実装は beforeEach で
+// 出荷時のフォールバック(iOS=リモート / Android=端末内蔵)へ揃える。
+jest.mock('~/lib/remoteConfig', () => ({
+  isRemoteTTSEnabled: jest.fn(),
+}));
+const mockedIsRemoteTTSEnabled = jest.mocked(isRemoteTTSEnabled);
 
 const mockSpeak = jest.fn();
 const mockSpeechStop = jest.fn();
@@ -125,6 +133,8 @@ describe('useTTS', () => {
     jest.clearAllMocks();
     settledSpeakCallCount = 0;
     mockGetAvailableVoicesAsync.mockResolvedValue([]);
+    // 未配信時のフォールバックと同じ判定にしておく
+    mockedIsRemoteTTSEnabled.mockImplementation(() => Platform.OS === 'ios');
     // 個別テストで差し替えたリモートエンジンの挙動を既定へ戻す
     mockRemoteSpeak.mockImplementation(remoteSpeakUnavailable);
     // テスト間で useTTSText の mock を復元
@@ -914,7 +924,7 @@ describe('useTTS', () => {
       );
     });
 
-    it('[Android] リモートTTSを呼ばず端末内蔵TTSで読み上げる', async () => {
+    it('[Android] 既定ではリモートTTSを呼ばず端末内蔵TTSで読み上げる', async () => {
       setPlatformOS('android');
 
       const store = createStore();
@@ -933,6 +943,81 @@ describe('useTTS', () => {
         2,
         'en text',
         expect.objectContaining({ language: 'en-US' })
+      );
+    });
+
+    it('[Android] Remote Configで有効ならリモートTTSで読み上げる', async () => {
+      setPlatformOS('android');
+      mockedIsRemoteTTSEnabled.mockReturnValue(true);
+      mockRemoteSpeak.mockImplementation(
+        (
+          _request: unknown,
+          callbacks: {
+            onSpeechStarted?: () => void;
+            onSettled: () => void;
+          }
+        ) => {
+          callbacks.onSpeechStarted?.();
+          callbacks.onSettled();
+        }
+      );
+
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).toHaveBeenCalledTimes(1);
+      expect(mockRemoteSpeak).toHaveBeenCalledWith(
+        {
+          ssmlJa: 'ja text',
+          ssmlEn: 'en text',
+          speakJa: true,
+          speakEn: true,
+        },
+        expect.any(Object)
+      );
+      expect(mockSpeak).not.toHaveBeenCalled();
+    });
+
+    it('[Android] Remote Configで有効でも合成できない回は端末内蔵TTSへフォールバックする', async () => {
+      setPlatformOS('android');
+      mockedIsRemoteTTSEnabled.mockReturnValue(true);
+
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).toHaveBeenCalledTimes(1);
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        1,
+        'ja text',
+        expect.objectContaining({ language: 'ja-JP' })
+      );
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        2,
+        'en text',
+        expect.objectContaining({ language: 'en-US' })
+      );
+    });
+
+    it('[iOS] Remote Configで無効なら端末内蔵TTSで読み上げる', async () => {
+      mockedIsRemoteTTSEnabled.mockReturnValue(false);
+
+      const store = createStore();
+      store.set(speechState, defaultSpeechState);
+
+      renderHook(() => useTTS(), { wrapper: createWrapper(store) });
+      await flushAsync();
+
+      expect(mockRemoteSpeak).not.toHaveBeenCalled();
+      expect(mockSpeak).toHaveBeenNthCalledWith(
+        1,
+        'ja text',
+        expect.objectContaining({ language: 'ja-JP' })
       );
     });
   });

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,8 +1,8 @@
 import { setAudioModeAsync } from 'expo-audio';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef } from 'react';
-import { Platform } from 'react-native';
 import { TransportType } from '~/@types/graphql';
+import { isRemoteTTSEnabled } from '~/lib/remoteConfig';
 import speechState, { resetFirstSpeechAtom } from '../store/atoms/speech';
 import { arrivedAtom, selectedBoundAtom } from '../store/atoms/station';
 import { computeSuppressionDecision } from '../utils/computeSuppressionDecision';
@@ -20,11 +20,6 @@ import { useTTSText } from './useTTSText';
 // 解放されず以降の TTS 全体が停止するのを防ぐ。正常な発話（日英合わせても数十秒
 // 程度、リモートは取得時間を含めても十分収まる）はこの時間内に必ず完了する。
 const PLAYBACK_TIMEOUT_MS = 300_000;
-
-// iOS のみ Worker 経由の gpt-4o-mini-tts（女性声）で読み上げる。Android は
-// 端末内蔵 TTS のまま据え置き。iOS でもリモート合成に失敗した回は端末内蔵 TTS へ
-// フォールバックするため、圏外・トンネル・API 障害でもアナウンスは途切れない。
-const shouldUseRemoteTTS = (): boolean => Platform.OS === 'ios';
 
 export const useTTS = (): void => {
   const { enabled, backgroundEnabled, ttsEnabledLanguages } =
@@ -68,8 +63,8 @@ export const useTTS = (): void => {
 
   const playingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 端末内蔵 TTS は Android の常用経路であり、iOS ではリモート合成が使えない
-  // ときのフォールバックも担うため、どちらのプラットフォームでも用意しておく。
+  // 端末内蔵 TTS はリモート合成を使わない構成での常用経路であり、リモート合成が
+  // 使えないときのフォールバックも担うため、どちらのプラットフォームでも用意しておく。
   const nativeEngine = useNativeSpeechEngine();
   const remoteEngine = useRemoteSpeechEngine();
 
@@ -225,7 +220,10 @@ export const useTTS = (): void => {
           return;
         }
 
-        if (!shouldUseRemoteTTS()) {
+        // 読み上げ直前に Remote Config を引き、リモート合成(Worker 経由の
+        // gpt-4o-mini-tts)と端末内蔵 TTS のどちらで読み上げるかを決める。起動後に
+        // 設定が届いた場合も次の放送から反映される。
+        if (!isRemoteTTSEnabled()) {
           nativeEngine.speak(request, { onSpeechStarted, onSettled });
           return;
         }

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -7,6 +7,7 @@ import {
   isAIAgentFeatureEnabled,
   isEtaAssistEnabled,
   isForceNotArrivedOnLowAccuracyEnabled,
+  isRemoteTTSEnabled,
   isTTSFeatureEnabled,
   resetRemoteConfigCache,
   setupRemoteConfig,
@@ -356,6 +357,110 @@ describe('isTTSFeatureEnabled（プラットフォーム別スイッチ）', () 
 
     resetRemoteConfigCache();
     expect(isTTSFeatureEnabled()).toBe(true);
+  });
+});
+
+describe('isRemoteTTSEnabled（リモートTTS切替スイッチ）', () => {
+  it('未配信時は既存挙動どおり iOS のみリモートTTSを使う', () => {
+    setPlatformOS('ios');
+    expect(isRemoteTTSEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(false);
+  });
+
+  it('Remote Config で有効化すると Android もリモートTTSを使う', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      remote_tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(true);
+    // Android 側の配信は iOS のフォールバック(true)に影響しない
+    setPlatformOS('ios');
+    expect(isRemoteTTSEnabled()).toBe(true);
+  });
+
+  it('iOSのリモートTTSだけを停止して端末内蔵TTSへ倒せる', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      remote_tts_enabled_ios: false,
+      remote_tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isRemoteTTSEnabled()).toBe(false);
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(true);
+  });
+
+  it('真偽値以外は無視してフォールバックする', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      remote_tts_enabled_ios: 'false',
+      remote_tts_enabled_android: 1,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('ios');
+    expect(isRemoteTTSEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(false);
+  });
+
+  it('取得に失敗してもフォールバックで動作する', async () => {
+    mockRemoteConfig({}, false);
+    await expect(setupRemoteConfig()).rejects.toThrow(
+      'remote config fetch failed: 503'
+    );
+
+    setPlatformOS('ios');
+    expect(isRemoteTTSEnabled()).toBe(true);
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(false);
+  });
+
+  // TTS機能自体のキルスイッチとは独立していることの回帰テスト。
+  // tts_enabled_* が false でもエンジン選択の判定には影響しない。
+  it('TTS機能キルスイッチとは独立して判定される', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      tts_enabled_android: false,
+      remote_tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('android');
+    expect(isTTSFeatureEnabled()).toBe(false);
+    expect(isRemoteTTSEnabled()).toBe(true);
+  });
+
+  it('iOS/Android以外のプラットフォームでは常に無効', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      remote_tts_enabled_ios: true,
+      remote_tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('web');
+    expect(isRemoteTTSEnabled()).toBe(false);
+  });
+
+  it('resetRemoteConfigCache でリモートTTSのキャッシュも破棄される', async () => {
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      remote_tts_enabled_android: true,
+    });
+    await setupRemoteConfig();
+
+    setPlatformOS('android');
+    expect(isRemoteTTSEnabled()).toBe(true);
+
+    resetRemoteConfigCache();
+    expect(isRemoteTTSEnabled()).toBe(false);
   });
 });
 

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -27,6 +27,12 @@ export const REMOTE_CONFIG_KEYS = {
   // 停止・再開できる。未配信・不正値のときはフォールバック(true=利用可能)。
   TTS_ENABLED_IOS: 'tts_enabled_ios',
   TTS_ENABLED_ANDROID: 'tts_enabled_android',
+  // リモートTTS(Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用)を使うかどうかの
+  // プラットフォーム別スイッチ。tts_enabled_* が「TTS 機能自体を提供するか」を決めるのに対し、
+  // こちらは「有効な TTS をどのエンジンで読み上げるか」を切り替える。false のときは
+  // 端末内蔵 TTS(expo-speech)で読み上げる。
+  REMOTE_TTS_ENABLED_IOS: 'remote_tts_enabled_ios',
+  REMOTE_TTS_ENABLED_ANDROID: 'remote_tts_enabled_android',
   // AIエージェント(行き先相談)機能の有効/無効。障害・コスト超過時にサーバー側から
   // エントリポイントごと機能を止められるようにするキルスイッチ。
   AI_AGENT_ENABLED: 'ai_agent_enabled',
@@ -42,6 +48,8 @@ type RemoteConfigResponse = {
   tts_enabled?: boolean;
   tts_enabled_ios?: boolean;
   tts_enabled_android?: boolean;
+  remote_tts_enabled_ios?: boolean;
+  remote_tts_enabled_android?: boolean;
   ai_agent_enabled?: boolean;
 };
 
@@ -59,6 +67,13 @@ const ETA_FALLBACK_MAX_DURATION_MIN_FALLBACK = 30;
 // TTS機能(プラットフォーム別スイッチ)のフォールバック既定値。キルスイッチ用途のため、
 // 未配信・取得失敗時は既存挙動（利用可能）を維持する true をフォールバックとする。
 const TTS_ENABLED_FALLBACK = true;
+
+// リモートTTSを使うかどうかのフォールバック既定値。現行挙動(iOS はリモート合成、
+// Android は端末内蔵 TTS)をそのまま維持するため、iOS のみ true とする。Android の
+// リモート合成は文字数課金が発生するため、Remote Config で明示的に有効化された
+// ときだけ /tts を参照させる。
+const REMOTE_TTS_ENABLED_IOS_FALLBACK = true;
+const REMOTE_TTS_ENABLED_ANDROID_FALLBACK = false;
 
 // AIエージェント機能のフォールバック既定値。LLM 利用料が発生する機能のため、
 // 未配信・取得失敗時は安全側に倒して無効とする。
@@ -83,6 +98,8 @@ let cachedEtaFallbackArrivalConfirmMarginSec: number | null = null;
 let cachedEtaFallbackMaxDurationMin: number | null = null;
 let cachedTTSEnabledIOS: boolean | null = null;
 let cachedTTSEnabledAndroid: boolean | null = null;
+let cachedRemoteTTSEnabledIOS: boolean | null = null;
+let cachedRemoteTTSEnabledAndroid: boolean | null = null;
 let cachedAIAgentEnabled: boolean | null = null;
 
 // setupRemoteConfig は起動時に非同期で完了するため、初回レンダー後にキャッシュが
@@ -113,6 +130,8 @@ export const resetRemoteConfigCache = (): void => {
   cachedEtaFallbackMaxDurationMin = null;
   cachedTTSEnabledIOS = null;
   cachedTTSEnabledAndroid = null;
+  cachedRemoteTTSEnabledIOS = null;
+  cachedRemoteTTSEnabledAndroid = null;
   cachedAIAgentEnabled = null;
   notifyRemoteConfigListeners();
 };
@@ -156,6 +175,12 @@ export const setupRemoteConfig = async (): Promise<void> => {
   }
   if (typeof data.tts_enabled_android === 'boolean') {
     cachedTTSEnabledAndroid = data.tts_enabled_android;
+  }
+  if (typeof data.remote_tts_enabled_ios === 'boolean') {
+    cachedRemoteTTSEnabledIOS = data.remote_tts_enabled_ios;
+  }
+  if (typeof data.remote_tts_enabled_android === 'boolean') {
+    cachedRemoteTTSEnabledAndroid = data.remote_tts_enabled_android;
   }
   if (typeof data.ai_agent_enabled === 'boolean') {
     cachedAIAgentEnabled = data.ai_agent_enabled;
@@ -233,6 +258,27 @@ export const isTTSFeatureEnabled = (): boolean => {
       return cachedTTSEnabledAndroid ?? TTS_ENABLED_FALLBACK;
     default:
       return TTS_ENABLED_FALLBACK;
+  }
+};
+
+// 自動アナウンスをリモートTTS(Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用)で
+// 読み上げるかどうかを同期的に取得する。false のときは端末内蔵 TTS(expo-speech)で読み上げる。
+// これは TTS 機能自体のキルスイッチ(isTTSFeatureEnabled)とは独立しており、TTS を提供したまま
+// エンジンだけを差し替える用途に使う。
+//   - Android でもリモート合成を使う: remote_tts_enabled_android=true
+//   - 障害・コスト超過時に iOS を端末内蔵 TTS へ退避: remote_tts_enabled_ios=false
+// 未配信・取得失敗時は既存挙動を維持するフォールバック(iOS=true / Android=false)を返す。
+// iOS/Android 以外(web など)はリモート再生経路を持たないため常に false。
+export const isRemoteTTSEnabled = (): boolean => {
+  switch (Platform.OS) {
+    case 'ios':
+      return cachedRemoteTTSEnabledIOS ?? REMOTE_TTS_ENABLED_IOS_FALLBACK;
+    case 'android':
+      return (
+        cachedRemoteTTSEnabledAndroid ?? REMOTE_TTS_ENABLED_ANDROID_FALLBACK
+      );
+    default:
+      return false;
   }
 };
 

--- a/src/utils/ttsAudioPlayer.ts
+++ b/src/utils/ttsAudioPlayer.ts
@@ -1,10 +1,11 @@
 import type { AudioPlayer } from 'expo-audio';
 import { createAudioPlayer } from 'expo-audio';
 
-// このプレイヤーは iOS のリモート TTS 再生専用。Android は端末内蔵の TTS
-// (expo-speech) で読み上げるため、ここを通らない。かつて Android 対応のために
-// あった「プレイヤーを replace() で使い回す」経路は、iOS ではバックグラウンド
-// 再生を壊すため使っておらず、iOS 専用化に伴い削除した。
+// このプレイヤーはリモート TTS の再生専用。リモート合成を使うかどうかは Remote Config
+// (remote_tts_enabled_ios / remote_tts_enabled_android) が決めるため、iOS・Android の
+// どちらもここを通りうる。端末内蔵の TTS (expo-speech) で読み上げる構成では通らない。
+// かつてあった「プレイヤーを replace() で使い回す」経路は、iOS ではバックグラウンド
+// 再生を壊すため復活させず、発話ごとの生成・解放で両プラットフォームを揃える。
 
 // 再生位置が進まない状態がこの時間続いたらストールとみなして打ち切る。
 // 再生エラーや音声フォーカス喪失で停止しても JS へ error イベントも


### PR DESCRIPTION
## 概要

リモート TTS（Worker `/tts` 経由の OpenAI `gpt-4o-mini-tts`）を使うかどうかがコード側で `Platform.OS === 'ios'` にハードコードされており、Android は常に端末内蔵 TTS でした。これを Remote Config のプラットフォーム別スイッチへ移し、配信側の判断で Android もリモート TTS を参照できるようにします。

フォールバック（キー未配信・取得失敗時）は **iOS = リモート TTS / Android = 端末内蔵 TTS** とし、現行の挙動をそのまま維持します。Android のリモート合成は文字数課金が発生するため、`remote_tts_enabled_android` を `true` で配信したときにだけ `/tts` を参照します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/lib/remoteConfig.ts`: Remote Config キー `remote_tts_enabled_ios` / `remote_tts_enabled_android` を追加し、実行中プラットフォームに応じて判定する `isRemoteTTSEnabled()` を新設。フォールバックは iOS `true` / Android `false`、iOS・Android 以外（web など）はリモート再生経路を持たないため常に `false`。
- `src/hooks/useTTS.ts`: ハードコードされていた `shouldUseRemoteTTS = () => Platform.OS === 'ios'` を削除し、放送直前に `isRemoteTTSEnabled()` を引いてエンジンを選択するよう変更。起動後に Remote Config が届いた場合も次の放送から反映される。
- `src/hooks/tts/speechEngine.ts` / `src/hooks/tts/useRemoteSpeechEngine.ts` / `src/utils/ttsAudioPlayer.ts` / `src/constants/tts.ts`: 「iOS 専用」を前提としたコメントを実態に合わせて更新（実装ロジックの変更なし）。
- `src/lib/remoteConfig.test.ts`: `isRemoteTTSEnabled` のテストを 8 件追加（フォールバック、Android 有効化、iOS のみ停止、非真偽値の無視、取得失敗、`tts_enabled_*` との独立性、web、キャッシュ破棄）。
- `src/hooks/useTTS.test.ts`: `~/lib/remoteConfig` をモックし、Android でリモート有効時にリモートエンジンを使うケース・その際に合成失敗で端末内蔵 TTS へフォールバックするケース・iOS でリモート無効時に端末内蔵 TTS を使うケースを追加。既存の Android ケースは「既定では」と明示する名前へ変更。
- `docs/spec/tts/remote-tts.md`: タイトルから `(iOS)` を外し、Remote Config キー 2 系統（機能キルスイッチ / エンジン選択）の役割・フォールバック・運用パターンを追記。

### 補足: iOS 側のキーも対で追加した理由

依頼は Android 分のみでしたが、同じ判定関数の分岐が 1 本増えるだけで、既存ドキュメントに「リモート合成だけを止めて端末内蔵 TTS へ倒す専用スイッチは現時点では持たない」と記載されていた運用上の穴（コスト超過・API 障害時の退避）を塞げるため、`remote_tts_enabled_ios` も同時に追加しています。既定 `true` のため iOS の挙動は変わりません。

### リポジトリ外の残作業

- Worker 側（[TrainLCD/functions](https://github.com/TrainLCD/functions)）の `/config/remote` に新キーを配信する対応が別途必要です。アプリ側は未配信でもフォールバックで動作するため、リリース順序の依存はありません。
- Android でリモート合成を実際に有効化する前に、実機でのバックグラウンド再生と音声フォーカス（他アプリのダッキング復帰、通話割り込み）の確認を推奨します。`ttsAudioPlayer` のストール検知・早期 `didJustFinish` 対策は iOS の実測に合わせて調整された経緯があり、Android 実機での通し確認は未実施です。

## リグレッションリスクと緩和策

| リスク | 緩和策 |
| --- | --- |
| キー未配信時に読み上げ経路が変わる | フォールバックを iOS `true` / Android `false` に固定し、Remote Config を一切配信しない場合の挙動を現行と一致させた。回帰テストで担保。 |
| Android でリモート合成が失敗し無音になる | 既存の `onUnavailable` → 端末内蔵 TTS フォールバックがプラットフォーム非依存で動作することをテストで確認。 |
| 機能キルスイッチとの取り違え | `tts_enabled_*`（機能自体）と `remote_tts_enabled_*`（エンジン選択）が独立して評価されることを回帰テストで固定し、docs に運用パターンを明記。 |
| Android のリモート合成による課金増 | 既定 OFF。配信側で明示的に有効化したときのみ `/tts` を参照する。既存の合成結果キャッシュ（`MAX_FETCH_CACHE_SIZE`）もそのまま効く。 |

## テスト

ローカルで実行したコマンドと結果:

```text
npm run lint       → Checked 651 files in 739ms. No fixes applied.
npm run typecheck  → エラーなし
npm test           → Test Suites: 227 passed, 227 total / Tests: 2435 passed, 2435 total
npx markdownlint-cli2 docs/spec/tts/remote-tts.md → 0 issues
```

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOS・AndroidでRemote ConfigによるリモートTTSの利用切り替えに対応。
  * リモートTTSが利用できない場合、端末内蔵TTSへ自動的にフォールバック。
  * 設定未配信時や取得失敗時は、プラットフォームごとの既定動作を適用。
  * TTS機能全体の停止と、リモートTTSのみの停止を個別に制御可能。

* **ドキュメント**
  * リモートTTSの対応プラットフォーム、切り替え条件、フォールバック動作を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->