### PR TITLE
現在駅が経路外のとき終着駅を種別変更駅として案内する不具合を修正

### DIFF
--- a/src/components/TypeChangeNotify.test.tsx
+++ b/src/components/TypeChangeNotify.test.tsx
@@ -594,10 +594,10 @@ describe('TypeChangeNotify', () => {
       expect(queryAllByText(/Ofuna/)).toHaveLength(0);
     });
 
-    // 現在駅が経路内に見つからない場合は境界を特定できないため、経路全体から
-    // 推定する従来のロジックへフォールバックする。進行方向より手前の区間を
-    // 除外できないベストエフォートの挙動であることを明示的に固定しておく。
-    it('現在駅がnullの場合はINBOUNDの従来ロジックにフォールバックする', () => {
+    // 現在駅が経路内に見つからない場合は種別変更の境界を特定できない。
+    // 経路全体から推定すると通過済みの区間や終着駅を拾ってしまうため、
+    // 案内自体を表示しないことを回帰テストで固定しておく。
+    it('現在駅がnullの場合は種別変更案内を表示しない', () => {
       setupMocks({
         stations: inboundStations,
         currentStation: null,
@@ -607,12 +607,12 @@ describe('TypeChangeNotify', () => {
 
       const { queryAllByText } = render(<TypeChangeNotify />);
 
-      // 経路全体で現在種別(快速)の最終駅となる大船
-      expect(queryAllByText(/大船/).length).toBeGreaterThan(0);
-      expect(queryAllByText(/Ofuna/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/大船/)).toHaveLength(0);
+      expect(queryAllByText(/Ofuna/)).toHaveLength(0);
+      expect(queryAllByText(/から/)).toHaveLength(0);
     });
 
-    it('現在駅が経路内に無い場合はOUTBOUNDの従来ロジックにフォールバックする', () => {
+    it('現在駅が経路内に無い場合は種別変更案内を表示しない', () => {
       const outboundStations = inboundStations.slice().reverse();
 
       setupMocks({
@@ -632,9 +632,146 @@ describe('TypeChangeNotify', () => {
 
       const { queryAllByText } = render(<TypeChangeNotify />);
 
-      // 乗車位置が不明なため、経路全体で次種別(普通)に該当する最初の駅である前橋になる
-      expect(queryAllByText(/前橋/).length).toBeGreaterThan(0);
-      expect(queryAllByText(/Maebashi/).length).toBeGreaterThan(0);
+      expect(queryAllByText(/前橋/)).toHaveLength(0);
+      expect(queryAllByText(/Maebashi/)).toHaveLength(0);
+      expect(queryAllByText(/から/)).toHaveLength(0);
+    });
+
+    it('種別が変わる駅が経路の終着駅になる場合は種別変更案内を表示しない', () => {
+      // 大船で東海道線に入って終着となる経路。終着駅で種別は変わらない
+      const endsAtTypeChangeStations = inboundStations.slice(0, -1);
+
+      setupMocks({
+        stations: endsAtTypeChangeStations,
+        currentStation: endsAtTypeChangeStations[2],
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '大船', nameRoman: 'Ofuna' },
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/大船/)).toHaveLength(0);
+      expect(queryAllByText(/Ofuna/)).toHaveLength(0);
+    });
+  });
+
+  // Issue #6746: 種別が各駅停車→急行→各駅停車と往復する経路で、現在駅が経路内に
+  // 見つからないと終着駅を種別変更駅として拾い「海老名から急行海老名ゆきとなります」
+  // という行き先と種別変更駅が同一の案内が生成されていた
+  describe('種別が往復する直通経路(埼玉高速鉄道→相鉄本線)', () => {
+    const localType = { typeId: 1, name: '各駅停車', nameRoman: 'Local' };
+    const expressType = { typeId: 2, name: '急行', nameRoman: 'Express' };
+
+    const createLine = (id: number, nameShort: string, nameRoman: string) => ({
+      id,
+      nameShort,
+      nameRoman,
+      color: '#00A0E9',
+      company: { id, nameShort, nameEnglishShort: nameRoman },
+    });
+
+    const saitamaRapidLine = createLine(
+      99301,
+      '埼玉高速鉄道線',
+      'Saitama Railway Line'
+    );
+    const nambokuLine = createLine(99302, '南北線', 'Namboku Line');
+    const meguroLine = createLine(99303, '東急目黒線', 'Tokyu Meguro Line');
+    const sotetsuMainLine = createLine(99304, '相鉄本線', 'Sotetsu Main Line');
+
+    // 浦和美園→海老名。各駅停車→急行→各駅停車と種別が往復する
+    const stations = [
+      {
+        id: 1,
+        groupId: 1,
+        name: '浦和美園',
+        nameRoman: 'Urawa-Misono',
+        line: saitamaRapidLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 2,
+        groupId: 2,
+        name: '目黒',
+        nameRoman: 'Meguro',
+        line: nambokuLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 3,
+        groupId: 2,
+        name: '目黒',
+        nameRoman: 'Meguro',
+        line: meguroLine,
+        trainType: expressType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 4,
+        groupId: 3,
+        name: '新横浜',
+        nameRoman: 'Shin-Yokohama',
+        line: meguroLine,
+        trainType: expressType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 5,
+        groupId: 3,
+        name: '新横浜',
+        nameRoman: 'Shin-Yokohama',
+        line: sotetsuMainLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+      {
+        id: 6,
+        groupId: 4,
+        name: '海老名',
+        nameRoman: 'Ebina',
+        line: sotetsuMainLine,
+        trainType: localType,
+        stopCondition: 'STOP',
+      },
+    ];
+
+    it('現在駅が経路内に無いとき終着駅を種別変更駅として案内しない', () => {
+      const {
+        useCurrentLine,
+        useCurrentStation,
+        useCurrentTrainType,
+        useNextTrainType,
+      } = require('~/hooks');
+
+      useCurrentLine.mockReturnValue(saitamaRapidLine);
+      // 経路設定直後などで現在地が経路上の駅に一致しない状態
+      useCurrentStation.mockReturnValue(null);
+      useCurrentTrainType.mockReturnValue({
+        ...localType,
+        color: '#00A0E9',
+        line: saitamaRapidLine,
+      });
+      // 修正前の useNextTrainType が返していた、既に過ぎた区間の種別
+      useNextTrainType.mockReturnValue({
+        ...expressType,
+        color: '#00A0E9',
+        line: meguroLine,
+      });
+
+      mockAtomValues({
+        stations,
+        selectedDirection: 'INBOUND',
+        selectedBound: { name: '海老名', nameRoman: 'Ebina' },
+        enabledLanguages: ['JA', 'EN'],
+      });
+
+      const { queryAllByText } = render(<TypeChangeNotify />);
+
+      expect(queryAllByText(/海老名/)).toHaveLength(0);
+      expect(queryAllByText(/Ebina/)).toHaveLength(0);
+      expect(queryAllByText(/となります/)).toHaveLength(0);
     });
   });
 

--- a/src/components/TypeChangeNotify.tsx
+++ b/src/components/TypeChangeNotify.tsx
@@ -1373,25 +1373,21 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
       return afterAllStopLastStation;
     }
 
-    // 現在駅が経路内に見つからない場合のみ、経路全体から推定する従来ロジックへ
-    // フォールバックする(進行方向より手前の区間を除外できないベストエフォート)
+    // NOTE: 現在駅が経路内に見つからないと進行方向より手前の区間を除外できない。
+    // 経路全体から推定すると、種別が往復する直通経路(埼玉高速鉄道→相鉄本線の
+    // 各駅停車→急行→各駅停車など)で終着駅を種別変更駅として拾ってしまうため、
+    // 境界を特定できないものとして案内自体を表示しない。
     if (orderedCurrentStationIndex === -1) {
-      if (selectedDirection === 'INBOUND') {
-        const currentTypeStations = stations.filter(
-          (s) => s.trainType?.typeId === trainType?.typeId
-        );
-        return currentTypeStations.at(-1);
-      }
-
-      const nextTypeStations = stations.filter(
-        (s) => s.trainType?.typeId === nextTrainType?.typeId
-      );
-      return nextTypeStations.at(-1);
+      return undefined;
     }
 
     // 現在駅より先に種別が変わる駅がない場合、経路全体から探すと通過済みの
-    // 同一種別区間を拾ってしまうため何も表示しない
-    if (typeChangedStationIndex === -1) {
+    // 同一種別区間を拾ってしまうため何も表示しない。
+    // 経路の終着駅で種別が変わることはないため、境界が終着駅になる場合も同様に扱う
+    if (
+      typeChangedStationIndex === -1 ||
+      typeChangedStationIndex === orderedStations.length - 1
+    ) {
       return undefined;
     }
 
@@ -1412,7 +1408,6 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     );
   }, [
     trainType,
-    nextTrainType,
     selectedDirection,
     afterAllStopLastStation,
     currentLine,
@@ -1421,7 +1416,6 @@ const TypeChangeNotify: React.FC<TypeChangeNotifyProps> = ({
     orderedStations,
     reversedFinalPassedStationIndex,
     reversedStations,
-    stations,
     typeChangedStationIndex,
   ]);
 

--- a/src/hooks/useNextTrainType.test.tsx
+++ b/src/hooks/useNextTrainType.test.tsx
@@ -1,0 +1,189 @@
+import { render } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type React from 'react';
+import { Text } from 'react-native';
+import type { Station, TrainType } from '~/@types/graphql';
+import { createStation } from '~/utils/test/factories';
+import type { LineDirection } from '../models/Bound';
+import { selectedDirectionAtom, stationsAtom } from '../store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
+import { useCurrentTrainType } from './useCurrentTrainType';
+import { useNextTrainType } from './useNextTrainType';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  useAtomValue: jest.fn(),
+  atom: jest.fn(),
+}));
+jest.mock('../store/atoms/station', () => ({
+  __esModule: true,
+  stationsAtom: { __atom: 'stations' },
+  selectedDirectionAtom: { __atom: 'selectedDirection' },
+}));
+jest.mock('./useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+jest.mock('./useCurrentTrainType', () => ({
+  useCurrentTrainType: jest.fn(),
+}));
+
+const TestComponent: React.FC = () => {
+  const nextTrainType = useNextTrainType();
+  return (
+    <Text testID="nextTrainType">
+      {nextTrainType ? String(nextTrainType.typeId) : 'null'}
+    </Text>
+  );
+};
+
+const TRAIN_TYPE_IDS = { LOCAL: 1, EXPRESS: 2 } as const;
+
+const createTrainType = (typeId: number, name: string): TrainType =>
+  ({
+    __typename: 'TrainTypeNested',
+    color: '#00A0E9',
+    direction: null,
+    groupId: null,
+    id: typeId,
+    kind: null,
+    line: null,
+    lines: [],
+    name,
+    nameChinese: null,
+    nameIpa: null,
+    nameKatakana: name,
+    nameKorean: null,
+    nameRoman: name,
+    nameRomanIpa: null,
+    nameTtsSegments: null,
+    typeId,
+  }) as TrainType;
+
+const localType = createTrainType(TRAIN_TYPE_IDS.LOCAL, '各駅停車');
+const expressType = createTrainType(TRAIN_TYPE_IDS.EXPRESS, '急行');
+
+const createStationWithType = (id: number, trainType: TrainType): Station =>
+  createStation(id, { trainType } as Parameters<typeof createStation>[1]);
+
+describe('useNextTrainType', () => {
+  const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+    typeof useAtomValue
+  >;
+  const mockUseCurrentStation = useCurrentStation as jest.MockedFunction<
+    typeof useCurrentStation
+  >;
+  const mockUseCurrentTrainType = useCurrentTrainType as jest.MockedFunction<
+    typeof useCurrentTrainType
+  >;
+
+  // 浦和美園→海老名を模した、各駅停車→急行→各駅停車と種別が往復する経路
+  const inboundStations = [
+    createStationWithType(1, localType),
+    createStationWithType(2, localType),
+    createStationWithType(3, expressType),
+    createStationWithType(4, expressType),
+    createStationWithType(5, localType),
+    createStationWithType(6, localType),
+  ];
+
+  const setup = ({
+    stations,
+    currentStation,
+    trainType,
+    selectedDirection = 'INBOUND',
+  }: {
+    stations: Station[];
+    currentStation: Station | undefined;
+    trainType: TrainType | null;
+    selectedDirection?: LineDirection;
+  }) => {
+    mockUseAtomValue.mockImplementation((atom) => {
+      if (atom === stationsAtom) {
+        return stations;
+      }
+      if (atom === selectedDirectionAtom) {
+        return selectedDirection;
+      }
+      throw new Error('unknown atom');
+    });
+    mockUseCurrentStation.mockReturnValue(currentStation);
+    mockUseCurrentTrainType.mockReturnValue(trainType);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('現在駅より先で最初に変わる種別を返す', () => {
+    setup({
+      stations: inboundStations,
+      currentStation: inboundStations[0],
+      trainType: localType,
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('nextTrainType').props.children).toBe(
+      String(TRAIN_TYPE_IDS.EXPRESS)
+    );
+  });
+
+  it('現在駅より先に種別が変わる駅が無い場合はnullを返す', () => {
+    setup({
+      stations: inboundStations,
+      currentStation: inboundStations[4],
+      trainType: localType,
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('nextTrainType').props.children).toBe('null');
+  });
+
+  // Issue #6746: 経路全体を先頭から走査していたため、既に通過したはずの
+  // 急行区間を次の種別として返し、終着駅での種別変更が案内されていた
+  it('現在駅が経路内に無い場合は経路全体から推定せずnullを返す', () => {
+    setup({
+      stations: inboundStations,
+      currentStation: undefined,
+      trainType: localType,
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('nextTrainType').props.children).toBe('null');
+  });
+
+  it('OUTBOUND時も現在駅より進行方向側の区間から次の種別を探す', () => {
+    // OUTBOUND では stations が進行方向と逆順で保持される
+    const outboundStations = inboundStations.slice().reverse();
+
+    setup({
+      stations: outboundStations,
+      currentStation: inboundStations[0],
+      trainType: localType,
+      selectedDirection: 'OUTBOUND',
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('nextTrainType').props.children).toBe(
+      String(TRAIN_TYPE_IDS.EXPRESS)
+    );
+  });
+
+  it('OUTBOUND時に現在駅が経路内に無い場合もnullを返す', () => {
+    const outboundStations = inboundStations.slice().reverse();
+
+    setup({
+      stations: outboundStations,
+      currentStation: createStationWithType(999, localType),
+      trainType: localType,
+      selectedDirection: 'OUTBOUND',
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('nextTrainType').props.children).toBe('null');
+  });
+});

--- a/src/hooks/useNextTrainType.ts
+++ b/src/hooks/useNextTrainType.ts
@@ -12,36 +12,24 @@ export const useNextTrainType = (): TrainType | null => {
   const trainType = useCurrentTrainType();
 
   const nextTrainType = useMemo((): TrainType | null => {
-    if (selectedDirection === 'INBOUND') {
-      const currentIndex = stations.findIndex(
-        (sta) => sta.id === currentStation?.id
-      );
+    // OUTBOUND時のstationsは進行方向と逆順で保持されているため進行方向順に揃える
+    const orderedStations =
+      selectedDirection === 'INBOUND' ? stations : stations.slice().reverse();
 
-      const slicedStations = stations.slice(currentIndex + 1, stations.length);
-
-      const nextTypeStation = slicedStations
-        .filter((s) => s.trainType)
-        .find((s) => s.trainType?.typeId !== trainType?.typeId);
-
-      if (!nextTypeStation || !nextTypeStation.trainType) {
-        return null;
-      }
-
-      return {
-        ...nextTypeStation.trainType,
-        __typename: 'TrainType' as const,
-        line: nextTypeStation.line,
-      };
-    }
-
-    const reversedStations = stations.slice().reverse();
-
-    const currentIndex = reversedStations.findIndex(
+    const currentIndex = orderedStations.findIndex(
       (sta) => sta.id === currentStation?.id
     );
 
-    const nextTypeStation = reversedStations
-      .slice(currentIndex + 1, stations.length)
+    // NOTE: 現在駅を経路内に特定できないと進行方向より先の区間を切り出せない。
+    // 経路全体を先頭から走査すると、種別が往復する直通経路(埼玉高速鉄道→相鉄本線の
+    // 各駅停車→急行→各駅停車など)で既に通過した区間の種別を次の種別として拾って
+    // しまうため、推定せず「次の種別なし」として扱う。
+    if (currentIndex === -1) {
+      return null;
+    }
+
+    const nextTypeStation = orderedStations
+      .slice(currentIndex + 1)
       .filter((s) => s.trainType)
       .find((s) => s.trainType?.typeId !== trainType?.typeId);
 


### PR DESCRIPTION
## 概要

現在駅が経路内に見つからない状態（経路設定直後・沿線外など）で、終着駅を種別変更駅として案内してしまう不具合を修正します。埼玉高速鉄道 → 相鉄本線 海老名の経路で「海老名から急行海老名ゆきとなります」という、行き先と種別変更駅が同一の案内が生成されていました。

原因は「現在駅を経路内に特定できないとき、経路全体を先頭から走査して推定するフォールバック」が 2 箇所に存在することです。この経路は各駅停車 → 急行 → 各駅停車と種別が往復するため、進行方向より手前の区間を除外できないフォールバックが、既に通過したはずの区間や終着駅を拾っていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useNextTrainType.ts`: 現在駅を経路内に特定できない (`currentIndex === -1`) とき、経路全体を先頭から走査せず `null` を返すようにした。従来は `stations.slice(0)` で全区間を走査し、既に通過した東急目黒線内の急行を `nextTrainType` として返していた。あわせて INBOUND / OUTBOUND で重複していた分岐を、進行方向順に揃えた 1 本の処理へ統合
- `src/components/TypeChangeNotify.tsx`: `orderedCurrentStationIndex === -1` のときの経路全体フォールバックを削除し、種別変更案内自体を表示しないようにした。加えて、種別変更駅が経路の終着駅になる場合も案内対象外とするガードを追加（終着駅で種別は変わらないため）
- `src/hooks/useNextTrainType.test.tsx`: 新規。経路外時に `null` を返すこと、通常時・OUTBOUND 時の探索範囲を検証
- `src/components/TypeChangeNotify.test.tsx`: フォールバック挙動を固定していた既存 2 件を新仕様へ更新し、浦和美園 → 海老名の再現ケースと終着駅ガードのテストを追加

`useNextTrainType` が `null` を返すことで `useTypeWillChange` が `false` となり、`bottomState` が `TYPE_CHANGE` へ遷移しなくなります。そのため「現在駅が経路内に特定できないときは種別変更案内自体を表示しない」という Issue の想定動作と一致します。

### リグレッションリスクと緩和策

- **`useNextTrainType` の戻り値変更**: 現在駅が経路外の間だけ `null` になります。影響を受ける利用箇所は `useTypeWillChange` / `TrainTypeBox` / `TypeChangeNotify` の 3 つで、いずれも「現在駅を特定できない間は次種別を表示しない」という安全側の挙動になります。`TrainTypeBox` の「◯◯線内 △△」表示も同様に非表示となりますが、従来はここに誤った直通先種別が出る可能性がありました
- **経路内に現在駅がある通常ケースへの影響なし**: `currentIndex !== -1` の経路では従来と同じ探索結果になります。INBOUND / OUTBOUND の分岐統合が等価であることは既存テストおよび追加テストで確認しています
- **終着駅ガード**: Issue の調査で「始発駅・終着駅で種別が変わる `line_group` は StationAPI 側に 1 件も存在しない」ことが確認されているため、実データへの影響はありません。防御的なガードです
- 修正前のソースに対して新規・更新テストを当てたところ 6 件が失敗し、修正後は全件パスすることを確認済みです

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカルで実行したコマンド:

```bash
npm run format   # 1 ファイル整形
npm run lint     # OK
npm run typecheck # OK
npm test         # 243 suites / 2625 tests すべてパス
```

## 関連Issue

Closes #6746

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: 誤った種別変更案内を出さなくする修正で、修正後は該当状態で種別変更案内そのものが表示されなくなるため、静止画では差分を示せません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 現在駅を特定できない場合や経路外の場合に、誤った種別変更案内を表示しないよう改善しました。
  - 終着駅で種別が変わるケースでは、不要な案内を表示しないようにしました。
  - 進行方向に応じた次の種別変更駅の判定を正確にしました。

- **テスト**
  - 種別変更がない場合、経路外の駅、各進行方向などのケースを追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->