### PR TITLE
mise.toml のNodeを24へ更新してmise環境でのnpm ci失敗を解消

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
+# Node のバージョンは .nvmrc・.github/workflows/**・package.json の engines と
+# 揃える。mise は既定で .nvmrc を読まない（idiomatic_version_file_enable_tools が
+# 空のため）ので、ここに明示しないと mise で用意した環境だけ別バージョンになる。
 [tools]
-node = "22"
+node = "24"


### PR DESCRIPTION
## 概要

`mise.toml` だけ Node 22 のまま取り残されており、`.nvmrc`・GitHub Actions ワークフロー・`package.json` の `engines` が指す Node 24 / npm 11 と食い違っていました。mise で開発環境を用意すると Node 22（同梱 npm 10.x）が入り、`engine-strict=true` と `engines.npm: ">=11"` により `npm ci` が失敗します。`mise.toml` の Node 指定を 24 に揃えて解消します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

アプリの挙動には影響しない、開発環境（ツールチェイン）の設定変更です。

## 変更内容

- `mise.toml` の `[tools] node` を `22` から `24` に更新
- 同ファイルに、なぜ `.nvmrc` があってもここへ明示が必要かをコメントで記載

### `.nvmrc` を単一の情報源にする案について

Issue で「検討の余地あり（実現可能かは mise 側の設定を要確認）」とされていた点を調査し、**今回は採用していません**。

- mise の `idiomatic_version_file_enable_tools` は既定値が空配列で、`.nvmrc` / `.node-version` の読み取りは既定で無効（[mise Settings](https://mise.jdx.dev/configuration/settings.html) / [jdx/mise settings.toml](https://github.com/jdx/mise/blob/main/settings.toml)）
- そのため `mise.toml` から `[tools] node` を落とすと、設定を有効化していない開発者の環境では mise が node を一切管理しなくなる。バージョン不一致より検知しづらい壊れ方になる
- この設定はリポジトリ内の `mise.toml` ではなくグローバル設定（`~/.config/mise/config.toml`）や環境変数側に置く必要があるという報告もあり、リポジトリ側だけで完結させられない（[jdx/mise Discussion #7058](https://github.com/jdx/mise/discussions/7058) / [#6598](https://github.com/jdx/mise/discussions/6598)）

再発防止としては、`.nvmrc` と `mise.toml` の major 一致を検査する軽量スクリプトを `.github/scripts/**` と `test_scripts.yml` の枠に乗せるほうが現実的だと考えます。本 PR のスコープ外とし、必要であれば別 Issue / PR で対応します。

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: コード本体（`src/**` / `android/**` / `ios/**` / `assets/**`）に変更が無いため。参考として `npm run lint` は実行済みで green（`Checked 682 files in 764ms. No fixes applied.`）。`mise` は作業環境に導入されていないため、`mise install` 後の `npm ci` 成功は実機確認できていません（ローカルは Node v24.15.0 / npm 11.17.0 で `npm ci` が通る状態）。

## 関連Issue

Closes #6731

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: `mise.toml`（開発環境の Node バージョン指定）のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Node.js の使用バージョンを 22 から 24 に更新しました。
  * 各種設定で使用する Node.js バージョンの整合性に関する注記を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->