### PR TITLE
Androidで音声アナウンス中に他アプリの音声がダッキングされない不具合を修正

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,15 @@ CLAUDE.md「Security & Configuration Guardrails」に従い、依存更新後に
 - `npm test` — 成功
 - `npm run typecheck` — 成功
 
+### 未検証
+
+上記は JavaScript 側のチェックのみで、ネイティブ側は未検証。
+
+- Android SDK を用いた Kotlin のコンパイル確認（作業環境に Android SDK が無いため未実施）。
+  最初の検証は canary のネイティブビルドになる。
+- Android 実機での動作確認（音楽再生中にアナウンスで他アプリの音量が下がり、
+  読み上げ終了後に戻るか）。
+
 ## 2026-08-26 — Expo SDK 57 系の依存を推奨バージョンへ更新
 
 対象バージョン: v10.13.1 / PR [#6720](https://github.com/TrainLCD/MobileApp/pull/6720)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,35 @@ CLAUDE.md「Security & Configuration Guardrails」に従い、依存更新後に
 
 新しいエントリを上に追加する。
 
+## 2026-08-26 — Android の端末内蔵 TTS でダッキングが効かない不具合を修正
+
+対象バージョン: v10.13.1 / Issue [TrainLCD/Issues#1263](https://github.com/TrainLCD/Issues/issues/1263)
+
+### 内容
+
+- 音楽再生中にアナウンスが流れても他アプリの音量が下がらない、という Android からの
+  報告を修正した。Android のダッキングは `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` の
+  要求でしか起きないが、`expo-speech` の Android 実装は `AudioManager` に一切触れず、
+  `expo-audio` の `setAudioModeAsync` も値を保持するだけでフォーカスを要求しない
+  （要求するのはプレイヤーの再生開始時のみ）。そのため端末内蔵 TTS 経路では
+  `duckOthers` を指定してもダッキングが一度も発生していなかった。
+- デグレは PR [#6453](https://github.com/TrainLCD/MobileApp/pull/6453)（v10.11.0）。
+  それ以前は合成済み音声を `expo-audio` のプレイヤーで再生していたため、プレイヤーが
+  フォーカスを要求し結果としてダッキングが効いていた。端末内蔵 TTS へ置き換えた際に
+  プレイヤーが経路から外れ、ダッキングだけが落ちた。
+- 発話中だけフォーカスを保持する Android 専用ローカル Expo モジュール
+  `modules/audio-focus` を追加し、`useNativeSpeechEngine` が発話の直前・直後に
+  取得・返却するようにした。iOS は従来どおり `AVAudioSession` のカテゴリオプションで
+  完結するため、モジュールは autolink されず何もしない。
+- **ネイティブモジュールの追加を含むため、反映にはネイティブビルドが必要**で
+  OTA アップデートでは配信されない。
+
+### 検証結果
+
+- `npm run lint` — 成功
+- `npm test` — 成功
+- `npm run typecheck` — 成功
+
 ## 2026-08-26 — Expo SDK 57 系の依存を推奨バージョンへ更新
 
 対象バージョン: v10.13.1 / PR [#6720](https://github.com/TrainLCD/MobileApp/pull/6720)

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -20,7 +20,7 @@ API 障害でアナウンスが丸ごと欠落しないようにするための�
 ## 構成
 
 ```text
-useTTS ────────────────── 放送タイミング・抑止判定・ダッキング・保留キュー
+useTTS ────────────────── 放送タイミング・抑止判定・音声セッション・保留キュー
   ├─ useRemoteSpeechEngine  /tts へ合成要求 → expo-audio で再生
   └─ useNativeSpeechEngine  リモートを使わない構成の常用経路 / リモートのフォールバック
 ```
@@ -35,6 +35,31 @@ useTTS ────────────────── 放送タイミン
 - `onUnavailable` は「音声を一切生成できず発話しなかった」場合のみ。再生が始まった
   後の失敗は `onSettled` で終える（途中まで読み上げた放送を頭から読み直さない）。
 - `stop()` — 進行中の発話を中断し、ネイティブ資源を解放する。コールバックは呼ばない。
+
+## 他アプリ音声のダッキング
+
+読み上げ中だけ他アプリ（音楽など）の音量を下げる。仕組みはプラットフォームで異なる。
+
+| プラットフォーム | 仕組み | 実装 |
+| --- | --- | --- |
+| iOS | `AVAudioSession` のカテゴリオプション (`duckOthers`) | `useTTS` の `setDuckingActiveAsync` |
+| Android | オーディオフォーカス (`AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`) | `modules/audio-focus`（`src/utils/speechAudioFocus.ts` 経由） |
+
+iOS の `AVSpeechSynthesizer` はアプリの音声セッションを共有するため、`expo-audio` の
+`setAudioModeAsync` に `duckOthers` を指定すれば端末内蔵 TTS・リモート TTS のどちらでも
+ダッキングされる。ダッキングは発話の直前にだけ張り、完了後は `mixWithOthers` へ戻す
+（張ったままにすると、再生停止後も他アプリの音量が復元されないことがある）。
+
+Android のダッキングはオーディオフォーカスの要求でしか起きない。`expo-audio` の Android
+実装は `setAudioModeAsync` では `interruptionMode` を保持するだけで、フォーカスを要求するのは
+プレイヤーが再生を開始したときだけである。リモート TTS は `expo-audio` で再生するのでこれに
+乗るが、端末内蔵 TTS (`expo-speech`) は `android.speech.tts.TextToSpeech` を直接呼ぶだけで
+`AudioManager` に触れないため、フォーカスが一度も要求されずダッキングが起きない。そのため
+`useNativeSpeechEngine` は、発話の直前と直後に Android 専用のローカル Expo モジュール
+`modules/audio-focus` でフォーカスを取得・返却する。
+
+このモジュールはネイティブコードを含むため、反映にはネイティブビルドが必要で
+OTA アップデートでは配信されない。
 
 ## テキストの前処理
 

--- a/modules/audio-focus/android/build.gradle
+++ b/modules/audio-focus/android/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.audiofocus'
+version = '1.0.0'
+
+android {
+  namespace "expo.modules.audiofocus"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/audio-focus/android/src/main/AndroidManifest.xml
+++ b/modules/audio-focus/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/audio-focus/android/src/main/java/expo/modules/audiofocus/AudioFocusModule.kt
+++ b/modules/audio-focus/android/src/main/java/expo/modules/audiofocus/AudioFocusModule.kt
@@ -1,0 +1,124 @@
+package expo.modules.audiofocus
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+/**
+ * 端末内蔵 TTS の発話中だけオーディオフォーカスを保持するための Android 専用モジュール。
+ *
+ * expo-speech の Android 実装は android.speech.tts.TextToSpeech をそのまま呼ぶだけで
+ * AudioManager に一切触れない。Android で他アプリ（音楽など）の音量が下がるのは
+ * 「アプリが AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK でフォーカスを要求したとき」だけなので、
+ * expo-audio の setAudioModeAsync に duckOthers を指定してもダッキングは起こらない
+ * (expo-audio の Android 実装はフォーカス要求をプレイヤーの再生開始時にしか行わない)。
+ * そのため、端末内蔵 TTS 経路ではこのモジュールが発話の直前・直後にフォーカスを
+ * 取得・返却する。iOS は AVAudioSession のカテゴリオプションで完結するため不要。
+ */
+class AudioFocusModule : Module() {
+  // AudioManager は「要求時と同じリスナーインスタンス」でフォーカスを対応付けるため、
+  // モジュールの生存期間で 1 つだけ保持する。
+  private val focusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+    // 恒久的な喪失を通知された時点でフォーカスは既に剥がされている。読み上げ自体は
+    // TextToSpeech 側に任せて継続させ、ここでは保持状態だけ実態に合わせる。
+    if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+      synchronized(this) {
+        hasFocus = false
+        focusRequest = null
+      }
+    }
+  }
+
+  private var focusRequest: AudioFocusRequest? = null
+  private var hasFocus = false
+
+  private val audioManager: AudioManager?
+    get() = appContext.reactContext?.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+
+  override fun definition() = ModuleDefinition {
+    Name("AudioFocus")
+
+    // 発話は待たせられないため同期関数にする。AudioManager への要求は
+    // audio service への短い IPC だけで、再生パイプラインを持たない。
+    Function("requestTransientMayDuck") {
+      requestTransientMayDuck()
+    }
+
+    Function("abandon") {
+      abandon()
+    }
+
+    // 画面破棄・リロードでフォーカスを握ったままにすると、他アプリの音量が
+    // 下がりっぱなしになるため確実に返す。
+    OnActivityDestroys {
+      abandon()
+    }
+
+    OnDestroy {
+      abandon()
+    }
+  }
+
+  @Synchronized
+  private fun requestTransientMayDuck(): Boolean {
+    if (hasFocus) {
+      return true
+    }
+    val manager = audioManager ?: return false
+
+    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+        .setAudioAttributes(
+          AudioAttributes.Builder()
+            // 車内放送は経路案内そのものなので、音楽アプリ側に「一時的な案内」として
+            // 扱わせる。API 26 以降はこの組み合わせでシステムが自動ダッキングを行う。
+            .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+        )
+        // アナウンスは後から流しても意味がないため、遅延付与は受け付けない
+        .setAcceptsDelayedFocusGain(false)
+        // 音量を下げるのは相手側。こちらの読み上げは止めない
+        .setWillPauseWhenDucked(false)
+        .setOnAudioFocusChangeListener(focusChangeListener)
+        .build()
+      focusRequest = request
+      manager.requestAudioFocus(request)
+    } else {
+      @Suppress("DEPRECATION")
+      manager.requestAudioFocus(
+        focusChangeListener,
+        AudioManager.STREAM_MUSIC,
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+      )
+    }
+
+    hasFocus = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    if (!hasFocus) {
+      focusRequest = null
+    }
+    return hasFocus
+  }
+
+  @Synchronized
+  private fun abandon() {
+    if (!hasFocus && focusRequest == null) {
+      return
+    }
+    val manager = audioManager
+    if (manager != null) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        focusRequest?.let { manager.abandonAudioFocusRequest(it) }
+      } else {
+        @Suppress("DEPRECATION")
+        manager.abandonAudioFocus(focusChangeListener)
+      }
+    }
+    focusRequest = null
+    hasFocus = false
+  }
+}

