### PR TITLE
常磐線直通 快速で終点が沼津として扱われ逆方向が案内される不具合を修正

### DIFF
--- a/src/hooks/useLineSelection.test.tsx
+++ b/src/hooks/useLineSelection.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react-native';
 import { useAtomValue, useSetAtom } from 'jotai';
 import type React from 'react';
-import type { Line, TrainType } from '~/@types/graphql';
+import type { Line, Station, TrainType } from '~/@types/graphql';
 import { TransportType } from '~/@types/graphql';
 import { createLine, createStation } from '~/utils/test/factories';
 import type { LineState } from '../store/atoms/line';
@@ -560,6 +560,111 @@ describe('useLineSelection', () => {
     const navSetter = mockSetNavigationState.mock.calls[0][0];
     const navResult = navSetter(createNavigationState());
     expect(navResult.pendingTrainType).toBe(trainType);
+  });
+
+  it('既定種別の駅一覧が遅れて解決しても、後から選ばれた種別の駅一覧を上書きしない', async () => {
+    const { mockSetStationState, mockSetNavigationState } = setupMolecules();
+    const { mockFetchByLineId, mockFetchByGroupId, mockFetchTrainTypes } =
+      setupQueries();
+
+    const tokaidoLine = { id: 3 };
+    const jobanLine = { id: 11319 };
+
+    // 品川(東海道線)の既定種別は普通(東京→沼津 / groupId 411)
+    const shinagawa = createStation(1130103, {
+      name: '品川',
+      line: tokaidoLine,
+      hasTrainTypes: true,
+      trainType: {
+        id: 1,
+        groupId: 411,
+        name: '普通',
+      } as Station['trainType'],
+    });
+    const lineStations = [
+      createStation(1130101, { name: '東京', line: tokaidoLine }),
+      createStation(1130102, { name: '新橋', line: tokaidoLine }),
+      shinagawa,
+      createStation(1130130, { name: '沼津', line: tokaidoLine }),
+    ];
+    mockFetchByLineId.mockResolvedValue({ data: { lineStations } });
+
+    const localType = { id: 1, groupId: 411, name: '普通' } as TrainType;
+    const rapidType = { id: 2, groupId: 499, name: '快速' } as TrainType;
+    mockFetchTrainTypes.mockResolvedValue({
+      data: { stationTrainTypes: [localType, rapidType] },
+    });
+
+    // 常磐線直通 快速(品川→原ノ町 / groupId 499)
+    const rapidGroupStations = [
+      shinagawa,
+      createStation(1130102, { name: '新橋', line: tokaidoLine }),
+      createStation(1130101, { name: '東京', line: tokaidoLine }),
+      createStation(1131801, { name: '上野', line: jobanLine }),
+      createStation(1131899, { name: '原ノ町', line: jobanLine }),
+    ];
+
+    // 既定種別(411)の駅一覧取得だけを遅延させ、種別選択後に解決させる
+    let resolveLocalGroup: (value: unknown) => void = () => {};
+    const deferredLocalGroup = new Promise((resolve) => {
+      resolveLocalGroup = resolve;
+    });
+    mockFetchByGroupId.mockImplementation(({ variables }) =>
+      variables.lineGroupId === 411
+        ? deferredLocalGroup
+        : Promise.resolve({ data: { lineGroupStations: rapidGroupStations } })
+    );
+
+    const line = createLine(3, {
+      nameShort: '東海道線',
+      station: { id: 1130103, hasTrainTypes: true } as Line['station'],
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    let lineSelection: Promise<void> | undefined;
+    await act(async () => {
+      lineSelection = hookRef.current?.handleLineSelected(line);
+      // 種別一覧が出そろい、既定種別の駅一覧取得が始まるところまで進める
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 既定種別の駅一覧取得中にユーザーが快速(原ノ町行)を選ぶ
+    await act(async () => {
+      await hookRef.current?.handleTrainTypeSelect(rapidType);
+    });
+
+    // 遅れて既定種別の駅一覧が返ってくる
+    await act(async () => {
+      resolveLocalGroup({ data: { lineGroupStations: lineStations } });
+      await lineSelection;
+    });
+
+    const finalStationState =
+      mockSetStationState.mock.calls.reduce<StationState>(
+        (acc, [updater]) =>
+          typeof updater === 'function' ? updater(acc) : updater,
+        createStationState()
+      );
+    const finalNavigationState =
+      mockSetNavigationState.mock.calls.reduce<NavigationState>(
+        (acc, [updater]) =>
+          typeof updater === 'function' ? updater(acc) : updater,
+        createNavigationState()
+      );
+
+    expect(finalStationState.pendingStations).toEqual(rapidGroupStations);
+    expect(finalStationState.pendingStations.at(-1)?.name).toBe('原ノ町');
+    expect(finalNavigationState.pendingTrainType).toBe(rapidType);
   });
 
   it('handleCloseSelectBoundModal が isSelectBoundModalOpen を false にする', () => {

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -57,7 +57,8 @@ export type UseLineSelectionResult = {
 
 export const useLineSelection = (): UseLineSelectionResult => {
   const [isSelectBoundModalOpen, setIsSelectBoundModalOpen] = useState(false);
-  // 路線を選び直した際に、前の選択の取得結果が新しい状態を上書きしないよう世代を管理する
+  // 路線・種別・プリセットを選び直した際に、前の選択の取得結果が新しい状態を
+  // 上書きしないよう世代を管理する
   const selectionGenerationRef = useRef(0);
   const setStationState = useSetAtom(stationState);
   const setLineState = useSetAtom(lineStateAtom);
@@ -212,11 +213,20 @@ export const useLineSelection = (): UseLineSelectionResult => {
   const handleTrainTypeSelect = useCallback(
     async (trainType: TrainType) => {
       if (trainType.groupId == null) return;
+
+      // handleLineSelected は既定種別の駅一覧を非同期に取得して pendingStations を
+      // 上書きする。世代を進めておかないと、ユーザーがその取得中に別の種別を選んだ場合に
+      // 既定種別(例: 東海道線 普通 沼津行)の駅一覧が後から選択結果を潰し、
+      // 選んだ種別と噛み合わない終点・方面が案内される。
+      const generation = ++selectionGenerationRef.current;
+
       const res = await fetchStationsByLineGroupId({
         variables: {
           lineGroupId: trainType.groupId,
         },
       });
+      if (generation !== selectionGenerationRef.current) return;
+
       setStationState((prev) => ({
         ...prev,
         pendingStations: res.data?.lineGroupStations ?? [],
@@ -231,9 +241,13 @@ export const useLineSelection = (): UseLineSelectionResult => {
 
   const openModalByLineId = useCallback(
     async (lineId: number, wantedDestinationId?: number | null) => {
+      const generation = ++selectionGenerationRef.current;
+
       const result = await fetchStationsByLineId({
         variables: { lineId },
       });
+      if (generation !== selectionGenerationRef.current) return;
+
       const stations = result.data?.lineStations ?? [];
       if (!stations.length) return;
 
@@ -293,9 +307,13 @@ export const useLineSelection = (): UseLineSelectionResult => {
 
   const openModalByTrainTypeId = useCallback(
     async (lineGroupId: number, wantedDestinationId?: number | null) => {
+      const generation = ++selectionGenerationRef.current;
+
       const result = await fetchStationsByLineGroupId({
         variables: { lineGroupId },
       });
+      if (generation !== selectionGenerationRef.current) return;
+
       const stations = result.data?.lineGroupStations ?? [];
       if (!stations.length) return;
 
@@ -353,6 +371,8 @@ export const useLineSelection = (): UseLineSelectionResult => {
           stationId: station.id as number,
         },
       });
+      if (generation !== selectionGenerationRef.current) return;
+
       const trainTypes = fetchedTrainTypesData.data?.stationTrainTypes ?? [];
 
       setNavigationState((prev) => ({

--- a/src/hooks/useLineSelection.ts
+++ b/src/hooks/useLineSelection.ts
@@ -1,7 +1,7 @@
 import findNearest from 'geolib/es/findNearest';
 import orderByDistance from 'geolib/es/orderByDistance';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
   GET_LINE_GROUP_STATIONS,
@@ -10,6 +10,7 @@ import {
 } from '~/lib/graphql/queries';
 import type { SavedRoute } from '~/models/SavedRoute';
 import { isBusLine } from '~/utils/line';
+import { beginSelection, isLatestSelection } from '~/utils/selectionGeneration';
 import lineStateAtom from '../store/atoms/line';
 import { locationAtom } from '../store/atoms/location';
 import navigationState from '../store/atoms/navigation';
@@ -57,9 +58,6 @@ export type UseLineSelectionResult = {
 
 export const useLineSelection = (): UseLineSelectionResult => {
   const [isSelectBoundModalOpen, setIsSelectBoundModalOpen] = useState(false);
-  // 路線・種別・プリセットを選び直した際に、前の選択の取得結果が新しい状態を
-  // 上書きしないよう世代を管理する
-  const selectionGenerationRef = useRef(0);
   const setStationState = useSetAtom(stationState);
   const setLineState = useSetAtom(lineStateAtom);
   const setNavigationState = useSetAtom(navigationState);
@@ -100,7 +98,7 @@ export const useLineSelection = (): UseLineSelectionResult => {
       const lineStationId = line.station?.id;
       if (!lineId || !lineStationId) return;
 
-      const generation = ++selectionGenerationRef.current;
+      const generation = beginSelection();
 
       setIsSelectBoundModalOpen(true);
 
@@ -138,7 +136,7 @@ export const useLineSelection = (): UseLineSelectionResult => {
           : null,
       ]);
       // 取得中に別の路線が選ばれていたら、この呼び出しの結果は破棄する
-      if (generation !== selectionGenerationRef.current) return;
+      if (!isLatestSelection(generation)) return;
 
       const fetchedStations = data?.lineStations ?? [];
 
@@ -180,7 +178,7 @@ export const useLineSelection = (): UseLineSelectionResult => {
           const groupResult = await fetchStationsByLineGroupId({
             variables: { lineGroupId: initialTrainType.groupId },
           });
-          if (generation !== selectionGenerationRef.current) return;
+          if (!isLatestSelection(generation)) return;
 
           const lineGroupStations = groupResult.data?.lineGroupStations ?? [];
           // 取得できなかった場合は路線単独の駅一覧を残す（空で潰さない）
@@ -218,14 +216,14 @@ export const useLineSelection = (): UseLineSelectionResult => {
       // 上書きする。世代を進めておかないと、ユーザーがその取得中に別の種別を選んだ場合に
       // 既定種別(例: 東海道線 普通 沼津行)の駅一覧が後から選択結果を潰し、
       // 選んだ種別と噛み合わない終点・方面が案内される。
-      const generation = ++selectionGenerationRef.current;
+      const generation = beginSelection();
 
       const res = await fetchStationsByLineGroupId({
         variables: {
           lineGroupId: trainType.groupId,
         },
       });
-      if (generation !== selectionGenerationRef.current) return;
+      if (!isLatestSelection(generation)) return;
 
       setStationState((prev) => ({
         ...prev,
@@ -241,12 +239,12 @@ export const useLineSelection = (): UseLineSelectionResult => {
 
   const openModalByLineId = useCallback(
     async (lineId: number, wantedDestinationId?: number | null) => {
-      const generation = ++selectionGenerationRef.current;
+      const generation = beginSelection();
 
       const result = await fetchStationsByLineId({
         variables: { lineId },
       });
-      if (generation !== selectionGenerationRef.current) return;
+      if (!isLatestSelection(generation)) return;
 
       const stations = result.data?.lineStations ?? [];
       if (!stations.length) return;
@@ -307,12 +305,12 @@ export const useLineSelection = (): UseLineSelectionResult => {
 
   const openModalByTrainTypeId = useCallback(
     async (lineGroupId: number, wantedDestinationId?: number | null) => {
-      const generation = ++selectionGenerationRef.current;
+      const generation = beginSelection();
 
       const result = await fetchStationsByLineGroupId({
         variables: { lineGroupId },
       });
-      if (generation !== selectionGenerationRef.current) return;
+      if (!isLatestSelection(generation)) return;
 
       const stations = result.data?.lineGroupStations ?? [];
       if (!stations.length) return;
@@ -371,7 +369,7 @@ export const useLineSelection = (): UseLineSelectionResult => {
           stationId: station.id as number,
         },
       });
-      if (generation !== selectionGenerationRef.current) return;
+      if (!isLatestSelection(generation)) return;
 
       const trainTypes = fetchedTrainTypesData.data?.stationTrainTypes ?? [];
 

--- a/src/hooks/useTrainTypeModal.test.tsx
+++ b/src/hooks/useTrainTypeModal.test.tsx
@@ -493,6 +493,73 @@ describe('useTrainTypeModal', () => {
     expect(result.selectedDirection).toBe('INBOUND');
   });
 
+  it('取得中に別の種別が選ばれたら、遅れて返った旧種別の駅一覧で上書きしない', async () => {
+    const oldTypeStations = [
+      createStation(4110001, { name: '東京' }),
+      createStation(4110002, { name: '沼津' }),
+    ];
+    const newTypeStations = [
+      createStation(4990001, { name: '品川' }),
+      createStation(4990002, { name: '原ノ町' }),
+    ];
+
+    setupMocks();
+
+    // 先に選んだ種別の取得だけ保留し、後に選んだ種別を先に完了させる
+    let resolveFirstSelection: (value: unknown) => void = () => {};
+    const deferredFirstSelection = new Promise((resolve) => {
+      resolveFirstSelection = resolve;
+    });
+    mockFetchStationsByLineGroupId.mockImplementation(({ variables }) =>
+      variables.lineGroupId === 411
+        ? deferredFirstSelection
+        : Promise.resolve({ data: { lineGroupStations: newTypeStations } })
+    );
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    let firstSelection: Promise<void> | undefined;
+    await act(async () => {
+      firstSelection = hookRef.current?.handleTrainTypeModalSelect(
+        createTrainType(411)
+      ) as unknown as Promise<void>;
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypeModalSelect(createTrainType(499));
+    });
+
+    const callCountAfterSecondSelection = mockSetStationState.mock.calls.length;
+
+    // 遅れて先の種別の駅一覧が返ってくる
+    await act(async () => {
+      resolveFirstSelection({ data: { lineGroupStations: oldTypeStations } });
+      await firstSelection;
+    });
+
+    // 破棄されるため state 更新は増えない
+    expect(mockSetStationState.mock.calls.length).toBe(
+      callCountAfterSecondSelection
+    );
+    const lastStationSetter =
+      mockSetStationState.mock.calls[callCountAfterSecondSelection - 1][0];
+    const result = lastStationSetter({
+      stations: [],
+      station: null,
+      selectedBound: createStation(100),
+      selectedDirection: 'INBOUND',
+    });
+    expect(result.stations).toEqual(newTypeStations);
+  });
+
   it('handleTrainTypeModalSelect で列車種別選択後にモーダルを閉じてstateを更新する', async () => {
     const trainType = createTrainType(5);
     const newStations = [createStation(10), createStation(11)];

--- a/src/hooks/useTrainTypeModal.test.tsx
+++ b/src/hooks/useTrainTypeModal.test.tsx
@@ -422,6 +422,77 @@ describe('useTrainTypeModal', () => {
     expect(hookRef.current?.trainTypeDisabled).toBe(false);
   });
 
+  it('乗車中の種別変更で進行方向と終点を新しい系統の並びへ引き直す', async () => {
+    const tokaidoLine = { id: 3 };
+    const jobanLine = { id: 11319 };
+
+    // 東海道線 普通(東京→沼津)。品川から東京方面(=OUTBOUND)へ乗車中
+    const shinagawa = createStation(1130103, {
+      name: '品川',
+      line: tokaidoLine,
+    });
+    const numazu = createStation(1130130, { name: '沼津', line: tokaidoLine });
+    const oldStations = [
+      createStation(1130101, { name: '東京', line: tokaidoLine }),
+      createStation(1130102, { name: '新橋', line: tokaidoLine }),
+      shinagawa,
+      numazu,
+    ];
+
+    // 常磐線直通 快速(品川→原ノ町)。東海道線とは並び順が逆になる
+    const haranomachi = createStation(1131899, {
+      name: '原ノ町',
+      line: jobanLine,
+    });
+    const newStations = [
+      shinagawa,
+      createStation(1130102, { name: '新橋', line: tokaidoLine }),
+      createStation(1130101, { name: '東京', line: tokaidoLine }),
+      createStation(1131801, { name: '上野', line: jobanLine }),
+      haranomachi,
+    ];
+
+    setupMocks({
+      stationStateValue: {
+        selectedBound: numazu,
+        station: shinagawa,
+        selectedDirection: 'OUTBOUND' as const,
+      },
+      currentStoppingStation: shinagawa,
+    });
+
+    mockFetchStationsByLineGroupId.mockResolvedValue({
+      data: { lineGroupStations: newStations },
+    });
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    await act(async () => {
+      hookRef.current?.handleTrainTypeModalSelect(createTrainType(499));
+    });
+
+    const stationSetter = mockSetStationState.mock.calls[0][0];
+    const result = stationSetter({
+      stations: oldStations,
+      station: shinagawa,
+      selectedBound: numazu,
+      selectedDirection: 'OUTBOUND',
+    });
+
+    expect(result.stations).toEqual(newStations);
+    // 旧系統の終点(沼津)ではなく新系統の終点(原ノ町)が案内される
+    expect(result.selectedBound).toEqual(haranomachi);
+    // 東海道線のOUTBOUND(東京方面)は常磐線快速の並びではINBOUNDにあたる
+    expect(result.selectedDirection).toBe('INBOUND');
+  });
+
   it('handleTrainTypeModalSelect で列車種別選択後にモーダルを閉じてstateを更新する', async () => {
     const trainType = createTrainType(5);
     const newStations = [createStation(10), createStation(11)];

--- a/src/hooks/useTrainTypeModal.test.tsx
+++ b/src/hooks/useTrainTypeModal.test.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import type React from 'react';
 import type { Line, Station, TrainType } from '~/@types/graphql';
 import { StopCondition } from '~/@types/graphql';
+import { beginSelection } from '~/utils/selectionGeneration';
 import { createLine, createStation } from '~/utils/test/factories';
 import { useCurrentLine } from './useCurrentLine';
 import { useCurrentStation } from './useCurrentStation';
@@ -558,6 +559,53 @@ describe('useTrainTypeModal', () => {
       selectedDirection: 'INBOUND',
     });
     expect(result.stations).toEqual(newTypeStations);
+  });
+
+  it('取得中に路線やプリセットが選び直されたら種別の取得結果を破棄する', async () => {
+    const trainTypeStations = [
+      createStation(4990001, { name: '品川' }),
+      createStation(4990002, { name: '原ノ町' }),
+    ];
+
+    setupMocks();
+
+    let resolveTrainTypeSelection: (value: unknown) => void = () => {};
+    const deferredTrainTypeSelection = new Promise((resolve) => {
+      resolveTrainTypeSelection = resolve;
+    });
+    mockFetchStationsByLineGroupId.mockReturnValue(deferredTrainTypeSelection);
+
+    const hookRef: { current: HookResult } = { current: null };
+    render(
+      <HookBridge
+        onReady={(v) => {
+          hookRef.current = v;
+        }}
+      />
+    );
+
+    let trainTypeSelection: Promise<void> | undefined;
+    await act(async () => {
+      trainTypeSelection = hookRef.current?.handleTrainTypeModalSelect(
+        createTrainType(499)
+      ) as unknown as Promise<void>;
+      await Promise.resolve();
+    });
+
+    // 種別の駅一覧取得中に、別フック(useLineSelection)側で路線・プリセットが選び直される
+    act(() => {
+      beginSelection();
+    });
+
+    await act(async () => {
+      resolveTrainTypeSelection({
+        data: { lineGroupStations: trainTypeStations },
+      });
+      await trainTypeSelection;
+    });
+
+    expect(mockSetStationState).not.toHaveBeenCalled();
+    expect(mockSetNavigation).not.toHaveBeenCalled();
   });
 
   it('handleTrainTypeModalSelect で列車種別選択後にモーダルを閉じてstateを更新する', async () => {

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -38,6 +38,8 @@ export const useTrainTypeModal = () => {
   const [isSettingListModalOpen, setIsSettingListModalOpen] = useState(false);
   const [isTrainTypeModalVisible, setIsTrainTypeModalVisible] = useState(false);
   const pendingTrainTypeModalRef = useRef(false);
+  // 種別を選び直した際に、前の選択の取得結果が新しい状態を上書きしないよう世代を管理する
+  const trainTypeSelectionGenerationRef = useRef(0);
 
   const [fetchStationsByLineGroupId, { loading: trainTypeSelectLoading }] =
     useLazyGraphQLQuery<
@@ -65,9 +67,15 @@ export const useTrainTypeModal = () => {
   const handleTrainTypeSelect = useCallback(
     async (trainType: TrainType) => {
       if (trainType.groupId == null) return;
+
+      const generation = ++trainTypeSelectionGenerationRef.current;
+
       const res = await fetchStationsByLineGroupId({
         variables: { lineGroupId: trainType.groupId },
       });
+      // 取得中に別の種別が選ばれていたら、この呼び出しの結果は破棄する
+      // (遅れて返った旧種別の駅一覧が、新しい種別の駅一覧・方向・終点を潰さないようにする)
+      if (generation !== trainTypeSelectionGenerationRef.current) return;
       if (!res.data?.lineGroupStations) return;
       const newStations = res.data.lineGroupStations;
 

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -6,6 +6,7 @@ import {
   GET_STATION_TRAIN_TYPES_LIGHT,
 } from '~/lib/graphql/queries';
 import { findNearestStation } from '~/utils/findNearestStation';
+import { resolveDirectionForNewStations } from '~/utils/resolveDirectionForNewStations';
 import { selectedLineAtom } from '../store/atoms/line';
 import navigationState, {
   fetchedTrainTypesAtom,
@@ -14,7 +15,6 @@ import navigationState, {
 import { resetFirstSpeechAtom } from '../store/atoms/speech';
 import stationState, {
   selectedBoundAtom,
-  selectedDirectionAtom,
   stationAtom,
 } from '../store/atoms/station';
 import { isJapanese } from '../translation';
@@ -25,7 +25,6 @@ import { useLazyGraphQLQuery } from './useLazyGraphQLQuery';
 export const useTrainTypeModal = () => {
   const selectedBound = useAtomValue(selectedBoundAtom);
   const currentStation = useAtomValue(stationAtom);
-  const selectedDirection = useAtomValue(selectedDirectionAtom);
   const setStationState = useSetAtom(stationState);
   const selectedLine = useAtomValue(selectedLineAtom);
   const fetchedTrainTypes = useAtomValue(fetchedTrainTypesAtom);
@@ -81,21 +80,44 @@ export const useTrainTypeModal = () => {
         );
 
         setStationState((prev) => {
+          // 種別を変えると駅配列が別系統のものへ丸ごと入れ替わるため、
+          // 旧系統基準の進行方向・終点をそのまま引き継ぐと、逆方向や別系統の
+          // 終点(例: 常磐線快速へ変えたのに東海道線の沼津)が案内されてしまう。
+          // 新しい駅配列の並びで方向を引き直し、終点もその方向の端の駅に揃える。
+          const direction = resolveDirectionForNewStations(
+            prev.stations,
+            newStations,
+            currentStation,
+            prev.selectedDirection
+          );
+          const bound = direction
+            ? ((direction === 'INBOUND'
+                ? newStations[newStations.length - 1]
+                : newStations[0]) ?? prev.selectedBound)
+            : prev.selectedBound;
+
           if (currentInNewList) {
-            return { ...prev, stations: newStations };
+            return {
+              ...prev,
+              stations: newStations,
+              selectedDirection: direction,
+              selectedBound: bound,
+            };
           }
 
           const nearest = findNearestStation(
             prev.stations,
             newStations,
             currentStation?.id,
-            selectedDirection
+            prev.selectedDirection
           );
 
           return {
             ...prev,
             stations: newStations,
             ...(nearest ? { station: nearest } : {}),
+            selectedDirection: direction,
+            selectedBound: bound,
           };
         });
 
@@ -122,8 +144,7 @@ export const useTrainTypeModal = () => {
       setNavigation,
       setResetFirstSpeech,
       selectedBound,
-      currentStation?.id,
-      selectedDirection,
+      currentStation,
     ]
   );
 

--- a/src/hooks/useTrainTypeModal.ts
+++ b/src/hooks/useTrainTypeModal.ts
@@ -7,6 +7,7 @@ import {
 } from '~/lib/graphql/queries';
 import { findNearestStation } from '~/utils/findNearestStation';
 import { resolveDirectionForNewStations } from '~/utils/resolveDirectionForNewStations';
+import { beginSelection, isLatestSelection } from '~/utils/selectionGeneration';
 import { selectedLineAtom } from '../store/atoms/line';
 import navigationState, {
   fetchedTrainTypesAtom,
@@ -38,8 +39,6 @@ export const useTrainTypeModal = () => {
   const [isSettingListModalOpen, setIsSettingListModalOpen] = useState(false);
   const [isTrainTypeModalVisible, setIsTrainTypeModalVisible] = useState(false);
   const pendingTrainTypeModalRef = useRef(false);
-  // 種別を選び直した際に、前の選択の取得結果が新しい状態を上書きしないよう世代を管理する
-  const trainTypeSelectionGenerationRef = useRef(0);
 
   const [fetchStationsByLineGroupId, { loading: trainTypeSelectLoading }] =
     useLazyGraphQLQuery<
@@ -68,14 +67,16 @@ export const useTrainTypeModal = () => {
     async (trainType: TrainType) => {
       if (trainType.groupId == null) return;
 
-      const generation = ++trainTypeSelectionGenerationRef.current;
+      // 路線・プリセット選択とも世代を共有し、フックをまたいだ選択の割り込みでも
+      // 古い取得結果が新しい選択を上書きしないようにする
+      const generation = beginSelection();
 
       const res = await fetchStationsByLineGroupId({
         variables: { lineGroupId: trainType.groupId },
       });
-      // 取得中に別の種別が選ばれていたら、この呼び出しの結果は破棄する
-      // (遅れて返った旧種別の駅一覧が、新しい種別の駅一覧・方向・終点を潰さないようにする)
-      if (generation !== trainTypeSelectionGenerationRef.current) return;
+      // 取得中に別の選択(種別・路線・プリセット)が行われていたら、この呼び出しの
+      // 結果は破棄する(遅れて返った駅一覧が新しい選択の駅一覧・方向・終点を潰さないようにする)
+      if (!isLatestSelection(generation)) return;
       if (!res.data?.lineGroupStations) return;
       const newStations = res.data.lineGroupStations;
 

--- a/src/utils/resolveDirectionForNewStations.test.ts
+++ b/src/utils/resolveDirectionForNewStations.test.ts
@@ -1,0 +1,115 @@
+import { createStation } from '~/utils/test/factories';
+import { resolveDirectionForNewStations } from './resolveDirectionForNewStations';
+
+const TOKAIDO = { id: 3 };
+const JOBAN = { id: 11319 };
+
+// 東海道線 普通(東京→沼津)
+const tokaidoStations = [
+  createStation(1130101, { name: '東京', line: TOKAIDO }),
+  createStation(1130102, { name: '新橋', line: TOKAIDO }),
+  createStation(1130103, { name: '品川', line: TOKAIDO }),
+  createStation(1130130, { name: '沼津', line: TOKAIDO }),
+];
+
+// 常磐線直通 快速(品川→原ノ町)。品川・新橋・東京は東海道線の駅IDを共有する
+const jobanRapidStations = [
+  createStation(1130103, { name: '品川', line: TOKAIDO }),
+  createStation(1130102, { name: '新橋', line: TOKAIDO }),
+  createStation(1130101, { name: '東京', line: TOKAIDO }),
+  createStation(1131801, { name: '上野', line: JOBAN }),
+  createStation(1131899, { name: '原ノ町', line: JOBAN }),
+];
+
+describe('resolveDirectionForNewStations', () => {
+  it('並び順が反転する系統では進行方向を引き直す', () => {
+    // 品川から東京方面(東海道線ではOUTBOUND)へ向かう途中で常磐線快速へ変更
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        jobanRapidStations,
+        tokaidoStations[2],
+        'OUTBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+
+  it('並び順が同じ向きなら方向を維持する', () => {
+    const extendedTokaido = [
+      ...tokaidoStations,
+      createStation(1130140, { name: '静岡', line: TOKAIDO }),
+    ];
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        extendedTokaido,
+        tokaidoStations[2],
+        'INBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+
+  it('現在駅が新しい駅一覧に無くても前方の共通駅から方向を決める', () => {
+    // 沼津(新系統に存在しない)から東京方面へ向かっている状態
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        jobanRapidStations,
+        tokaidoStations[3],
+        'OUTBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+
+  it('共通駅が1駅以下の場合は従来の方向を維持する', () => {
+    const disjointStations = [
+      createStation(9000001, { name: '甲', line: JOBAN }),
+      createStation(9000002, { name: '乙', line: JOBAN }),
+    ];
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        disjointStations,
+        tokaidoStations[2],
+        'INBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+
+  it('駅IDが変わる直通系統では groupId で読み替える', () => {
+    const renumbered = jobanRapidStations.map((s, i) =>
+      createStation(2000000 + i, {
+        name: s.name,
+        groupId: s.groupId,
+        line: JOBAN,
+      })
+    );
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        renumbered,
+        tokaidoStations[2],
+        'OUTBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+
+  it('方向未確定・駅数不足のときはそのまま返す', () => {
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        jobanRapidStations,
+        tokaidoStations[2],
+        null
+      )
+    ).toBeNull();
+    expect(
+      resolveDirectionForNewStations(
+        tokaidoStations,
+        [jobanRapidStations[0]],
+        tokaidoStations[2],
+        'INBOUND'
+      )
+    ).toBe('INBOUND');
+  });
+});

--- a/src/utils/resolveDirectionForNewStations.ts
+++ b/src/utils/resolveDirectionForNewStations.ts
@@ -1,0 +1,76 @@
+import type { Station } from '~/@types/graphql';
+import type { LineDirection } from '~/models/Bound';
+
+const indexOfStation = (
+  stations: Station[],
+  station: Station | null | undefined
+): number => {
+  if (!station) {
+    return -1;
+  }
+  // 直通系統では同じ駅でも駅IDが変わりうるため、idで引けなければgroupIdで読み替える
+  const byId =
+    station.id != null ? stations.findIndex((s) => s.id === station.id) : -1;
+  if (byId !== -1) {
+    return byId;
+  }
+  return station.groupId != null
+    ? stations.findIndex((s) => s.groupId === station.groupId)
+    : -1;
+};
+
+/**
+ * 列車種別の変更で駅リストが別系統のものへ入れ替わったとき、
+ * 実際の進行方向を新しい駅リストの並び基準で引き直す。
+ *
+ * INBOUND / OUTBOUND は「配列の末尾方向 / 先頭方向」でしかないため、
+ * 系統が変わると同じ値が逆向きを指しうる。例えば上野東京ライン経由の
+ * 常磐線快速(品川→原ノ町)と東海道線の普通(東京→沼津)は品川・新橋・東京を
+ * 共有しつつ並び順が逆になるので、旧系統の値をそのまま引き継ぐと逆方向が案内される。
+ *
+ * 旧駅リスト上で現在駅から進行方向へ並ぶ駅のうち、新駅リストにも存在するものを
+ * 2駅拾い、その2駅が新駅リストでどちらへ進むかで方向を決める。
+ *
+ * @param oldStations 旧駅リスト
+ * @param newStations 新しい駅リスト
+ * @param currentStation 現在駅(旧駅リスト基準)
+ * @param prevDirection 旧駅リスト基準の進行方向
+ * @returns 新駅リスト基準の進行方向(判定できない場合は prevDirection)
+ */
+export const resolveDirectionForNewStations = (
+  oldStations: Station[],
+  newStations: Station[],
+  currentStation: Station | null | undefined,
+  prevDirection: LineDirection | null
+): LineDirection | null => {
+  if (!prevDirection || newStations.length < 2) {
+    return prevDirection;
+  }
+
+  const currentIdxInOld = indexOfStation(oldStations, currentStation);
+  if (currentIdxInOld === -1) {
+    return prevDirection;
+  }
+
+  const step = prevDirection === 'INBOUND' ? 1 : -1;
+  const anchors: number[] = [];
+  for (
+    let i = currentIdxInOld;
+    i >= 0 && i < oldStations.length && anchors.length < 2;
+    i += step
+  ) {
+    const idx = indexOfStation(newStations, oldStations[i]);
+    if (idx !== -1 && !anchors.includes(idx)) {
+      anchors.push(idx);
+    }
+  }
+
+  // 新旧で共有する駅が1駅以下だと並び順を比べられないため、従来の方向を維持する
+  if (anchors.length < 2) {
+    return prevDirection;
+  }
+
+  return (anchors[1] as number) > (anchors[0] as number)
+    ? 'INBOUND'
+    : 'OUTBOUND';
+};

--- a/src/utils/selectionGeneration.test.ts
+++ b/src/utils/selectionGeneration.test.ts
@@ -1,0 +1,18 @@
+import { beginSelection, isLatestSelection } from './selectionGeneration';
+
+describe('selectionGeneration', () => {
+  it('最後に開始した選択だけが最新になる', () => {
+    const first = beginSelection();
+    expect(isLatestSelection(first)).toBe(true);
+
+    const second = beginSelection();
+    expect(isLatestSelection(first)).toBe(false);
+    expect(isLatestSelection(second)).toBe(true);
+  });
+
+  it('世代は呼び出しごとに進む', () => {
+    const a = beginSelection();
+    const b = beginSelection();
+    expect(b).toBeGreaterThan(a);
+  });
+});

--- a/src/utils/selectionGeneration.ts
+++ b/src/utils/selectionGeneration.ts
@@ -1,0 +1,20 @@
+/**
+ * 路線・列車種別・プリセットの選択で共有する世代カウンタ。
+ *
+ * これらの選択はいずれも非同期に駅一覧を取得してから `stationState` /
+ * `navigationState` を書き換えるため、取得中に別の選択が行われると、遅れて
+ * 完了した古い要求が新しい選択を上書きしうる。各フックがそれぞれ `useRef` で
+ * 世代を持つとフックをまたいだ競合(例: 乗車中に種別を選んだ直後に路線選択画面で
+ * 別路線を選ぶ)を検出できないため、モジュールレベルで1つの世代を共有する。
+ *
+ * 選択の開始時に `beginSelection()` を呼んで世代を受け取り、`await` の直後に
+ * `isLatestSelection()` で自分がまだ最新の選択かを確認してから state を書き換える。
+ */
+let currentGeneration = 0;
+
+/** 新しい選択を開始し、その世代を返す。 */
+export const beginSelection = (): number => ++currentGeneration;
+
+/** 与えられた世代が最新の選択かどうかを返す。 */
+export const isLatestSelection = (generation: number): boolean =>
+  generation === currentGeneration;


### PR DESCRIPTION
## 概要

上野東京ライン経由の「常磐線直通 快速 原ノ町行」(`line_group_cd` = 499) で、終点が沼津として扱われ逆方向が案内される不具合 (#6749) を修正した。StationAPI は正しい系統を返しており、アプリ側で選択結果が別系統の駅一覧・方向へ倒れていた。原因は独立した2つの経路にあったため、それぞれ修正している。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 1. 既定種別の駅一覧が後から選ばれた種別の駅一覧を上書きする (`src/hooks/useLineSelection.ts`)

`handleLineSelected` は既定種別 (品川なら東海道線 普通 = `line_group_cd` 411, 東京→沼津) の `lineGroupStations` を非同期に取得して `pendingStations` を上書きする。この取得中でも種別ボタンは押せる (無効化条件は `fetchedTrainTypes.length <= 1` のみ) ため、ユーザーが快速 (499) を選んだ後に 411 の応答が返ると、`pendingTrainType` は快速のまま `pendingStations` だけ東海道線へ戻り、終点＝沼津・方面カード＝東海道線の東京/沼津になる。破棄判定の世代カウンタが路線の選び直しでしか進んでいなかったのが原因。

- `selectionGenerationRef` の世代を、種別選択 (`handleTrainTypeSelect`) とプリセット復元 (`openModalByLineId` / `openModalByTrainTypeId`) でも進めるようにした
- 各 await 後に世代チェックを入れ、古い応答による state 書き込みを破棄するようにした

### 2. 乗車中の種別変更で終点・進行方向が旧系統のまま残る (`src/hooks/useTrainTypeModal.ts`)

`selectedBound` がある状態 (乗車中) の種別変更は `stations` を差し替えるだけで、`selectedBound` / `selectedDirection` を新系統基準で引き直していなかった。INBOUND / OUTBOUND は「配列の末尾方向 / 先頭方向」でしかないため、品川・新橋・東京を共有しつつ並び順が逆になる東海道線 普通 ↔ 常磐線快速の間では、同じ値がそのまま逆向きを指す。

- `src/utils/resolveDirectionForNewStations.ts` を追加し、旧駅一覧で現在駅から進行方向へ並ぶ駅のうち新駅一覧にも存在する 2 駅を拾って、新しい並び基準の方向を決めるようにした (直通で駅IDが変わる区間は groupId で読み替える)
- 種別変更時に上記で方向を引き直し、終点もその方向の端の駅へ揃えるようにした
- 共通駅が 1 駅以下で判定できない場合は従来の方向を維持する

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること (241 suites / 2614 tests)
- [x] `npm run typecheck` が通ること

追加した回帰テスト (いずれも修正前は fail することを確認済み):

- `src/hooks/useLineSelection.test.tsx`: 既定種別 (411) の取得を遅延させ、その間に快速 (499) を選んだとき `pendingStations` が原ノ町行のままであること
- `src/hooks/useTrainTypeModal.test.tsx`: 品川から東京方面 (東海道線 OUTBOUND) 乗車中に常磐線快速へ変更したとき、終点が原ノ町・方向が INBOUND へ引き直されること
- `src/utils/resolveDirectionForNewStations.test.ts`: 並び反転・同一方向・現在駅が新系統に無い場合・共通駅不足・駅ID差し替えの各ケース

実機/シミュレータでの動作確認は未実施 (作業環境にエミュレータと GraphQL エンドポイントが無いため)。品川での実データ確認をお願いしたい。

## 関連Issue

Closes #6749

関連: #6748 (武豊線直通 普通 岐阜行) も種別自動選択→系統差し替えの同じ経路を通るため、1 の修正で改善する可能性がある (未検証)。

## スクリーンショット（任意）

UI変更なし: 状態遷移のみの修正で、画面レイアウト・表示要素の変更はない。


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2FxfU1bePwoyyCy8gqipD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 列車種別・路線・プリセットの切り替え時、古い非同期取得結果が新しい選択内容を上書きしないよう改善しました。
  * 乗車中に列車種別を変更した際、駅順・終点・進行方向が新しい経路に合わせて更新されるようになりました。
  * 現在駅が新しい経路に含まれない場合や駅情報が変更された場合も、適切な駅と進行方向を判定できるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->