### PR TITLE
種別絞り込みの日本語変換候補が出ない不具合をSearchBarのautoCorrect既定値撤廃で修正

### DIFF
--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -157,16 +157,22 @@ describe('SearchBar（親が値を持つ使い方）', () => {
     expect(onSearch).toHaveBeenCalledWith('渋谷');
   });
 
-  // iOS は autoCorrect={false}(autocorrectionType = .no) にすると日本語入力の
-  // 変換候補バーごと消え、かなを漢字へ変換できなくなる。Android でも
-  // TYPE_TEXT_FLAG_NO_SUGGESTIONS が立って候補が出なくなる。
-  // 省略して既定に委ねると、New Architecture のビュー再利用で .no が残った
-  // ビューを引き継ぐことがあるため、true を明示することまで含めて固定する
-  it('日本語入力の変換候補を潰さないよう、オートコレクトを明示的に有効化する', () => {
+  // New Architecture の RCTTextInputComponentView は autoCorrect が前回 props から
+  // 変化したときしか autocorrectionType を代入しない。共有コンポーネント側で
+  // true を固定すると、変換候補のために true を明示している呼び出し元と署名が
+  // 一致し、再利用ビューでは true → true となって代入が飛び、残った .no を
+  // 引き継いで変換候補が出なくなる。既定を持たないことまで含めて固定する
+  it('オートコレクトは既定値を持たず、渡されたときだけ入力欄へ通す', () => {
     const { getByTestId } = renderWithProviders(
       <SearchBar testID="searchInput" />
     );
 
-    expect(getByTestId('searchInput').props.autoCorrect).toBe(true);
+    expect(getByTestId('searchInput').props.autoCorrect).toBeUndefined();
+
+    const explicit = renderWithProviders(
+      <SearchBar autoCorrect testID="explicitInput" />
+    );
+
+    expect(explicit.getByTestId('explicitInput').props.autoCorrect).toBe(true);
   });
 });

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -68,6 +68,11 @@ type Props = {
   /** 入力があるときに入力欄内のクリアボタンを出す */
   clearable?: boolean;
   autoCapitalize?: TextInputProps['autoCapitalize'];
+  /**
+   * 日本語入力の変換候補を確実に出したい呼び出し元だけが true を明示する。
+   * ここで既定値を持たせてはいけない理由は下の TextInput のコメントを参照。
+   */
+  autoCorrect?: TextInputProps['autoCorrect'];
   testID?: string;
   clearButtonTestID?: string;
 };
