### PR TITLE
廃止済みGraphQL BFFの記述をStationAPI直参照へ更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 - `utils/`: developer tooling scripts such as GraphQL codegen config.
 - `android/`, `ios/`: native projects.
 
-> The Cloudflare Workers backend (TTS, session issuance, feedback triage via Workers AI, review notifiers) has been moved out of this repository into [TrainLCD/functions](https://github.com/TrainLCD/functions); the GraphQL BFF lives separately in [TrainLCD/BFF](https://github.com/TrainLCD/BFF). The former `functions/` directory no longer lives here.
+> The Cloudflare Workers backend (TTS, session issuance, feedback triage via Workers AI, review notifiers, the AI destination agent) has been moved out of this repository into [TrainLCD/functions](https://github.com/TrainLCD/functions); the former `functions/` directory no longer lives here. The GraphQL API that `src/lib/gql.ts` talks to (`gql.trainlcd.app` / `gql-stg.trainlcd.app`) is served directly by [TrainLCD/StationAPI](https://github.com/TrainLCD/StationAPI), so schema and resolver changes belong there. The GraphQL BFF that used to sit in front of it has been retired and [TrainLCD/BFF](https://github.com/TrainLCD/BFF) is archived — do not send anyone there.
 
 ## Tooling & Environment Expectations
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ npm run watch:test
 
 ### Backend (Cloudflare Workers)
 
-The backend Worker (TTS synthesis, session issuance, feedback triage, review notifiers) lives in [TrainLCD/functions](https://github.com/TrainLCD/functions), and the GraphQL BFF lives in [TrainLCD/BFF](https://github.com/TrainLCD/BFF). Neither is part of this repository.
+The backend Worker (TTS synthesis, session issuance, feedback triage, review notifiers, the AI destination agent) lives in [TrainLCD/functions](https://github.com/TrainLCD/functions), and the GraphQL API is served directly by [TrainLCD/StationAPI](https://github.com/TrainLCD/StationAPI). Neither is part of this repository. The GraphQL BFF that used to sit between the app and StationAPI has been retired.
 
 Voice announcements (TTS) use a different engine per platform:
 

--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -115,13 +115,16 @@ flowchart TB
 | チャット画面 | MobileApp（新規） | 対話 UI・提案カード・既存フロー接続 |
 | エージェント API | trainlcd-worker | 認証・ゲート・LLM 呼び出し・検証 |
 | LLM 経路 | AI Gateway | ログ・コスト集計・レート制限・キャッシュ |
-| 駅名検索ツール | StationAPI `/graphql` | `stationsByName` で実在性確認 |
+| 駅名検索ツール | StationAPI `POST /` | `stationsByName` で実在性確認 |
 | フラグ配信 | `/config/remote` | `ai_agent_enabled` キルスイッチ |
 
 StationAPI への接続は同一 Cloudflare アカウント内なので Service Binding を
 推奨する（ネットワーク往復なし・認証不要で worker 間呼び出しできる）。
-バインディングが難しい場合は既存 GraphQL エンドポイントへの fetch でも
-成立する。
+バインディングが難しい場合は GraphQL エンドポイントへの fetch でも成立する。
+いずれの経路でも **StationAPI はサブドメイン直下（`POST /`）でしか GraphQL を
+受け付けない**（`/graphql` は 404）。外部 fetch に使う
+`STATION_API_GRAPHQL_URL` も `https://gql.trainlcd.app/` のようにルートを
+指すこと。
 
 ## 対話 API 設計（trainlcd-worker）
 

--- a/docs/spec/ai-agent/architecture.md
+++ b/docs/spec/ai-agent/architecture.md
@@ -10,10 +10,10 @@
 独自の AI エージェントとユーザが自然言語で対話し、「海が見える駅に行きたい」の
 ような曖昧な要望から実在する駅を最大 5 件提案して、既存の行き先決定フロー
 （`SelectBoundModal` → `selectedBound` 確定）に接続する。LLM 呼び出しは
-BFF（`TrainLCD/BFF` の `functions/` = trainlcd-worker）に新設する
+Worker（`TrainLCD/functions` = trainlcd-worker）に新設する
 `POST /agent/chat` に集約し、アプリは既存のセッション JWT + callable 互換
 ワイヤ形式で fetch するだけにする。駅名の実在性は LLM の tool use から
-BFF ルートワーカー（sapi-bff）の GraphQL `stationsByName` を呼んで担保し、
+StationAPI の GraphQL `stationsByName` を呼んで担保し、
 サーバ側でも「ツール結果に含まれない駅の提案は破棄する」検証を行い、
 嘘をつけない構造にする。トピック外プロンプトは本体 LLM の手前の軽量ゲートで
 謝絶しトークンを守る。
@@ -69,7 +69,7 @@ BFF ルートワーカー（sapi-bff）の GraphQL `stationsByName` を呼んで
 
 ## 全体アーキテクチャ
 
-LLM 呼び出しは必ずサーバ側（BFF）に置く。理由は次の 3 点。
+LLM 呼び出しは必ずサーバ側（Worker）に置く。理由は次の 3 点。
 
 1. API キーをクライアントに配布しない。
 2. レート制限・トピックゲート・実在性検証をサーバで強制でき、
@@ -82,7 +82,7 @@ flowchart TB
     screen["DestinationAgentScreen（新規チャットUI）"]
   end
 
-  subgraph worker["trainlcd-worker（BFF functions/）"]
+  subgraph worker["trainlcd-worker（TrainLCD/functions）"]
     auth["1. JWT検証・レート制限"]
     gate["2. トピックゲート"]
     agent["3. エージェント本体（tool useループ）"]
@@ -93,11 +93,9 @@ flowchart TB
   gw["Cloudflare AI Gateway"]
   llm["LLM API（対話本体: GPT / Claude）"]
 
-  subgraph bff["sapi-bff（BFFルートワーカー）"]
+  subgraph sapi["StationAPI（Cloudflare Workers / Rust）"]
     gql["GraphQL stationsByName"]
   end
-
-  sapi["StationAPI（gRPC-Web）"]
 
   screen -- "POST /agent/chat + セッションJWT" --> auth
   auth --> gate
@@ -106,7 +104,6 @@ flowchart TB
   agent -. "対話・tool use" .-> gw
   gw -.-> llm
   agent -- "search_stations_by_name" --> gql
-  gql --> sapi
   agent --> validate
   validate -- "reply + suggestions" --> screen
 ```
@@ -118,10 +115,10 @@ flowchart TB
 | チャット画面 | MobileApp（新規） | 対話 UI・提案カード・既存フロー接続 |
 | エージェント API | trainlcd-worker | 認証・ゲート・LLM 呼び出し・検証 |
 | LLM 経路 | AI Gateway | ログ・コスト集計・レート制限・キャッシュ |
-| 駅名検索ツール | sapi-bff `/graphql` | `stationsByName` で実在性確認 |
+| 駅名検索ツール | StationAPI `/graphql` | `stationsByName` で実在性確認 |
 | フラグ配信 | `/config/remote` | `ai_agent_enabled` キルスイッチ |
 
-sapi-bff への接続は同一 Cloudflare アカウント内なので Service Binding を
+StationAPI への接続は同一 Cloudflare アカウント内なので Service Binding を
 推奨する（ネットワーク往復なし・認証不要で worker 間呼び出しできる）。
 バインディングが難しい場合は既存 GraphQL エンドポイントへの fetch でも
 成立する。
@@ -256,7 +253,7 @@ tool use ループを挟むと確定応答まで 10〜20 秒かかり、体感�
   ラップするため既存機構のまま機能する。AI Gateway は SSE を
   パススルーする（本文ログ無効化ヘッダも同一に付与）。
 
-## エージェント本体設計（BFF 側）
+## エージェント本体設計（Worker 側）
 
 ### 処理パイプライン
 
@@ -268,7 +265,7 @@ sequenceDiagram
   participant W as trainlcd-worker
   participant WAI as Workers AI
   participant LLM as LLM API（AI Gateway経由）
-  participant S as sapi-bff
+  participant S as StationAPI
 
   App->>W: POST /agent/chat（messages, locale）
   W->>W: JWT検証・入力バリデーション
@@ -377,12 +374,12 @@ calling の `parameters` + `strict: true` に同一スキーマを割り当て�
 }
 ```
 
-- 実装: sapi-bff の
+- 実装: StationAPI の
   `stationsByName(name, limit: 10, fromStationGroupId: <現在駅>)` を呼び、
   `stationId` / `stationGroupId` / `name` / `nameRoman` / `lineNames` に
   絞った軽量 JSON を返す（`StationFields` 全量を返すとツール結果で
   トークンを浪費する）。フィールド名は応答スキーマと同一に統一し、
-  `StationFields` の `groupId` は BFF 内で `stationGroupId` に改名して
+  `StationFields` の `groupId` は Worker 内で `stationGroupId` に改名して
   詰め替える。
 - 並列ツール呼び出しを許可する。モデルは 1 イテレーション内で複数の
   候補名を同時に検索してよい。
@@ -471,11 +468,11 @@ few-shot（`CONFIG_KV` の `config:fewshot`）と同じパターンで、`CONFIG
 | --- | --- |
 | リクエスト全体（Worker 側） | 25 秒 |
 | LLM API 1 呼び出し | 15 秒 |
-| sapi-bff（ツール実行） | 5 秒 |
+| StationAPI（ツール実行） | 5 秒 |
 
 - Worker はリクエスト全体の期限を `AbortController` で管理し、期限超過時
-  は下流の LLM・sapi-bff 呼び出しへキャンセルを伝播して 504 を返す。
-- LLM 呼び出しはコスト重複を避けるため自動再試行しない。sapi-bff への
+  は下流の LLM・StationAPI 呼び出しへキャンセルを伝播して 504 を返す。
+- LLM 呼び出しはコスト重複を避けるため自動再試行しない。StationAPI への
   ツール実行のみ読み取り専用で冪等のため 1 回だけ再試行を許す。
 - クライアントのタイムアウト（30 秒）はサーバ全体期限より長く取り、
   「サーバが先に諦めて確定応答を返す」関係を保つ。タイムアウト後の再送
@@ -488,7 +485,7 @@ few-shot（`CONFIG_KV` の `config:fewshot`）と同じパターンで、`CONFIG
 ## 技術選定
 
 実装に入る前に確定させる、ライブラリの採用・不採用の候補一覧。
-本節の判定は実装開始前のレビューで確定する。方針は「BFF の lean な
+本節の判定は実装開始前のレビューで確定する。方針は「Worker の lean な
 依存構成（現状 `dayjs` + `jsonc-parser` のみ）を崩さず、新規依存を
 最小セットに絞る」こと。
 
@@ -526,7 +523,7 @@ LangChain をエージェント実行基盤として使わない理由:
    自作し始めたら、その時点で LangChain / Mastra 等を再検討する。
    エージェントループが小さいうちは乗り換えコストも小さい。
 
-### ライブラリ候補（BFF: trainlcd-worker）
+### ライブラリ候補（Worker: trainlcd-worker）
 
 | 関心事 | 判定 | 候補 | 理由 |
 | --- | --- | --- | --- |
@@ -812,7 +809,7 @@ Expo SDK 更新時はこのパッチの要否を再確認する。
 
 ## WANT: 自然言語経路検索（将来スケッチ）
 
-sapi-bff には既に `routes` / `connectedRoutes` クエリ
+StationAPI には既に `routes` / `connectedRoutes` クエリ
 （`GetRoutesMinimal` / `GetConnectedRoutes` RPC）があるため、技術的には
 次の拡張で成立する:
 
@@ -831,10 +828,10 @@ sapi-bff には既に `routes` / `connectedRoutes` クエリ
 
 | 対象 | 方法 |
 | --- | --- |
-| BFF: バリデーション・提案検証 | 純関数に切り出して Jest |
-| BFF: エージェントループ | LLM クライアントをモックして Jest |
-| BFF: SSE エンコード・`reply` 差分抽出 | 純関数に切り出して Jest |
-| BFF: 結合 | `wrangler dev` + 手動シナリオ |
+| Worker: バリデーション・提案検証 | 純関数に切り出して Jest |
+| Worker: エージェントループ | LLM クライアントをモックして Jest |
+| Worker: SSE エンコード・`reply` 差分抽出 | 純関数に切り出して Jest |
+| Worker: 結合 | `wrangler dev` + 手動シナリオ |
 | アプリ: SSE パーサ | 純関数（`src/utils/sse.ts`）を Jest（チャンク分割・複数行 data 含む） |
 | アプリ: フック | fetch を `jest.mock`（iOS 経路は XHR フェイク・フォールバックも検証） |
 | アプリ: UI | dev ビルドで手動 QA + スクリーンショット |
@@ -843,7 +840,7 @@ sapi-bff には既に `routes` / `connectedRoutes` クエリ
   空結果時の挙動を重点的に検証する。
 - 手動シナリオは比較検証用の評価セット（曖昧な要望 / 存在しない駅 /
   無関係な話題 / 使い方質問）を流用する。
-- BFF の結合テストでは、AI Gateway のログに本文ペイロードが保存されて
+- Worker の結合テストでは、AI Gateway のログに本文ペイロードが保存されて
   いないこと（`cf-aig-collect-log-payload: false` の適用）も確認する。
 - アプリ側は既存の `src/utils/test/` ヘルパーを流用し、提案タップ →
   `SelectBoundModal` → Main 遷移までを QA する。
@@ -889,17 +886,17 @@ LangChain を使わず、検証プラットフォームとして LangSmith を�
 
 ## 変更ファイル一覧（想定）
 
-### TrainLCD/BFF（functions/ = trainlcd-worker）
+### TrainLCD/functions（trainlcd-worker）
 
 | ファイル | 内容 |
 | --- | --- |
-| `functions/src/agent/handler.ts`（新規） | `/agent/chat` ハンドラ |
-| `functions/src/agent/gate.ts`（新規） | Workers AI トピックゲート |
-| `functions/src/agent/tools.ts`（新規） | 駅検索ツール（sapi-bff 呼び出し） |
-| `functions/src/agent/validate.ts`（新規） | 提案駅突合・切り詰め（純関数） |
-| `functions/wrangler.jsonc` | ルート・Service Binding・AI Gateway・vars |
-| `functions/package.json` | `ai`・`@ai-sdk/*`・`zod`・`langsmith` 追加 |
-| `functions/.secrets.env.example` | LLM・LangSmith の API キー追記 |
+| `src/agent/handler.ts`（新規） | `/agent/chat` ハンドラ |
+| `src/agent/gate.ts`（新規） | Workers AI トピックゲート |
+| `src/agent/tools.ts`（新規） | 駅検索ツール（StationAPI 呼び出し） |
+| `src/agent/validate.ts`（新規） | 提案駅突合・切り詰め（純関数） |
+| `wrangler.jsonc` | ルート・Service Binding・AI Gateway・vars |
+| `package.json` | `ai`・`@ai-sdk/*`・`zod`・`langsmith` 追加 |
+| `.secrets.env.example` | LLM・LangSmith の API キー追記 |
 
 設定 KV には `config:remote` への `ai_agent_enabled` 追加と、
 `config:agent-faq` の新設を行う。
@@ -923,9 +920,9 @@ LangChain を使わず、検証プラットフォームとして LangSmith を�
 
 | リポジトリ | ファイル | 内容 |
 | --- | --- | --- |
-| BFF | `agent/stream.ts`（新規） | SSE エンコード・差分抽出（純関数） |
-| BFF | `agent/handler.ts` | `streamText` 化・stream ハンドラ |
-| BFF | `index.ts` | `/agent/chat/stream` ルート追加 |
+| trainlcd-worker | `agent/stream.ts`（新規） | SSE エンコード・差分抽出（純関数） |
+| trainlcd-worker | `agent/handler.ts` | `streamText` 化・stream ハンドラ |
+| trainlcd-worker | `index.ts` | `/agent/chat/stream` ルート追加 |
 | MobileApp | `src/utils/sse.ts`（新規） | 最小 SSE パーサ（純関数） |
 | MobileApp | `patches/expo+55.0.26.patch`（新規） | expo/fetch の close 競合ガード |
 | MobileApp | `src/hooks/useDestinationAgent.ts` | SSE 受信 + フォールバック |

--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -81,7 +81,7 @@ Worker 側の設定（`TTS_SPEED` / `TTS_PITCH`）で決まる。
 
 アプリ側は以下を送受信する。Worker 側の実装は
 [TrainLCD/functions](https://github.com/TrainLCD/functions) の
-`src/routes/tts.ts` にある（GraphQL BFF とは別リポジトリ）。
+`src/routes/tts.ts` にある（GraphQL API の StationAPI とは別リポジトリ）。
 
 ### リクエスト
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

エージェント向けハンドブック（`AGENTS.md` = `CLAUDE.md`）の Repository Map が GraphQL BFF を現役として記載していたため、現行構成に合わせて書き換える。BFF はすでに廃止され `TrainLCD/BFF` はアーカイブ済みで、アプリが叩く GraphQL API は `TrainLCD/StationAPI` が直接提供している。

誤った参照先を案内してしまう記述は `AGENTS.md` だけでなく `README.md` と `docs/` にも残っていたため、あわせて修正した。

### 実態の確認結果

| リポジトリ | 状態 | 役割 |
| ---- | ---- | ---- |
| `TrainLCD/BFF` | アーカイブ済み | 廃止 |
| `TrainLCD/StationAPI` | 稼働中 | GraphQL API 本体（Rust + Cloudflare Workers） |
| `TrainLCD/functions` | 稼働中 | trainlcd-worker（TTS・セッション・トリアージ・AIエージェント） |

根拠:

- StationAPI の `wrangler.jsonc` に `"pattern": "gql-stg.trainlcd.app"` があり、「BFF が持っていた staging の custom domain を引き継ぐ」と明記されている。つまり `src/lib/gql.ts` の向き先は StationAPI 直。
- `TrainLCD/functions` の `wrangler.jsonc` に「BFF 廃止に伴い staging・本番とも stationapi へ移行済み」とあり、Service Binding は `STATION_API` → `stationapi-stg`。
- AIエージェント（`/agent/chat/stream`）も `src/hooks/useDestinationAgent.ts` が `workerUrl()` 経由で呼んでおり、実装は `TrainLCD/functions` の `src/agent/**` にある。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `AGENTS.md`（= `CLAUDE.md`）: Repository Map 末尾の注記を書き換え。GraphQL API は `TrainLCD/StationAPI` が直接提供しスキーマ・リゾルバ変更はそちらに属すること、BFF は廃止済みでリポジトリもアーカイブ済みのため参照先にしないことを明記。Worker の責務に AIエージェントを追加。
- `README.md`: Backend (Cloudflare Workers) 節に同じ誤りがあったため同様に修正。
- `docs/spec/tts/remote-tts.md`: 「GraphQL BFF とは別リポジトリ」→「GraphQL API の StationAPI とは別リポジトリ」。
- `docs/spec/ai-agent/architecture.md`: BFF 前提の記述が最も多く残っていた箇所。**参照先の更新のみで設計内容は変更していない**。
  - `TrainLCD/BFF` の `functions/` → `TrainLCD/functions`（変更ファイル一覧のパスも `functions/src/...` → `src/...`）
  - `sapi-bff` → `StationAPI`。mermaid 図では BFF ラッパ層を削除し、StationAPI が GraphQL を直接提供する 1 層構成に修正
  - 汎用的に「サーバ側」の意味で使われていた「BFF」→「Worker」
  - 駅名検索ツールのエンドポイント表記を `/graphql` → `POST /` に修正（CodeRabbit 指摘対応）。StationAPI の `src/lib.rs` は `method == POST && path == "/"` のときだけ GraphQL を処理し、それ以外は 404 を返すため。外部 fetch 用の `STATION_API_GRAPHQL_URL` もルートを指す必要がある旨を明記した

Issue のチェック項目「他に BFF を前提にした記述が残っていないか `docs/` と `.claude/skills/` を確認する」について、`.claude/skills/` には該当記述はなかった。修正後にリポジトリ全体を `rg` で再走査し、残る "BFF" は上記 2 ファイルの「廃止済み」という説明のみであることを確認済み。

### 回帰リスクと緩和

ドキュメントのみの変更でアプリの挙動には一切影響しない。リスクは「新しい記述自体が誤っている」ことだが、上記のとおり StationAPI / functions 双方の `wrangler.jsonc` とアプリ側の呼び出し実装を突き合わせて裏取りしている。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: コード変更なし（`src/**` / `android/**` / `ios/**` / `assets/**` に差分が無いため、これらを実行する意味が無い）。参考として `npm run lint` は実行し通過を確認している（682 files, no fixes applied）。

代わりに `markdownlint-cli2` を変更前後で比較し、新規の指摘が増えていないことを確認した（`docs/spec/ai-agent/architecture.md` は変更前後とも 0 issues。他 3 ファイルの既存 MD013 はリポジトリ全体で元から違反しており、ルール種別は増えていない）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Closes #6740

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `AGENTS.md` / `README.md` / `docs/**` のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - AI destination agent の実行環境を Worker として整理し、駅検索が StationAPI の GraphQL API を利用する構成を明記しました。
  - GraphQL BFF が廃止・アーカイブ済みで、スキーマやリゾルバの変更先が StationAPI であることを追記しました。
  - GraphQL エンドポイント、外部アクセス時の URL、`/graphql` の挙動を明確化しました。
  - TTS の実装場所や構成図、責務、タイムアウト、テスト方針を最新化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
