### PR TITLE
iOSで外観を「自動」にしても端末のダークモード設定に追従しない不具合を修正

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -43,6 +43,10 @@ export default {
       projectId: 'dad36dde-0056-4760-8eda-37f05e7c9c6c',
     },
   },
+  // 既定値は 'light' で、prebuild すると Info.plist の UIUserInterfaceStyle が
+  // Light で書き戻される。それだと端末のダークモード設定を JS から読めなくなり
+  // 外観設定の「自動」が機能しないため、明示的に automatic を指定する
+  userInterfaceStyle: 'automatic',
   ios: {
     // Expo SDK 57 の各モジュール（expo / expo-modules-core ほか）は podspec で iOS 16.4 以上を要求する
     deploymentTarget: '16.4',

--- a/app.config.ts
+++ b/app.config.ts
@@ -43,16 +43,20 @@ export default {
       projectId: 'dad36dde-0056-4760-8eda-37f05e7c9c6c',
     },
   },
-  // 既定値は 'light' で、prebuild すると Info.plist の UIUserInterfaceStyle が
-  // Light で書き戻される。それだと端末のダークモード設定を JS から読めなくなり
-  // 外観設定の「自動」が機能しないため、明示的に automatic を指定する
-  userInterfaceStyle: 'automatic',
   ios: {
+    // 既定値は 'light' で、prebuild すると Info.plist の UIUserInterfaceStyle が
+    // Light で書き戻される。それだと端末のダークモード設定を JS から読めなくなり
+    // 外観設定の「自動」が機能しないため、明示的に automatic を指定する。
+    // Android は元から固定されておらず、この指定は expo-system-ui を入れないと
+    // 無視されるため、iOS 側にだけ置く
+    userInterfaceStyle: 'automatic',
     // Expo SDK 57 の各モジュール（expo / expo-modules-core ほか）は podspec で iOS 16.4 以上を要求する
     deploymentTarget: '16.4',
     buildNumber: '2847',
     scheme: IS_DEV ? 'CanaryTrainLCD' : 'ProdTrainLCD',
-    bundleIdentifier: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',
+    bundleIdentifier: IS_DEV
+      ? 'me.tinykitten.trainlcd.dev'
+      : 'me.tinykitten.trainlcd',
     supportsTablet: true,
   },
   android: {

--- a/docs/color-scheme.md
+++ b/docs/color-scheme.md
@@ -158,6 +158,34 @@ iOS のネイティブシートは既定で端末の外観に追従してしま�
 走行画面から開くアクションシート(`Permitted.tsx` の長押しメニュー)もモーダルと同じ扱いで
 配色に追従する。走行画面は Provider の外側にあるため、そこでは `appColorsAtom` を直接購読する。
 
+## native の外観設定
+
+iOS は `Info.plist` の `UIUserInterfaceStyle` が `Light` だとアプリ全体がライトに固定され、
+`Appearance.getColorScheme()` が常に `'light'` を返す(`RCTAppearance.mm` は key window
+の trait collection を読むため)。この状態では端末設定を読めず「自動」が機能しないので、
+`Automatic` にしてある。Expo の既定値は `light` で prebuild すると書き戻されるため、
+`app.config.ts` にも `userInterfaceStyle: 'automatic'` を明示している。
+
+固定を外すと `Alert` やキーボードなど native が描く UI が端末設定に従うようになり、
+アプリで「ライト」を選んでいても端末がダークならそこだけ黒くなる。これを防ぐため
+`FxSystemColorScheme` が `Appearance.setColorScheme()` で window の外観を上書きする。
+
+| 配色設定 | `setColorScheme()` へ渡す値 |
+| ---- | ---- |
+| 自動 | `'unspecified'`(上書きの解除) |
+| ライト | `'light'` |
+| ダーク | `'dark'` |
+
+解除に `null` ではなく `'unspecified'` を渡すこと。react-native 側は `'unspecified'` の
+ときだけ native から現在値を読み直してキャッシュを更新する実装になっている。
+
+上書き中は window の外観がアプリの設定値そのものなので、変更イベントを端末の値として
+記録できない。そのため `FxSystemColorScheme` は「自動」のときだけイベントを
+`systemColorSchemeAtom` へ反映する。「自動」へ戻すと上書きが外れて端末の値でイベントが
+飛ぶので、そこで追従が復帰する。
+
+Android は `Configuration.uiMode` を読むため、この固定の影響を受けない。
+
 ## 制限事項
 
 `GlobalToast` は元からダークな見た目(背景 `#333` に白文字)なので、配色設定の対象外。

--- a/docs/color-scheme.md
+++ b/docs/color-scheme.md
@@ -179,10 +179,18 @@ iOS は `Info.plist` の `UIUserInterfaceStyle` が `Light` だとアプリ全�
 解除に `null` ではなく `'unspecified'` を渡すこと。react-native 側は `'unspecified'` の
 ときだけ native から現在値を読み直してキャッシュを更新する実装になっている。
 
-上書き中は window の外観がアプリの設定値そのものなので、変更イベントを端末の値として
-記録できない。そのため `FxSystemColorScheme` は「自動」のときだけイベントを
-`systemColorSchemeAtom` へ反映する。「自動」へ戻すと上書きが外れて端末の値でイベントが
-飛ぶので、そこで追従が復帰する。
+上書き中は window の外観がアプリの設定値そのものなので、変更イベントも
+`getColorScheme()` の戻り値も端末の値としては使えない。そのため `FxSystemColorScheme` は
+「自動」のときだけ `systemColorSchemeAtom` へ反映する。マウント時の読み取りも同じ条件で
+弾く(StrictMode や再マウントで effect が再実行されると、既に効いている上書きの値を
+読んでしまうため)。atom の初期値は上書き前(モジュール評価時)の端末の値を持っている。
+
+「自動」へ戻すときは、上書きを解除したうえで `getColorScheme()` を読み直す。解除の前後で
+実効の配色が変わらないと変更イベントが飛ばないためで、ダークを選んでいる間に端末も
+ダークへ変わっていたようなケースでは、これが無いと古い値のまま追従が復帰しない。
+
+`react-native-web` の `Appearance` は `setColorScheme` を持たない。無条件に呼ぶと web
+プレビューがマウント時に落ちるので、存在を確認してから呼ぶ。
 
 Android は `Configuration.uiMode` を読むため、この固定の影響を受けない。
 

--- a/ios/TrainLCD/Schemes/Dev/Info.plist
+++ b/ios/TrainLCD/Schemes/Dev/Info.plist
@@ -109,7 +109,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/ios/TrainLCD/Schemes/Prod/Info.plist
+++ b/ios/TrainLCD/Schemes/Prod/Info.plist
@@ -103,7 +103,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/src/components/FxSystemColorScheme.test.tsx
+++ b/src/components/FxSystemColorScheme.test.tsx
@@ -1,5 +1,6 @@
 import { act, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
+import React from 'react';
 import { Appearance } from 'react-native';
 import { COLOR_SCHEME, COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
 import {
@@ -152,6 +153,8 @@ describe('FxSystemColorScheme', () => {
       });
 
     const store = createStore();
+    // モジュール評価時(上書き前)に読んだ端末の値
+    store.set(systemColorSchemeAtom, COLOR_SCHEME.DARK);
     store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.LIGHT);
 
     render(
@@ -160,7 +163,7 @@ describe('FxSystemColorScheme', () => {
       </Provider>
     );
 
-    // マウント時点の端末の値はダーク
+    // 上書き中はマウント時の読み取りもしないため、端末の値は保たれる
     expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
 
     // 上書き適用によりライトのイベントが飛んでも、端末の値は書き換えない
@@ -173,5 +176,33 @@ describe('FxSystemColorScheme', () => {
     });
     (listener as AppearanceListener | null)?.({ colorScheme: 'light' });
     expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.LIGHT);
+  });
+
+  // StrictMode は effect の setup/cleanup/setup を行う。2回目のセットアップ時には
+  // 既に上書きが効いているため、無条件に読むとアプリの設定値を端末の値として記録してしまう
+  it('StrictModeで再セットアップされても上書き値を端末の配色として記録しない', () => {
+    let overridden = false;
+    jest.spyOn(Appearance, 'setColorScheme').mockImplementation(() => {
+      overridden = true;
+    });
+    // 上書きが効いた後の読み取りはアプリの設定値(ライト)を返す
+    jest
+      .spyOn(Appearance, 'getColorScheme')
+      .mockImplementation(() => (overridden ? 'light' : 'dark'));
+
+    const store = createStore();
+    // モジュール評価時に読んだ上書き前の端末の値
+    store.set(systemColorSchemeAtom, COLOR_SCHEME.DARK);
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.LIGHT);
+
+    render(
+      <React.StrictMode>
+        <Provider store={store}>
+          <FxSystemColorScheme />
+        </Provider>
+      </React.StrictMode>
+    );
+
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
   });
 });

