### PR TITLE
列車種別の絞り込み入力でiOSの日本語変換候補が出ない不具合を修正

### DIFF
--- a/src/components/TrainTypeFilterBar.test.tsx
+++ b/src/components/TrainTypeFilterBar.test.tsx
@@ -151,6 +151,17 @@ describe('TrainTypeFilterBar', () => {
     });
   });
 
+  // iOS は autoCorrect={false}(autocorrectionType = .no) にすると日本語入力の
+  // 変換候補バーごと消え、かなを漢字へ変換できなくなる。Android でも
+  // TYPE_TEXT_FLAG_NO_SUGGESTIONS が立って候補が出なくなるため、無効化しない
+  it('日本語入力の変換候補を潰さないよう、入力欄のオートコレクトは無効化しない', () => {
+    const { getByTestId } = setup();
+
+    expect(
+      getByTestId('trainTypeFilterSearchInput').props.autoCorrect
+    ).not.toBe(false);
+  });
+
   it('入力があるときだけ入力欄のクリアが出る', () => {
     const { queryByTestId } = setup();
     expect(queryByTestId('trainTypeFilterClearQuery')).toBeNull();

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -391,7 +391,12 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
           placeholder={translate('trainTypeFilterPlaceholder')}
           placeholderTextColor={palette.placeholder}
           autoCapitalize="none"
-          autoCorrect={false}
+          // autoCorrect は既定(true)のままにする。false にすると iOS は
+          // autocorrectionType = .no になり、日本語入力の変換候補バーごと消えて
+          // かなを漢字へ変換できなくなる(iOS の日本語キーボードは候補バー以外に
+          // 変換する手段を持たない)。Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS
+          // が立ち IME の候補が出なくなる。ローマ字入力に英語のオートコレクトが
+          // かかる副作用より、日本語を入力できることを優先する。
           returnKeyType="search"
           testID="trainTypeFilterSearchInput"
         />


### PR DESCRIPTION
## 概要

列車種別モーダルのフリーワード検索欄で、iPhone の日本語入力（IME）が使えない不具合を修正します。

原因は検索欄に付いていた `autoCorrect={false}` です。iOS ではこれが `autocorrectionType = .no` になり、**日本語入力の変換候補バーごと消えます**。iOS の日本語キーボードは候補バー以外に変換する手段を持たないため、かなは打てても漢字に変換できない＝IME が使えない状態になっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `TrainTypeFilterBar` の検索欄から `autoCorrect={false}` を削除し、既定値（`true`）に戻した。理由が再び失われないよう、iOS / Android それぞれで何が起きるかをコメントとして残している
- 再発防止として、検索欄の `autoCorrect` が `false` でないことを検証するユニットテストを追加した

補足:

- Android でも `autoCorrect={false}` は `TYPE_TEXT_FLAG_NO_SUGGESTIONS` を立てるため IME の候補が出なくなる。両プラットフォームで同じ理由から、プラットフォーム分岐はせず指定ごと外している
- ローマ字入力に英語のオートコレクトがかかる副作用は残るが、日本語を入力できることを優先した
- アプリ内の他の `TextInput`（`SearchBar` / `NewReportModal` / `SavePresetNameModal` / `AgentInputBar`）はいずれもこの指定を持たないため、影響はこの入力欄のみ
- 混入元は #6742（列車種別モーダルへの絞り込み追加）で、実装当初から入っていた

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint` → Checked 677 files、指摘なし
- `npm test` → 240 suites / 2601 tests すべて成功
- `npm run typecheck` → エラーなし
- 追加したテストが、修正前の状態（`autoCorrect={false}` を戻した状態）では失敗し、修正後は通ることを確認済み

リグレッションリスク: 低。変更は `TextInput` の 1 プロパティの削除のみで、絞り込みロジック・レイアウト・他の入力欄には触れていない。想定される副作用は英字入力時に iOS のオートコレクトが働くことのみ。

未検証: 作業環境に iOS シミュレータが無く、argent MCP サーバーも接続に失敗している（`ENOENT: argent`）ため、実機で変換候補バーが出ることの目視確認はできていません。マージ前に実機での確認をお願いします。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

未添付: 変更はキーボード（IME）の挙動のみで、アプリ側の画面表示には差分がありません。変換候補バーの有無は iOS 実機 / シミュレータの日本語キーボードでしか確認できず、この作業環境（Linux コンテナ・iOS シミュレータなし・argent MCP 未接続）では撮影できないためです。

<!-- create-pr:screenshots:end -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvskPeHetTTeNcJKSi35RT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvskPeHetTTeNcJKSi35RT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 検索入力欄で、日本語入力時の変換候補や漢字変換が正しく維持されるよう改善しました。
  - iOS・Androidでの入力時の挙動を確認し、安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->