### PR TITLE
種別絞り込み入力のautoCorrectを明示的に有効化して日本語変換候補を確実に出す

### DIFF
--- a/src/components/TrainTypeFilterBar.test.tsx
+++ b/src/components/TrainTypeFilterBar.test.tsx
@@ -153,13 +153,15 @@ describe('TrainTypeFilterBar', () => {
 
   // iOS は autoCorrect={false}(autocorrectionType = .no) にすると日本語入力の
   // 変換候補バーごと消え、かなを漢字へ変換できなくなる。Android でも
-  // TYPE_TEXT_FLAG_NO_SUGGESTIONS が立って候補が出なくなるため、無効化しない
-  it('日本語入力の変換候補を潰さないよう、入力欄のオートコレクトは無効化しない', () => {
+  // TYPE_TEXT_FLAG_NO_SUGGESTIONS が立って候補が出なくなる。
+  // 省略して既定に委ねると、New Architecture のビュー再利用で .no が残った
+  // ビューを引き継ぐことがあるため、true を明示することまで含めて固定する
+  it('日本語入力の変換候補を潰さないよう、入力欄のオートコレクトを明示的に有効化する', () => {
     const { getByTestId } = setup();
 
-    expect(
-      getByTestId('trainTypeFilterSearchInput').props.autoCorrect
-    ).not.toBe(false);
+    expect(getByTestId('trainTypeFilterSearchInput').props.autoCorrect).toBe(
+      true
+    );
   });
 
   it('入力があるときだけ入力欄のクリアが出る', () => {

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -391,12 +391,20 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
           placeholder={translate('trainTypeFilterPlaceholder')}
           placeholderTextColor={palette.placeholder}
           autoCapitalize="none"
-          // autoCorrect は既定(true)のままにする。false にすると iOS は
-          // autocorrectionType = .no になり、日本語入力の変換候補バーごと消えて
-          // かなを漢字へ変換できなくなる(iOS の日本語キーボードは候補バー以外に
-          // 変換する手段を持たない)。Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS
-          // が立ち IME の候補が出なくなる。ローマ字入力に英語のオートコレクトが
-          // かかる副作用より、日本語を入力できることを優先する。
+          // autoCorrect を false にすると iOS は autocorrectionType = .no になり、
+          // 日本語入力の変換候補バーごと消えてかなを漢字へ変換できなくなる
+          // (iOS の日本語キーボードは候補バー以外に変換する手段を持たない)。
+          // Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS が立ち IME の候補が出ない。
+          //
+          // 省略して既定に委ねるだけでは足りない。New Architecture の
+          // RCTTextInputComponentView は autoCorrect が前回 props から変化した
+          // ときしか autocorrectionType を代入せず、prepareForRecycle も
+          // autocorrectionType を戻さない。そのため .no が残ったビューが再利用
+          // されると、props 省略(std::nullopt 同士で変化なし)では .no を引き継ぐ。
+          // 明示的に true を渡してマウントのたびに .yes を確定させる。
+          // ローマ字入力に英語のオートコレクトがかかる副作用より、日本語を
+          // 入力できることを優先する。
+          autoCorrect
           returnKeyType="search"
           testID="trainTypeFilterSearchInput"
         />


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別絞り込みの検索入力欄で、iPhone の日本語入力の変換候補バーが出ずかなを漢字に変換できない不具合を、New Architecture のビュー再利用を踏まえて確実に塞ぎます。

#6750 で `autoCorrect={false}` を削除して「既定に委ねる」形にしましたが、RN 0.86.2 の New Architecture の実装を確認したところ、props を省略しただけでは `autocorrectionType = .no` が残ったビューを再利用したときに `.no` を引き継ぎうることが分かったため、`autoCorrect` を明示的に有効化して固定します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `TrainTypeFilterBar` の検索入力欄で `autoCorrect` を明示的に有効化した（`src/components/TrainTypeFilterBar.tsx`）
- 既存テストを「`false` でないこと」から「明示的に `true` であること」に強化した（`src/components/TrainTypeFilterBar.test.tsx`）
- 判断の根拠をコード側のコメントに残した

### なぜ省略では足りないか

`react-native` 0.86.2 の `RCTTextInputComponentView` を読んだ結果、以下が確認できました。

- `updateProps` は `autoCorrect` が**前回 props から変化したときにしか** `autocorrectionType` を代入しない
- `prepareForRecycle` は `attributedText` や `inputAccessoryView` はリセットするが、`autocorrectionType` は戻さない
- props 省略時の値は `std::optional<bool>` の `std::nullopt` なので、リサイクル元も新規マウントも `nullopt` 同士で「変化なし」と判定される

結果として、`autocorrectionType = .no` が残ったビューが再利用されると、props を省略しているマウントはその `.no` をそのまま引き継ぎます。`autoCorrect` を明示的に渡せば「デフォルト props（`nullopt`）→ `true`」で必ず差分が立つため、マウントのたびに `.yes` が確定的に代入されます。

なお iOS の日本語キーボードは変換候補バー以外に変換手段を持たないため、`.no` になると候補バーごと消えてかなが打った端から確定します。Android でも `TYPE_TEXT_FLAG_NO_SUGGESTIONS` が立って IME の候補が出なくなります。ローマ字入力に英語のオートコレクトがかかる副作用より、日本語を入力できることを優先しています。

## テスト

<!-- どのようにテストしたかを記述してください -->

Node 24.20.0 / npm 11.19.0 で実行し、すべて成功しています（`npm test` はスコープを絞って実行し、種別絞り込みに関わる 2 スイートを対象にしました）。

- `npm run lint` → Checked 677 files, エラーなし
- `npx jest src/components/TrainTypeFilterBar.test.tsx` → 14 passed
- `npx jest src/components/TrainTypeListModal.test.tsx` → 10 passed
- `npm run typecheck` → エラーなし

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

### 回帰リスクと緩和

- 影響範囲は種別一覧モーダルの絞り込み入力欄 1 箇所のみで、他の `TextInput` には触れていません。
- 副作用は iOS でローマ字入力時に英語のオートコレクトが働くことです。検索欄なので誤変換の実害は小さく、日本語が入力できないことのほうが重大と判断しました。
- 挙動を props の値として固定したため、将来 `autoCorrect={false}` に戻す変更が入ればテストが落ちて検知できます。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6750

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: 変更が現れるのは iOS 日本語キーボードの変換候補バーの有無で、実機またはシミュレータの日本語 IME でしか差分を示せないため（React Native Web では iOS の IME 候補バーを再現できず、この作業環境にシミュレータはありません）。レイアウト自体は変わりません。

<!-- create-pr:screenshots:end -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01A3iYXFgbj6HmNAXG38kKPY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 検索入力欄で自動修正を明示的に有効化し、日本語入力時の変換候補が表示されるよう改善しました。
  * 入力欄の再利用後も、iOS・Androidで適切に変換候補を表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->