--- a/src/components/FxSystemColorScheme.test.tsx
+++ b/src/components/FxSystemColorScheme.test.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react-native';
-import { createStore, Provider } from 'jotai';
-import React from 'react';
+import { createStore, Provider, useAtomValue } from 'jotai';
+import React, { useLayoutEffect } from 'react';
 import { Appearance } from 'react-native';
 import { COLOR_SCHEME, COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
 import {
@@ -269,5 +269,59 @@ describe('FxSystemColorScheme', () => {
         writable: true,
       });
     }
+  });
+
+  // 設定変更のコミット直後、preference 用の useEffect より前に端末イベントが届く状況。
+  // レイアウトエフェクトはツリー順に走るため、FxSystemColorScheme の後ろに置いた
+  // コンポーネントから呼べば「ref 同期後・passive effect 前」を再現できる
+  it('自動へ切り替えた直後に届いた端末イベントを新しい設定で処理する', () => {
+    const EventFirer: React.FC<{ fire: () => void }> = ({ fire }) => {
+      const preference = useAtomValue(colorSchemePreferenceAtom);
+
+      useLayoutEffect(() => {
+        if (preference === COLOR_SCHEME_PREFERENCE.AUTO) {
+          fire();
+        }
+      }, [preference, fire]);
+
+      return null;
+    };
+
+    jest.spyOn(Appearance, 'setColorScheme').mockImplementation(() => {});
+    // 上書き解除直後は native 側のキャッシュがまだ更新されていない状況を再現する
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
+    let listener: AppearanceListener | null = null;
+    jest
+      .spyOn(Appearance, 'addChangeListener')
+      .mockImplementation((cb: unknown) => {
+        listener = cb as AppearanceListener;
+        return { remove: jest.fn() } as never;
+      });
+
+    const store = createStore();
+    store.set(systemColorSchemeAtom, COLOR_SCHEME.DARK);
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.LIGHT);
+
+    const seen: string[] = [];
+    store.sub(systemColorSchemeAtom, () => {
+      seen.push(store.get(systemColorSchemeAtom));
+    });
+
+    const fire = () =>
+      (listener as AppearanceListener | null)?.({ colorScheme: 'light' });
+
+    render(
+      <Provider store={store}>
+        <FxSystemColorScheme />
+        <EventFirer fire={fire} />
+      </Provider>
+    );
+
+    act(() => {
+      store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.AUTO);
+    });
+
+    // ref の同期が遅れていると、このイベントは旧設定(ライト)で弾かれて記録されない
+    expect(seen).toContain(COLOR_SCHEME.LIGHT);
   });
 });

