### PR TITLE
種別絞り込みとAIエージェントの入力欄で入力値の書き戻しをやめて日本語変換候補が出ない不具合を修正

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -63,6 +63,11 @@ type Props = {
    */
   value?: string;
   onChangeText?: (text: string) => void;
+  /**
+   * 初期表示だけ親から与えたいときに渡す。以降は入力欄が自分で値を持つので、
+   * 1 文字ごとの書き戻しが起きない（iOS の変換候補が壊れない）
+   */
+  defaultValue?: string;
   /** 既定の翻訳文以外を出したいときだけ渡す */
   placeholder?: string;
   /** 入力があるときに入力欄内のクリアボタンを出す */
@@ -82,6 +87,7 @@ export const SearchBar = ({
   nameSearch,
   value,
   onChangeText,
+  defaultValue,
   placeholder,
   clearable,
   autoCapitalize,
@@ -89,7 +95,7 @@ export const SearchBar = ({
   testID,
   clearButtonTestID,
 }: Props) => {
-  const [internalText, setInternalText] = useState('');
+  const [internalText, setInternalText] = useState(defaultValue ?? '');
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const colors = useAppColors();
 

--- a/src/components/TrainTypeFilterBar.test.tsx
+++ b/src/components/TrainTypeFilterBar.test.tsx
@@ -1,4 +1,6 @@
 import { fireEvent, render } from '@testing-library/react-native';
+import { useState } from 'react';
+import { Text } from 'react-native';
 import {
   EMPTY_TRAIN_TYPE_FILTER,
   type TrainTypeFilterOptions,
@@ -192,5 +194,42 @@ describe('TrainTypeFilterBar', () => {
 
     expect(queryByTestId('trainTypeFilterAxis-typeNames')).toBeTruthy();
     expect(queryByTestId('trainTypeFilterAxis-lines')).toBeNull();
+  });
+  // 入力欄のクリアボタンは入力欄が自分で空にするため、ここで作り直すと
+  // 焦点と IME セッションが切れる。外からのクリアだけ作り直す
+  it('入力欄内のクリアでは入力欄を作り直さず、外からのクリアでのみ作り直す', () => {
+    const Harness = () => {
+      const [filter, setFilter] = useState<TrainTypeFilterState>(
+        EMPTY_TRAIN_TYPE_FILTER
+      );
+      return (
+        <>
+          <TrainTypeFilterBar
+            options={options}
+            filter={filter}
+            onChange={setFilter}
+          />
+          <Text
+            testID="externalClear"
+            onPress={() => setFilter(EMPTY_TRAIN_TYPE_FILTER)}
+          >
+            ext
+          </Text>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<Harness />);
+    const input = getByTestId('trainTypeFilterSearchInput');
+
+    fireEvent.changeText(input, '東上');
+    fireEvent.press(getByTestId('trainTypeFilterClearQuery'));
+
+    expect(getByTestId('trainTypeFilterSearchInput')).toBe(input);
+
+    fireEvent.changeText(getByTestId('trainTypeFilterSearchInput'), '東上');
+    fireEvent.press(getByTestId('externalClear'));
+
+    expect(getByTestId('trainTypeFilterSearchInput')).not.toBe(input);
   });
 });

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAtomValue } from 'jotai';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
   ScrollView,
@@ -132,6 +132,20 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
   const colors = useAppColors();
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const [openAxis, setOpenAxis] = useState<AxisKey | null>(null);
+
+  // 入力欄には value を渡さない。1 文字ごとに一覧を絞り込んだ結果を書き戻すと、
+  // iOS では未確定文字列(marked text)が壊れて日本語の変換候補が出せなくなる。
+  // 代わりに入力値は SearchBar のローカル state に持たせ(経路検索と同じ扱い)、
+  // 親へは通知するだけにする。外から絞り込みが空に戻されたとき(クリア操作)だけ、
+  // key を変えて入力欄を作り直して表示を合わせる
+  const [searchResetKey, setSearchResetKey] = useState(0);
+  const prevQuery = useRef(filter.query);
+  useEffect(() => {
+    if (prevQuery.current !== '' && filter.query === '') {
+      setSearchResetKey((n) => n + 1);
+    }
+    prevQuery.current = filter.query;
+  }, [filter.query]);
 
   // 電光掲示板風テーマは黒地に白抜きの独自配色を持つので、選択状態の塗りも反転させる
   const palette = useMemo(
@@ -355,7 +369,8 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
     <View style={[styles.root, openAxis ? null : styles.rootClosed]}>
       <View style={styles.search}>
         <SearchBar
-          value={filter.query}
+          key={searchResetKey}
+          defaultValue={filter.query}
           onChangeText={handleQueryChange}
           onSearch={handleSubmitQuery}
           placeholder={translate('trainTypeFilterPlaceholder')}

--- a/src/components/TrainTypeFilterBar.tsx
+++ b/src/components/TrainTypeFilterBar.tsx
@@ -140,10 +140,18 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
   // key を変えて入力欄を作り直して表示を合わせる
   const [searchResetKey, setSearchResetKey] = useState(0);
   const prevQuery = useRef(filter.query);
+  // 入力欄のクリアボタン由来の空文字は入力欄が自分で空にしているため、
+  // 作り直す必要がない。ここで作り直すと焦点と IME セッションが切れる
+  const queryChangedByInput = useRef(false);
   useEffect(() => {
-    if (prevQuery.current !== '' && filter.query === '') {
+    if (
+      prevQuery.current !== '' &&
+      filter.query === '' &&
+      !queryChangedByInput.current
+    ) {
       setSearchResetKey((n) => n + 1);
     }
+    queryChangedByInput.current = false;
     prevQuery.current = filter.query;
   }, [filter.query]);
 
@@ -172,7 +180,10 @@ export const TrainTypeFilterBar = ({ options, filter, onChange }: Props) => {
   const filterActive = isTrainTypeFilterActive(filter);
 
   const handleQueryChange = useCallback(
-    (query: string) => onChange({ ...filter, query }),
+    (query: string) => {
+      queryChangedByInput.current = true;
+      onChange({ ...filter, query });
+    },
     [filter, onChange]
   );
 

--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -127,7 +127,11 @@ export const AgentInputBar = ({
               fontFamily,
             },
           ]}
-          value={value}
+          // value を渡して書き戻すと、iOS では未確定文字列(marked text)が壊れて
+          // 日本語の変換候補が出せなくなる。入力値は入力欄自身に持たせ、親へは
+          // onChangeText で通知するだけにする。親から中身を変えたいときは
+          // ref.clear() か、呼び出し側で key を変えて作り直す
+          defaultValue={value}
           onChangeText={onChangeText}
           editable={!rateLimited}
           multiline

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -154,9 +154,17 @@ const DestinationAgentScreen = () => {
 
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [inputText, setInputText] = useState('');
+  // 入力欄は非制御なので、setInputText の更新関数の外から現在値を読めるよう
+  // ref にも持つ。送信失敗時に「下書きがあるか」を判定するのに使う
+  const inputTextRef = useRef('');
   // 入力欄は値を書き戻さない非制御入力なので、親から中身を変えるときは
   // ref.clear() を使い、空にできない場合だけこの key を変えて作り直す
   const [inputResetKey, setInputResetKey] = useState(0);
+
+  const handleInputChange = useCallback((text: string) => {
+    inputTextRef.current = text;
+    setInputText(text);
+  }, []);
   const [sending, setSending] = useState(false);
   // tool イベント受信中(駅検索の tool use ループ中)であることを示すフラグ。
   // 最初の delta が届くか応答が確定した時点で降ろす
@@ -299,6 +307,7 @@ const DestinationAgentScreen = () => {
       setSending(true);
       setSearching(false);
       setInputText('');
+      inputTextRef.current = '';
       // 入力欄自身が値を持つので、表示は明示的に消す。key を変えないのは
       // 送信後もキーボードと焦点を保って続けて質問できるようにするため
       inputRef.current?.clear();
@@ -421,10 +430,15 @@ const DestinationAgentScreen = () => {
           (entry) => entry.id !== userEntry.id && entry.id !== streamingEntry.id
         )
       );
-      // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する
-      setInputText((prev) => (prev.length ? prev : text));
-      // 空でない文字列は ref では戻せないため、入力欄を作り直して表示を合わせる
-      setInputResetKey((n) => n + 1);
+      // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する。
+      // 下書きがあるときは入力欄に手を触れない。作り直すと焦点と IME セッションが
+      // 切れるため、戻す文字列が要らない場合は key を変えないこと
+      if (!inputTextRef.current.length) {
+        setInputText(text);
+        inputTextRef.current = text;
+        // 空でない文字列は ref では戻せないため、入力欄を作り直して表示を合わせる
+        setInputResetKey((n) => n + 1);
+      }
       showToast({
         type: 'error',
         text1: translate('errorTitle'),
@@ -448,6 +462,7 @@ const DestinationAgentScreen = () => {
             setEntries([]);
             setSuggestionStates({});
             setInputText('');
+            inputTextRef.current = '';
             inputRef.current?.clear();
             setRateLimited(false);
           },
@@ -667,7 +682,7 @@ const DestinationAgentScreen = () => {
           <AgentInputBar
             key={inputResetKey}
             value={inputText}
-            onChangeText={setInputText}
+            onChangeText={handleInputChange}
             onSend={() => handleSend(inputText)}
             sending={sending}
             rateLimited={rateLimited}

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -154,6 +154,9 @@ const DestinationAgentScreen = () => {
 
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [inputText, setInputText] = useState('');
+  // 入力欄は値を書き戻さない非制御入力なので、親から中身を変えるときは
+  // ref.clear() を使い、空にできない場合だけこの key を変えて作り直す
+  const [inputResetKey, setInputResetKey] = useState(0);
   const [sending, setSending] = useState(false);
   // tool イベント受信中(駅検索の tool use ループ中)であることを示すフラグ。
   // 最初の delta が届くか応答が確定した時点で降ろす
@@ -296,6 +299,9 @@ const DestinationAgentScreen = () => {
       setSending(true);
       setSearching(false);
       setInputText('');
+      // 入力欄自身が値を持つので、表示は明示的に消す。key を変えないのは
+      // 送信後もキーボードと焦点を保って続けて質問できるようにするため
+      inputRef.current?.clear();
       const conversationGen = conversationGenRef.current;
       // 検索中文言の読み上げは 1 送信につき 1 回だけ(tool イベントは複数回届きうる)
       let searchingAnnounced = false;
@@ -417,6 +423,8 @@ const DestinationAgentScreen = () => {
       );
       // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する
       setInputText((prev) => (prev.length ? prev : text));
+      // 空でない文字列は ref では戻せないため、入力欄を作り直して表示を合わせる
+      setInputResetKey((n) => n + 1);
       showToast({
         type: 'error',
         text1: translate('errorTitle'),
@@ -440,6 +448,7 @@ const DestinationAgentScreen = () => {
             setEntries([]);
             setSuggestionStates({});
             setInputText('');
+            inputRef.current?.clear();
             setRateLimited(false);
           },
         },
@@ -656,6 +665,7 @@ const DestinationAgentScreen = () => {
           ]}
         >
           <AgentInputBar
+            key={inputResetKey}
             value={inputText}
             onChangeText={setInputText}
             onSend={() => handleSend(inputText)}


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別絞り込みで iOS の日本語変換候補が出ない不具合が、#6766 をマージした canary でも再現しています。`autoCorrect` は #6750 / #6753 / #6766 と 3 回変更して直っていないため原因ではないと判断し、この入力欄が持つもう一つの性質——**1 文字ごとに一覧を絞り込んだ結果を `value` として入力欄へ書き戻していること**——を解消します。同じ実装が残っていた AI エージェントのチャット入力欄も、あわせて揃えます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

**種別絞り込み（`TrainTypeFilterBar` / `SearchBar`）**

- `SearchBar` へ `value` を渡すのをやめ、初期表示用の `defaultValue` に変更した。入力値は `SearchBar` のローカル state が持ち、親へは `onChangeText` で通知するだけになる（経路検索・駅名検索と同じ扱い）
- 外から絞り込みが空に戻されたとき（軸チップの「クリア」、一覧が 0 件のときの「条件をクリア」）だけ `key` を変えて入力欄を作り直し、表示を親の状態と合わせる
- 入力欄内のクリアボタン由来の空文字では作り直さない。入力欄が自分で空にしているため作り直す必要がなく、作り直すと焦点と IME セッションが切れる（CodeRabbit 指摘対応）
- `SearchBar` に `defaultValue` props を追加し、内部 state の初期値として使うようにした

**AI エージェントのチャット入力欄（`AgentInputBar` / `DestinationAgent`）**

- 同じ書き戻しが残っていたため `value` → `defaultValue` に変更した。親の `inputText` は `onChangeText` で従来どおり更新されるので、送信可否判定・`handleSend` に渡す本文・文字数カウントは変わらない
- 送信後のクリアと会話リセットは `inputRef.current?.clear()` で行う。`key` を変えないのでキーボードと焦点が残り、続けて質問できる
- 送信失敗時に入力内容を復元する経路だけは空でない文字列を戻す必要があるため、`inputResetKey` を増やして入力欄を作り直す

**判断の根拠**: iOS は入力欄へ文字列を書き戻すと未確定文字列（marked text）が壊れ、変換候補を出せなくなります。種別絞り込みは 1 文字ごとに `filterTrainTypeRows` と `FlashList` の再描画を挟んでから `value` が返ってくるため、この書き戻しの影響を受けます。同じ `SearchBar` を使う経路検索・駅名検索は `value` を渡しておらず、同じ症状の報告がありません。アプリ内の他の `TextInput`（`NewReportModal` / `SavePresetNameModal`）も既に `defaultValue` で書かれており、書き戻しをしていたのは上記 2 箇所だけでした。

**リグレッションリスクと緩和策**: 入力値の保持場所が親から入力欄へ移りますが、絞り込み・送信可否判定はどちらも `onChangeText` 経由で従来どおり動きます。モーダルやチャットを開き直したときの初期表示は `defaultValue` で維持されます。親から中身を変える経路はすべて `ref.clear()` か `key` の変更で明示的に反映しています。入力欄内のクリアの表示条件・動作を含む `TrainTypeFilterBar.test.tsx` の既存テストは変更せずに通っており、内部クリアでは入力欄を作り直さず外部クリアでのみ作り直すことを確認する回帰テストを追加しました。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果: `biome check ./src` → 682 files / 指摘なし、`jest` → 243 スイート・2631 テストすべて成功、`tsc --noEmit` → エラーなし。

**未検証の点**: 作業環境に iOS シミュレータがないため、変換候補が実際に出るようになったかは確認できていません。`autoCorrect` 側の 3 回の修正が効かなかったことから書き戻しを疑ったもので、機序の裏取りは取れていません。マージ前に iOS 実機での確認をお願いします。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: 差分は入力値の保持場所と、親から中身を変えるときの反映方法だけで、レイアウト・配色・スタイルには触れていません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 検索欄を改善し、日本語入力（IME）の未確定文字列が再描画で失われにくくなりました。
  * 外部から検索条件をリセットした際、検索欄が正しく空になります。
  * 入力欄内でクリアした場合は、フォーカスと入力状態を維持します。
  * 送信時や会話リセット時に入力内容を消去できるようになりました。
  * APIエラー時は、送信中に入力した下書きを優先して保持し、下書きがない場合は送信内容を復元します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->