### PR TITLE
種別絞り込みの検索欄を共通のSearchBarへ置き換えて既存のデザインに揃える

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -172,6 +172,7 @@
   "emptySearchResult": "No matching information was found.",
   "stationNameSearchPlaceholder": "Where are you?",
   "routeSearchPlaceholder": "Where to?",
+  "searchBarClear": "Clear input",
   "trainTypesNotExist": "No train types available",
   "trainTypeFilterPlaceholder": "Filter by keyword",
   "trainTypeFilterAxisType": "Type",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -173,6 +173,7 @@
   "emptySearchResult": "一致する情報が見つかりませんでした。",
   "stationNameSearchPlaceholder": "どこにいますか？",
   "routeSearchPlaceholder": "どこへ行きますか？",
+  "searchBarClear": "入力をクリア",
   "trainTypesNotExist": "列車種別がありません",
   "trainTypeFilterPlaceholder": "キーワードで絞り込み",
   "trainTypeFilterAxisType": "種別",

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { StyleSheet, type ViewStyle } from 'react-native';
 import { DARK_APP_COLORS } from '~/constants/colorScheme';
@@ -18,6 +18,13 @@ type Options = {
   colorScheme?: (typeof COLOR_SCHEME_PREFERENCE)[keyof typeof COLOR_SCHEME_PREFERENCE];
   led?: boolean;
 };
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <Provider store={createStore()}>
+      <AppColorsProvider>{ui}</AppColorsProvider>
+    </Provider>
+  );
 
 const renderSearchBar = ({
   colorScheme = COLOR_SCHEME_PREFERENCE.LIGHT,
@@ -81,5 +88,70 @@ describe('SearchBar', () => {
 
     expect(containerStyle.backgroundColor).toBe('#333');
     expect(inputColor).toBe('white');
+  });
+});
+
+// 種別の絞り込みなど、1 文字ごとに結果を更新する使い方を共通化した分の担保
+describe('SearchBar（親が値を持つ使い方）', () => {
+  it('渡した値を表示し、入力のたびに親へ通知する', () => {
+    const onChangeText = jest.fn();
+    const { getByTestId } = renderWithProviders(
+      <SearchBar
+        value="東上"
+        onChangeText={onChangeText}
+        testID="searchInput"
+      />
+    );
+
+    expect(getByTestId('searchInput').props.value).toBe('東上');
+
+    fireEvent.changeText(getByTestId('searchInput'), '東上線');
+
+    expect(onChangeText).toHaveBeenCalledWith('東上線');
+  });
+
+  it('clearable では入力があるときだけクリアが出て、押すと空文字を通知する', () => {
+    const onChangeText = jest.fn();
+    const { queryByTestId } = renderWithProviders(
+      <SearchBar value="" clearable clearButtonTestID="clear" />
+    );
+    expect(queryByTestId('clear')).toBeNull();
+
+    const { getByTestId } = renderWithProviders(
+      <SearchBar
+        value="東上"
+        onChangeText={onChangeText}
+        clearable
+        clearButtonTestID="clear"
+      />
+    );
+    fireEvent.press(getByTestId('clear'));
+
+    expect(onChangeText).toHaveBeenCalledWith('');
+  });
+
+  it('値を渡さないときは自前で入力を保持し、送信で現在の入力を渡す', () => {
+    const onSearch = jest.fn();
+    const { getByTestId } = renderWithProviders(
+      <SearchBar onSearch={onSearch} testID="searchInput" />
+    );
+
+    fireEvent.changeText(getByTestId('searchInput'), '渋谷');
+    fireEvent(getByTestId('searchInput'), 'submitEditing');
+
+    expect(onSearch).toHaveBeenCalledWith('渋谷');
+  });
+
+  // iOS は autoCorrect={false}(autocorrectionType = .no) にすると日本語入力の
+  // 変換候補バーごと消え、かなを漢字へ変換できなくなる。Android でも
+  // TYPE_TEXT_FLAG_NO_SUGGESTIONS が立って候補が出なくなる。
+  // 省略して既定に委ねると、New Architecture のビュー再利用で .no が残った
+  // ビューを引き継ぐことがあるため、true を明示することまで含めて固定する
+  it('日本語入力の変換候補を潰さないよう、オートコレクトを明示的に有効化する', () => {
+    const { getByTestId } = renderWithProviders(
+      <SearchBar testID="searchInput" />
+    );
+
+    expect(getByTestId('searchInput').props.autoCorrect).toBe(true);
   });
 });

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -130,6 +130,21 @@ describe('SearchBar（親が値を持つ使い方）', () => {
     expect(onChangeText).toHaveBeenCalledWith('');
   });
 