--- a/src/components/FxSystemColorScheme.test.tsx
+++ b/src/components/FxSystemColorScheme.test.tsx
@@ -1,8 +1,11 @@
-import { render } from '@testing-library/react-native';
+import { act, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { Appearance } from 'react-native';
-import { COLOR_SCHEME } from '~/models/ColorScheme';
-import { systemColorSchemeAtom } from '~/store/atoms/colorScheme';
+import { COLOR_SCHEME, COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
+import {
+  colorSchemePreferenceAtom,
+  systemColorSchemeAtom,
+} from '~/store/atoms/colorScheme';
 import FxSystemColorScheme from './FxSystemColorScheme';
 
 type AppearanceListener = (preferences: {
@@ -98,5 +101,77 @@ describe('FxSystemColorScheme', () => {
 
     unmount();
     expect(remove).toHaveBeenCalled();
+  });
+
+  // iOS は Info.plist を Automatic にしてあるため、上書きしないと Alert やキーボードなど
+  // native が描く UI だけ端末設定に従ってしまう
+  it('ライト・ダークを明示している間はnativeの外観も上書きする', () => {
+    const setColorScheme = jest
+      .spyOn(Appearance, 'setColorScheme')
+      .mockImplementation(() => {});
+    const store = createStore();
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.DARK);
+
+    render(
+      <Provider store={store}>
+        <FxSystemColorScheme />
+      </Provider>
+    );
+
+    // COLOR_SCHEME は大文字なので、そのまま渡すと native 側の変換に失敗する
+    expect(setColorScheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('自動では上書きを解除する', () => {
+    const setColorScheme = jest
+      .spyOn(Appearance, 'setColorScheme')
+      .mockImplementation(() => {});
+    const store = createStore();
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.AUTO);
+
+    render(
+      <Provider store={store}>
+        <FxSystemColorScheme />
+      </Provider>
+    );
+
+    // null ではなく 'unspecified' でないと react-native 側のキャッシュが更新されない
+    expect(setColorScheme).toHaveBeenCalledWith('unspecified');
+  });
+
+  // 上書き中の変更イベントはアプリ自身が起こしたもので、端末の値ではない
+  it('上書き中の変更イベントを端末の配色として記録しない', () => {
+    jest.spyOn(Appearance, 'setColorScheme').mockImplementation(() => {});
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
+    let listener: AppearanceListener | null = null;
+    jest
+      .spyOn(Appearance, 'addChangeListener')
+      .mockImplementation((cb: unknown) => {
+        listener = cb as AppearanceListener;
+        return { remove: jest.fn() } as never;
+      });
+
+    const store = createStore();
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.LIGHT);
+
+    render(
+      <Provider store={store}>
+        <FxSystemColorScheme />
+      </Provider>
+    );
+
+    // マウント時点の端末の値はダーク
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
+
+    // 上書き適用によりライトのイベントが飛んでも、端末の値は書き換えない
+    (listener as AppearanceListener | null)?.({ colorScheme: 'light' });
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
+
+    // 自動へ戻すと上書きが外れ、以降のイベントは端末の値として記録する
+    act(() => {
+      store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.AUTO);
+    });
+    (listener as AppearanceListener | null)?.({ colorScheme: 'light' });
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.LIGHT);
   });
 });

