### PR TITLE
リモートTTSのGoogle Cloud Text-to-Speech移行に追従しモデルと読み方指示の送信を廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The backend Worker (TTS synthesis, session issuance, feedback triage, review not
 
 Voice announcements (TTS) use a different engine per platform:
 
-- **iOS**: synthesized remotely by `gpt-4o-mini-tts` (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped. See [the spec](./docs/spec/tts/remote-tts.md) for the wire contract.
+- **iOS**: synthesized remotely by Google Cloud Text-to-Speech (female voice) through the Worker's `/tts` endpoint and played back with `expo-audio`. When synthesis is unavailable — no signal, a tunnel, or an API outage — that announcement falls back to the on-device synthesizer so it is never silently dropped. See [the spec](./docs/spec/tts/remote-tts.md) for the wire contract.
 - **Android**: synthesized on-device with the OS-native speech synthesizer via `expo-speech`.
 
 Both paths share the same announcement text pipeline; the SSML fragments emitted by the templates are converted to plain text before reaching either engine (`src/utils/speakableText.ts`), because neither engine interprets SSML.

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -5,7 +5,7 @@
 
 | 読み上げ手段 | 合成 | 再生 |
 | --- | --- | --- |
-| リモート TTS | Worker `/tts` 経由の `gpt-4o-mini-tts`（女性声 `nova`） | `expo-audio` |
+| リモート TTS | Worker `/tts` 経由の Google Cloud TTS（女性声 `ja-JP-Standard-B` / `en-US-Standard-G`） | `expo-audio` |
 | 端末内蔵 TTS | 端末内蔵 TTS (`expo-speech`) | 端末内蔵 TTS |
 
 キー未配信・取得失敗時のフォールバックは **iOS = リモート TTS / Android = 端末内蔵 TTS**
@@ -38,7 +38,7 @@ useTTS ────────────────── 放送タイミン
 
 ## テキストの前処理
 
-TTS テンプレートは SSML 断片を生成するが、`gpt-4o-mini-tts` も `expo-speech` も
+TTS テンプレートは SSML 断片を生成するが、Cloud TTS（`input.text`）も `expo-speech` も
 SSML を解釈せずタグをそのまま読み上げる。そのため双方のエンジンが
 `toSpeakableText()` (`src/utils/speakableText.ts`) でプレーンテキストへ変換してから
 合成へ渡す。
@@ -48,8 +48,9 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
 - 「JR」→ 日本語 `ジェーアール` / 英語 `J-R`（`Jr.` = ジュニアとの誤読を防ぐ）
 - 英語文に混入した日本語は除去する
 
-`gpt-4o-mini-tts` は SSML の代わりに `instructions` で読み方を指示するため、声色・
-速度・間の取り方は `src/constants/tts.ts` の定数で渡す。
+Cloud TTS の Standard 系ボイスは読み方のプロンプト指示を受け付けないため、アプリが
+指定するのはボイス名（`src/constants/tts.ts`）だけで、読み上げ速度・声の高さは
+Worker 側の設定（`TTS_SPEED` / `TTS_PITCH`）で決まる。
 
 ## Worker `/tts` の契約
 
@@ -66,14 +67,14 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
   "data": {
     "textJa": "次は、オオサキです",
     "textEn": "The next station is Osaki, J Y 24.",
-    "model": "gpt-4o-mini-tts",
-    "jaVoiceName": "nova",
-    "enVoiceName": "nova",
-    "instructionsJa": "鉄道の車内自動放送のアナウンサーとして…",
-    "instructionsEn": "Read this as an automated train announcement…"
+    "jaVoiceName": "ja-JP-Standard-B",
+    "enVoiceName": "en-US-Standard-G"
   }
 }
 ```
+
+ボイス名は `<言語>-<地域>-<系統>-<記号>` でロケールを含むため、日英で同じ名前は
+使えない（OpenAI 時代の `nova` のような多言語プリセットは存在しない）。
 
 合成は文字数課金のため、**ユーザーが無効にしている言語のフィールドは送らない**。
 `textJa` のみ・`textEn` のみのリクエストが正常系として発生するので、Worker は
@@ -95,18 +96,27 @@ SSML を解釈せずタグをそのまま読み上げる。そのため双方の
 
 - 要求した言語の音声が欠けている応答は失敗として扱い、端末内蔵 TTS へフォールバック
   する。要求していない言語のフィールドは省略してよい。
+- 音声は既定で MP3 (`audio/mpeg`)。Worker の `TTS_RESPONSE_FORMAT` を変えると
+  WAV (`audio/wav`) でも返せるが、アプリが再生できない形式を選ばないこと。
 - MIME タイプは省略可。省略時はアプリ側が先頭バイトから MP3 / WAV を判定し、どちらとも
   判定できない場合のみ生 PCM (16bit LE / 24kHz) とみなして WAV ヘッダーを付与する。
   誤判定を避けるため、可能な限り MIME タイプを返すこと。
 
 ### サーバー側の実装メモ
 
-Azure Speech 版から全面移行済み（Azure 関連のコード・環境変数・シークレットは
-削除された）。アプリ側と対応が取れている前提は以下のとおり。
+合成エンジンは Google Cloud Text-to-Speech（`text:synthesize`、サービスアカウント認証）。
+OpenAI 版・Azure Speech 版からは全面移行済みで、旧エンジン向けのコード・環境変数・
+シークレットは削除された。アプリ側と対応が取れている前提は以下のとおり。
 
-- ボイス名とモデルは Worker 側で許可制。未知の値はリクエスト → KV(`config:tts`)
-  → `TTS_*` 環境変数の順にフォールバックするため、アプリが古いボイス名を送っても
-  400 にはならず既定の女性声で合成される。
+- ボイス名は Worker 側で許可制（実在を確認済みの Standard / Wavenet / Neural2 のみ。
+  単価が桁違いの Studio・Chirp3-HD・Gemini-TTS は名指しできない）。未知の値は
+  リクエスト → KV(`config:tts`) → `TTS_*` 環境変数の順にフォールバックするため、
+  旧バージョンのアプリが OpenAI 時代のボイス名（`nova`）を送っても 400 にはならず
+  既定の女性声で合成される。
+- `model` / `instructionsJa` / `instructionsEn` は OpenAI 時代のフィールド。Standard 系
+  ボイスにはモデル指定も読み方のプロンプト指示も無いため、Worker は受け取っても
+  無視する（旧バージョンのアプリからの呼び出しを壊さないための互換）。当バージョンの
+  アプリは送らない。
 - 入力上限は Worker 側が UTF-8 **バイト**で検証する（4000 バイト）。アプリ側も
   同じバイト数で丸める（`REMOTE_TTS_MAX_INPUT_BYTES`）ので、文字数と
   バイト数の食い違いで無用なフォールバックが起きない。
@@ -140,6 +150,6 @@ iOS / Android 以外（web など）はリモート再生経路を持たない�
 
 ## キャッシュ
 
-`fetchSpeechAudio` はテキスト・モデル・音声名をキーに合成結果のファイルパスを
+`fetchSpeechAudio` はテキスト・音声名をキーに合成結果のファイルパスを
 メモリへ保持する（上限 `MAX_FETCH_CACHE_SIZE` 件、超過時は最古から破棄）。同一文面の
 再放送では再合成しないため、折り返し運転や同じ駅を繰り返し通る経路で課金が膨らまない。

--- a/src/constants/tts.ts
+++ b/src/constants/tts.ts
@@ -1,27 +1,17 @@
-// リモート TTS (Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用) の既定値。
+// リモート TTS (Worker の /tts 経由で Google Cloud Text-to-Speech を利用) の既定値。
 // リモート合成を使うかどうかは Remote Config (remote_tts_enabled_ios /
 // remote_tts_enabled_android) が決めるため、端末内蔵 TTS (expo-speech) で読み上げる
 // 構成では参照されない。
 
-// 合成に使うモデル。Worker 側が別モデルへ切り替える場合もリクエストで明示するため、
-// アプリ側の期待するモデルをここで固定する。
-export const REMOTE_TTS_MODEL = 'gpt-4o-mini-tts';
+// 車内放送に使う女性声。Cloud TTS のボイス名は `<言語>-<地域>-<系統>-<記号>` で
+// ロケールを含むため、多言語共通のプリセットは無く日英で別々に指定する。系統は
+// 端末内蔵 TTS と同水準の Standard で揃える (Studio・Chirp3-HD 等は単価が桁違いで
+// Worker 側の許可リストにも入っていない)。
+export const REMOTE_TTS_VOICE_JA = 'ja-JP-Standard-B';
+export const REMOTE_TTS_VOICE_EN = 'en-US-Standard-G';
 
-// 車内放送に使う女性声。gpt-4o-mini-tts の音声は多言語対応のため、日英で同一の
-// 声を指定して一人のアナウンサーが読み上げている印象を保つ。
-export const REMOTE_TTS_VOICE = 'nova';
-
-// gpt-4o-mini-tts は SSML を解釈せず、代わりに instructions で読み方を指示する。
-// 駅名・路線名の固有名詞が続くため、速度と間の取り方を明示して聞き取りやすくする。
-export const REMOTE_TTS_INSTRUCTIONS_JA =
-  '鉄道の車内自動放送のアナウンサーとして、落ち着いた丁寧な女性の声で読み上げてください。' +
-  '一定の速さを保ち、句読点では短く間を取ります。駅名や路線名は一語ずつ明瞭に発音し、' +
-  '感情を込めすぎず、事務的で聞き取りやすい調子にしてください。';
-
-export const REMOTE_TTS_INSTRUCTIONS_EN =
-  'Read this as an automated train announcement in a calm, polite female voice. ' +
-  'Keep a steady pace, pause briefly at commas, and pronounce station and line names ' +
-  'clearly. Stay neutral and business-like rather than expressive.';
+// 読み上げ速度・声の高さは Worker の TTS_SPEED / TTS_PITCH で決まる。Standard 系は
+// 読み方のプロンプト指示を受け付けないため、アプリから調整する手段は無い。
 
 // Worker(/tts) が受け付ける読み上げテキストの上限(UTF-8 バイト)。超過すると
 // 400 で弾かれて無用なフォールバックを招くため、送信前に切り詰める。

--- a/src/hooks/tts/speechEngine.ts
+++ b/src/hooks/tts/speechEngine.ts
@@ -1,5 +1,5 @@
 // 自動アナウンスの読み上げ手段を差し替えられるようにするための共通インターフェース。
-// Worker 経由の gpt-4o-mini-tts (useRemoteSpeechEngine) と端末内蔵 TTS
+// Worker 経由の Google Cloud TTS (useRemoteSpeechEngine) と端末内蔵 TTS
 // (useNativeSpeechEngine) のどちらを使うかは Remote Config
 // (remote_tts_enabled_ios / remote_tts_enabled_android) が決め、リモートが
 // 使えないときは useTTS がその回だけ内蔵 TTS へフォールバックする。

--- a/src/hooks/tts/useRemoteSpeechEngine.test.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.test.ts
@@ -1,10 +1,5 @@
 import { act, renderHook } from '@testing-library/react-native';
-import {
-  REMOTE_TTS_INSTRUCTIONS_EN,
-  REMOTE_TTS_INSTRUCTIONS_JA,
-  REMOTE_TTS_MODEL,
-  REMOTE_TTS_VOICE,
-} from '~/constants';
+import { REMOTE_TTS_VOICE_EN, REMOTE_TTS_VOICE_JA } from '~/constants';
 import type { SpeechEngineRequest } from './speechEngine';
 import { useRemoteSpeechEngine } from './useRemoteSpeechEngine';
 
@@ -75,7 +70,7 @@ describe('useRemoteSpeechEngine', () => {
     jest.clearAllMocks();
   });
 
-  it('SSML をプレーンテキストへ変換し、モデル・女性声・読み方指示を添えて要求する', async () => {
+  it('SSML をプレーンテキストへ変換し、日英それぞれの女性声を添えて要求する', async () => {
     const { result } = renderEngine();
 
     result.current.speak(defaultRequest, { onSettled: jest.fn() });
@@ -88,11 +83,9 @@ describe('useRemoteSpeechEngine', () => {
         textEn: 'The next station is Osaki, J Y 24.',
         apiUrl: 'https://worker.example.com/tts',
         idToken: 'test-token',
-        model: REMOTE_TTS_MODEL,
-        jaVoiceName: REMOTE_TTS_VOICE,
-        enVoiceName: REMOTE_TTS_VOICE,
-        instructionsJa: REMOTE_TTS_INSTRUCTIONS_JA,
-        instructionsEn: REMOTE_TTS_INSTRUCTIONS_EN,
+        // Cloud TTS のボイス名はロケールを含むため日英で別々に指定する
+        jaVoiceName: REMOTE_TTS_VOICE_JA,
+        enVoiceName: REMOTE_TTS_VOICE_EN,
       })
     );
   });

--- a/src/hooks/tts/useRemoteSpeechEngine.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.ts
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
-  REMOTE_TTS_INSTRUCTIONS_EN,
-  REMOTE_TTS_INSTRUCTIONS_JA,
   REMOTE_TTS_MAX_INPUT_BYTES,
-  REMOTE_TTS_MODEL,
-  REMOTE_TTS_VOICE,
+  REMOTE_TTS_VOICE_EN,
+  REMOTE_TTS_VOICE_JA,
 } from '../../constants';
 import { getSessionToken } from '../../lib/session';
 import { workerUrl } from '../../lib/workerApi';
@@ -26,7 +24,7 @@ import type {
 } from './speechEngine';
 
 /**
- * Worker の /tts 経由で gpt-4o-mini-tts に合成させ、expo-audio で再生するエンジン。
+ * Worker の /tts 経由で Google Cloud TTS に合成させ、expo-audio で再生するエンジン。
  * 使用するかどうかは Remote Config (remote_tts_enabled_ios /
  * remote_tts_enabled_android) が決める。合成に失敗した場合は onUnavailable を呼び、
  * 呼び出し側 (useTTS) がその回だけ端末内蔵 TTS へフォールバックする。
@@ -180,11 +178,8 @@ export const useRemoteSpeechEngine = (): SpeechEngine => {
             textEn,
             apiUrl: workerUrl('/tts'),
             idToken,
-            model: REMOTE_TTS_MODEL,
-            jaVoiceName: REMOTE_TTS_VOICE,
-            enVoiceName: REMOTE_TTS_VOICE,
-            instructionsJa: REMOTE_TTS_INSTRUCTIONS_JA,
-            instructionsEn: REMOTE_TTS_INSTRUCTIONS_EN,
+            jaVoiceName: REMOTE_TTS_VOICE_JA,
+            enVoiceName: REMOTE_TTS_VOICE_EN,
           });
 
           if (isStaleRun()) {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -221,7 +221,7 @@ export const useTTS = (): void => {
         }
 
         // 読み上げ直前に Remote Config を引き、リモート合成(Worker 経由の
-        // gpt-4o-mini-tts)と端末内蔵 TTS のどちらで読み上げるかを決める。起動後に
+        // Google Cloud TTS)と端末内蔵 TTS のどちらで読み上げるかを決める。起動後に
         // 設定が届いた場合も次の放送から反映される。
         if (!isRemoteTTSEnabled()) {
           nativeEngine.speak(request, { onSpeechStarted, onSettled });

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -27,7 +27,7 @@ export const REMOTE_CONFIG_KEYS = {
   // 停止・再開できる。未配信・不正値のときはフォールバック(true=利用可能)。
   TTS_ENABLED_IOS: 'tts_enabled_ios',
   TTS_ENABLED_ANDROID: 'tts_enabled_android',
-  // リモートTTS(Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用)を使うかどうかの
+  // リモートTTS(Worker の /tts 経由で Google Cloud TTS を利用)を使うかどうかの
   // プラットフォーム別スイッチ。tts_enabled_* が「TTS 機能自体を提供するか」を決めるのに対し、
   // こちらは「有効な TTS をどのエンジンで読み上げるか」を切り替える。false のときは
   // 端末内蔵 TTS(expo-speech)で読み上げる。
@@ -261,7 +261,7 @@ export const isTTSFeatureEnabled = (): boolean => {
   }
 };
 
-// 自動アナウンスをリモートTTS(Worker の /tts 経由で OpenAI gpt-4o-mini-tts を利用)で
+// 自動アナウンスをリモートTTS(Worker の /tts 経由で Google Cloud TTS を利用)で
 // 読み上げるかどうかを同期的に取得する。false のときは端末内蔵 TTS(expo-speech)で読み上げる。
 // これは TTS 機能自体のキルスイッチ(isTTSFeatureEnabled)とは独立しており、TTS を提供したまま
 // エンジンだけを差し替える用途に使う。

--- a/src/utils/speakableText.ts
+++ b/src/utils/speakableText.ts
@@ -5,7 +5,7 @@ import getStringBytes from './stringBytes';
 
 // TTS テンプレートが生成する SSML 断片を、読み上げエンジンへ渡せるプレーン
 // テキストへ変換する。端末内蔵 TTS (expo-speech) も iOS のリモート TTS
-// (gpt-4o-mini-tts) も SSML を解釈せずタグをそのまま読み上げてしまうため、
+// (Google Cloud TTS) も SSML を解釈せずタグをそのまま読み上げてしまうため、
 // どちらの経路でもこの変換を通す。
 
 /**

--- a/src/utils/ttsSpeechFetcher.test.ts
+++ b/src/utils/ttsSpeechFetcher.test.ts
@@ -62,8 +62,8 @@ describe('fetchSpeechAudio', () => {
   });
 
   it('プレーンテキストをそのまま送信する（SSML でラップしない）', async () => {
-    // gpt-4o-mini-tts は SSML を解釈せずタグをそのまま読み上げてしまうため、
-    // 呼び出し側が変換済みのプレーンテキストを送る契約になっている
+    // Cloud TTS は input.text に渡された SSML を解釈せずタグをそのまま読み上げて
+    // しまうため、呼び出し側が変換済みのプレーンテキストを送る契約になっている
     mockFetch.mockResolvedValue(
       okResponse({
         id: 'tts-123',
@@ -85,7 +85,8 @@ describe('fetchSpeechAudio', () => {
     expect(body.data.ssmlEn).toBeUndefined();
   });
 
-  it('モデル・音声・読み方指示をリクエストに含める', async () => {
+  it('日英それぞれの音声名をリクエストに含める', async () => {
+    // Cloud TTS のボイス名はロケールを含むため、日英で同じ名前は使えない
     mockFetch.mockResolvedValue(
       okResponse({
         id: 'tts-130',
@@ -96,23 +97,22 @@ describe('fetchSpeechAudio', () => {
 
     await fetchSpeechAudio({
       ...defaultOptions,
-      model: 'gpt-4o-mini-tts',
-      jaVoiceName: 'nova',
-      enVoiceName: 'nova',
-      instructionsJa: '落ち着いた女性の声で',
-      instructionsEn: 'calm female voice',
+      jaVoiceName: 'ja-JP-Standard-B',
+      enVoiceName: 'en-US-Standard-G',
     });
 
     const body = parseRequestBody();
     expect(body.data).toEqual(
       expect.objectContaining({
-        model: 'gpt-4o-mini-tts',
-        jaVoiceName: 'nova',
-        enVoiceName: 'nova',
-        instructionsJa: '落ち着いた女性の声で',
-        instructionsEn: 'calm female voice',
+        jaVoiceName: 'ja-JP-Standard-B',
+        enVoiceName: 'en-US-Standard-G',
       })
     );
+    // Standard 系にはモデル指定も読み方のプロンプト指示も無く、Worker は
+    // 受け取っても無視するため送らない
+    expect(body.data).not.toHaveProperty('model');
+    expect(body.data).not.toHaveProperty('instructionsJa');
+    expect(body.data).not.toHaveProperty('instructionsEn');
   });
 
   it('日本語のみ要求した場合は英語を送らず英語パスも返さない', async () => {
@@ -305,8 +305,14 @@ describe('fetchSpeechAudio', () => {
       })
     );
 
-    await fetchSpeechAudio({ ...defaultOptions, jaVoiceName: 'nova' });
-    await fetchSpeechAudio({ ...defaultOptions, jaVoiceName: 'shimmer' });
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      jaVoiceName: 'ja-JP-Standard-B',
+    });
+    await fetchSpeechAudio({
+      ...defaultOptions,
+      jaVoiceName: 'ja-JP-Standard-C',
+    });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
@@ -430,7 +436,7 @@ describe('fetchSpeechAudio', () => {
   });
 
   it('MIME 不明でも中身が MP3 なら MP3 として保存する', async () => {
-    // gpt-4o-mini-tts の既定応答は MP3。MIME 欠落時に PCM 扱いして WAV ヘッダーを
+    // Cloud TTS の既定応答は MP3。MIME 欠落時に PCM 扱いして WAV ヘッダーを
     // 被せると再生できなくなるため、先頭バイトで判定する
     // 'SUQz...' = "ID3" タグ、'/+AA' = 0xFF 0xE0 のフレーム同期
     mockFetch.mockResolvedValue(

--- a/src/utils/ttsSpeechFetcher.ts
+++ b/src/utils/ttsSpeechFetcher.ts
@@ -15,21 +15,18 @@ const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 export const MAX_FETCH_CACHE_SIZE = 50;
 
 export interface FetchSpeechOptions {
-  // 読み上げるプレーンテキスト。gpt-4o-mini-tts は SSML を解釈せずタグを
-  // そのまま読み上げてしまうため、呼び出し側で変換済みのものを渡すこと。
-  // 合成は文字数課金のため、ユーザーが無効にしている言語は空/未指定にして
-  // 送信対象から外す（両方空なら何も要求しない）。
+  // 読み上げるプレーンテキスト。Cloud TTS へは input.text として渡るため SSML は
+  // 解釈されず、タグはそのまま読み上げられてしまう。呼び出し側で変換済みのものを
+  // 渡すこと。合成は文字数課金のため、ユーザーが無効にしている言語は空/未指定に
+  // して送信対象から外す（両方空なら何も要求しない）。
   textJa?: string;
   textEn?: string;
   apiUrl: string;
   idToken: string;
-  model?: string;
+  // Cloud TTS のボイス名（例: ja-JP-Standard-B）。ロケールを含むため日英で別々に
+  // 指定する。読み上げ速度・声の高さは Worker 側の設定で決まる。
   jaVoiceName?: string;
   enVoiceName?: string;
-  // 読み方の指示 (gpt-4o-mini-tts の instructions)。SSML の代替として声色・
-  // 速度・間の取り方を指定する。
-  instructionsJa?: string;
-  instructionsEn?: string;
   timeoutMs?: number;
 }
 
@@ -85,10 +82,10 @@ const wrapPcm16LeToWav = (
   return out;
 };
 
-// MIME が欠落・不明なときに先頭バイトから形式を判定する。gpt-4o-mini-tts の
-// 既定応答は MP3 で、生 PCM が返るのは response_format を明示した場合に限られる
-// ため、判定できないバイト列を無条件に PCM 扱いすると MP3 を WAV ヘッダーで
-// 包んで再生不能にしてしまう。
+// MIME が欠落・不明なときに先頭バイトから形式を判定する。Cloud TTS の応答は
+// MP3（既定）か RIFF ヘッダー付きの WAV(LINEAR16) で生 PCM は返らないため、
+// 判定できないバイト列を無条件に PCM 扱いすると MP3 を WAV ヘッダーで包んで
+// 再生不能にしてしまう。
 const sniffAudioFormat = (bytes: Uint8Array): 'mp3' | 'wav' | 'unknown' => {
   // "RIFF" .... "WAVE"
   if (
@@ -148,7 +145,7 @@ const normalizeAudioForFile = (
   }
 
   // MIME 不明時は中身から判定する。どちらとも判定できなければ生 PCM とみなして
-  // WAV 化する（旧 API の既定挙動に合わせたフォールバック）。
+  // WAV 化する（生 PCM を返し得た旧合成エンジン向けに残している保険）。
   const sniffed = sniffAudioFormat(bytes);
   if (sniffed !== 'unknown') {
     return { bytes, ext: sniffed };
@@ -207,7 +204,6 @@ const stripMacrons = (text: string): string =>
 const buildCacheKey = (opts: {
   textJa: string;
   textEn: string;
-  model?: string;
   jaVoiceName?: string;
   enVoiceName?: string;
 }): string =>
@@ -216,7 +212,6 @@ const buildCacheKey = (opts: {
     // 日本語のみ・英語のみ・両方のリクエストが別エントリとして区別される
     opts.textJa,
     opts.textEn,
-    normalizeOptional(opts.model),
     normalizeOptional(opts.jaVoiceName),
     normalizeOptional(opts.enVoiceName),
   ].join('\0');
@@ -236,11 +231,8 @@ export const fetchSpeechAudio = async (
     textEn,
     apiUrl,
     idToken,
-    model,
     jaVoiceName,
     enVoiceName,
-    instructionsJa,
-    instructionsEn,
     timeoutMs = TTS_FETCH_TIMEOUT_MS,
   } = options;
   // 0・負値・NaN・Infinity が明示的に渡された場合もタイムアウト保護が
@@ -261,14 +253,12 @@ export const fetchSpeechAudio = async (
     return null;
   }
 
-  const normalizedModel = normalizeOptional(model);
   const normalizedJaVoiceName = normalizeOptional(jaVoiceName);
   const normalizedEnVoiceName = normalizeOptional(enVoiceName);
 
   const cacheKey = buildCacheKey({
     textJa: trimmedTextJa,
     textEn: sanitizedTextEn,
-    model: normalizedModel,
     jaVoiceName: normalizedJaVoiceName,
     enVoiceName: normalizedEnVoiceName,
   });
@@ -276,9 +266,6 @@ export const fetchSpeechAudio = async (
   if (cached) {
     return cached;
   }
-
-  const normalizedInstructionsJa = normalizeOptional(instructionsJa);
-  const normalizedInstructionsEn = normalizeOptional(instructionsEn);
 
   // 要求しない言語のフィールドは送らない。Worker 側は届いた言語だけを合成する。
   const reqBody = {
@@ -289,9 +276,6 @@ export const fetchSpeechAudio = async (
             ...(normalizedJaVoiceName
               ? { jaVoiceName: normalizedJaVoiceName }
               : {}),
-            ...(normalizedInstructionsJa
-              ? { instructionsJa: normalizedInstructionsJa }
-              : {}),
           }
         : {}),
       ...(wantsEn
@@ -300,12 +284,8 @@ export const fetchSpeechAudio = async (
             ...(normalizedEnVoiceName
               ? { enVoiceName: normalizedEnVoiceName }
               : {}),
-            ...(normalizedInstructionsEn
-              ? { instructionsEn: normalizedInstructionsEn }
-              : {}),
           }
         : {}),
-      ...(normalizedModel ? { model: normalizedModel } : {}),
     },
   };
 


### PR DESCRIPTION
## 概要

リモート TTS の合成エンジンが Worker 側で OpenAI (`gpt-4o-mini-tts`) から Google Cloud Text-to-Speech へ全面移行された（[TrainLCD/functions](https://github.com/TrainLCD/functions) の `bf4776d`）ため、アプリが送るリクエスト内容と設計書を新しい契約へ追従させる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `REMOTE_TTS_VOICE`（`nova`）を言語別の `REMOTE_TTS_VOICE_JA` = `ja-JP-Standard-B` / `REMOTE_TTS_VOICE_EN` = `en-US-Standard-G` へ分割。Cloud TTS のボイス名は `<言語>-<地域>-<系統>-<記号>` でロケールを含むため、日英共通のプリセットが存在しない
- `REMOTE_TTS_MODEL` と `REMOTE_TTS_INSTRUCTIONS_JA` / `REMOTE_TTS_INSTRUCTIONS_EN` を削除し、`fetchSpeechAudio` の送信ボディからも `model` / `instructionsJa` / `instructionsEn` を除去。Standard 系ボイスにはモデル指定も読み方のプロンプト指示も無く、Worker は受け取っても無視する
- 合成結果キャッシュのキーから `model` を除去（テキスト + ボイス名で決定）
- 読み上げ速度・声の高さが Worker 側の `TTS_SPEED` / `TTS_PITCH` 管理になったことを `src/constants/tts.ts` に明記
- 旧エンジン名を参照していたコメントを更新（`speechEngine.ts` / `useTTS.ts` / `speakableText.ts` / `remoteConfig.ts` / `ttsSpeechFetcher.ts`）
- `docs/spec/tts/remote-tts.md` のリクエスト例・サーバー側実装メモ・応答形式・キャッシュ節と、`README.md` の TTS 説明を実態へ更新
- 上記に合わせて `ttsSpeechFetcher.test.ts` / `useRemoteSpeechEngine.test.ts` を更新

### 回帰リスクと緩和

- 影響範囲はリモート TTS を使う構成（既定では iOS、Android は `remote_tts_enabled_android` を `true` で配信した場合）に限られる。端末内蔵 TTS 経路（`useNativeSpeechEngine`）は変更していない
- ボイス名を Google 形式へ変えても、Worker は未知の名前をリクエスト → KV(`config:tts`) → 環境変数の順にフォールバックするため 400 にはならない。今回送る `ja-JP-Standard-B` / `en-US-Standard-G` は Worker の許可リストと既定値の両方に一致する
- 送信フィールドが減るだけで応答形式（既定 MP3）は変わらないため、`expo-audio` の再生パイプラインには影響しない
- 合成に失敗した回はこれまでどおり `onUnavailable` 経由でその放送だけ端末内蔵 TTS へフォールバックする

## テスト

ローカルで `npm run lint` / `npm test` / `npm run typecheck` を実行し、いずれも成功（227 suites / 2441 tests passed）。リモート TTS 経路の既存テスト（`ttsSpeechFetcher` / `useRemoteSpeechEngine` / `useTTS` / `FxTTS` / `remoteConfig` / `TTSSettings`）も緑であることを確認済み。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リモート音声合成エンジンを Google Cloud Text-to-Speech に移行しました。
  - 日本語・英語でそれぞれ最適化された音声を使用するようになりました。
  - 読み上げ速度と声の高さを設定に基づいて管理します。

- **ドキュメント**
  - iOS向けおよびリモートTTSの説明を、現在の音声合成エンジンに合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->