### PR TITLE
種別変更駅の特定を現在駅より先の区間に限定して通過済み駅の誤表示を修正

### DIFF
--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -552,6 +552,32 @@ describe('TypeChangeNotify', () => {
       expect(queryAllByText(/Odawara/)).toHaveLength(0);
     });
 
+    it('現在駅より先に種別変更駅が無い場合は通過済み駅にフォールバックしない', () => {
+      // 現在駅(新宿)より先はすべて同一種別で、通過済みの高崎線内にのみ
+      // nextTrainTypeと同じ普通が存在する経路
+      const noChangeAheadStations = [
+        inboundStations[0],
+        inboundStations[1],
+        inboundStations[2],
+        inboundStations[3],
+        inboundStations[4],
+      ];
+
+      setupMocks({
+        stations: noChangeAheadStations,
+        currentStation: noChangeAheadStations[2],
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/前橋/)).toHaveLength(0);
+      expect(queryAllByText(/Maebashi/)).toHaveLength(0);
+      expect(queryAllByText(/大船/)).toHaveLength(0);
+      expect(queryAllByText(/Ofuna/)).toHaveLength(0);
+    });
+
     // 現在駅が経路内に見つからない場合は境界を特定できないため、経路全体から
     // 推定する従来のロジックへフォールバックする。進行方向より手前の区間を
     // 除外できないベストエフォートの挙動であることを明示的に固定しておく。

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -505,6 +505,30 @@ describe('TypeChangeNotify', () => {
       expect(queryAllByText(/Maebashi/)).toHaveLength(0);
     });
 