--- a/src/components/FxSystemColorScheme.test.tsx
+++ b/src/components/FxSystemColorScheme.test.tsx
@@ -50,7 +50,11 @@ describe('FxSystemColorScheme', () => {
       </Provider>
     );
 
-    expect(callOrder).toEqual(['addChangeListener', 'getColorScheme']);
+    // 自動のときは追従復帰用の読み直しも走るため、先頭2件の順序で検証する
+    expect(callOrder.slice(0, 2)).toEqual([
+      'addChangeListener',
+      'getColorScheme',
+    ]);
   });
 
   it('購読開始から現在値取得までの間に変わってもダークを取りこぼさない', () => {
@@ -204,5 +208,66 @@ describe('FxSystemColorScheme', () => {
     );
 
     expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
+  });
+
+  // 上書き値と端末の値が同じなら、解除しても実効の配色が変わらず変更イベントは飛ばない
+  it('自動へ戻したとき変更イベントが飛ばなくても端末の値へ追従する', () => {
+    let overridden = true;
+    jest.spyOn(Appearance, 'setColorScheme').mockImplementation((scheme) => {
+      overridden = scheme !== 'unspecified';
+    });
+    // 上書き中はダーク、解除するとライト(端末の現在値)を返す
+    jest
+      .spyOn(Appearance, 'getColorScheme')
+      .mockImplementation(() => (overridden ? 'dark' : 'light'));
+    jest
+      .spyOn(Appearance, 'addChangeListener')
+      .mockImplementation(() => ({ remove: jest.fn() }) as never);
+
+    const store = createStore();
+    // ダークを選ぶ前に記録した、古い端末の値
+    store.set(systemColorSchemeAtom, COLOR_SCHEME.DARK);
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.DARK);
+
+    render(
+      <Provider store={store}>
+        <FxSystemColorScheme />
+      </Provider>
+    );
+
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.DARK);
+
+    // リスナーを一切呼ばずに自動へ戻す
+    act(() => {
+      store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.AUTO);
+    });
+
+    expect(store.get(systemColorSchemeAtom)).toBe(COLOR_SCHEME.LIGHT);
+  });
+
+  // react-native-web の Appearance は setColorScheme を持たない
+  it('setColorSchemeが無い環境でもマウントできる', () => {
+    const original = Appearance.setColorScheme;
+    Object.defineProperty(Appearance, 'setColorScheme', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      expect(() =>
+        render(
+          <Provider store={createStore()}>
+            <FxSystemColorScheme />
+          </Provider>
+        )
+      ).not.toThrow();
+    } finally {
+      Object.defineProperty(Appearance, 'setColorScheme', {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+    }
   });
 });

