### PR TITLE
2行種別ラベルの行送りを箱の高さにクランプして種別名が消える問題を修正

### DIFF
--- a/src/components/TrainTypeBox.test.tsx
+++ b/src/components/TrainTypeBox.test.tsx
@@ -174,6 +174,85 @@ describe('TrainTypeBox font family', () => {
   });
 });
 
+describe('TrainTypeBox 2行種別の可読性', () => {
+  const BOX_HEIGHT = 30.25;
+
+  const twoLineTrainType: TrainType = {
+    __typename: 'TrainType',
+    id: 1,
+    typeId: 1,
+    groupId: 1,
+    name: '通勤特急\n(狭山線直通)',
+    nameKatakana: 'ツウキントッキュウ',
+    nameRoman: 'Commuter\nLimited Express',
+    nameIpa: null,
+    nameRomanIpa: null,
+    nameTtsSegments: null,
+    nameChinese: '通勤特快',
+    nameKorean: '통근특급',
+    color: '#f00',
+    direction: null,
+    kind: null,
+    line: null,
+    lines: null,
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderWithScale = (fontSizeScale: number) => {
+    (useAtomValue as jest.Mock).mockImplementation((atom: unknown) => {
+      if (atom === headerStateAtom) return 'CURRENT_JA';
+      if (atom === themeAtom) return APP_THEME.TOKYO_METRO;
+      if (atom === tuningState) return { headerTransitionDelay: 1000 };
+      return undefined;
+    });
+    jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation(() => ({ start: jest.fn() }) as never);
+
+    return render(
+      <TrainTypeBox
+        trainType={twoLineTrainType}
+        fontSizeScale={fontSizeScale}
+      />
+    );
+  };
+
+  // 小田急テーマは fontSizeScale 1.2 を渡す。クランプがないと 2 行分の行送りが
+  // 箱の高さ(30.25)を超え、adjustsFontSizeToFit が高さ制約を満たせずに
+  // グリフを潰してしまい種別名が消えたように見える。
+  it.each([1, 1.2])(
+    'fontSizeScale=%p でも2行分の行送りが箱の高さに収まる',
+    (fontSizeScale) => {
+      // マウント直後はクロスフェードの新旧2層が同じ種別名を描画するため、
+      // 両方の行送りが箱に収まっていることを確認する。
+      const { getAllByText } = renderWithScale(fontSizeScale);
+      const labels = getAllByText('通勤特急\n');
+
+      expect(labels.length).toBeGreaterThan(0);
+      for (const label of labels) {
+        const style = StyleSheet.flatten(label.props.style) as {
+          lineHeight: number;
+        };
+        expect(style.lineHeight * 2).toBeLessThanOrEqual(BOX_HEIGHT);
+      }
+    }
+  );
+
+  it('adjustsFontSizeToFitの縮小下限を指定してグリフの消失を防ぐ', () => {
+    const { UNSAFE_root } = renderWithScale(1.2);
+    const texts = UNSAFE_root.findAllByType(Animated.Text);
+
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text.props.adjustsFontSizeToFit).toBe(true);
+      expect(text.props.minimumFontScale).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe('TrainTypeBox language transition', () => {
   const trainType: TrainType = {
     __typename: 'TrainType',

--- a/src/components/TrainTypeBox.test.tsx
+++ b/src/components/TrainTypeBox.test.tsx
@@ -176,6 +176,9 @@ describe('TrainTypeBox font family', () => {
 
 describe('TrainTypeBox 2行種別の可読性', () => {
   const BOX_HEIGHT = 30.25;
+  // TrainTypeBox の MINIMUM_FONT_SCALE と揃える。可読性を保てない値
+  // (0.01 など) へ緩められた場合に検知できるよう実値で固定する。
+  const MINIMUM_FONT_SCALE = 0.5;
 
   const twoLineTrainType: TrainType = {
     __typename: 'TrainType',
@@ -198,6 +201,7 @@ describe('TrainTypeBox 2行種別の可読性', () => {
   };
 
   afterEach(() => {
+    jest.clearAllMocks();
     jest.restoreAllMocks();
   });
 
@@ -248,7 +252,7 @@ describe('TrainTypeBox 2行種別の可読性', () => {
     expect(texts.length).toBeGreaterThan(0);
     for (const text of texts) {
       expect(text.props.adjustsFontSizeToFit).toBe(true);
-      expect(text.props.minimumFontScale).toBeGreaterThan(0);
+      expect(text.props.minimumFontScale).toBe(MINIMUM_FONT_SCALE);
     }
   });
 });

--- a/src/components/TrainTypeBox.tsx
+++ b/src/components/TrainTypeBox.tsx
@@ -55,16 +55,24 @@ export const resolveTrainTypeFontFamily = (
   return theme === APP_THEME.LED ? FONTS.JFDotJiskan24h : FONTS.RobotoBold;
 };
 
+// 種別箱の内寸。styles と 2 行レイアウトの高さクランプで同じ値を使う必要があるため、
+// 各所へ数値を直書きせず定数から参照する。
+const BOX_WIDTH = isTablet ? 175 : 96.25;
+const BOX_HEIGHT = isTablet ? 55 : 30.25;
+// adjustsFontSizeToFit の縮小下限。既定 (0) のままだと収まらないときに
+// グリフが潰れて種別名が消えたように見えるため、可読サイズで下げ止める。
+const MINIMUM_FONT_SCALE = 0.5;
+
 const styles = StyleSheet.create({
   box: {
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
     justifyContent: 'center',
     alignItems: 'center',
   },
   gradient: {
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
     position: 'absolute',
     borderRadius: 4,
   },
@@ -83,12 +91,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
   },
   nextTrainTypeWrapper: {
     position: 'absolute',
-    top: isTablet ? 55 : 30.25,
+    top: BOX_HEIGHT,
     alignItems: 'flex-start',
     overflow: 'visible',
     marginTop: 4,
@@ -327,6 +335,7 @@ const TrainTypeBox: React.FC<Props> = ({
     fontSizeScale,
     numberOfLines,
     prevNumberOfLines,
+    maxHeight: BOX_HEIGHT,
   });
 
   return (
@@ -374,6 +383,7 @@ const TrainTypeBox: React.FC<Props> = ({
               ],
             ]}
             adjustsFontSizeToFit
+            minimumFontScale={MINIMUM_FONT_SCALE}
             numberOfLines={numberOfLines}
           >
             {trainTypeName}
@@ -393,6 +403,7 @@ const TrainTypeBox: React.FC<Props> = ({
             },
           ]}
           adjustsFontSizeToFit
+          minimumFontScale={MINIMUM_FONT_SCALE}
           numberOfLines={prevNumberOfLines}
         >
           {prevTrainTypeName}

--- a/src/components/TrainTypeBoxJRKyushu.tablet.test.tsx
+++ b/src/components/TrainTypeBoxJRKyushu.tablet.test.tsx
@@ -1,0 +1,102 @@
+import { render } from '@testing-library/react-native';
+import { Animated, StyleSheet, View } from 'react-native';
+import type { TrainType } from '~/@types/graphql';
+import TrainTypeBoxJRKyushu from './TrainTypeBoxJRKyushu';
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  return {
+    ...Reanimated,
+    useSharedValue: jest.fn(() => ({ value: 1 })),
+    useAnimatedStyle: jest.fn(() => ({})),
+    withTiming: jest.fn((value) => value),
+    runOnJS: jest.fn((fn) => fn),
+    Easing: {
+      ease: jest.fn(),
+    },
+  };
+});
+
+jest.mock('~/hooks/useLazyPrevious', () => ({
+  useLazyPrevious: jest.fn((value) => value),
+}));
+
+// styles は module ロード時に確定するため、タブレット寸法は別ファイルで検証する。
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: true,
+}));
+
+describe('TrainTypeBoxJRKyushu - tablet', () => {
+  const TABLET_BOX_WIDTH = 175;
+  const TABLET_BOX_HEIGHT = 55;
+
+  const mockTrainType: TrainType = {
+    __typename: 'TrainType',
+    id: 1,
+    typeId: 1,
+    groupId: 1,
+    name: 'Test',
+    nameKatakana: 'テスト',
+    nameRoman: 'Test',
+    nameIpa: null,
+    nameRomanIpa: null,
+    nameTtsSegments: null,
+    nameChinese: '测试',
+    nameKorean: '테스트',
+    color: '#000000',
+    direction: undefined,
+    kind: undefined,
+    line: undefined,
+    lines: undefined,
+  };
+
+  const twoLineTrainType: TrainType = {
+    ...mockTrainType,
+    name: '特急\nゆふいんの森',
+    nameRoman: 'Limited Express\nYufuin no Mori',
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  // 寸法を持つViewはboxとtextWrapperの2つだけ。
+  const collectSizedViewStyles = (root: ReturnType<typeof render>) =>
+    root
+      .UNSAFE_getAllByType(View)
+      .map((view) => StyleSheet.flatten(view.props.style))
+      .filter(
+        (style): style is { width: number; height: number } =>
+          typeof style?.width === 'number' && typeof style?.height === 'number'
+      );
+
+  it('textWrapperの内寸がタブレット時のboxと一致する', () => {
+    const sizes = collectSizedViewStyles(
+      render(<TrainTypeBoxJRKyushu trainType={mockTrainType} />)
+    );
+
+    expect(sizes).toHaveLength(2);
+    for (const size of sizes) {
+      expect(size.width).toBe(TABLET_BOX_WIDTH);
+      expect(size.height).toBe(TABLET_BOX_HEIGHT);
+    }
+  });
+
+  it('2行種別の行送り2行分がタブレット時の箱の高さに収まる', () => {
+    const view = render(<TrainTypeBoxJRKyushu trainType={twoLineTrainType} />);
+    // クロスフェードの新旧2層とも2行レイアウトで描画される。
+    const labels = view
+      .UNSAFE_getAllByType(Animated.Text)
+      .filter((label) => label.props.numberOfLines === 2);
+
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      const { lineHeight } = StyleSheet.flatten(label.props.style) as {
+        lineHeight: number;
+      };
+      expect(lineHeight * 2).toBeLessThanOrEqual(TABLET_BOX_HEIGHT);
+    }
+  });
+});

--- a/src/components/TrainTypeBoxJRKyushu.test.tsx
+++ b/src/components/TrainTypeBoxJRKyushu.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import TrainTypeBoxJRKyushu from './TrainTypeBoxJRKyushu';
 
@@ -128,6 +129,56 @@ describe('TrainTypeBoxJRKyushu', () => {
       expect(() => {
         render(<TrainTypeBoxJRKyushu trainType={null} />);
       }).not.toThrow();
+    });
+  });
+
+  describe('種別箱のレイアウト', () => {
+    const twoLineTrainType: TrainType = {
+      ...mockTrainType,
+      name: '特急\nゆふいんの森',
+      nameRoman: 'Limited Express\nYufuin no Mori',
+    };
+
+    // 寸法を持つViewはboxとtextWrapperの2つだけ。
+    const collectSizedViewStyles = (root: ReturnType<typeof render>) =>
+      root
+        .UNSAFE_getAllByType(View)
+        .map((view) => StyleSheet.flatten(view.props.style))
+        .filter(
+          (style): style is { width: number; height: number } =>
+            typeof style?.width === 'number' &&
+            typeof style?.height === 'number'
+        );
+
+    // textWrapperにbox(128x35)より小さい旧内寸(96.25x30.25)が残っていると、
+    // 種別名が箱からはみ出して潰れる。両者が同じ内寸であることを固定する。
+    it('textWrapperの内寸がboxと一致する', () => {
+      const sizes = collectSizedViewStyles(
+        render(<TrainTypeBoxJRKyushu trainType={mockTrainType} />)
+      );
+
+      expect(sizes).toHaveLength(2);
+      expect(sizes[1].width).toBe(sizes[0].width);
+      expect(sizes[1].height).toBe(sizes[0].height);
+    });
+
+    it('2行種別の行送り2行分が箱の高さに収まる', () => {
+      const view = render(
+        <TrainTypeBoxJRKyushu trainType={twoLineTrainType} />
+      );
+      const boxHeight = collectSizedViewStyles(view)[0].height;
+      // クロスフェードの新旧2層とも2行レイアウトで描画される。
+      const labels = view
+        .UNSAFE_getAllByType(Animated.Text)
+        .filter((label) => label.props.numberOfLines === 2);
+
+      expect(labels.length).toBeGreaterThan(0);
+      for (const label of labels) {
+        const { lineHeight } = StyleSheet.flatten(label.props.style) as {
+          lineHeight: number;
+        };
+        expect(lineHeight * 2).toBeLessThanOrEqual(boxHeight);
+      }
     });
   });
 });

--- a/src/components/TrainTypeBoxJRKyushu.tsx
+++ b/src/components/TrainTypeBoxJRKyushu.tsx
@@ -30,10 +30,15 @@ type Props = {
   trainType: TrainType | null;
 };
 
+// 種別箱の内寸。styles と 2 行レイアウトの高さクランプで同じ値を使う必要があるため、
+// 各所へ数値を直書きせず定数から参照する。
+const BOX_WIDTH = isTablet ? 175 : 128;
+const BOX_HEIGHT = isTablet ? 55 : 35;
+
 const styles = StyleSheet.create({
   box: {
-    width: isTablet ? 175 : 128,
-    height: isTablet ? 55 : 35,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#fff',
@@ -50,8 +55,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    // box より小さい旧値(96.25 x 30.25)が残っており、種別名が箱からはみ出して
+    // 潰れる原因になっていたため box と同じ内寸に揃える。
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
   },
 });
 
@@ -221,6 +228,7 @@ const TrainTypeBoxJRKyushu: React.FC<Props> = ({ trainType }: Props) => {
     isTablet,
     numberOfLines,
     prevNumberOfLines,
+    maxHeight: BOX_HEIGHT,
   });
 
   return (

--- a/src/components/TrainTypeBoxSaikyo.test.tsx
+++ b/src/components/TrainTypeBoxSaikyo.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
+import { computeTwoLineTypography } from '~/utils/computeTwoLineTypography';
 import TrainTypeBoxSaikyo from './TrainTypeBoxSaikyo';
 
 // Mock dependencies
@@ -23,6 +24,15 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('~/hooks/useLazyPrevious', () => ({
   useLazyPrevious: jest.fn((value) => value),
 }));
+
+// 実計算はそのまま使いつつ、maxHeight の結線自体を検証できるよう呼び出しを記録する
+jest.mock('~/utils/computeTwoLineTypography', () => {
+  const actual = jest.requireActual('~/utils/computeTwoLineTypography');
+  return {
+    ...actual,
+    computeTwoLineTypography: jest.fn(actual.computeTwoLineTypography),
+  };
+});
 
 // LinearGradientのcolors propをDOM上から取得できるようにする
 jest.mock('expo-linear-gradient', () => {
@@ -237,9 +247,18 @@ describe('TrainTypeBoxSaikyo', () => {
       nameRoman: 'Commuter Rapid\nvia Kawagoe Line',
     };
 
-    // computeTwoLineTypography へ箱の高さを渡さなくなると 2 行分の行送りが
-    // 箱を超え、adjustsFontSizeToFit が高さ制約を満たせずグリフが潰れる。
-    // maxHeight の結線が外れた場合に検知できるよう不変条件を固定する。
+    // 埼京線版は現行値では maxHeight なしでも箱に収まるため、行送りの確認だけでは
+    // 結線が外れても検知できない。渡している maxHeight 自体を検証して固定する。
+    it('2行種別で箱の高さをmaxHeightとして渡す', () => {
+      render(
+        <TrainTypeBoxSaikyo lineColor="#00ac9a" trainType={twoLineTrainType} />
+      );
+
+      expect(computeTwoLineTypography).toHaveBeenCalledWith(
+        expect.objectContaining({ maxHeight: SAIKYO_BOX_HEIGHT })
+      );
+    });
+
     it('2行種別の行送り2行分が箱の高さに収まる', () => {
       const { UNSAFE_getAllByType } = render(
         <TrainTypeBoxSaikyo lineColor="#00ac9a" trainType={twoLineTrainType} />
@@ -249,7 +268,7 @@ describe('TrainTypeBoxSaikyo', () => {
         (label) => label.props.numberOfLines === 2
       );
 
-      expect(labels.length).toBeGreaterThan(0);
+      expect(labels).toHaveLength(2);
       for (const label of labels) {
         const { lineHeight } = StyleSheet.flatten(label.props.style) as {
           lineHeight: number;

--- a/src/components/TrainTypeBoxSaikyo.test.tsx
+++ b/src/components/TrainTypeBoxSaikyo.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
+import { Animated, StyleSheet } from 'react-native';
 import type { TrainType } from '~/@types/graphql';
 import { TrainTypeKind } from '~/@types/graphql';
 import TrainTypeBoxSaikyo from './TrainTypeBoxSaikyo';
@@ -66,6 +67,9 @@ const TestSplitFunction = ({
 
   return null; // We just care that the component doesn't crash
 };
+
+// TrainTypeBoxSaikyo の BOX_HEIGHT (スマホ時) と揃える。
+const SAIKYO_BOX_HEIGHT = 30.25;
 
 describe('TrainTypeBoxSaikyo', () => {
   const mockTrainType: TrainType = {
@@ -223,6 +227,35 @@ describe('TrainTypeBoxSaikyo', () => {
         />
       );
       expect(hasGradientWithColor(queryAllByTestId, '#abcdef')).toBe(true);
+    });
+  });
+
+  describe('種別箱のレイアウト', () => {
+    const twoLineTrainType: TrainType = {
+      ...mockTrainType,
+      name: '通勤快速\n(川越線直通)',
+      nameRoman: 'Commuter Rapid\nvia Kawagoe Line',
+    };
+
+    // computeTwoLineTypography へ箱の高さを渡さなくなると 2 行分の行送りが
+    // 箱を超え、adjustsFontSizeToFit が高さ制約を満たせずグリフが潰れる。
+    // maxHeight の結線が外れた場合に検知できるよう不変条件を固定する。
+    it('2行種別の行送り2行分が箱の高さに収まる', () => {
+      const { UNSAFE_getAllByType } = render(
+        <TrainTypeBoxSaikyo lineColor="#00ac9a" trainType={twoLineTrainType} />
+      );
+      // クロスフェードの新旧2層とも2行レイアウトで描画される。
+      const labels = UNSAFE_getAllByType(Animated.Text).filter(
+        (label) => label.props.numberOfLines === 2
+      );
+
+      expect(labels.length).toBeGreaterThan(0);
+      for (const label of labels) {
+        const { lineHeight } = StyleSheet.flatten(label.props.style) as {
+          lineHeight: number;
+        };
+        expect(lineHeight * 2).toBeLessThanOrEqual(SAIKYO_BOX_HEIGHT);
+      }
     });
   });
 });

--- a/src/components/TrainTypeBoxSaikyo.tsx
+++ b/src/components/TrainTypeBoxSaikyo.tsx
@@ -37,6 +37,11 @@ type Props = {
   lineColor: string;
 };
 
+// 種別箱の内寸。styles と 2 行レイアウトの高さクランプで同じ値を使う必要があるため、
+// 各所へ数値を直書きせず定数から参照する。
+const BOX_WIDTH = isTablet ? 175 : 96.25;
+const BOX_HEIGHT = isTablet ? 55 : 30.25;
+
 const styles = StyleSheet.create({
   root: {
     justifyContent: 'center',
@@ -50,16 +55,16 @@ const styles = StyleSheet.create({
     borderColor: 'white',
   },
   container: {
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
     borderBottomLeftRadius: isTablet ? 8 : 4,
     borderBottomRightRadius: isTablet ? 8 : 4,
     overflow: 'hidden',
     position: 'relative',
   },
   gradient: {
-    width: isTablet ? 175 : 96.25,
-    height: isTablet ? 55 : 30.25,
+    width: BOX_WIDTH,
+    height: BOX_HEIGHT,
     position: 'absolute',
   },
   text: {
@@ -267,6 +272,7 @@ const TrainTypeBoxSaikyo: React.FC<Props> = ({
     isTablet,
     numberOfLines,
     prevNumberOfLines,
+    maxHeight: BOX_HEIGHT,
   });
 
   return (

--- a/src/utils/computeTwoLineTypography.test.ts
+++ b/src/utils/computeTwoLineTypography.test.ts
@@ -48,6 +48,64 @@ describe('computeTwoLineTypography', () => {
     expect(result.fontSize).toBe(18 * 0.5);
   });
 
+  it('maxHeight未指定なら従来通りクランプしない', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      fontSizeScale: 1.2,
+      numberOfLines: 2,
+      prevNumberOfLines: 2,
+    });
+    expect(result.lineHeight).toBeCloseTo(18 * 1.2 * 0.7 * 1.05);
+  });
+
+  it('2行分の行送りがmaxHeightを超えるときはfontSizeとlineHeightを縮める', () => {
+    // 小田急テーマ(fontSizeScale 1.2)のスマホ実寸。
+    // クランプなしでは 15.876 * 2 = 31.752 > 30.25 となり箱に収まらない。
+    const maxHeight = 30.25;
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      fontSizeScale: 1.2,
+      numberOfLines: 2,
+      prevNumberOfLines: 2,
+      maxHeight,
+    });
+
+    expect(result.lineHeight).toBeCloseTo(maxHeight / 2);
+    expect((result.lineHeight as number) * 2).toBeLessThanOrEqual(maxHeight);
+    expect(result.fontSize).toBeCloseTo(maxHeight / 2 / 1.05);
+    expect(result.fontSize).toBeLessThan(18 * 1.2 * 0.7);
+    expect((result.prevLineHeight as number) * 2).toBeLessThanOrEqual(
+      maxHeight
+    );
+  });
+
+  it('2行分の行送りがmaxHeightに収まるときは縮めない', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      numberOfLines: 2,
+      prevNumberOfLines: 2,
+      maxHeight: 30.25,
+    });
+    expect(result.fontSize).toBeCloseTo(18 * 0.7);
+    expect(result.lineHeight).toBeCloseTo(18 * 0.7 * 1.05);
+  });
+
+  it('1行のときはmaxHeightを指定してもlineHeightを付けない', () => {
+    const result = computeTwoLineTypography({
+      baseFontSize: 18,
+      isTablet: false,
+      fontSizeScale: 1.2,
+      numberOfLines: 1,
+      prevNumberOfLines: 1,
+      maxHeight: 30.25,
+    });
+    expect(result.fontSize).toBeCloseTo(18 * 1.2);
+    expect(result.lineHeight).toBeUndefined();
+  });
+
   it('currentとprevで異なるnumberOfLinesに対応する', () => {
     const result = computeTwoLineTypography({
       baseFontSize: 21,

--- a/src/utils/computeTwoLineTypography.ts
+++ b/src/utils/computeTwoLineTypography.ts
@@ -15,6 +15,17 @@ export type TwoLineTypographyArgs = {
   fontSizeScale?: number;
   numberOfLines: 1 | 2;
   prevNumberOfLines: 1 | 2;
+  /**
+   * 種別箱の内寸高さ。指定すると 2 行分の行送りが必ずこの高さへ収まるよう
+   * fontSize / lineHeight を縮める。
+   *
+   * adjustsFontSizeToFit は fontSize だけを縮め、明示指定した lineHeight は
+   * 縮めない。そのため `lineHeight * 2` が箱の高さを超えていると、
+   * どれだけ字を小さくしても高さ制約を満たせず、グリフが潰れて種別名が
+   * 消えたように見える (例: fontSizeScale 1.2 の小田急テーマ + 改行入り種別)。
+   * ここで上限クランプしておくことで、その状態自体を発生させない。
+   */
+  maxHeight?: number;
 };
 
 export type TwoLineTypographyResult = {
@@ -24,11 +35,30 @@ export type TwoLineTypographyResult = {
   prevLineHeight: number | undefined;
 };
 
-const resolve = (effectiveBase: number, lines: 1 | 2) => {
-  const fontSize =
-    lines === 2 ? effectiveBase * TWO_LINE_FONT_SCALE : effectiveBase;
-  const lineHeight =
-    lines === 2 ? fontSize * TWO_LINE_LINE_HEIGHT_MULTIPLIER : undefined;
+const resolve = (
+  effectiveBase: number,
+  lines: 1 | 2,
+  maxHeight: number | undefined
+) => {
+  if (lines === 1) {
+    return { fontSize: effectiveBase, lineHeight: undefined };
+  }
+
+  const fontSize = effectiveBase * TWO_LINE_FONT_SCALE;
+  const lineHeight = fontSize * TWO_LINE_LINE_HEIGHT_MULTIPLIER;
+
+  if (
+    maxHeight !== undefined &&
+    maxHeight > 0 &&
+    lineHeight * lines > maxHeight
+  ) {
+    const clampedLineHeight = maxHeight / lines;
+    return {
+      fontSize: clampedLineHeight / TWO_LINE_LINE_HEIGHT_MULTIPLIER,
+      lineHeight: clampedLineHeight,
+    };
+  }
+
   return { fontSize, lineHeight };
 };
 
@@ -38,12 +68,13 @@ export const computeTwoLineTypography = ({
   fontSizeScale = 1,
   numberOfLines,
   prevNumberOfLines,
+  maxHeight,
 }: TwoLineTypographyArgs): TwoLineTypographyResult => {
   const effectiveBase =
     baseFontSize * (isTablet ? TABLET_FONT_MULTIPLIER : 1) * fontSizeScale;
 
-  const current = resolve(effectiveBase, numberOfLines);
-  const prev = resolve(effectiveBase, prevNumberOfLines);
+  const current = resolve(effectiveBase, numberOfLines, maxHeight);
+  const prev = resolve(effectiveBase, prevNumberOfLines, maxHeight);
 
   return {
     fontSize: current.fontSize,


### PR DESCRIPTION
## 概要

TrainTypeBox の種別名がたまに消える問題を修正する。

`adjustsFontSizeToFit` は `fontSize` のみを縮小し、明示指定した `lineHeight` は縮めない。そのため 2 行分の行送り (`lineHeight × 2`) が種別箱の固定高さを超えていると、**どれだけ字を小さくしても高さ制約を満たせず**、`minimumFontScale` の既定値が 0 であることと相まってグリフが潰れきり、種別名が消えたように見えていた。

改行入りの種別名 (`numberOfLines === 2`) のときだけ `lineHeight` が明示指定されるため、症状が「たまに」発生していた。

実際に破綻していた条件 (`src/components/HeaderOdakyu.tsx` の `fontSizeScale: 1.2`):

| 条件 | 2行分の行送り | 箱の高さ | 判定 |
| ---- | ---- | ---- | ---- |
| スマホ・通常テーマ | 26.46 | 30.25 | 収まる |
| **スマホ・小田急テーマ** | **31.75** | **30.25** | **破綻** |
| タブレット・小田急テーマ | 47.63 | 55 | 収まる |

また `TrainTypeBoxJRKyushu` は `textWrapper` に旧内寸 (96.25 × 30.25) が残っており、`box` (128 × 35) より小さい枠へ種別名を押し込んでいた。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `computeTwoLineTypography` に `maxHeight` を追加し、2 行分の行送りが必ず箱の高さへ収まるよう `fontSize` / `lineHeight` を上限クランプする（根本修正）
- `TrainTypeBox` / `TrainTypeBoxSaikyo` / `TrainTypeBoxJRKyushu` から箱の内寸を `maxHeight` として渡す。内寸は `BOX_WIDTH` / `BOX_HEIGHT` として定数化し、スタイルとクランプで同じ値を参照するようにしてドリフトを防ぐ
- `TrainTypeBox` の `adjustsFontSizeToFit` に `minimumFontScale` を指定し、想定外の窮屈なレイアウトでもグリフが消えないよう下げ止める
- `TrainTypeBoxJRKyushu` の `textWrapper` に残っていた旧内寸 (96.25 × 30.25) を `box` (128 × 35) へ揃え、種別名が箱からはみ出さないようにする
- テストを追加
  - `computeTwoLineTypography`: クランプの発火・非発火条件 4 件
  - `TrainTypeBox`: 行送りが箱に収まること・`minimumFontScale` の実値固定 3 件
  - `TrainTypeBoxJRKyushu`: `box` と `textWrapper` の内寸一致、行送りの不変条件（スマホ / タブレット各 2 件）
  - `TrainTypeBoxSaikyo`: `maxHeight` の結線検証、行送りの不変条件 2 件

### 検証の性質（回帰テストとガードの区別）

修正前の状態へ戻して実際に失敗を再現できたのは以下の 3 件。

| テスト | 種別 |
| --- | --- |
| `TrainTypeBox`: `fontSizeScale=1.2` で `lineHeight × 2 > 30.25` を検出 | ✅ 回帰テスト |
| `TrainTypeBoxJRKyushu`（スマホ）: `textWrapper` を旧内寸へ戻すと内寸一致テストが失敗 | ✅ 回帰テスト |
| `TrainTypeBoxSaikyo`: `maxHeight` の結線を外すと呼び出し検証が失敗 | ✅ 回帰テスト |
| `TrainTypeBoxJRKyushu`（タブレット） | ガード |

埼京線版は `baseFontSize: 18` かつ `fontSizeScale` を受け取らないため 2 行の行送りは `26.46` で、行送りの確認だけでは `maxHeight` の結線解除を検出できなかった。そのため `computeTwoLineTypography` の呼び出しを記録し、渡している `maxHeight` を直接検証している。

JR九州のタブレット分岐は旧値でも `175 × 55` で `box` と一致しており、内寸ドリフトはスマホ側のみで発生していた。タブレット側のテストは将来分岐がずれた場合に検知するためのガード。

### 退行リスクと緩和

- **クランプは 2 行レイアウトかつ `maxHeight` 指定時のみ発火する。** 1 行時の `fontSize` / `lineHeight` は従来どおりで、`maxHeight` 未指定の呼び出しも従来の計算結果を保つ（`maxHeight未指定なら従来通りクランプしない` テストで固定）。
- 現行構成でクランプが実際に発火するのは小田急テーマ（`fontSizeScale: 1.2`）のスマホ表示のみ。それ以外のテーマ・タブレットは既に箱へ収まっており、算出値は変わらない。
- `minimumFontScale` の追加は縮小の下限を設けるだけで、収まるケースの見た目には影響しない。
- `TrainTypeBoxJRKyushu` の `textWrapper` 拡大は `box` の実寸に合わせる是正であり、テキストは引き続き中央寄せのまま。

## テスト

ローカルで下記コマンドを実行し、いずれも成功することを確認済み（228 suites / 2474 tests）。

なお、この作業環境にはシミュレータ／実機が無いため**目視確認は未実施**。`adjustsFontSizeToFit` と `lineHeight` の組み合わせはネイティブ描画に依存し Jest では見た目を確認できないため、小田急テーマ + 改行入り種別、および JR九州向け表示の確認をお願いしたい。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

チャットでの不具合報告から着手したため、リンクする既存 Issue はなし。

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 種別表示ボックスの幅・高さを統一し、画面サイズに応じたレイアウトの安定性を向上しました。
  - 2行表示時の文字サイズと行間をボックス内に収まるよう自動調整し、文字の欠けやはみ出しを防止しました。
  - 現在・前回の種別名表示に最小文字サイズを設定し、読みやすさを改善しました。

- **品質向上**
  - スマートフォンやタブレットでの表示レイアウトを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->