### PR TITLE
通過駅走行中に種別が各駅停車へ戻る不具合を修正

### DIFF
--- a/src/hooks/useCurrentTrainType.test.tsx
+++ b/src/hooks/useCurrentTrainType.test.tsx
@@ -48,6 +48,7 @@ const TRAIN_TYPE_IDS = {
   LOCAL: 1,
   RAPID: 2,
   EXPRESS: 3,
+  MU_SKY: 511,
 } as const;
 
 const createTrainType = (
@@ -189,6 +190,95 @@ describe('useCurrentTrainType', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('trainType').props.children).toBe('null')
+    );
+  });
+
+  it('直近の停車駅と路線が異なる通過駅を走行中でも種別を維持する', async () => {
+    // NOTE: 名鉄ミュースカイ(中部国際空港→新可児)のように、
+    // 直近の停車駅 (空港線) と現在走行中の路線 (常滑線) がずれるケース。
+    // 通過駅には API から trainType が返らないため、現在駅をそのまま引くと
+    // 種別が失われて各駅停車扱いになってしまう。
+    const muSky = createTrainType({
+      typeId: TRAIN_TYPE_IDS.MU_SKY,
+      name: 'ミュースカイ',
+      __typename: 'TrainTypeNested',
+    });
+    const airportLineStop = createStation(3000703, {
+      line: { id: 30007 },
+      trainType: muSky,
+    } as Parameters<typeof createStation>[1]);
+    const tokonameLinePassing = createStation(3000813, {
+      line: { id: 30008 },
+      trainType: null,
+    } as Parameters<typeof createStation>[1]);
+    const tokonameLineStop = createStation(3000804, {
+      line: { id: 30008 },
+      trainType: muSky,
+    } as Parameters<typeof createStation>[1]);
+    stationAtomValue = {
+      stations: [airportLineStop, tokonameLinePassing, tokonameLineStop],
+    };
+    currentStationValue = airportLineStop;
+    currentLineValue = createLine(30008, {
+      station: { id: 3000813, __typename: 'StationNested' } as Line['station'],
+    });
+    navigationAtomValue.trainType = createTrainType({
+      typeId: TRAIN_TYPE_IDS.MU_SKY,
+      name: 'ミュースカイ',
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() =>
+      expect(getByTestId('trainType').props.children).toBe(
+        TRAIN_TYPE_IDS.MU_SKY
+      )
+    );
+  });
+
+  it('同一路線内で種別が変わる系統では現在地に近い停車駅の種別を採用する', async () => {
+    const rapid = createTrainType({
+      typeId: TRAIN_TYPE_IDS.RAPID,
+      __typename: 'TrainTypeNested',
+    });
+    const local = createTrainType({
+      typeId: TRAIN_TYPE_IDS.LOCAL,
+      __typename: 'TrainTypeNested',
+    });
+    const otherLineStop = createStation(100, {
+      line: { id: 1 },
+      trainType: createTrainType({
+        typeId: TRAIN_TYPE_IDS.EXPRESS,
+        __typename: 'TrainTypeNested',
+      }),
+    } as Parameters<typeof createStation>[1]);
+    const farStop = createStation(200, {
+      line: { id: 2 },
+      trainType: rapid,
+    } as Parameters<typeof createStation>[1]);
+    const nearStop = createStation(201, {
+      line: { id: 2 },
+      trainType: local,
+    } as Parameters<typeof createStation>[1]);
+    const passing = createStation(202, {
+      line: { id: 2 },
+      trainType: null,
+    } as Parameters<typeof createStation>[1]);
+    stationAtomValue = {
+      stations: [otherLineStop, farStop, nearStop, passing],
+    };
+    currentStationValue = otherLineStop;
+    currentLineValue = createLine(2, {
+      station: { id: 202, __typename: 'StationNested' } as Line['station'],
+    });
+    navigationAtomValue.trainType = createTrainType({
+      typeId: TRAIN_TYPE_IDS.RAPID,
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() =>
+      expect(getByTestId('trainType').props.children).toBe(TRAIN_TYPE_IDS.LOCAL)
     );
   });
 

--- a/src/hooks/useCurrentTrainType.ts
+++ b/src/hooks/useCurrentTrainType.ts
@@ -1,11 +1,48 @@
 import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
-import type { Station, TrainType } from '~/@types/graphql';
+import type { Line, Station, TrainType } from '~/@types/graphql';
 import { trainTypeAtom } from '../store/atoms/navigation';
 import { stationsAtom } from '../store/atoms/station';
 import getIsPass from '../utils/isPass';
 import { useCurrentLine } from './useCurrentLine';
 import { useCurrentStation } from './useCurrentStation';
+
+// NOTE: APIは系統内の「停車駅」にしか種別を紐づけないため、通過駅のtrainTypeは常にnullで返る。
+// そのため現在地の駅を直接引くだけだと、通過駅を走行している間だけ種別が失われてしまう。
+// 同一路線上で種別を持つ(=停車する)駅から引き直すことで種別を維持する。
+// 系統によっては同じ路線の途中で種別が変わるものがあるので、
+// 現在地から前後に近い駅を優先して探索する。
+const findTrainTypeOnLine = (
+  stations: Station[],
+  line: Line | null
+): TrainType | null => {
+  if (!line) {
+    return null;
+  }
+
+  const originIndex = stations.findIndex((s) => s?.id === line.station?.id);
+  if (originIndex === -1) {
+    return null;
+  }
+
+  const originTrainType = stations[originIndex]?.trainType;
+  if (originTrainType) {
+    return originTrainType;
+  }
+
+  for (let offset = 1; offset < stations.length; offset++) {
+    const behind = stations[originIndex - offset];
+    if (behind?.line?.id === line.id && behind.trainType) {
+      return behind.trainType;
+    }
+    const ahead = stations[originIndex + offset];
+    if (ahead?.line?.id === line.id && ahead.trainType) {
+      return ahead.trainType;
+    }
+  }
+
+  return null;
+};
 
 export const useCurrentTrainType = (): TrainType | null => {
   const stations = useAtomValue(stationsAtom);
@@ -28,9 +65,7 @@ export const useCurrentTrainType = (): TrainType | null => {
     // NOTE: 選択した路線と選択した種別に紐づいている路線が違う時に選んだ方面の種別と合わせる処理
     // 例として渋谷駅で東横線選んで特急種別を選んだ後、同一種別の存在しないメトロ線方面を選んだ等;
     if (currentStation?.line?.id !== currentLine?.id) {
-      const actualTrainType = stations.find(
-        (s: Station) => s?.id === currentLine?.station?.id
-      )?.trainType;
+      const actualTrainType = findTrainTypeOnLine(stations, currentLine);
       setCachedTrainType((prev: TrainType | null) =>
         prev?.typeId === actualTrainType?.typeId
           ? prev


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

直通系統の通過駅を走行している間だけ、ヘッダーの種別表示が本来の種別から `各駅停車` に化ける不具合を修正します。

APIは系統内の「停車駅」にのみ種別を紐づけて返すため、通過駅の `trainType` は常に `null` になります。`useCurrentTrainType` は「直近の停車駅の路線」と「現在走行中の路線」がずれたときに現在地の駅から種別を引き直しますが、その駅が通過駅だと `null` をそのまま採用してキャッシュを消してしまっていました。`TrainTypeBox` は種別が `null` のとき `各駅停車` + 既定色にフォールバックするため、青い「各駅停車」が表示されます。

例として名鉄ミュースカイ（中部国際空港→新可児, lineGroupId 1077）の場合、直近の停車駅である中部国際空港は名鉄常滑・空港線 (30007) に属する一方、走行中の常滑 (3000826) 〜 豊田本町 (3000805) は名鉄常滑線 (30008) の通過駅であるため、常滑を通過した時点で種別が失われ、次の停車駅である神宮前 (3000804) に到達するまで復帰しませんでした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useCurrentTrainType` に `findTrainTypeOnLine()` を追加し、現在地の駅が種別を持たない（＝通過駅）場合は同一路線上の停車駅から種別を引き直すようにした
- StationAPI のデータを検査したところ「同一系統・同一路線内で種別が変わる」組み合わせが 2527 組中 23 組存在したため、単純な先頭一致ではなく現在地から前後に近い駅を優先して探索する実装にした
- 上記の挙動を固定する回帰テストを 2 件追加（直通系統の通過駅走行中に種別を維持すること / 同一路線内で種別が変わる系統では現在地に近い停車駅の種別を採用すること）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加した回帰テスト 2 件が修正前のコードでは失敗し、修正後に成功することを確認済みです。

回帰リスクと緩和:

- 影響範囲は `useCurrentTrainType` の「直近の停車駅の路線と現在の路線が異なる」分岐のみで、既存の 2 分岐（現在駅の種別をそのまま返す / 通過駅では前回の種別を維持する）は変更していません。
- 従来の `currentLine.station.id` による完全一致検索は最優先のまま残してあるため、その駅が停車駅であるケースの挙動は変わりません。追加した路線内探索は完全一致で種別が取れなかった場合のみ走ります。
- 対象路線に種別を持つ駅が 1 つも無い場合は従来どおり `null` を返します。
- 既存テスト 4 件を含め、全 237 スイート / 2546 テストが通っています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- Refs TrainLCD/Issues#1264

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: ヘッダーの種別表示に影響する変更ですが、名鉄ミュースカイのような直通系統を通過駅区間で走行しているという位置条件でしか差分が現れないため、静止画では変更前後の違いを示せません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - 通過駅などで列車種別が取得できない場合、同一路線上の近隣停車駅を参照して種別を補完できるようになりました。
  - 同一路線内で列車種別が変わる場合も、現在地に適した種別を表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->