--- a/src/components/FxSystemColorScheme.tsx
+++ b/src/components/FxSystemColorScheme.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { Appearance } from 'react-native';
 import {
   COLOR_SCHEME,
@@ -71,11 +71,13 @@ const FxSystemColorScheme: React.FC = () => {
     return () => subscription.remove();
   }, [setSystemColorScheme]);
 
-  useEffect(() => {
-    // 上書きの適用より先に ref を更新する。適用時に飛ぶ変更イベントを
-    // 端末の値として記録してしまわないようにするため
+  // 設定変更のコミット直後、下の useEffect が走る前に端末イベントが届くことがある。
+  // その一件を古い設定で判定してしまわないよう、ref の同期だけ先に済ませる
+  useLayoutEffect(() => {
     preferenceRef.current = preference;
+  }, [preference]);
 
+  useEffect(() => {
     // react-native-web の Appearance は setColorScheme を持たない。無条件に呼ぶと
     // web プレビューがマウント時に落ちるため、存在を確認してから呼ぶ
     if (typeof Appearance.setColorScheme === 'function') {

--- a/src/components/FxSystemColorScheme.tsx
+++ b/src/components/FxSystemColorScheme.tsx
@@ -1,23 +1,62 @@
-import { useSetAtom } from 'jotai';
-import React, { useEffect } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import React, { useEffect, useRef } from 'react';
 import { Appearance } from 'react-native';
 import {
+  COLOR_SCHEME,
+  COLOR_SCHEME_PREFERENCE,
+  type ColorSchemePreference,
+} from '~/models/ColorScheme';
+import {
+  colorSchemePreferenceAtom,
   normalizeSystemScheme,
   systemColorSchemeAtom,
 } from '~/store/atoms/colorScheme';
 
 /**
- * 端末のダークモード設定を atom へ反映するレンダーレスの副作用ホスト。
- * 配色設定が「自動」のときの追従元になる。
+ * アプリ内の設定値を react-native の `Appearance` が受け取る値へ変換する。
+ *
+ * `COLOR_SCHEME` は `'LIGHT'` / `'DARK'` の大文字なので、そのまま渡すと native 側の
+ * 変換に失敗して上書きが効かない。`'unspecified'` は上書きの解除で、null ではなく
+ * この値を渡すこと(react-native は `'unspecified'` のときだけ native から現在値を
+ * 読み直してキャッシュを更新する)。
+ */
+const toNativeColorScheme = (
+  preference: ColorSchemePreference
+): 'light' | 'dark' | 'unspecified' => {
+  switch (preference) {
+    case COLOR_SCHEME.LIGHT:
+      return 'light';
+    case COLOR_SCHEME.DARK:
+      return 'dark';
+    default:
+      return 'unspecified';
+  }
+};
+
+/**
+ * 端末のダークモード設定を atom へ反映し、アプリ側の設定を native の外観へ適用する
+ * レンダーレスの副作用ホスト。
+ *
+ * iOS は Info.plist の `UIUserInterfaceStyle` を `Automatic` にしてあり、端末設定を
+ * そのまま受け取る。「ライト」「ダーク」を明示している間は `Appearance.setColorScheme()`
+ * で window の外観を上書きし、`Alert` やキーボードなど native が描く UI もアプリの
+ * 設定へ揃える。上書きしないと、端末がダークでアプリがライトのときにそれらだけ黒くなる。
  */
 const FxSystemColorScheme: React.FC = () => {
   const setSystemColorScheme = useSetAtom(systemColorSchemeAtom);
+  const preference = useAtomValue(colorSchemePreferenceAtom);
+  const preferenceRef = useRef(preference);
 
   useEffect(() => {
     // 先に購読を開始してから現在値を読む。逆順だと、現在値の取得から購読開始までの
     // 間に端末側が変わった場合にその変更イベントを受け取れず、次に変わるまで
     // 「自動」が端末設定とずれたままになる
     const subscription = Appearance.addChangeListener(({ colorScheme }) => {
+      // 上書き中は window の外観＝アプリの設定値なので、端末の値としては記録できない。
+      // 「自動」へ戻すと上書きが外れて端末の値でイベントが飛ぶため、そこで復帰する
+      if (preferenceRef.current !== COLOR_SCHEME_PREFERENCE.AUTO) {
+        return;
+      }
       setSystemColorScheme(normalizeSystemScheme(colorScheme));
     });
 
@@ -25,6 +64,14 @@ const FxSystemColorScheme: React.FC = () => {
 
     return () => subscription.remove();
   }, [setSystemColorScheme]);
+
+  useEffect(() => {
+    // 上書きの適用より先に ref を更新する。適用時に飛ぶ変更イベントを
+    // 端末の値として記録してしまわないようにするため
+    preferenceRef.current = preference;
+
+    Appearance.setColorScheme(toNativeColorScheme(preference));
+  }, [preference]);
 
   return null;
 };

--- a/src/components/FxSystemColorScheme.tsx
+++ b/src/components/FxSystemColorScheme.tsx
@@ -60,7 +60,13 @@ const FxSystemColorScheme: React.FC = () => {
       setSystemColorScheme(normalizeSystemScheme(colorScheme));
     });
 
-    setSystemColorScheme(normalizeSystemScheme(Appearance.getColorScheme()));
+    // 上書き中の読み取りもアプリの設定値を返すため、端末の値としては記録できない。
+    // StrictMode や再マウントでこの effect が再実行されると、既に効いている上書きの値を
+    // 読んでしまうので、イベントと同じ条件で弾く。「自動」以外で読まなくても、
+    // systemColorSchemeAtom の初期値が上書き前(モジュール評価時)の端末の値を持っている
+    if (preferenceRef.current === COLOR_SCHEME_PREFERENCE.AUTO) {
+      setSystemColorScheme(normalizeSystemScheme(Appearance.getColorScheme()));
+    }
 
     return () => subscription.remove();
   }, [setSystemColorScheme]);

--- a/src/components/FxSystemColorScheme.tsx
+++ b/src/components/FxSystemColorScheme.tsx
@@ -76,8 +76,21 @@ const FxSystemColorScheme: React.FC = () => {
     // 端末の値として記録してしまわないようにするため
     preferenceRef.current = preference;
 
-    Appearance.setColorScheme(toNativeColorScheme(preference));
-  }, [preference]);
+    // react-native-web の Appearance は setColorScheme を持たない。無条件に呼ぶと
+    // web プレビューがマウント時に落ちるため、存在を確認してから呼ぶ
+    if (typeof Appearance.setColorScheme === 'function') {
+      Appearance.setColorScheme(toNativeColorScheme(preference));
+    }
+
+    if (preference !== COLOR_SCHEME_PREFERENCE.AUTO) {
+      return;
+    }
+
+    // 上書きを解除しても、解除の前後で実効の配色が変わらなければ変更イベントは飛ばない。
+    // 例えばダークを選んでいる間に端末もダークへ変わっていた場合、記録済みの端末の値は
+    // 古いままイベントも来ないので、ここで読み直して追従を復帰させる
+    setSystemColorScheme(normalizeSystemScheme(Appearance.getColorScheme()));
+  }, [preference, setSystemColorScheme]);
 
   return null;
 };