@@ -80,6 +85,7 @@ export const SearchBar = ({
   placeholder,
   clearable,
   autoCapitalize,
+  autoCorrect,
   testID,
   clearButtonTestID,
 }: Props) => {
@@ -154,20 +160,20 @@ export const SearchBar = ({
           )
         }
         autoCapitalize={autoCapitalize}
-        // autoCorrect を false にすると iOS は autocorrectionType = .no になり、
-        // 日本語入力の変換候補バーごと消えてかなを漢字へ変換できなくなる
-        // (iOS の日本語キーボードは候補バー以外に変換する手段を持たない)。
-        // Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS が立ち IME の候補が出ない。
+        // autoCorrect は呼び出し元から受け取るだけで、ここで既定値を持たせない。
         //
-        // 省略して既定に委ねるだけでは足りない。New Architecture の
-        // RCTTextInputComponentView は autoCorrect が前回 props から変化した
-        // ときしか autocorrectionType を代入せず、prepareForRecycle も
-        // autocorrectionType を戻さない。そのため .no が残ったビューが再利用
-        // されると、props 省略(std::nullopt 同士で変化なし)では .no を引き継ぐ。
-        // 明示的に true を渡してマウントのたびに .yes を確定させる。
-        // ローマ字入力に英語のオートコレクトがかかる副作用より、日本語を
-        // 入力できることを優先する。
-        autoCorrect
+        // New Architecture の RCTTextInputComponentView は autoCorrect が前回
+        // props から変化したときしか autocorrectionType を代入せず、
+        // prepareForRecycle でも autocorrectionType を戻さない
+        // (react-native/React/Fabric/Mounting/ComponentViews/TextInput/
+        //  RCTTextInputComponentView.mm)。
+        //
+        // このコンポーネント自身が true を固定すると、変換候補のために true を
+        // 明示している種別絞り込みと署名が一致し、再利用ビューでは true → true で
+        // 代入自体が起きず、残っていた .no を引き継いで変換候補が出なくなる。
+        // 既定を std::nullopt のままにしておくことで、明示した呼び出し元の true が
+        // 必ず「変化あり」と判定される。
+        autoCorrect={autoCorrect}
         returnKeyType="search"
       />
       {clearable && searchText.length ? (

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -361,6 +361,21 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
           placeholder={translate('trainTypeFilterPlaceholder')}
           clearable
           autoCapitalize="none"
+          // autoCorrect を false にすると iOS は autocorrectionType = .no になり、
+          // 日本語入力の変換候補バーごと消えてかなを漢字へ変換できなくなる
+          // (iOS の日本語キーボードは候補バー以外に変換する手段を持たない)。
+          // Android でも TYPE_TEXT_FLAG_NO_SUGGESTIONS が立ち IME の候補が出ない。
+          //
+          // 省略して既定に委ねるだけでは足りない。New Architecture の
+          // RCTTextInputComponentView は autoCorrect が前回 props から変化した
+          // ときしか autocorrectionType を代入せず、prepareForRecycle も
+          // autocorrectionType を戻さない。そのため .no が残ったビューが再利用
+          // されると、props 省略(std::nullopt 同士で変化なし)では .no を引き継ぐ。
+          // 明示的に true を渡してマウントのたびに .yes を確定させる。
+          //
+          // SearchBar 側が既定値を持たないのはこの明示を「変化あり」にするため。
+          // 共有コンポーネントで true を固定すると署名が一致して代入が飛ぶ。
+          autoCorrect
           testID="trainTypeFilterSearchInput"
           clearButtonTestID="trainTypeFilterClearQuery"
         />


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6763 で種別絞り込みの検索欄を共通の `SearchBar` へ寄せた結果、iOS で日本語の変換候補が出ない不具合（#6750 / #6753 で対処した症状）が再発しました。`SearchBar` 側が `autoCorrect` の既定値を持ってしまったことが原因なので、既定値を外して呼び出し元の明示指定に戻します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `SearchBar` に任意 props `autoCorrect` を追加し、受け取った値を `TextInput` へ素通しするだけにした。コンポーネント側では既定値を持たない
- `TrainTypeFilterBar` から `SearchBar` へ `autoCorrect` を明示的に渡すようにした（#6753 と同じ指定を、`SearchBar` 経由に戻したもの）
- `SearchBar.test.tsx` を、既定では `autoCorrect` が `undefined` であること、渡されたときだけ入力欄へ通ることを固定するテストへ更新

**再発の機序**: New Architecture の `RCTTextInputComponentView` は `autoCorrect` が前回 props から変化したときしか `autocorrectionType` を代入せず、`prepareForRecycle` でも戻しません（`react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm`）。#6763 以前は `autoCorrect: true` を持つ入力欄が種別絞り込みだけで、他の検索欄はすべて未指定だったため、再利用ビューが来ても必ず未指定 → `true` の変化が起きて `.yes` が代入されていました。#6763 で経路検索・駅名検索も同じ `SearchBar` になり `true` を持つと、再利用時に `true` → `true` となって代入自体がスキップされ、ビューに残った `.no` を引き継ぎます。共有コンポーネント側を未指定に戻すことで、明示した呼び出し元の `true` が必ず「変化あり」と判定されます。

**リグレッションリスクと緩和策**: 変更は `autoCorrect` の受け渡しのみで、レイアウト・配色・`testID` には触れていません。#6763 で揃えたデザインはそのままです。経路検索・駅名検索は `autoCorrect` を渡さないため #6763 以前と同じ扱いに戻ります。種別絞り込み側は `trainTypeFilterSearchInput` に `autoCorrect === true` が付くことを検証する既存テスト（#6753 で追加）がそのまま通っています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果: `biome check ./src` → 682 files / 指摘なし、`jest` → 243 suites・2630 tests すべて成功、`tsc --noEmit` → エラーなし。

**未検証の点**: 症状は iOS 実機で報告されているものですが、作業環境に iOS シミュレータがないため、変換候補が実際に出るようになったかは未確認です。機序は上記のとおり RN の実装から特定していますが、マージ前に iOS 実機での確認をお願いします。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: 差分は `autoCorrect` の受け渡しのみで、レイアウト・配色・スタイルには一切触れていません。#6763 で揃えた見た目はそのままです。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 検索入力欄の自動修正設定を、必要な場合のみ明示的に適用できるようになりました。
  * 列車種別フィルターでは、日本語入力時の候補表示を引き続き有効化しました。
* **テスト**
  * 自動修正設定が指定どおり入力欄へ反映されることを確認するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->