--- a/modules/audio-focus/expo-module.config.json
+++ b/modules/audio-focus/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.audiofocus.AudioFocusModule"]
+  }
+}

--- a/modules/audio-focus/index.ts
+++ b/modules/audio-focus/index.ts
@@ -1,0 +1,18 @@
+import { requireOptionalNativeModule } from 'expo';
+
+/**
+ * 端末内蔵 TTS (expo-speech) の発話中だけオーディオフォーカスを保持するための
+ * Android 専用ローカルモジュール。詳細な背景は AudioFocusModule.kt を参照。
+ */
+export type AudioFocusModule = {
+  /**
+   * AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK を要求し、獲得できたかどうかを返す。
+   * 既に保持している場合は何もせず true を返す。
+   */
+  requestTransientMayDuck(): boolean;
+  /** 保持中のフォーカスを返却する。保持していない場合は何もしない。 */
+  abandon(): void;
+};
+
+// Android 以外のプラットフォームでは autolink されないため null になる。
+export default requireOptionalNativeModule<AudioFocusModule>('AudioFocus');

--- a/src/hooks/tts/useNativeSpeechEngine.test.ts
+++ b/src/hooks/tts/useNativeSpeechEngine.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react-native';
+import type { SpeechEngineRequest } from './speechEngine';
+import { useNativeSpeechEngine } from './useNativeSpeechEngine';
+
+type SpeakOptions = {
+  language?: string;
+  voice?: string;
+  onDone?: () => void;
+  onStopped?: () => void;
+  onError?: (error: unknown) => void;
+};
+
+const speakCalls: SpeakOptions[] = [];
+const mockSpeak = jest.fn((_text: string, options: SpeakOptions) => {
+  speakCalls.push(options);
+});
+const mockStop = jest.fn();
+const mockGetAvailableVoicesAsync = jest.fn();
+
+jest.mock('expo-speech', () => ({
+  speak: (text: string, options: SpeakOptions) => mockSpeak(text, options),
+  stop: () => mockStop(),
+  getAvailableVoicesAsync: () => mockGetAvailableVoicesAsync(),
+  maxSpeechInputLength: 4000,
+  VoiceQuality: { Default: 'Default', Enhanced: 'Enhanced' },
+}));
+
+// 音声選択そのものは nativeTtsVoice のテストで担保する。ここでは
+// Android でも音声が見つかった状態にして、発話がスキップされないようにする。
+jest.mock('~/utils/nativeTtsVoice', () => ({
+  selectBestVoiceIdentifier: () => 'test-voice',
+}));
+
+const mockAcquireSpeechAudioFocus = jest.fn();
+const mockReleaseSpeechAudioFocus = jest.fn();
+jest.mock('~/utils/speechAudioFocus', () => ({
+  acquireSpeechAudioFocus: () => mockAcquireSpeechAudioFocus(),
+  releaseSpeechAudioFocus: () => mockReleaseSpeechAudioFocus(),
+}));
+
+const defaultRequest: SpeechEngineRequest = {
+  ssmlJa: '次は<sub alias="オオサキ">大崎</sub>です',
+  ssmlEn: 'The next station is Osaki,<break time="200ms"/> J Y 24.',
+  speakJa: true,
+  speakEn: true,
+};
+
+// 発話は音声一覧の取得完了を待つため非同期。マイクロタスクを進めて
+// Speech.speak の呼び出しまで到達させる。
+const flushAsync = async () => {
+  await act(async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+  });
+};
+
+const renderEngine = () => renderHook(() => useNativeSpeechEngine());
+
+describe('useNativeSpeechEngine', () => {
+  beforeEach(() => {
+    // 音声一覧取得の上限待ち（VOICES_READY_TIMEOUT_MS）が実タイマーのまま
+    // テスト終了後も残らないよう、この suite では偽タイマーを使う。
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    speakCalls.length = 0;
+    mockGetAvailableVoicesAsync.mockResolvedValue([
+      { identifier: 'test-voice', name: 'test-voice', language: 'ja-JP' },
+    ]);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('発話の直前にオーディオフォーカスを取得し、全発話の完了で返却する', async () => {
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled });
+    await flushAsync();
+
+    expect(mockAcquireSpeechAudioFocus).toHaveBeenCalledTimes(1);
+    expect(speakCalls).toHaveLength(2);
+    expect(mockReleaseSpeechAudioFocus).not.toHaveBeenCalled();
+
+    // 日本語だけ完了した時点ではまだ英語が残るため返却しない
+    act(() => {
+      speakCalls[0]?.onDone?.();
+    });
+    expect(mockReleaseSpeechAudioFocus).not.toHaveBeenCalled();
+    expect(onSettled).not.toHaveBeenCalled();
+
+    act(() => {
+      speakCalls[1]?.onDone?.();
+    });
+    expect(mockReleaseSpeechAudioFocus).toHaveBeenCalledTimes(1);
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('読み上げ途中で stop された場合もオーディオフォーカスを返却する', async () => {
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(defaultRequest, { onSettled });
+    await flushAsync();
+    expect(mockAcquireSpeechAudioFocus).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockReleaseSpeechAudioFocus).toHaveBeenCalledTimes(1);
+
+    // 停止で無効化された発話のコールバックが後から届いても onSettled は呼ばない
+    act(() => {
+      speakCalls[0]?.onStopped?.();
+      speakCalls[1]?.onStopped?.();
+    });
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it('読み上げ対象が無い場合はオーディオフォーカスを取得しない', async () => {
+    const onSettled = jest.fn();
+    const { result } = renderEngine();
+
+    result.current.speak(
+      { ...defaultRequest, speakJa: false, speakEn: false },
+      { onSettled }
+    );
+    await flushAsync();
+
+    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(mockAcquireSpeechAudioFocus).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/tts/useNativeSpeechEngine.ts
+++ b/src/hooks/tts/useNativeSpeechEngine.ts
@@ -6,6 +6,10 @@ import {
   toSpeakableText,
   truncateToSpeechLimit,
 } from '../../utils/speakableText';
+import {
+  acquireSpeechAudioFocus,
+  releaseSpeechAudioFocus,
+} from '../../utils/speechAudioFocus';
 import type {
   SpeechEngine,
   SpeechEngineCallbacks,
@@ -114,6 +118,9 @@ export const useNativeSpeechEngine = (): SpeechEngine => {
     try {
       Speech.stop();
     } catch {}
+    // 発話が終わらないまま中断された場合でも、他アプリの音量を下げたままに
+    // しないよう必ずフォーカスを返す（Android 以外では何もしない）
+    releaseSpeechAudioFocus();
   }, []);
 
   const speak = useCallback(
@@ -203,9 +210,16 @@ export const useNativeSpeechEngine = (): SpeechEngine => {
           }
           remaining -= 1;
           if (remaining <= 0) {
+            releaseSpeechAudioFocus();
             callbacks.onSettled();
           }
         };
+        // Android の TextToSpeech はオーディオフォーカスを自分では要求せず、
+        // useTTS が expo-audio へ設定する duckOthers も（再生中のプレイヤーが
+        // 無いため）フォーカス要求を伴わない。発話中だけ自前でフォーカスを
+        // 取得して、音楽など他アプリの音量を下げてもらう。
+        acquireSpeechAudioFocus();
+
         for (const utterance of utterances) {
           Speech.speak(utterance.text, {
             language: utterance.language,

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -85,6 +85,11 @@ export const useTTS = (): void => {
   // audio mode に従う。リモート TTS の再生（expo-audio）も同じセッションを使う。
   // 他アプリ音声のダッキングは発話開始直前にのみ有効化し
   // （setDuckingActiveAsync 参照）、ここでは非ダッキング状態を既定にする。
+  // ここでのダッキング指定が効くのは iOS だけである。Android は
+  // オーディオフォーカスを要求しない限りダッキングが起きず、interruptionModeAndroid は
+  // expo-audio のプレイヤーが再生を開始したときのフォーカス要求にしか反映されない。
+  // 端末内蔵 TTS 経路のダッキングは useNativeSpeechEngine が
+  // src/utils/speechAudioFocus.ts 経由で自前に取得する。
   const backgroundEnabledRef = useRef(backgroundEnabled);
   backgroundEnabledRef.current = backgroundEnabled;
   // 直近に要求したダッキング状態。backgroundEnabled 変更時の再設定で

--- a/src/utils/speechAudioFocus.ts
+++ b/src/utils/speechAudioFocus.ts
@@ -1,0 +1,23 @@
+import AudioFocus from '../../modules/audio-focus';
+
+// 端末内蔵 TTS (expo-speech) で読み上げる間だけ、他アプリ音声をダッキングさせるための
+// オーディオフォーカス制御。Android の TextToSpeech はフォーカスを自分では要求せず、
+// expo-audio の setAudioModeAsync も値を保持するだけでフォーカス要求を伴わないため、
+// この経路では明示的に取得しないとダッキングが一切起こらない。
+// ネイティブモジュールは Android でのみ autolink されるので、iOS・web では何もしない。
+
+export const acquireSpeechAudioFocus = (): void => {
+  try {
+    AudioFocus?.requestTransientMayDuck();
+  } catch (e) {
+    console.warn('[speechAudioFocus] failed to request audio focus:', e);
+  }
+};
+
+export const releaseSpeechAudioFocus = (): void => {
+  try {
+    AudioFocus?.abandon();
+  } catch (e) {
+    console.warn('[speechAudioFocus] failed to abandon audio focus:', e);
+  }
+};


### PR DESCRIPTION
## 概要

音楽を再生しながらアプリを使うと、音声アナウンス中に他アプリの音量が下がらない（ダッキングされない）という Android からの報告を修正します。

Android のダッキングは `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` の要求でしか起きませんが、`expo-speech` の Android 実装は `android.speech.tts.TextToSpeech` を直接呼ぶだけで `AudioManager` に一切触れず、`expo-audio` の `setAudioModeAsync` も `interruptionMode` を保持するだけでフォーカスを要求しません（要求するのはプレイヤーの再生開始時のみ）。そのため端末内蔵 TTS 経路では `duckOthers` を指定してもダッキングが一度も発生していませんでした。

デグレ地点は #6453（v10.11.0）です。それ以前は合成済み音声を `expo-audio` のプレイヤーで再生していたため、プレイヤーがフォーカスを要求し結果としてダッキングが効いていました。端末内蔵 TTS へ置き換えた際にプレイヤーが経路から外れ、ダッキングだけが落ちています。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 発話中だけオーディオフォーカスを保持する Android 専用ローカル Expo モジュール `modules/audio-focus` を追加
  - `AudioFocusModule.kt`: `requestTransientMayDuck()` / `abandon()` の 2 つの同期関数。`USAGE_ASSISTANCE_NAVIGATION_GUIDANCE` + `CONTENT_TYPE_SPEECH` の `AudioAttributes` で `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` を要求する（API 26 未満は旧 API へフォールバック）
  - `setAcceptsDelayedFocusGain(false)`（アナウンスは後から流しても意味がない）／`setWillPauseWhenDucked(false)`（音量を下げるのは相手側で、こちらの読み上げは止めない）
  - `OnActivityDestroys` / `OnDestroy` と恒久喪失時の状態同期により、フォーカスを握ったままにしない
  - `expo-module.config.json` は `"platforms": ["android"]` のみ。`modules/` は `expo-modules-autolinking` の既定 `nativeModulesDir` なので `settings.gradle` の変更は不要
- `src/utils/speechAudioFocus.ts` を追加。例外を握って警告ログに落とす薄いラッパで、ネイティブモジュールが無いプラットフォームでは何もしない
- `src/hooks/tts/useNativeSpeechEngine.ts`: 発話キューを積む直前にフォーカスを取得し、全発話の完了（`settle`）と `stop()` で返却する
- `src/hooks/useTTS.ts`: ここでのダッキング指定が効くのは iOS だけである旨をコメントへ追記
- `src/hooks/tts/useNativeSpeechEngine.test.ts` を新規追加（取得・返却のタイミング、途中停止、読み上げ対象ゼロの 3 ケース）
- `docs/spec/tts/remote-tts.md` に「他アプリ音声のダッキング」節を追加し、`docs/changelog.md` に記録

### リグレッションリスク

リモート TTS 経路には手を入れていません。あちらは `expo-audio` のプレイヤーが自分でフォーカスを取るため、二重に要求すると expo-audio 側の `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` ハンドラが自前の再生音量を半分に落としてしまいます。フォーカスの取得は端末内蔵 TTS 経路（`useNativeSpeechEngine`）に閉じているので、リモート合成に失敗した回のフォールバック発話も含めて二重要求は起きません。

iOS は `expo-module.config.json` が `android` のみを宣言しており autolink されないため、`requireOptionalNativeModule` が `null` を返して挙動は変わりません。

**ネイティブモジュールの追加を含むため、反映にはネイティブビルドが必要で OTA アップデートでは配信されません。**

Kotlin のコンパイルは作業環境に Android SDK が無く確認できていません。初回の検証は canary のネイティブビルドになります。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint` — 成功（`biome check ./src`、670 files）
- `npm test` — 成功（237 suites / 2544 tests）
- `npm run typecheck` — 成功（`modules/audio-focus` も型検査の対象に入っていることを `tsc --listFiles` で確認）

未実施: 実機での動作確認（音楽再生中にアナウンスで音量が下がり、終了後に戻るか）。ネイティブビルドが必要なため。

## 関連Issue

- Refs TrainLCD/Issues#1263

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: オーディオフォーカスと音声セッションの制御のみの変更で、画面表示に変化はありません。

<!-- create-pr:screenshots:end -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01JASbvSpMEbvp4nfpFYUFzb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Androidの端末内蔵TTS発話中、他アプリの音声を適切にダッキングできるようになりました。
  * 発話の完了、停止、エラー時に音声フォーカスを自動的に返却します。
  * iOSの動作に変更はありません。

* **ドキュメント**
  * 音声ダッキングの仕組みとAndroid・iOSでの適用範囲を明記しました。
  * Androidでの変更を利用するにはネイティブビルドが必要で、OTA配信には含まれません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->