### PR TITLE
同一会社の路線が連続する直通で次に入る路線が候補から落ちる不具合を修正

### DIFF
--- a/src/hooks/useConnectedLines.test.tsx
+++ b/src/hooks/useConnectedLines.test.tsx
@@ -3,7 +3,11 @@ import { useAtomValue } from 'jotai';
 import type React from 'react';
 import { Text } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
-import { createLine, createStation } from '~/utils/test/factories';
+import {
+  createCompany,
+  createLine,
+  createStation,
+} from '~/utils/test/factories';
 import {
   selectedBoundAtom,
   selectedDirectionAtom,
@@ -27,6 +31,14 @@ const TestComponent: React.FC<{ excludePassed?: boolean }> = ({
   const lines = useConnectedLines(excludePassed);
   return <Text testID="lines">{JSON.stringify(lines)}</Text>;
 };
+
+// createStation の line は LineNested なので、createLine の結果から
+// テストで意味のあるフィールドだけを詰め替える
+const toNestedLine = (line: Line) => ({
+  id: line.id,
+  nameShort: line.nameShort,
+  company: line.company,
+});
 
 describe('useConnectedLines', () => {
   const mockUseAtomValue = useAtomValue as jest.MockedFunction<
@@ -158,5 +170,125 @@ describe('useConnectedLines', () => {
 
     expect(lines.map((l: Line) => l.id)).toEqual([13, 12, 11]);
     expect(lines.find((l: Line) => l.id === 10)).toBeUndefined();
+  });
+
+  // 同一会社の路線を続けて直通する系統で、直通先として「次に入る路線」ではなく
+  // 「その会社の最後の路線」が案内されていた不具合の回帰テスト (#6747)
+  it('同一会社の路線が連続する場合でも直通順の先頭（次に入る路線）を落とさない', () => {
+    const tokyu = createCompany(1, { nameShort: '東急' });
+    const sotetsu = createCompany(2, { nameShort: '相鉄' });
+
+    const tokyuShinYokohamaLine = createLine(1, {
+      nameShort: '東急新横浜線',
+      company: tokyu,
+    });
+    const sotetsuShinYokohamaLine = createLine(2, {
+      nameShort: '相鉄新横浜線',
+      company: sotetsu,
+    });
+    const sotetsuMainLine = createLine(3, {
+      nameShort: '相鉄本線',
+      company: sotetsu,
+    });
+
+    stationAtomValue = {
+      selectedBound: createStation(5, {
+        line: toNestedLine(sotetsuMainLine),
+      }),
+      selectedDirection: 'INBOUND',
+      stations: [
+        createStation(1, { line: toNestedLine(tokyuShinYokohamaLine) }),
+        createStation(2, { line: toNestedLine(tokyuShinYokohamaLine) }),
+        createStation(3, { line: toNestedLine(sotetsuShinYokohamaLine) }),
+        createStation(4, { line: toNestedLine(sotetsuMainLine) }),
+        createStation(5, { line: toNestedLine(sotetsuMainLine) }),
+      ],
+    };
+    currentLineValue = tokyuShinYokohamaLine;
+
+    const { getByTestId } = render(<TestComponent />);
+    const lines = JSON.parse(getByTestId('lines').props.children as string);
+
+    expect(lines.map((l: Line) => l.nameShort)).toEqual([
+      '相鉄新横浜線',
+      '相鉄本線',
+    ]);
+  });
+
+  it('OUTBOUND でも同一会社の路線が連続する場合に直通順の先頭を落とさない', () => {
+    const tokyu = createCompany(1, { nameShort: '東急' });
+    const sotetsu = createCompany(2, { nameShort: '相鉄' });
+
+    const tokyuShinYokohamaLine = createLine(1, {
+      nameShort: '東急新横浜線',
+      company: tokyu,
+    });
+    const sotetsuShinYokohamaLine = createLine(2, {
+      nameShort: '相鉄新横浜線',
+      company: sotetsu,
+    });
+    const sotetsuMainLine = createLine(3, {
+      nameShort: '相鉄本線',
+      company: sotetsu,
+    });
+
+    stationAtomValue = {
+      selectedBound: createStation(1, {
+        line: toNestedLine(sotetsuMainLine),
+      }),
+      selectedDirection: 'OUTBOUND',
+      stations: [
+        createStation(1, { line: toNestedLine(sotetsuMainLine) }),
+        createStation(2, { line: toNestedLine(sotetsuMainLine) }),
+        createStation(3, { line: toNestedLine(sotetsuShinYokohamaLine) }),
+        createStation(4, { line: toNestedLine(tokyuShinYokohamaLine) }),
+        createStation(5, { line: toNestedLine(tokyuShinYokohamaLine) }),
+      ],
+    };
+    currentLineValue = tokyuShinYokohamaLine;
+
+    const { getByTestId } = render(<TestComponent />);
+    const lines = JSON.parse(getByTestId('lines').props.children as string);
+
+    expect(lines.map((l: Line) => l.nameShort)).toEqual([
+      '相鉄新横浜線',
+      '相鉄本線',
+    ]);
+  });
+
+  // 同一会社が飛び飛びで現れる並び (A社→A社→B社→A社) では、
+  // 旧実装だと最後の路線が候補から落ちていた (#6747)
+  it('同一会社が飛び飛びで現れる場合でも最後の直通先を落とさない', () => {
+    const companyA = createCompany(1, { nameShort: 'A社' });
+    const companyB = createCompany(2, { nameShort: 'B社' });
+    const companyC = createCompany(3, { nameShort: 'C社' });
+
+    const currentLine = createLine(1, {
+      nameShort: 'C社線',
+      company: companyC,
+    });
+    const lineA1 = createLine(2, { nameShort: 'A社本線', company: companyA });
+    const lineA2 = createLine(3, { nameShort: 'A社支線', company: companyA });
+    const lineB = createLine(4, { nameShort: 'B社線', company: companyB });
+    const lineA3 = createLine(5, { nameShort: 'A社新線', company: companyA });
+
+    stationAtomValue = {
+      selectedBound: createStation(6, { line: toNestedLine(lineA3) }),
+      selectedDirection: 'INBOUND',
+      stations: [
+        createStation(1, { line: toNestedLine(currentLine) }),
+        createStation(2, { line: toNestedLine(lineA1) }),
+        createStation(3, { line: toNestedLine(lineA2) }),
+        createStation(4, { line: toNestedLine(lineB) }),
+        createStation(5, { line: toNestedLine(lineA3) }),
+        createStation(6, { line: toNestedLine(lineA3) }),
+      ],
+    };
+    currentLineValue = currentLine;
+
+    const { getByTestId } = render(<TestComponent />);
+    const lines = JSON.parse(getByTestId('lines').props.children as string);
+
+    expect(lines.map((l: Line) => l.id)).toEqual([2, 3, 4, 5]);
   });
 });

--- a/src/hooks/useConnectedLines.ts
+++ b/src/hooks/useConnectedLines.ts
@@ -54,7 +54,7 @@ export const useConnectedLines = (excludePassed = true): Line[] => {
     const reversedBelongLines =
       selectedDirection === 'INBOUND' ? belongLines.slice().reverse() : null;
 
-    const notGroupedJoinedLines: Line[] =
+    const joinedLinesInOrder: Line[] =
       selectedDirection === 'INBOUND'
         ? joinedLineIds
             .slice(currentLineIndex + 1, joinedLineIds.length)
@@ -72,60 +72,20 @@ export const useConnectedLines = (excludePassed = true): Line[] => {
               name: l.nameShort?.replace(parenthesisRegexp, ''),
             }))
             .reverse();
-    const companyDuplicatedLines = notGroupedJoinedLines
-      .filter((l, i, arr) => l.company?.id === arr[i - 1]?.company?.id)
-      .map((l) => {
-        if (
-          notGroupedJoinedLines.findIndex(
-            (jl) => jl.company?.id === l.company?.id
-          )
-        ) {
-          return {
-            ...l,
-            name: `${l.company?.nameShort}線`,
-            nameR: `${l.company?.nameEnglishShort} Line`,
-          };
-        }
-        return l;
-      });
-    const companyNotDuplicatedLines = notGroupedJoinedLines.filter((l) => {
-      return (
-        companyDuplicatedLines.findIndex(
-          (jl) => jl.company?.id === l.company?.id
-        ) === -1
-      );
-    });
-
-    const joinedLines = [
-      ...companyDuplicatedLines,
-      ...companyNotDuplicatedLines,
-    ]
-      // 直通する順番通りにソートする
-      .reduce<Line[]>((acc, cur, idx, arr) => {
-        // 直通先が1つしかなければ別に計算する必要はない
-        if (arr.length === 1) {
-          return [cur];
-        }
-
-        // 処理中の路線がグループ化されていない配列の何番目にあるか調べる
-        // このindexが実際の直通順に入るようにしたい
-        const currentIndex = notGroupedJoinedLines.findIndex(
-          (l) => l.id === cur.id
-        );
-
-        // 処理中のindexがcurrentIndexより大きいまたは等しい場合、
-        // 処理が終わった配列を展開しグループ化されていない
-        // 現在路線~最終直通先の配列を返し、次のループへ
-        if (currentIndex <= idx) {
-          return acc.concat(notGroupedJoinedLines.slice(currentIndex));
-        }
-
-        // 処理中のindexがcurrentIndexより小さい場合、
-        // 処理が終わった配列を展開しグループ化されていない
-        // 配列の最初から現在のindexまでを返し、次のループへ
-        return acc.concat(notGroupedJoinedLines.slice(0, currentIndex + 1));
-      }, [])
-      // ループ設計上路線が重複する可能性があるのでここで重複をしばく
+    // NOTE: 以前はここで「同じ会社の路線が連続する場合は会社名でまとめる」処理を挟み、
+    // まとめた配列を直通順へ並べ直していた。しかし並べ直しの reduce が
+    // joinedLinesInOrder から要素を取り直す実装だったため、まとめた結果は
+    // 実質的に破棄されており、グループ化は name / nameR にしか効いていなかった
+    // （表示は nameShort、TTS は nameShort / nameRoman / nameTtsSegments を見る）。
+    // その上で絞り込みが路線 ID ではなく会社 ID を基準にしていたせいで、
+    //   - [相鉄新横浜線, 相鉄本線] のように同一会社が連続すると先に入る路線が落ち、
+    //     直通先として「その会社の最後の路線」が案内される
+    //   - [A社, A社, B社, A社] のように同一会社が飛び飛びで現れると末尾が落ちる
+    // という欠落が起きていた (#6747)。
+    // 直通順の配列をそのまま使えば、グループ化の絞り込みを路線 ID 基準に直した場合と
+    // 同じ並びになる（長さ5・会社3種までの全並びで一致を確認済み）ため、単純化する。
+    const joinedLines = joinedLinesInOrder
+      // 同じ路線が飛び飛びで現れることがあるのでここで重複をしばく
       .filter((l, i, arr) => arr.findIndex((il) => il.id === l.id) === i)
       // NOTE: 終点駅が直通先の次の駅に接続していない場合、実質接続していない路線は省く
       // 例: 池袋→元町・中華街の際横浜を終点と指定した際にみなとみらい線が入り込む

--- a/src/utils/test/factories.ts
+++ b/src/utils/test/factories.ts
@@ -1,5 +1,10 @@
-import type { Line, Station, StationNumber } from '~/@types/graphql';
-import { LineType, OperationStatus, StopCondition } from '~/@types/graphql';
+import type { Company, Line, Station, StationNumber } from '~/@types/graphql';
+import {
+  CompanyType,
+  LineType,
+  OperationStatus,
+  StopCondition,
+} from '~/@types/graphql';
 
 export const createStationNumber = (
   lineSymbol: string,
@@ -102,5 +107,24 @@ export const createLine = (
   status: OperationStatus.InOperation,
   trainType: null,
   transportType: null,
+  ...overrides,
+});
+
+export const createCompany = (
+  id: number,
+  overrides: Partial<Company> = {}
+): Company => ({
+  __typename: 'Company',
+  id,
+  name: `Company${id}`,
+  nameEnglishFull: `Company${id} Railways`,
+  nameEnglishShort: `Company${id}`,
+  nameFull: `Company${id}鉄道`,
+  nameKatakana: `カンパニー${id}`,
+  nameShort: `Company${id}`,
+  railroadId: id,
+  status: OperationStatus.InOperation,
+  type: CompanyType.Private,
+  url: null,
   ...overrides,
 });


### PR DESCRIPTION
## 概要

同一会社の路線を続けて直通する系統で、直通先の案内に「次に入る路線」ではなく「その会社の最後の路線」が出る不具合を修正しました。`useConnectedLines` のグループ化処理が原因で、`[相鉄新横浜線, 相鉄本線]` のように同一会社が連続すると先に入る相鉄新横浜線が候補から脱落していました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useConnectedLines.ts`: 会社名でのグループ化と並べ直しの `reduce` を削除し、直通順の配列 (`joinedLinesInOrder`) をそのまま使うよう単純化
- `src/hooks/useConnectedLines.test.tsx`: 同一会社が連続するケース（INBOUND / OUTBOUND）と、同一会社が飛び飛びで現れるケースの回帰テストを追加
- `src/utils/test/factories.ts`: `createCompany` ファクトリを追加

### 原因の詳細

問題は 2 段階でした。

1. **グループ化が実質的に機能していなかった**
   グループ化は `name` / `nameR` しか書き換えていませんが、この 2 つはどこからも読まれていません（表示は `nameShort`、TTS は `nameShort` / `nameRoman` / `nameTtsSegments` を参照）。さらに、まとめた配列を直通順へ並べ直す `reduce` が元配列から要素を取り直す実装だったため、まとめた結果自体が捨てられていました。

2. **絞り込みが路線 ID ではなく会社 ID 基準だった**
   `companyNotDuplicatedLines` が会社 ID で一致判定していたため、同一会社が連続する区間の起点となる路線まで巻き添えで落ちていました。`[相鉄新横浜線, 相鉄本線]` ではグループ化後の配列が 1 要素になり、`reduce` の `arr.length === 1` 早期リターンに入って `connectedLines[0]` が相鉄本線になっていました。

長さ 5・会社 3 種までの全並びを総当たりで検証したところ、Issue に報告されていない 2 つ目の欠落も見つかりました。`[A社, A社, B社, A社]` の並びでは**最後の路線**が落ちます。あわせて、絞り込みを路線 ID 基準に直した場合の出力が、直通順の配列をそのまま使った場合と全ケースで一致することも確認しました。したがってグループ化の機構は削除可能と判断しています。

なお Issue で指摘されている `findIndex` の戻り値を真偽値として扱っている箇所も、グループ化ごと削除されたため解消しています。

## テスト

追加した 3 件の回帰テストは、いずれも**修正前のフックに対して失敗し、修正後に通る**ことを確認済みです。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（240 スイート / 2606 テスト）
- [x] `npm run typecheck` が通ること

## 関連Issue

Closes #6747

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

[修正前後の比較図を開く（6747-before-after.png）](https://github.com/TrainLCD/MobileApp/blob/assets/pr-screenshots/claude_station-name-display-gwsmlw-6d0cc2a/203201d79a9a-6747-before-after.png)

東急新横浜線を乗車中（海老名ゆき・新横浜到着前）の想定で、ヘッダーの行先表示と日本語自動放送に出る直通先路線名の差分を示した作図です。

| | ヘッダー（行先表示） | 日本語自動放送 |
| --- | --- | --- |
| 修正前 | 相鉄本線直通 海老名 | この電車は相鉄本線直通、急行、海老名ゆきです。 |
| 修正後 | 相鉄新横浜線・相鉄本線直通 海老名 | この電車は相鉄新横浜線、相鉄本線直通、急行、海老名ゆきです。 |

実行環境の制約により実機・シミュレータのキャプチャは取得できないため、コードから導かれる表示文字列をもとに作図しています。実装を動かしたレンダリング結果ではありません。

<!-- create-pr:screenshots:end -->
