### PR TITLE
分岐駅で直通先路線の逆方向への乗換が案内されない不具合を修正

### DIFF
--- a/src/hooks/useTransferLinesFromStation.test.tsx
+++ b/src/hooks/useTransferLinesFromStation.test.tsx
@@ -2,7 +2,12 @@ import { render } from '@testing-library/react-native';
 import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { Text } from 'react-native';
-import type { Line, LineNested, Station } from '~/@types/graphql';
+import type {
+  Line,
+  LineNested,
+  Station,
+  StationNested,
+} from '~/@types/graphql';
 import { TransportType } from '~/@types/graphql';
 import { createStation } from '~/utils/test/factories';
 import { stationsAtom } from '../store/atoms/station';
@@ -48,6 +53,37 @@ const createLineNested = (overrides: Partial<LineNested> = {}): LineNested => ({
   trainType: null,
   transportType: TransportType.Rail,
   ...overrides,
+});
+
+const createStationNested = (id: number): StationNested => ({
+  __typename: 'StationNested',
+  address: null,
+  closedAt: null,
+  distance: null,
+  groupId: id,
+  hasTrainTypes: false,
+  id,
+  latitude: null,
+  line: null,
+  lines: [],
+  longitude: null,
+  name: `Station${id}`,
+  nameChinese: null,
+  nameIpa: null,
+  nameKatakana: null,
+  nameKorean: null,
+  nameRoman: null,
+  nameRomanIpa: null,
+  nameTtsSegments: null,
+  openedAt: null,
+  postalCode: null,
+  prefectureId: null,
+  stationNumbers: [],
+  status: undefined,
+  stopCondition: undefined,
+  threeLetterCode: null,
+  trainType: null,
+  transportType: undefined,
 });
 
 describe('useTransferLinesFromStation', () => {
@@ -247,6 +283,124 @@ describe('useTransferLinesFromStation', () => {
 
     expect(lines.find((l: Line) => l.id === 2)).toBeUndefined();
     expect(lines.find((l: Line) => l.id === 3)).toBeDefined();
+  });
+
+  // 相鉄 西谷: 相鉄新横浜線から相鉄本線へ直通するが、本線の横浜方面(起点側)へは
+  // 乗り換えが必要なため、直通先路線でも乗換案内に残す
+  it('分岐駅で直通先路線の起点側が経路に含まれない場合は乗り換え路線として残す', () => {
+    const sotetsuMainLine = createLineNested({
+      id: 29001,
+      nameShort: '相鉄本線',
+      station: createStationNested(2900108),
+    });
+    const sotetsuJrLine = createLineNested({
+      id: 29003,
+      nameShort: '相鉄・JR直通線',
+      station: createStationNested(2900302),
+    });
+    const sotetsuShinYokohamaLine = createLineNested({
+      id: 29004,
+      nameShort: '相鉄新横浜線',
+      station: createStationNested(2900403),
+    });
+
+    const nishiyaLines = [
+      sotetsuMainLine,
+      sotetsuJrLine,
+      sotetsuShinYokohamaLine,
+    ];
+
+    const shinYokohama = createStation(2900401, {
+      line: sotetsuShinYokohamaLine,
+      lines: [sotetsuShinYokohamaLine],
+    });
+    const hazawaYokohamaKokudai = createStation(2900402, {
+      line: sotetsuShinYokohamaLine,
+      lines: [sotetsuShinYokohamaLine],
+    });
+    const nishiya = createStation(2900403, {
+      line: sotetsuShinYokohamaLine,
+      lines: nishiyaLines,
+    });
+    const tsurugamine = createStation(2900109, {
+      line: sotetsuMainLine,
+      lines: [sotetsuMainLine],
+    });
+    const futamatagawa = createStation(2900110, {
+      line: sotetsuMainLine,
+      lines: [sotetsuMainLine],
+    });
+
+    stationAtomValue.stations = [
+      shinYokohama,
+      hazawaYokohamaKokudai,
+      nishiya,
+      tsurugamine,
+      futamatagawa,
+    ];
+
+    const { getByTestId } = render(<TestComponent station={nishiya} />);
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([29001, 29003]);
+  });
+
+  // 東急東横線と東京メトロ副都心線の直通: 渋谷は東横線の起点なので
+  // 逆方向の区間が存在せず、従来通り除外される
+  it('直通先路線の起点駅では逆方向の区間が無いため除外したままにする', () => {
+    const fukutoshinLine = createLineNested({
+      id: 28009,
+      nameShort: '東京メトロ副都心線',
+      station: createStationNested(2800916),
+    });
+    const toyokoLine = createLineNested({
+      id: 26001,
+      nameShort: '東急東横線',
+      station: createStationNested(2600101),
+    });
+    const ginzaLine = createLineNested({
+      id: 28001,
+      nameShort: '東京メトロ銀座線',
+      station: createStationNested(2800101),
+    });
+
+    const kitasando = createStation(2800914, {
+      line: fukutoshinLine,
+      lines: [fukutoshinLine],
+    });
+    const meijiJingumae = createStation(2800915, {
+      line: fukutoshinLine,
+      lines: [fukutoshinLine],
+    });
+    const shibuya = createStation(2800916, {
+      line: fukutoshinLine,
+      lines: [fukutoshinLine, toyokoLine, ginzaLine],
+    });
+    const daikanyama = createStation(2600102, {
+      line: toyokoLine,
+      lines: [toyokoLine],
+    });
+    const nakameguro = createStation(2600103, {
+      line: toyokoLine,
+      lines: [toyokoLine],
+    });
+
+    stationAtomValue.stations = [
+      kitasando,
+      meijiJingumae,
+      shibuya,
+      daikanyama,
+      nakameguro,
+    ];
+
+    const { getByTestId } = render(<TestComponent station={shibuya} />);
+    const lines = JSON.parse(
+      getByTestId('transferLines').props.children as string
+    );
+
+    expect(lines.map((l: Line) => l.id)).toEqual([28001]);
   });
 
   it('omitJR が true で JR路線が閾値以上の場合、JR線として集約される', () => {

--- a/src/hooks/useTransferLinesFromStation.ts
+++ b/src/hooks/useTransferLinesFromStation.ts
@@ -1,10 +1,39 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import type { Line, Station } from '~/@types/graphql';
+import {
+  DISNEY_RESORT_LINE_ID,
+  MEIJO_LINE_ID,
+  OSAKA_LOOP_LINE_ID,
+  TOEI_OEDO_LINE_ID,
+  YAMANOTE_LINE_ID,
+} from '~/constants';
 import { isBusLine } from '~/utils/line';
 import { parenthesisRegexp } from '../constants';
 import { stationsAtom } from '../store/atoms/station';
 import omitJRLinesIfThresholdExceeded from '../utils/jr';
+
+// StationAPI の駅IDは `路線ID * 100 + 路線内の連番(1始まり)` で構成される。
+// ex. 相鉄本線(29001)の横浜は 2900101、西谷は 2900108
+// 路線の全駅一覧はこのフックからは引けないため、この規約を頼りに
+// 「現在駅が路線の起点か」「経路が現在駅より終点側しか通っていないか」を判定する。
+const STATION_SEQUENCE_BASE = 100;
+
+const getLineIdFromStationId = (stationId: number): number =>
+  Math.floor(stationId / STATION_SEQUENCE_BASE);
+
+const getStationSequenceFromStationId = (stationId: number): number =>
+  stationId % STATION_SEQUENCE_BASE;
+
+// 環状運転する路線は乗り換えずとも一周して反対方向の駅へ到達できるため、
+// 「逆方向が経路に含まれない」判定の対象から外す
+const LOOP_LINE_ID_SET = new Set<number>([
+  YAMANOTE_LINE_ID,
+  OSAKA_LOOP_LINE_ID,
+  MEIJO_LINE_ID,
+  TOEI_OEDO_LINE_ID,
+  DISNEY_RESORT_LINE_ID,
+]);
 
 type Option = {
   omitRepeatingLine?: boolean;
@@ -33,12 +62,60 @@ export const useTransferLinesFromStation = (
     // 乗車中の列車が直通運転で通る路線一覧
     // 同じ列車に乗ったままで到達するため乗り換え対象から外す
     const throughServiceLineIds = new Set<number>();
+    // 直通で通る路線ごとに、現在駅以外で経路上に現れる駅IDの最小値を控えておく。
+    // 同一路線内の駅IDは起点からの連番なので、この最小値と現在駅のIDを比べると
+    // 経路が現在駅より終点側しか通っていないかどうかが分かる。
+    const minRouteStationIdByLineId = new Map<number, number>();
     for (const s of stations) {
       const id = s.line?.id;
-      if (id != null) {
-        throughServiceLineIds.add(id);
+      if (id == null) {
+        continue;
+      }
+      throughServiceLineIds.add(id);
+
+      // 現在駅そのもの(路線ごとに別レコードになる)は起点側判定の材料にならない
+      if (s.groupId != null && s.groupId === station.groupId) {
+        continue;
+      }
+      const stationId = s.id;
+      if (stationId == null || getLineIdFromStationId(stationId) !== id) {
+        continue;
+      }
+      const currentMin = minRouteStationIdByLineId.get(id);
+      if (currentMin == null || stationId < currentMin) {
+        minRouteStationIdByLineId.set(id, stationId);
       }
     }
+
+    // 直通先の路線であっても、分岐駅では「乗り換えないと到達できない方向」が残る。
+    // ex. 相鉄新横浜線から相鉄本線へ直通する西谷では、海老名方面へはそのまま行けるが
+    //     横浜方面(＝本線の起点側)は経路外なので乗換案内に残す必要がある。
+    // 経路が現在駅より終点側しか通っておらず、かつ現在駅が路線の起点でない場合に true。
+    // 逆に終点側が経路外となるケース(ex. 立川での中央線高尾方面)は路線の終端IDが
+    // 分からないため判定できず、従来通り除外される。
+    const hasUnreachableSectionOnOriginSide = (line: Line): boolean => {
+      const lineId = line.id;
+      const stationIdOnLine = line.station?.id;
+      if (lineId == null || stationIdOnLine == null) {
+        return false;
+      }
+      if (LOOP_LINE_ID_SET.has(lineId)) {
+        return false;
+      }
+      // 駅IDが規約通りでない場合は判定できないため従来の挙動に倒す
+      if (getLineIdFromStationId(stationIdOnLine) !== lineId) {
+        return false;
+      }
+      // 現在駅がその路線の起点なら起点側の区間自体が存在しない
+      if (getStationSequenceFromStationId(stationIdOnLine) <= 1) {
+        return false;
+      }
+      const minRouteStationId = minRouteStationIdByLineId.get(lineId);
+      if (minRouteStationId == null) {
+        return false;
+      }
+      return minRouteStationId > stationIdOnLine;
+    };
 
     // 隣接駅判定で何度も使うため一度だけ findIndex する。
     // findIndex が -1 (= ルート外駅を渡された) の場合 stations[-1+1]=stations[0] が
@@ -76,8 +153,13 @@ export const useTransferLinesFromStation = (
       }
 
       // 乗車中の列車が直通運転で通る路線は同じ列車のまま到達できるので
-      // 乗り換え路線として表示しない
-      if (line.id != null && throughServiceLineIds.has(line.id)) {
+      // 乗り換え路線として表示しない。
+      // ただし分岐駅で逆方向の区間が経路に含まれない場合は乗り換えが必要なため残す。
+      if (
+        line.id != null &&
+        throughServiceLineIds.has(line.id) &&
+        !hasUnreachableSectionOnOriginSide(line)
+      ) {
         continue;
       }
 
@@ -87,6 +169,7 @@ export const useTransferLinesFromStation = (
     return filtered;
   }, [
     omitRepeatingLine,
+    station?.groupId,
     station?.id,
     station?.line?.id,
     station?.line?.nameShort,


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

直通運転で通る路線を乗換候補から一律に除外していたため、分岐駅で「乗り換えないと到達できない方向」まで案内から消えていた不具合を修正します。

代表例が相鉄 西谷駅です。相鉄新横浜線から相鉄本線へ直通する列車に乗車中、相鉄本線は経路（海老名方面）に含まれるため `throughServiceLineIds` に入りますが、横浜方面は乗り換えないと到達できないため、乗換案内に残す必要があります。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `useTransferLinesFromStation` で、直通先の路線ごとに「現在駅グループを除いた経路上の駅IDの最小値」を控えるようにした
- 次の条件をすべて満たす場合は、直通先の路線でも乗換候補として残すようにした
  - 現在駅がその路線の起点ではない
  - 経路がその路線を現在駅より終点側でしか通らない
  - 環状路線ではない（一周すれば乗り換えずに到達できるため）
- 判定できない場合（`line.station` が無い／駅IDが規約どおりでない／環状路線）は、従来どおり除外する
- 西谷の分岐ケースと、渋谷（東急東横線の起点）ケースの回帰テストを追加した

### 判定に駅IDを使っている理由

経路データ（`stationsAtom`）だけでは、西谷（相鉄新横浜線 → 相鉄本線）と渋谷（東急東横線 → 東京メトロ副都心線）を区別できません。どちらも「現在駅の `line` は直通元、前駅に該当路線なし、次駅に該当路線あり」という同じ形をしており、違いは「渋谷は副都心線の終端だが、西谷は本線の途中駅」という路線側の事実だけです。路線の全駅一覧はこのフックからは引けないため、StationAPI（ekidata 由来）の駅ID規約 `路線ID * 100 + 路線内の連番(1始まり)` を判定材料にしています。この規約はリポジトリ内のフィクスチャとも一致します（山手線 `11302` / 新宿 `1130208`、都営新宿線 `99304` / 新宿 `9930401`）。

### 既知の制限

逆に「終点側が経路外」となるケース（例: 立川での中央線 高尾方面）は、路線の終端の駅IDが分からないため判定できず、従来どおり除外されたままです。今回のリグレッションではなく既存挙動の据え置きで、コード内にコメントとして明記しています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint` — `Checked 677 files`, 指摘なし
- `npm test` — `240 passed, 240 total` / `2603 passed, 2603 total`
- `npm run typecheck` — エラーなし

また、追加した西谷の回帰テストが修正前のコードでは失敗し、修正後に通ることを確認しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Closes #6745

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/claude_github-issue-6745-mkdng1-4098e917f73c/d4dc77fe4e07-nishiya-transfer.png" width="820" alt="西谷駅の乗換案内の修正前後と、乗り換えが必要になる方向を示したイメージ図" />

西谷駅での乗換案内の修正前後、および乗り換えが必要になる方向を示した図です。作業環境でシミュレータ・実機・実データAPIのいずれも利用できなかったため、実装を動かしたレンダリングではなく作図したものです。

<!-- create-pr:screenshots:end -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01R4WoUw9XawpqgaWfLAtgJc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 分岐駅で、直通先路線の起点側へ乗り換えが必要な場合に、適切な乗換路線が表示されるようになりました。
  * 直通先路線の起点駅では、従来どおり不要な乗換路線を表示しません。
  * 環状線などのケースでは、既存の判定を維持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->