+    it('INBOUND時に種別情報のない駅が挟まっても現在種別の最終駅を表示する', () => {
+      const stationsWithUnknownType = [
+        inboundStations[2],
+        inboundStations[3],
+        // trainTypeが取得できない駅
+        { ...inboundStations[4], id: 99, groupId: 99, trainType: undefined },
+        inboundStations[5],
+        inboundStations[6],
+      ];
+
+      setupMocks({
+        stations: stationsWithUnknownType,
+        currentStation: stationsWithUnknownType[0],
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/渋谷/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Shibuya/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/大船/)).toHaveLength(0);
+    });
+
     it('INBOUND時に現在の種別が経路の後方で再度現れても最初に変わる駅を表示する', () => {
       const typeRevertingStations = [
         inboundStations[2],

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -332,6 +332,203 @@ describe('TypeChangeNotify', () => {
     expect(odakyuTexts).toHaveLength(0);
   });
 
+  describe('種別が変わる駅の特定', () => {
+    const jrEast = { id: 1, nameShort: 'JR東日本' };
+    const shonanShinjukuLine = {
+      id: 11302,
+      nameShort: '湘南新宿ライン',
+      nameRoman: 'Shonan-Shinjuku Line',
+      color: '#E21F26',
+      company: jrEast,
+    };
+    const takasakiLine = {
+      id: 11332,
+      nameShort: '高崎線',
+      nameRoman: 'Takasaki Line',
+      color: '#F68B1E',
+      company: jrEast,
+    };
+    const tokaidoLine = {
+      id: 11301,
+      nameShort: '東海道線',
+      nameRoman: 'Tokaido Line',
+      color: '#F68B1E',
+      company: jrEast,
+    };
+
+    // 高崎線内は普通、湘南新宿ライン内は快速、東海道線内は普通に変わる経路。
+    // 高崎線内の普通と東海道線内の普通は同一の typeId を持つ。
+    const localType = { typeId: 1, name: '普通', nameRoman: 'Local' };
+    const rapidType = { typeId: 2, name: '快速', nameRoman: 'Rapid' };
+
+    // 前橋→小田原の進行方向順(INBOUND時の stations の並び)
+    const inboundStations = [
+      {
+        id: 1,
+        groupId: 1,
+        name: '前橋',
+        nameRoman: 'Maebashi',
+        line: takasakiLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 2,
+        groupId: 2,
+        name: '大宮',
+        nameRoman: 'Omiya',
+        line: shonanShinjukuLine,
+        trainType: rapidType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 3,
+        groupId: 3,
+        name: '新宿',
+        nameRoman: 'Shinjuku',
+        line: shonanShinjukuLine,
+        trainType: rapidType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 4,
+        groupId: 4,
+        name: '渋谷',
+        nameRoman: 'Shibuya',
+        line: shonanShinjukuLine,
+        trainType: rapidType,
+        stopCondition: 'STOP',
+      },
+      // 直通の境界駅は路線ごとに1駅ずつ現れる
+      {
+        id: 5,
+        groupId: 5,
+        name: '大船',
+        nameRoman: 'Ofuna',
+        line: shonanShinjukuLine,
+        trainType: rapidType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 6,
+        groupId: 5,
+        name: '大船',
+        nameRoman: 'Ofuna',
+        line: tokaidoLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 7,
+        groupId: 6,
+        name: '小田原',
+        nameRoman: 'Odawara',
+        line: tokaidoLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+    ];
+
+    const setupMocks = ({
+      stations,
+      currentStation,
+      selectedDirection,
+      selectedBound,
+    }: {
+      stations: unknown[];
+      currentStation: unknown;
+      selectedDirection: 'INBOUND' | 'OUTBOUND';
+      selectedBound: { name: string; nameRoman: string };
+    }) => {
+      const {
+        useCurrentLine,
+        useCurrentStation,
+        useCurrentTrainType,
+        useNextTrainType,
+      } = require('~/hooks');
+
+      useCurrentLine.mockReturnValue(shonanShinjukuLine);
+      useCurrentStation.mockReturnValue(currentStation);
+      useCurrentTrainType.mockReturnValue({
+        ...rapidType,
+        color: '#E21F26',
+        line: shonanShinjukuLine,
+      });
+      useNextTrainType.mockReturnValue({
+        ...localType,
+        color: '#F68B1E',
+        line: tokaidoLine,
+      });
+
+      mockAtomValues({
+        stations,
+        selectedDirection,
+        selectedBound,
+        enabledLanguages: ['JA', 'EN'],
+      });
+    };
+
+    it('OUTBOUND時に通過済みの同一種別区間の駅を種別変更駅として表示しない', () => {
+      // OUTBOUND では stations が進行方向と逆順(小田原→前橋)で保持される
+      const outboundStations = inboundStations.slice().reverse();
+
+      setupMocks({
+        stations: outboundStations,
+        // 新宿から乗車し小田原へ向かう
+        currentStation: outboundStations[4],
+        selectedDirection: 'OUTBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      // 進行方向で最初に普通となる大船が表示され、通過済みの前橋は表示されない
+      expect(queryAllByText(/大船/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Ofuna/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/前橋/)).toHaveLength(0);
+      expect(queryAllByText(/Maebashi/)).toHaveLength(0);
+    });
+
+    it('INBOUND時は現在駅より先で種別が変わる駅を表示する', () => {
+      setupMocks({
+        stations: inboundStations,
+        currentStation: inboundStations[2],
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/大船/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Ofuna/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/前橋/)).toHaveLength(0);
+      expect(queryAllByText(/Maebashi/)).toHaveLength(0);
+    });
+
+    it('INBOUND時に現在の種別が経路の後方で再度現れても最初に変わる駅を表示する', () => {
+      const typeRevertingStations = [
+        inboundStations[2],
+        inboundStations[3],
+        inboundStations[5],
+        { ...inboundStations[6], trainType: rapidType },
+      ];
+
+      setupMocks({
+        stations: typeRevertingStations,
+        currentStation: typeRevertingStations[0],
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '熱海', nameRoman: 'Atami' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/渋谷/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Shibuya/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/小田原/)).toHaveLength(0);
+      expect(queryAllByText(/Odawara/)).toHaveLength(0);
+    });
+  });
+
   describe('enabledLanguages による表示切替', () => {
     const setupLanguageScenario = (enabledLanguages: string[]) => {
       const {

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -551,6 +551,49 @@ describe('TypeChangeNotify', () => {
       expect(queryAllByText(/小田原/)).toHaveLength(0);
       expect(queryAllByText(/Odawara/)).toHaveLength(0);
     });
+
+    // 現在駅が経路内に見つからない場合は境界を特定できないため、経路全体から
+    // 推定する従来のロジックへフォールバックする。進行方向より手前の区間を
+    // 除外できないベストエフォートの挙動であることを明示的に固定しておく。
+    it('現在駅がnullの場合はINBOUNDの従来ロジックにフォールバックする', () => {
+      setupMocks({
+        stations: inboundStations,
+        currentStation: null,
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      // 経路全体で現在種別(快速)の最終駅となる大船
+      expect(queryAllByText(/大船/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Ofuna/).length).toBeGreaterThan(0);
+    });
+
+    it('現在駅が経路内に無い場合はOUTBOUNDの従来ロジックにフォールバックする', () => {
+      const outboundStations = inboundStations.slice().reverse();
+
+      setupMocks({
+        stations: outboundStations,
+        currentStation: {
+          id: 999,
+          groupId: 999,
+          name: '経路外駅',
+          nameRoman: 'Unknown',
+          line: tokaidoLine,
+          trainType: rapidType,
+          stopCondition: 'STOP',
+        },
+        selectedDirection: 'OUTBOUND',
+        selectedBound: { name: '小田原', nameRoman: 'Odawara' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      // 乗車位置が不明なため、経路全体で次種別(普通)に該当する最初の駅である前橋になる
+      expect(queryAllByText(/前橋/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/Maebashi/).length).toBeGreaterThan(0);
+    });
   });
 
   describe('enabledLanguages による表示切替', () => {

--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -62,21 +62,31 @@ jest.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// jest.clearAllMocks() は呼び出し履歴のみを消去しmockReturnValueの実装は残るため、
+// 各テストの beforeEach で下記の既定値を再設定してテスト間の独立性を保つ
+const mockDefaultWindowDimensions = {
+  width: 812,
+  height: 375,
+  isPortrait: false,
+};
+const mockDefaultLine = {
+  id: 1,
+  nameShort: 'テスト線',
+  nameRoman: 'Test Line',
+  color: '#FF0000',
+  company: { id: 1, nameShort: 'テスト', nameEnglishShort: 'Test' },
+};
+const mockDefaultStation = {
+  id: 1,
+  groupId: 1,
+  name: 'テスト駅',
+  nameRoman: 'Test Station',
+};
+
 jest.mock('~/hooks', () => ({
-  useLandscapeWindowDimensions: jest.fn(() => ({ width: 812, height: 375 })),
-  useCurrentLine: jest.fn(() => ({
-    id: 1,
-    nameShort: 'テスト線',
-    nameRoman: 'Test Line',
-    color: '#FF0000',
-    company: { id: 1, nameShort: 'テスト', nameEnglishShort: 'Test' },
-  })),
-  useCurrentStation: jest.fn(() => ({
-    id: 1,
-    groupId: 1,
-    name: 'テスト駅',
-    nameRoman: 'Test Station',
-  })),
+  useLandscapeWindowDimensions: jest.fn(() => mockDefaultWindowDimensions),
+  useCurrentLine: jest.fn(() => mockDefaultLine),
+  useCurrentStation: jest.fn(() => mockDefaultStation),
   useCurrentTrainType: jest.fn(() => null),
   useNextTrainType: jest.fn(() => null),
 }));
@@ -121,12 +131,18 @@ jest.mock('./Typography', () => {
 describe('TypeChangeNotify', () => {
   beforeEach(() => {
     mockAtomValues();
-    const { useLandscapeWindowDimensions } = require('~/hooks');
-    useLandscapeWindowDimensions.mockReturnValue({
-      width: 812,
-      height: 375,
-      isPortrait: false,
-    });
+    const {
+      useLandscapeWindowDimensions,
+      useCurrentLine,
+      useCurrentStation,
+      useCurrentTrainType,
+      useNextTrainType,
+    } = require('~/hooks');
+    useLandscapeWindowDimensions.mockReturnValue(mockDefaultWindowDimensions);
+    useCurrentLine.mockReturnValue(mockDefaultLine);
+    useCurrentStation.mockReturnValue(mockDefaultStation);
+    useCurrentTrainType.mockReturnValue(null);
+    useNextTrainType.mockReturnValue(null);
   });
 
   afterEach(() => {

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1373,36 +1373,43 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       return afterAllStopLastStation;
     }
 
-    if (typeChangedStationIndex > 0) {
-      // NOTE: 小田急線 小田原〜新宿の種別が変わる駅が開成駅になってしまうので
-      // OUTBOUNDでは現在種別の最終駅ではなく次種別の最初の駅を境界として扱う
-      if (selectedDirection !== 'INBOUND') {
-        return orderedStations[typeChangedStationIndex];
+    // 現在駅が経路内に見つからない場合のみ、経路全体から推定する従来ロジックへ
+    // フォールバックする(進行方向より手前の区間を除外できないベストエフォート)
+    if (orderedCurrentStationIndex === -1) {
+      if (selectedDirection === 'INBOUND') {
+        const currentTypeStations = stations.filter(
+          (s) => s.trainType?.typeId === trainType?.typeId
+        );
+        return currentTypeStations.at(-1);
       }
 
-      // trainTypeを持たない駅が種別変更駅の手前に挟まる経路でも現在種別の駅を返すため、
-      // 変更駅の直前要素ではなく現在駅から変更駅までの範囲を後方検索する
-      const currentTypeStationsUntilChange = orderedStations
-        .slice(orderedCurrentStationIndex, typeChangedStationIndex)
-        .filter((s) => s.trainType?.typeId === trainType?.typeId);
-      return (
-        currentTypeStationsUntilChange.at(-1) ??
-        orderedStations[typeChangedStationIndex]
+      const nextTypeStations = stations.filter(
+        (s) => s.trainType?.typeId === nextTrainType?.typeId
       );
+      return nextTypeStations.at(-1);
     }
 
-    // 現在駅が経路内に見つからない等で境界を特定できない場合のフォールバック
-    if (selectedDirection === 'INBOUND') {
-      const currentTypeStations = stations.filter(
-        (s) => s.trainType?.typeId === trainType?.typeId
-      );
-      return currentTypeStations.at(-1);
+    // 現在駅より先に種別が変わる駅がない場合、経路全体から探すと通過済みの
+    // 同一種別区間を拾ってしまうため何も表示しない
+    if (typeChangedStationIndex === -1) {
+      return undefined;
     }
 
-    const nextTypeStations = stations.filter(
-      (s) => s.trainType?.typeId === nextTrainType?.typeId
+    // NOTE: 小田急線 小田原〜新宿の種別が変わる駅が開成駅になってしまうので
+    // OUTBOUNDでは現在種別の最終駅ではなく次種別の最初の駅を境界として扱う
+    if (selectedDirection !== 'INBOUND') {
+      return orderedStations[typeChangedStationIndex];
+    }
+
+    // trainTypeを持たない駅が種別変更駅の手前に挟まる経路でも現在種別の駅を返すため、
+    // 変更駅の直前要素ではなく現在駅から変更駅までの範囲を後方検索する
+    const currentTypeStationsUntilChange = orderedStations
+      .slice(orderedCurrentStationIndex, typeChangedStationIndex)
+      .filter((s) => s.trainType?.typeId === trainType?.typeId);
+    return (
+      currentTypeStationsUntilChange.at(-1) ??
+      orderedStations[typeChangedStationIndex]
     );
-    return nextTypeStations.at(-1);
   }, [
     trainType,
     nextTrainType,

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1376,9 +1376,19 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     if (typeChangedStationIndex > 0) {
       // NOTE: 小田急線 小田原〜新宿の種別が変わる駅が開成駅になってしまうので
       // OUTBOUNDでは現在種別の最終駅ではなく次種別の最初の駅を境界として扱う
-      return selectedDirection === 'INBOUND'
-        ? orderedStations[typeChangedStationIndex - 1]
-        : orderedStations[typeChangedStationIndex];
+      if (selectedDirection !== 'INBOUND') {
+        return orderedStations[typeChangedStationIndex];
+      }
+
+      // trainTypeを持たない駅が種別変更駅の手前に挟まる経路でも現在種別の駅を返すため、
+      // 変更駅の直前要素ではなく現在駅から変更駅までの範囲を後方検索する
+      const currentTypeStationsUntilChange = orderedStations
+        .slice(orderedCurrentStationIndex, typeChangedStationIndex)
+        .filter((s) => s.trainType?.typeId === trainType?.typeId);
+      return (
+        currentTypeStationsUntilChange.at(-1) ??
+        orderedStations[typeChangedStationIndex]
+      );
     }
 
     // 現在駅が経路内に見つからない等で境界を特定できない場合のフォールバック
@@ -1400,6 +1410,7 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     afterAllStopLastStation,
     currentLine,
     isNextTypeIsLocal,
+    orderedCurrentStationIndex,
     orderedStations,
     reversedFinalPassedStationIndex,
     reversedStations,

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1317,6 +1317,30 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     () => reversedStations[reversedFinalPassedStationIndex - 2],
     [reversedStations, reversedFinalPassedStationIndex]
   );
+  // 進行方向順に並べた駅一覧。OUTBOUND時のstationsは進行方向と逆順で保持されている
+  const orderedStations = useMemo(
+    () => (selectedDirection === 'INBOUND' ? stations : reversedStations),
+    [reversedStations, selectedDirection, stations]
+  );
+  const orderedCurrentStationIndex = useMemo(
+    () => orderedStations.findIndex((s) => s.groupId === station?.groupId),
+    [orderedStations, station]
+  );
+  // 現在駅より先で最初に種別が変わる駅の位置
+  // NOTE: 全区間をtypeIdで絞り込むと、既に通過した同一typeIdの区間
+  // (例: 湘南新宿ライン新宿→小田原乗車時に残っている高崎線内の普通区間) を
+  // 拾ってしまうため、現在駅より先の区間だけを走査する
+  const typeChangedStationIndex = useMemo(() => {
+    if (orderedCurrentStationIndex === -1) {
+      return -1;
+    }
+    return orderedStations.findIndex(
+      (s, idx) =>
+        idx > orderedCurrentStationIndex &&
+        !!s.trainType &&
+        s.trainType.typeId !== trainType?.typeId
+    );
+  }, [orderedCurrentStationIndex, orderedStations, trainType]);
   // 「~から先は各駅に止まります」を表示するフラグ
   const isNextTypeIsLocal = useMemo(
     () =>
@@ -1349,6 +1373,15 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       return afterAllStopLastStation;
     }
 
+    if (typeChangedStationIndex > 0) {
+      // NOTE: 小田急線 小田原〜新宿の種別が変わる駅が開成駅になってしまうので
+      // OUTBOUNDでは現在種別の最終駅ではなく次種別の最初の駅を境界として扱う
+      return selectedDirection === 'INBOUND'
+        ? orderedStations[typeChangedStationIndex - 1]
+        : orderedStations[typeChangedStationIndex];
+    }
+
+    // 現在駅が経路内に見つからない等で境界を特定できない場合のフォールバック
     if (selectedDirection === 'INBOUND') {
       const currentTypeStations = stations.filter(
         (s) => s.trainType?.typeId === trainType?.typeId
@@ -1356,7 +1389,6 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       return currentTypeStations.at(-1);
     }
 
-    // NOTE: 小田急線 小田原〜新宿の種別が変わる駅が開成駅になってしまうのでOUTBOUNDではnextTrainTypeを使用している
     const nextTypeStations = stations.filter(
       (s) => s.trainType?.typeId === nextTrainType?.typeId
     );
@@ -1368,9 +1400,11 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     afterAllStopLastStation,
     currentLine,
     isNextTypeIsLocal,
+    orderedStations,
     reversedFinalPassedStationIndex,
     reversedStations,
     stations,
+    typeChangedStationIndex,
   ]);
 
   // バー表示用: 種別が変わる直前の駅のlineを中間路線として使用する


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別変更予告（`TypeChangeNotify`）で、すでに通過した駅が種別変更駅として表示される不具合を修正します。

経路検索で新宿駅から国府津駅の経路を選ぶと「前橋から普通小田原ゆきとなります」と表示されますが、前橋は乗車駅である新宿より手前（通過済み）の駅であり事実と異なります。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `TypeChangeNotify` の `currentTypeFinalStation` を、経路全体からの `typeId` 絞り込みではなく、進行方向順に並べた駅一覧を現在駅より先だけ走査して種別変更駅を求めるように変更
- INBOUND では種別変更駅の直前要素をそのまま返すのではなく、現在駅から種別変更駅までの範囲を後方検索して現在種別の最終駅を求める（`trainType` を持たない駅が挟まる経路で誤った駅を返さないようにするため）
- 経路全体から推定する従来ロジックへのフォールバックは現在駅を経路内で特定できない場合に限定し、現在駅より先に種別変更駅が無い場合は何も表示しない（通過済み区間の同一種別を拾わないようにするため）
- 方向ごとの境界駅の取り方（INBOUND は現在種別の最終駅、OUTBOUND は次種別の最初の駅）は従来どおり維持
- `TypeChangeNotify.test.tsx` に「種別が変わる駅の特定」のテストを 7 件追加

### 原因

`currentTypeFinalStation` は経路全体を `typeId` で `filter` して `.at(-1)` を取っていました。

```ts
const nextTypeStations = stations.filter(
  (s) => s.trainType?.typeId === nextTrainType?.typeId
);
return nextTypeStations.at(-1);
```

新宿から小田原方面への乗車は OUTBOUND のため `stations` は「小田原 → … → 新宿 → … → 前橋」の順で保持されます。この経路には東海道線内と高崎線内という同一 `typeId` の普通区間が 2 か所存在するため、`filter().at(-1)` が配列末尾＝高崎線側の前橋を拾っていました。INBOUND 側の分岐（現在種別で `filter`）も同じ構造の問題を抱えていたため併せて修正しています。

この経路では「大船から普通小田原ゆきとなります」と表示されるようになります。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 228 suites / 2481 tests がすべて成功しました。追加したテストは以下の 7 件です。

- OUTBOUND で通過済みの同一種別区間の駅を拾わないこと（本件の再現ケース。修正前のコードでは失敗）
- INBOUND で現在駅より先の種別変更駅を表示すること
- INBOUND で `trainType` を持たない駅が挟まっても現在種別の最終駅を表示すること（修正前のコードでは失敗）
- INBOUND で現在の種別が経路の後方に再出現しても最初の変更駅を表示すること（修正前のコードでは失敗）
- 現在駅より先に種別変更駅が無い場合に通過済み駅へフォールバックしないこと（修正前のコードでは失敗）
- 現在駅が `null` の場合に INBOUND の従来ロジックへフォールバックすること
- 現在駅が経路内に無い場合に OUTBOUND の従来ロジックへフォールバックすること

### 回帰リスクと緩和策

- 影響範囲は種別変更予告画面（`TypeChangeNotify`）の表示駅の決定ロジックのみで、TTS や他画面からは参照されていません。
- 方向ごとの境界駅の取り方は変更していないため、小田急線 小田原〜新宿のような既存ケースの表示は従来どおりです（既存テストの直通運転ケースを含め全テストが通過）。
- 現在駅を特定できているのに先に種別変更駅が見つからない場合は表示を行いません。この状態は本画面の表示条件（`useNextTrainType` が進行方向前方から次種別を求めている）から通常は発生しませんが、発生した場合に通過済み駅を表示するよりは安全側に倒しています。
- 現在駅を経路内で特定できない場合のみ従来ロジックへフォールバックするため、その経路では修正前と同じ表示に留まります。ベストエフォートである旨はテストのコメントに明記しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

該当する Issue はありません（利用者からの直接報告に基づく修正です）。

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->

未添付です。修正前の状態は報告時のスクリーンショット（新宿→国府津の経路で「前橋から普通小田原ゆきとなります」と表示される画面）が該当します。修正後の画面はシミュレータ／実機を起動できない環境で作業しているため取得できていません。マージ前に端末名付きのスクリーンショットを添付してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 種別変更駅直前に停車種別情報のない駅がある場合でも、現在の種別の最終停車駅を正しく表示できるようになりました。
  * 進行方向や路線直通区間を考慮し、最初の種別変更駅のみを案内するよう改善しました。
  * 現在駅以降に変更駅がない場合、不要な駅を案内せず表示しないようになりました。
  * 現在駅を特定できない場合は、経路全体から変更駅を適切に案内します。
* **テスト**
  * 種別変更案内に関する複数のケースを追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->