+  // アイコンだけのボタンは読み上げ名がアイコン由来のフォールバックになり、
+  // 何をするボタンなのかが伝わらないための担保
+  it('アイコンだけのボタンにローカライズ済みの読み上げ名を持たせる', () => {
+    const onChangeText = jest.fn();
+    const { getByRole } = renderWithProviders(
+      <SearchBar value="東上" onChangeText={onChangeText} clearable />
+    );
+
+    expect(getByRole('button', { name: 'search' })).toBeTruthy();
+
+    fireEvent.press(getByRole('button', { name: 'searchBarClear' }));
+
+    expect(onChangeText).toHaveBeenCalledWith('');
+  });
+
   it('値を渡さないときは自前で入力を保持し、送信で現在の入力を渡す', () => {
     const onSearch = jest.fn();
     const { getByTestId } = renderWithProviders(

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   Platform,
   StyleSheet,
   TextInput,
+  type TextInputProps,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -12,6 +13,11 @@ import { FONTS } from '~/constants';
 import { useAppColors } from '~/providers/AppColorsProvider';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
+
+/** 電光掲示板風テーマで背景から一段浮かせる面の色 */
+const LED_SURFACE_COLOR = '#333';
+/** 電光掲示板風テーマの黒地でも読めるプレースホルダーの色 */
+const LED_PLACEHOLDER_COLOR = '#9AA0A6';
 
 const styles = StyleSheet.create({
   root: {
@@ -30,7 +36,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   ledBg: {
-    backgroundColor: '#333',
+    backgroundColor: LED_SURFACE_COLOR,
   },
   button: {
     width: 48,
@@ -39,17 +45,50 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  clearButton: {
+    width: 32,
+    height: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
 });
 
 type Props = {
+  /** 検索の実行。送信キーと検索ボタンの両方から呼ばれる */
   onSearch?: (text: string) => void;
   nameSearch?: boolean;
+  /**
+   * 入力値を親で持つときに渡す。渡すと制御コンポーネントとして振る舞い、
+   * 1 文字ごとに絞り込むような用途に使える。
+   */
+  value?: string;
+  onChangeText?: (text: string) => void;
+  /** 既定の翻訳文以外を出したいときだけ渡す */
+  placeholder?: string;
+  /** 入力があるときに入力欄内のクリアボタンを出す */
+  clearable?: boolean;
+  autoCapitalize?: TextInputProps['autoCapitalize'];
+  testID?: string;
+  clearButtonTestID?: string;
 };
 
-export const SearchBar = ({ onSearch, nameSearch }: Props) => {
-  const [searchText, setSearchText] = useState('');
+export const SearchBar = ({
+  onSearch,
+  nameSearch,
+  value,
+  onChangeText,
+  placeholder,
+  clearable,
+  autoCapitalize,
+  testID,
+  clearButtonTestID,
+}: Props) => {
+  const [internalText, setInternalText] = useState('');
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const colors = useAppColors();
+
+  // value を渡さない従来の使い方では、これまで通り自前で入力値を持つ
+  const searchText = value ?? internalText;
 
   const fontFamily = useMemo(() => {
     if (isLEDTheme) {
@@ -57,6 +96,26 @@ export const SearchBar = ({ onSearch, nameSearch }: Props) => {
     }
     return FONTS.RobotoRegular;
   }, [isLEDTheme]);
+
+  const handleChangeText = useCallback(
+    (text: string) => {
+      if (value === undefined) {
+        setInternalText(text);
+      }
+      onChangeText?.(text);
+    },
+    [value, onChangeText]
+  );
+
+  const handleClear = useCallback(
+    () => handleChangeText(''),
+    [handleChangeText]
+  );
+
+  const handleSearch = useCallback(
+    () => onSearch?.(searchText),
+    [onSearch, searchText]
+  );
 
   return (
     <View
@@ -68,6 +127,7 @@ export const SearchBar = ({ onSearch, nameSearch }: Props) => {
       ]}
     >
       <TextInput
+        testID={testID}
         style={[
           styles.textInput,
           {
@@ -75,21 +135,64 @@ export const SearchBar = ({ onSearch, nameSearch }: Props) => {
             fontFamily,
           },
         ]}
-        placeholderTextColor={colors.isDark ? colors.secondaryText : undefined}
-        onChange={(e) => setSearchText(e.nativeEvent.text)}
-        onSubmitEditing={() => onSearch?.(searchText)}
-        placeholder={translate(
-          nameSearch ? 'stationNameSearchPlaceholder' : 'routeSearchPlaceholder'
-        )}
+        placeholderTextColor={
+          isLEDTheme
+            ? LED_PLACEHOLDER_COLOR
+            : colors.isDark
+              ? colors.secondaryText
+              : undefined
+        }
+        value={searchText}
+        onChangeText={handleChangeText}
+        onSubmitEditing={handleSearch}
+        placeholder={
+          placeholder ??
+          translate(
+            nameSearch
+              ? 'stationNameSearchPlaceholder'
+              : 'routeSearchPlaceholder'
+          )
+        }
+        autoCapitalize={autoCapitalize}
+        // autoCorrect を false にすると iOS は autocorrectionType = .no になり、
+        // 日本語入力の変換候補バーごと消えてかなを漢字へ変換できなくなる
+        // (iOS の日本語キーボードは候補バー以外に変換する手段を持たない)。
+        // Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS が立ち IME の候補が出ない。
+        //
+        // 省略して既定に委ねるだけでは足りない。New Architecture の
+        // RCTTextInputComponentView は autoCorrect が前回 props から変化した
+        // ときしか autocorrectionType を代入せず、prepareForRecycle も
+        // autocorrectionType を戻さない。そのため .no が残ったビューが再利用
+        // されると、props 省略(std::nullopt 同士で変化なし)では .no を引き継ぐ。
+        // 明示的に true を渡してマウントのたびに .yes を確定させる。
+        // ローマ字入力に英語のオートコレクトがかかる副作用より、日本語を
+        // 入力できることを優先する。
+        autoCorrect
+        returnKeyType="search"
       />
+      {clearable && searchText.length ? (
+        <TouchableOpacity
+          accessibilityRole="button"
+          testID={clearButtonTestID}
+          style={styles.clearButton}
+          onPress={handleClear}
+        >
+          <Ionicons
+            name="close-circle"
+            size={18}
+            color={isLEDTheme ? LED_PLACEHOLDER_COLOR : colors.secondaryText}
+          />
+        </TouchableOpacity>
+      ) : null}
       <TouchableOpacity
+        accessibilityRole="button"
         style={[
           styles.button,
           isLEDTheme
             ? undefined
             : { borderTopRightRadius: 8, borderBottomRightRadius: 8 },
         ]}
-        onPress={() => onSearch?.(searchText)}
+        onPress={handleSearch}
       >
         <Ionicons name="search" size={20} color="white" />
       </TouchableOpacity>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -173,6 +173,9 @@ export const SearchBar = ({
       {clearable && searchText.length ? (
         <TouchableOpacity
           accessibilityRole="button"
+          // アイコンだけのボタンは読み上げ名がフォールバックの記号名になり
+          // 操作の目的が伝わらないため、名前を明示する
+          accessibilityLabel={translate('searchBarClear')}
           testID={clearButtonTestID}
           style={styles.clearButton}
           onPress={handleClear}
@@ -186,6 +189,7 @@ export const SearchBar = ({
       ) : null}
       <TouchableOpacity
         accessibilityRole="button"
+        accessibilityLabel={translate('search')}
         style={[
           styles.button,
           isLEDTheme

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -2,13 +2,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
 import { useCallback, useMemo, useState } from 'react';
 import {
+  Keyboard,
   ScrollView,
   StyleSheet,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
-import { FONTS, LED_THEME_BG_COLOR } from '~/constants';
+import { LED_THEME_BG_COLOR } from '~/constants';
 import { useAppColors } from '~/providers/AppColorsProvider';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
@@ -21,6 +21,7 @@ import {
   type TrainTypeFilterState,
   toggleTrainTypeFilterValue,
 } from '~/utils/trainTypeFilter';
+import { SearchBar } from './SearchBar';
 import Typography from './Typography';
 
 /**
@@ -30,7 +31,7 @@ import Typography from './Typography';
 const HEADER_HORIZONTAL_INSET = 24;
 /** パネルを閉じているときにヘッダー下端との間に残す余白 */
 const CLOSED_BOTTOM_INSET = 12;
-/** 電光掲示板風テーマで背景から一段浮かせる面の色（SearchBar と同じ） */
+/** 展開パネルを背景から一段浮かせる面の色（電光掲示板風テーマ用） */
 const LED_SURFACE_COLOR = '#333';
 
 type AxisKey = 'typeNames' | 'lines';
@@ -44,18 +45,6 @@ const styles = StyleSheet.create({
   },
   search: {
     marginTop: 12,
-    height: 48,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 14,
-    boxShadow: '0px 0px 8px rgba(51, 51, 51, 0.25)',
-  },
-  searchInput: {
-    flex: 1,
-    fontSize: 16,
-    padding: 0,
-    includeFontPadding: false,
   },
   chipsRow: {
     marginTop: 10,
@@ -148,10 +137,6 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
   const palette = useMemo(
     () => ({
       surface: isLEDTheme ? LED_THEME_BG_COLOR : colors.surface,
-      searchBackground: isLEDTheme ? LED_SURFACE_COLOR : colors.subtleSurface,
-      searchRadius: isLEDTheme ? 0 : 8,
-      inputText: isLEDTheme || colors.isDark ? '#fff' : '#000',
-      placeholder: isLEDTheme ? '#9AA0A6' : colors.secondaryText,
       chipBorder: isLEDTheme ? '#fff' : colors.accent,
       chipFill: isLEDTheme ? '#fff' : colors.accent,
       chipTextOn: isLEDTheme ? LED_THEME_BG_COLOR : '#fff',
@@ -170,11 +155,6 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
     [colors, isLEDTheme]
   );
 
-  const fontFamily = useMemo(
-    () => (isLEDTheme ? FONTS.JFDotJiskan24h : FONTS.RobotoRegular),
-    [isLEDTheme]
-  );
-
   const filterActive = isTrainTypeFilterActive(filter);
 
   const handleQueryChange = useCallback(
@@ -182,10 +162,9 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
     [filter, onChange]
   );
 
-  const handleClearQuery = useCallback(
-    () => onChange({ ...filter, query: '' }),
-    [filter, onChange]
-  );
+  // 絞り込みは 1 文字ごとに反映されるので、検索ボタンと送信キーはキーボードを
+  // 畳んで結果を見せる役に回す
+  const handleSubmitQuery = useCallback(() => Keyboard.dismiss(), []);
 
   const handleClearAll = useCallback(() => {
     setOpenAxis(null);
@@ -374,53 +353,17 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
 
   return (
     <View style={[styles.root, openAxis ? null : styles.rootClosed]}>
-      <View
-        style={[
-          styles.search,
-          {
-            backgroundColor: palette.searchBackground,
-            borderRadius: palette.searchRadius,
-          },
-        ]}
-      >
-        <Ionicons name="search" size={20} color={palette.placeholder} />
-        <TextInput
-          style={[styles.searchInput, { color: palette.inputText, fontFamily }]}
+      <View style={styles.search}>
+        <SearchBar
           value={filter.query}
           onChangeText={handleQueryChange}
+          onSearch={handleSubmitQuery}
           placeholder={translate('trainTypeFilterPlaceholder')}
-          placeholderTextColor={palette.placeholder}
+          clearable
           autoCapitalize="none"
-          // autoCorrect を false にすると iOS は autocorrectionType = .no になり、
-          // 日本語入力の変換候補バーごと消えてかなを漢字へ変換できなくなる
-          // (iOS の日本語キーボードは候補バー以外に変換する手段を持たない)。
-          // Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS が立ち IME の候補が出ない。
-          //
-          // 省略して既定に委ねるだけでは足りない。New Architecture の
-          // RCTTextInputComponentView は autoCorrect が前回 props から変化した
-          // ときしか autocorrectionType を代入せず、prepareForRecycle も
-          // autocorrectionType を戻さない。そのため .no が残ったビューが再利用
-          // されると、props 省略(std::nullopt 同士で変化なし)では .no を引き継ぐ。
-          // 明示的に true を渡してマウントのたびに .yes を確定させる。
-          // ローマ字入力に英語のオートコレクトがかかる副作用より、日本語を
-          // 入力できることを優先する。
-          autoCorrect
-          returnKeyType="search"
           testID="trainTypeFilterSearchInput"
+          clearButtonTestID="trainTypeFilterClearQuery"
         />
-        {filter.query.length ? (
-          <TouchableOpacity
-            accessibilityRole="button"
-            onPress={handleClearQuery}
-            testID="trainTypeFilterClearQuery"
-          >
-            <Ionicons
-              name="close-circle"
-              size={18}
-              color={palette.placeholder}
-            />
-          </TouchableOpacity>
-        ) : null}
       </View>
 
       <ScrollView


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別一覧の絞り込み欄は独自の `TextInput` 実装を持っており、経路検索・駅名検索で使っている共通の `SearchBar` とデザインが揃っていませんでした。`SearchBar` を「親が入力値を持つ使い方」にも対応できるよう拡張したうえで置き換え、アプリ内の他の検索欄と見た目・挙動を統一します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `SearchBar` に `value` / `onChangeText` / `placeholder` / `clearable` / `autoCapitalize` / `testID` / `clearButtonTestID` を追加。`value` を渡すと制御コンポーネントとして振る舞い、1 文字ごとに絞り込む用途に使えるようにした
- `value` を渡さない従来の呼び出し（経路検索・駅名検索）は内部 state を保持したままで、挙動は変わらない
- `TrainTypeFilterBar` が独自に持っていた `TextInput`・検索アイコン・クリアボタン・入力欄用の配色計算（`searchBackground` / `searchRadius` / `inputText` / `placeholder`）と `fontFamily` の算出を削除し、共通の `SearchBar` へ置き換え
- 電光掲示板風テーマ用のプレースホルダー色、入力があるときだけ出るクリアボタン、`returnKeyType="search"`、日本語入力の変換候補を潰さないための `autoCorrect` 明示を `SearchBar` 側へ移設（New Architecture のビュー再利用で `autocorrectionType = .no` を引き継ぐ問題への対処コメントも移設）
- 絞り込みは 1 文字ごとに反映されるため、検索ボタンと送信キーは `Keyboard.dismiss()` に割り当て、結果を見せる役に回した
- アイコンだけで構成されるクリアボタン・検索ボタンに `accessibilityLabel` を付与し、読み上げ名を明示（クリア用に翻訳キー `searchBarClear`（入力をクリア / Clear input）を追加、検索は既存の `search` を利用）
- `SearchBar.test.tsx` に制御コンポーネントとしての振る舞い（値の反映・クリア・送信・`autoCorrect` の明示）と、`getByRole('button', { name })` で両ボタンを引ける読み上げ名のテストを追加

**リグレッションリスクと緩和策**: `SearchBar` は経路検索・駅名検索でも使われている共有コンポーネントのため、追加した props が既存呼び出しに影響しないことが要点です。新規 props はすべて任意で、`value === undefined` のときは従来どおり内部 state を使う分岐にしてあり、`clearable` を渡さない呼び出しにクリアボタンは出ません。既存の `SearchBar.test.tsx` のテーマ別スタイル検証は変更せずに通過しており、`TrainTypeFilterBar.test.tsx` の絞り込み・クリア動作のテスト（`trainTypeFilterSearchInput` / `trainTypeFilterClearQuery` の testID は据え置き）もそのまま通っています。`onChange` から `onChangeText` へ移行した点は、テストで入力ごとの通知を担保しています。追加した `accessibilityLabel` は表示に影響せず、`testID` も据え置きのため既存の検索画面のテスト・操作導線は変わりません。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果: `biome check ./src` → 682 files / 指摘なし、`jest` → 243 suites・2630 tests すべて成功、`tsc --noEmit` → エラーなし。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### React Native Web \(Chrome\)

`npm run web` で変更前後の `TrainTypeFilterBar` を並べて描画したものです（実装のレンダリング結果）。左が変更前、右が変更後。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/claude_category-search-bar-design-jih86g-21370c770a6b/c0ce4e4dc967-train-type-filter-empty.png" width="820" alt="変更前後の比較（通常テーマ・未入力）" />

変更前後の比較（通常テーマ・未入力）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/claude_category-search-bar-design-jih86g-21370c770a6b/31d40165986e-train-type-filter-typed.png" width="820" alt="変更前後の比較（通常テーマ・キーワード入力あり）" />

変更前後の比較（通常テーマ・キーワード入力あり）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/claude_category-search-bar-design-jih86g-21370c770a6b/690aa8ae085d-train-type-filter-led.png" width="820" alt="変更前後の比較（電光掲示板風テーマ・キーワード入力あり）" />

変更前後の比較（電光掲示板風テーマ・キーワード入力あり）

補足: `FONTS.JFDotJiskan24h` / `RobotoRegular` は `Platform.select({ ios, android })` のため Web では解決されず、フォントだけ実機と異なります（電光掲示板風テーマのドットフォントは反映されていません）。レイアウト・配色・要素の構成は実装どおりです。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 検索バーで入力値を外部から制御できるようになりました。
  - プレースホルダー、自動大文字化、クリアボタン、検索送信に対応しました。
  - 日本語入力時の自動修正を有効化しました。
  - 検索・クリア操作にアクセシビリティラベルを追加しました。

- **改善**
  - 列車タイプの検索欄を共通検索バーに統一しました。
  - 検索送信時にキーボードが自動で閉じるようになりました。
  - クリアボタンの表示を英語・日本語に対応しました。

- **テスト**
  - 入力変更、クリア、検索送信などの動作確認を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
