### PR TITLE
タグ作成とGitHub Release公開を手動実行できるワークフローを追加

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,79 @@
+# 手動実行でリリースタグを打ち、GitHub Release を公開するワークフロー。
+# 通常は publish-release / finalize-release スキルをローカルの gh CLI で走らせるが、
+# タグ push や Release 作成が使えない実行環境からリリースを仕上げるための経路として用意している。
+name: Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without leading v (e.g. 10.13.1)"
+        required: true
+        type: string
+      target:
+        description: "Branch or SHA to tag"
+        required: false
+        default: "master"
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  TZ: "Asia/Tokyo"
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target }}
+          fetch-depth: 0
+
+      # 破壊的操作の前に、版数・タグ重複・対象 SHA をまとめて検証する。
+      - name: Validate inputs and resolve SHA
+        id: resolve
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version は MAJOR.MINOR.PATCH 形式で指定してください: $VERSION"
+            exit 1
+          fi
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "::error::対象コミットの package.json version ($PKG_VERSION) が入力 ($VERSION) と一致しません"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "::error::タグ v$VERSION は既に存在します"
+            exit 1
+          fi
+          SHA="$(git rev-parse HEAD)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "対象 SHA: $SHA / version: v$VERSION"
+
+      - name: Create and push annotated tag
+        env:
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "v$VERSION" "$SHA"
+          git push origin "v$VERSION"
+
+      # タグは前ステップで作成済みのため --target は指定しない（既存タグが優先される）。
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## 概要

リリースタグの作成と GitHub Release の公開を `workflow_dispatch` で手動実行できるワークフロー `Publish Release` を追加します。

通常は `publish-release` / `finalize-release` スキルをローカルの `gh` CLI で実行しますが、タグ push や Release 作成が許可されていない実行環境（Claude Code のリモート実行環境など）からリリースを仕上げる経路がありませんでした。本ワークフローはその代替経路です。ローカルの既存フローは一切変更しません。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

新規ファイル `.github/workflows/publish_release.yml` のみ。アプリコードの変更はありません。

- トリガーは `workflow_dispatch` のみ（push / pull_request では発火しません）
- 入力: `version`（必須、先頭 `v` なし。例 `10.13.1`）、`target`（任意、既定 `master`）
- `permissions: contents: write`
- 破壊的操作の前に以下を検証し、いずれか失敗したら中断します
  - `version` が `MAJOR.MINOR.PATCH` 形式であること
  - 対象コミットの `package.json` の `version` が入力と一致すること
  - タグ `v<version>` が未作成であること
- 検証通過後に annotated tag `v<version>` を対象 SHA に作成して push し、`gh release create --generate-notes --latest` で Release を公開します

既存のリリース手順（`publish-release` スキル）と同じ検証項目・同じタグ形式を踏襲しています。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

本PRは `.github/workflows/` のみの変更でアプリコード（`src/` 等）を含まないため、テスト欄はチェックしていません。参考として、当ブランチ上で `npm run lint`（651 ファイル指摘なし）と `npm run typecheck`（エラーなし）は実行し、いずれも成功しています。YAML は構文パースを通して検証済みです。

ワークフロー自体の動作確認は、マージ後に `version=10.13.1` / `target=master` で dispatch して行います。

## 関連Issue

なし。

## スクリーンショット（任意）

なし（CI 設定のみの変更）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01KS9mYAZQa1SfvpRaJUqbpo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 指定したバージョンとブランチまたは SHA から、リリースを手動公開できるようになりました。
  * 入力内容や既存タグを検証し、生成ノート付きの GitHub リリースを作成します。
  * 公開したリリースを最新リリースとして設定します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->