### PR DESCRIPTION
## 概要

外観設定の「自動」が iOS で機能していなかった不具合の修正です。

`ios/TrainLCD/Schemes/{Dev,Prod}/Info.plist` の `UIUserInterfaceStyle` が `Light` になっており、UIKit レベルでアプリ全体がライトに固定されていました。`Appearance.getColorScheme()` は key window の trait collection を読む実装（`RCTAppearance.mm`）なので、**端末がダークでも常に `'light'` を返し**、「自動」がダークに解決されませんでした。iOS 固有の問題で、Android は `Configuration.uiMode` を読むため影響を受けていません。

固定を外すと `Alert` やキーボードなど native が描く UI が端末設定に従うようになり、アプリで「ライト」を選んでいても端末がダークならそこだけ黒くなります。これを避けるため、`Appearance.setColorScheme()` でアプリの設定値を window の外観へ上書きします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `Info.plist`（Dev / Prod）の `UIUserInterfaceStyle` を `Light` から `Automatic` へ変更
- `app.config.ts` に `userInterfaceStyle: 'automatic'` を明示。Expo の既定値は `light` で、prebuild すると `Info.plist` が Light で書き戻されるため
- `FxSystemColorScheme` がアプリの設定値を `Appearance.setColorScheme()` で native の外観へ適用（自動 → `'unspecified'` / ライト → `'light'` / ダーク → `'dark'`）
- 上書き中の変更イベントを端末の値として記録しないようにガードを追加
- `docs/color-scheme.md` に「native の外観設定」節を追加

