### PR TITLE
Android のローカル開発ビルドが Metro に接続されない不具合を修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,10 +28,17 @@ react {
     // codegenDir = file("../../node_modules/@react-native/codegen")
 
     /* Variants */
-    //   The list of variants to that are debuggable. For those we're going to
-    //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
-    //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-    // debuggableVariants = ["liteDebug", "prodDebug"]
+    //   ここに挙げたバリアントは JS バンドルとアセットの同梱をスキップし、Metro から
+    //   JS を読み込む。判定はバリアント名の完全一致（大文字小文字は無視）で行われる。
+    //   RN の既定値は ["debug", "debugOptimized"] だが、本プロジェクトは
+    //   flavorDimensions "environment" を持つためバリアント名が devDebug / prodDebug
+    //   （および RN プラグインが自動生成する build type の devDebugOptimized /
+    //   prodDebugOptimized）となり、既定リストに一致しない。明示しないと debug ビルドでも
+    //   createBundle<Variant>JsAndAssets が走って JS が APK に焼き込まれ、Metro に接続されず
+    //   Fast Refresh も CDP デバッガも使えなくなる。
+    //   配布ビルドは EAS / CI とも bundleDevRelease / bundleProdRelease（Release バリアント）
+    //   を使うため、このリストの影響を受けない。
+    debuggableVariants = ["devDebug", "prodDebug", "devDebugOptimized", "prodDebugOptimized"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,48 @@ CLAUDE.md「Security & Configuration Guardrails」に従い、依存更新後に
 
 新しいエントリを上に追加する。
 
+## 2026-08-28 — devDebug で JS が APK に焼き込まれ Fast Refresh とデバッガが使えない不具合を修正
+
+対象バージョン: v10.13.1 / Issue [#6741](https://github.com/TrainLCD/MobileApp/issues/6741)
+
+### 内容
+
+- `npm run android`（`APP_VARIANT=dev expo run:android -- --variant devDebug`）で入れた
+  ビルドが Metro に接続されず、Fast Refresh も CDP デバッガも使えなかった。JS だけの修正でも
+  毎回フルビルドが必要になっていた。
+- 原因は `android/app/build.gradle` の `react { }` ブロックで `debuggableVariants` が
+  コメントアウトのままだったこと。RN の Gradle プラグインは `debuggableVariants` に
+  **バリアント名が完全一致**（大文字小文字は無視）したときだけ
+  `createBundle<Variant>JsAndAssets` の登録をスキップする
+  （`@react-native/gradle-plugin` の `TaskConfiguration.kt` の `isDebuggableVariant`）。
+  既定値は RN 0.86 時点で `["debug", "debugOptimized"]` だが、本プロジェクトは
+  `flavorDimensions "environment"` を持つためバリアント名が `devDebug` / `prodDebug` になり
+  既定リストに一致せず、debug ビルドでも JS が APK に同梱されていた。
+- `debuggableVariants = ["devDebug", "prodDebug", "devDebugOptimized", "prodDebugOptimized"]`
+  を明示した。`*DebugOptimized` は RN の Gradle プラグインが `maybeCreate` で自動生成する
+  build type で、RN の既定値が `debugOptimized` を含むため同じ扱いに揃えている。
+- 配布ビルドは EAS（`eas.json`）・CI（`build_android_canary.yml` /
+  `build_android_production.yml`）とも `bundleDevRelease` / `bundleProdRelease` の
+  **Release バリアント**を使うため、この変更の影響を受けない。
+- **この変更以降、Android の debug ビルドは起動に Metro が必要**になる。
+
+### 検証結果
+
+Android 実機（Samsung SCG13 / Android 16・API 36）で確認した。
+
+- `./gradlew :app:assembleDevDebug --dry-run` の差分は
+  `:app:createBundleDevDebugJsAndAssets` の 1 タスク削除のみ（828 → 827 タスク）。
+- `assembleDevRelease` / `assembleProdRelease` では
+  `createBundle*ReleaseJsAndAssets` と Sentry のソースマップ関連タスクが従来どおり残る。
+- `assembleProdDebug` と `assembleDevDebugOptimized` /
+  `assembleProdDebugOptimized` はいずれもバンドルタスクが登録されない。
+- ビルドした APK に `index.android.bundle` が含まれない（`unzip -l` で確認）。
+- Metro がバンドルを配信する（`Android Bundled 53547ms index.js (3617 modules)`）。
+- `curl -s http://localhost:8081/json/list` が CDP ターゲット
+  （`React Native Bridgeless [C++ connection]`）を返す。
+- CDP 経由の式評価で `__DEV__ === true`、Hermes、Metro のモジュールレジストリ
+  （`__r` / `__d`）が揃っていることを確認。
+
 ## 2026-08-26 — Android の端末内蔵 TTS でダッキングが効かない不具合を修正
 
 対象バージョン: v10.13.1 / Issue [TrainLCD/Issues#1263](https://github.com/TrainLCD/Issues/issues/1263)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,43 @@ CLAUDE.md「Security & Configuration Guardrails」に従い、依存更新後に
 
 新しいエントリを上に追加する。
 
+## 2026-08-28 — `npm run android` がアプリ起動段階で失敗する不具合を修正
+
+対象バージョン: v10.13.1
+
+### 内容
+
+- `npm run android` はビルドとインストールに成功した直後、起動段階で
+  `No development build (me.tinykitten.trainlcd) ... is installed.` の
+  `CommandError` で失敗していた。実際に入るのは dev フレーバーの
+  `me.tinykitten.trainlcd.dev` で、expo が期待するパッケージ名と食い違っていた。
+- 原因は `@expo/config-plugins` の `getApplicationIdAsync` が
+  `android/app/build.gradle` を正規表現で走査し、**最初に現れる `applicationId`
+  だけ**を拾う実装になっていること。本プロジェクトでは
+  `defaultConfig.applicationId`（`me.tinykitten.trainlcd`）が先に現れるため、
+  `--variant devDebug` を指定しても product flavor 側の
+  `applicationId "me.tinykitten.trainlcd.dev"` は参照されない。
+- `expo run:android` に `--app-id` を渡すと `AndroidPlatformManager` が
+  `openProjectInCustomRuntimeWithCustomAppIdAsync` 経路に入り、インストール判定に
+  `customAppId` を、起動に `<customAppId>/<namespace>.MainActivity` を使うため、
+  フレーバー付きでも正しく解決される。`package.json` の `android` スクリプトへ
+  `--app-id me.tinykitten.trainlcd.dev` を追加した。
+
+### 検証結果
+
+Android 実機（Samsung SCG13 / Android 16・API 36）で確認した。
+
+- `npm run android` が次の行まで到達し、`CommandError` は発生しない。
+
+  ```text
+  › Opening me.tinykitten.trainlcd.dev/me.tinykitten.trainlcd.MainActivity on SCG13
+  ```
+
+- 起動後に Metro がバンドルを配信し
+  （`Android Bundled 1723ms index.js (3584 modules)`）、アプリが正常に描画される。
+- `assets/translations/ja.json` の `welcomeLabel` を書き換えると、リビルドなしで
+  約 1.4 秒後に画面へ反映される（Fast Refresh の動作確認）。
+
 ## 2026-08-28 — devDebug で JS が APK に焼き込まれ Fast Refresh とデバッガが使えない不具合を修正
 
 対象バージョン: v10.13.1 / Issue [#6741](https://github.com/TrainLCD/MobileApp/issues/6741)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "expo start",
-    "android": "cross-env APP_VARIANT=dev expo run:android -- --variant devDebug",
+    "android": "cross-env APP_VARIANT=dev expo run:android -- --variant devDebug --app-id me.tinykitten.trainlcd.dev",
     "ios": "cross-env APP_VARIANT=dev expo run:ios",
     "web": "expo start --web",
     "lint": "biome check ./src",


### PR DESCRIPTION
## 概要

Android のローカル開発ビルド（`npm run android` = `devDebug`）が Metro に接続されず、Fast Refresh も CDP デバッガも使えない状態だったのを修正します。あわせて、その検証中に見つかった `npm run android` の起動段階での失敗も直しました。

JS だけの修正でも毎回フルビルド（Issue 実測 3分12秒）が必要だった状態から、リビルドなしの Fast Refresh（実測 約1.4秒）へ改善します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `android/app/build.gradle`: `react { }` ブロックの `debuggableVariants` を明示し、debug 系バリアントで JS バンドルの同梱をスキップするようにした。
- `package.json`: `android` スクリプトに `--app-id me.tinykitten.trainlcd.dev` を追加し、product flavor 付きでもアプリの起動対象が正しく解決されるようにした。
- `docs/changelog.md`: 上記2件のエントリを追加。

### 1. devDebug で JS が APK に焼き込まれる問題

RN の Gradle プラグインは `debuggableVariants` に **バリアント名が完全一致**（大文字小文字は無視）したときだけ `createBundle<Variant>JsAndAssets` の登録をスキップします（`@react-native/gradle-plugin` の `TaskConfiguration.kt` の `isDebuggableVariant`）。

既定値は RN 0.86 時点で `["debug", "debugOptimized"]` ですが、本プロジェクトは `flavorDimensions "environment"` を持つためバリアント名が `devDebug` / `prodDebug` になり既定リストに一致しません。結果として debug ビルドでも JS が APK に同梱され、Metro に接続されませんでした。

指定した4つのバリアントは次の理由によります。

- `devDebug` / `prodDebug`: どちらも debug build type であり、CI・EAS では一切使われない。
- `devDebugOptimized` / `prodDebugOptimized`: `debugOptimized` は RN の Gradle プラグインが `AgpConfiguratorUtils.kt` の `maybeCreate` で自動生成する build type。RN の既定値が `debugOptimized` を含むため、フレーバー付きでも同じ扱いに揃えた。

**配布ビルドへの影響はありません。** EAS（`eas.json`）・CI（`build_android_canary.yml` / `build_android_production.yml`）とも `bundleDevRelease` / `bundleProdRelease` の Release バリアントを使うため、このリストの対象外です。

### 2. `npm run android` がアプリ起動段階で失敗する問題

`@expo/config-plugins` の `getApplicationIdAsync` が `android/app/build.gradle` を正規表現で走査し、**最初に現れる `applicationId` だけ**を採用します。本プロジェクトでは `defaultConfig.applicationId`（`me.tinykitten.trainlcd`）が先に現れるため、`--variant devDebug` を指定しても product flavor 側の `me.tinykitten.trainlcd.dev` は参照されず、次のエラーで停止していました。

```text
CommandError: No development build (me.tinykitten.trainlcd) for this project is installed.
```

`--app-id` を渡すと `AndroidPlatformManager` が `openProjectInCustomRuntimeWithCustomAppIdAsync` 経路に入り、インストール判定に `customAppId` を、起動に `<customAppId>/<namespace>.MainActivity` を使うため、フレーバー付きでも正しく解決されます。

`AndroidManifest.xml` の Activity は相対名 `.MainActivity` なので、`--app-id` を通さない経路では仮に ID が合っても `me.tinykitten.trainlcd.dev/.MainActivity` という存在しないコンポーネントになります。この点でも `--app-id` が正しい経路です。

gradle 側で `defaultConfig.applicationId` を dev の ID に入れ替える案も検討しましたが、本番の applicationId が既定値から外れる副作用があるため採用しませんでした。

## リグレッションリスクと緩和

| リスク | 評価 | 根拠 |
| --- | --- | --- |
| canary / production の配布ビルドから JS 同梱が外れる | **なし** | EAS・CI とも Release バリアントを使用。ドライランで `createBundleDevReleaseJsAndAssets` と Sentry のソースマップ関連タスクが従来どおり残ることを確認 |
| 意図しないタスクグラフの変化 | **なし** | `assembleDevDebug --dry-run` の差分は `:app:createBundleDevDebugJsAndAssets` の1タスク削除のみ（828 → 827） |
| `--app-id` 追加による起動先の変化 | **なし** | 起動コンポーネントは `me.tinykitten.trainlcd.dev/me.tinykitten.trainlcd.MainActivity` で、従来 `adb` から手動起動していたものと同一 |
| 開発者体験への影響 | **あり（意図的）** | 本変更以降、Android の debug ビルドは起動に Metro が必要になります |

## テスト

Android 実機（Samsung SCG13 / Android 16・API 36）で通しで確認しました。

- `assembleDevRelease` / `assembleProdRelease`: `createBundle*ReleaseJsAndAssets` が従来どおりタスクグラフに残る。
- `assembleProdDebug` / `assembleDevDebugOptimized` / `assembleProdDebugOptimized`: いずれもバンドルタスクが登録されない。
- ビルドした APK に `index.android.bundle` が含まれない（`unzip -l` で確認）。
- `npm run android` が `CommandError` なしで起動まで到達し、Metro がバンドルを配信する（`Android Bundled 1723ms index.js (3584 modules)`）。
- `curl -s http://localhost:8081/json/list` が CDP ターゲット（`React Native Bridgeless [C++ connection]`）を返す。Issue 記載の状態では `[]` でした。
- CDP 経由の式評価で `__DEV__ === true`、Hermes、Metro のモジュールレジストリ（`__r` / `__d`）が揃っていることを確認。
- `assets/translations/ja.json` の書き換えがリビルドなしで反映される（Fast Refresh、約1.4秒）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint`（677ファイル・指摘なし）、`npm test`（240 suites / 2606 tests 全通過）、`npm run typecheck`（エラーなし）。

## 関連Issue

Closes #6741

`npm run android` の起動失敗（変更内容の 2.）は Issue に紐づかない、検証中に発見した別件です。

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

本 PR にアプリの UI 変更はありません。下の画像は Fast Refresh が実際に動作することを示す検証証跡です。現在地が写り込む領域は塗り潰してあります。

<!-- create-pr:screenshots:start -->

### Samsung SCG13・Android 16 実機 ※現在地が写る領域はマスキング済み

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_android-dev-build-metro-8ef342269ff6/653a776b39cf-fastrefresh-before.png" width="320" alt="Fast Refresh 適用前 — welcomeLabel は「ようこそ」" />

Fast Refresh 適用前 — welcomeLabel は「ようこそ」

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_android-dev-build-metro-8ef342269ff6/0513578f30fc-fastrefresh-after.png" width="320" alt="Fast Refresh 適用後 — ja.json の書き換えがリビルドなしで約1.4秒後に反映" />

Fast Refresh 適用後 — ja.json の書き換えがリビルドなしで約1.4秒後に反映

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 開発用Androidビルドで正しいアプリIDを使用するようになりました。
  * 開発用デバッグビルドではMetroを利用し、起動時のJavaScriptバンドル生成を省略します。
  * リリースビルドは従来どおりJavaScriptバンドルを生成します。

* **ドキュメント**
  * Androidビルド構成と動作確認結果を変更履歴に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->