### 実装上の注意点

`COLOR_SCHEME.LIGHT` は `'LIGHT'`（大文字）で、`Appearance.setColorScheme()` が受け取る `'light'` とは別物です。そのまま渡すと native 側の変換に失敗して上書きが効かないため、`toNativeColorScheme()` で明示的に変換しています。

上書きを解除する際は `null` ではなく `'unspecified'` を渡します。react-native は `'unspecified'` のときだけ native から現在値を読み直してキャッシュを更新する実装のため、`null` だと `getColorScheme()` が `null` を返したままになります。

上書き中は window の外観がアプリの設定値そのものなので、変更イベントを端末の値として記録できません。そのため `systemColorSchemeAtom` へ反映するのは「自動」のときだけにしています。「自動」へ戻すと上書きが外れて端末の値でイベントが飛ぶため、そこで追従が復帰します。

### 回帰リスクと緩和

- **native UI への波及**: `UIUserInterfaceStyle` の固定を外すのはアプリ全体に効く変更です。`setColorScheme()` による上書きで、アプリの設定と native UI の外観を一致させています
- **走行画面**: 走行画面は自前で背景色・文字色を指定しているため、native の外観設定の影響を受けません。この PR では走行画面のコードを変更していません
- **prebuild での巻き戻り**: `app.config.ts` に `userInterfaceStyle` を明示することで、`Info.plist` が Light に戻るのを防いでいます

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果: lint クリーン / typecheck エラーなし / test 236スイート・2536件パス。`FxSystemColorScheme.test.tsx` に以下 3 件を追加しています（同ファイル計 7 件）。

- ライト・ダークを明示している間は native の外観も上書きすること（小文字の値で渡すこと）
- 自動では `'unspecified'` で上書きを解除すること
- 上書き中の変更イベントを端末の配色として記録せず、自動へ戻すと追従が復帰すること

**動作確認のお願い**: `Info.plist` の変更のため、確認には development build の作り直しが必要です（JS リロードでは反映されません）。次の 3 点をご確認ください。

1. 「自動」で端末のダークモード設定に追従すること
2. 「ライト」を選んだ状態で端末をダークにしても、`Alert`・キーボード・共有シートなど native の UI がライトのままであること
3. 走行画面の見た目が変わっていないこと

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は端末名とともにスクリーンショットまたは動画を添付してください（例: iPhone 15 Pro, Pixel 8） -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01BYg7tx35Sd7U9KTrpQdAEX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 「自動」設定時に、端末のライト／ダークモードへ追従するようになりました。
  * ライト／ダークを明示的に選択した場合、端末の外観変更に左右されず設定を維持します。
  * 自動設定へ戻すと、現在の端末の外観モードへ再び追従します。
  * iOSではシステムの外観設定が自動的に反映されます。

* **ドキュメント**
  * iOS・Androidにおける外観モードの動作と設定方法を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->