### PR TITLE
AIエージェントの入力欄でも入力値の書き戻しをやめて日本語変換候補が出ない不具合を防ぐ

### DIFF
--- a/src/screens/DestinationAgent/AgentInputBar.tsx
+++ b/src/screens/DestinationAgent/AgentInputBar.tsx
@@ -127,7 +127,11 @@ export const AgentInputBar = ({
               fontFamily,
             },
           ]}
-          value={value}
+          // value を渡して書き戻すと、iOS では未確定文字列(marked text)が壊れて
+          // 日本語の変換候補が出せなくなる。入力値は入力欄自身に持たせ、親へは
+          // onChangeText で通知するだけにする。親から中身を変えたいときは
+          // ref.clear() か、呼び出し側で key を変えて作り直す
+          defaultValue={value}
           onChangeText={onChangeText}
           editable={!rateLimited}
           multiline

--- a/src/screens/DestinationAgent/index.tsx
+++ b/src/screens/DestinationAgent/index.tsx
@@ -154,6 +154,9 @@ const DestinationAgentScreen = () => {
 
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [inputText, setInputText] = useState('');
+  // 入力欄は値を書き戻さない非制御入力なので、親から中身を変えるときは
+  // ref.clear() を使い、空にできない場合だけこの key を変えて作り直す
+  const [inputResetKey, setInputResetKey] = useState(0);
   const [sending, setSending] = useState(false);
   // tool イベント受信中(駅検索の tool use ループ中)であることを示すフラグ。
   // 最初の delta が届くか応答が確定した時点で降ろす
@@ -296,6 +299,9 @@ const DestinationAgentScreen = () => {
       setSending(true);
       setSearching(false);
       setInputText('');
+      // 入力欄自身が値を持つので、表示は明示的に消す。key を変えないのは
+      // 送信後もキーボードと焦点を保って続けて質問できるようにするため
+      inputRef.current?.clear();
       const conversationGen = conversationGenRef.current;
       // 検索中文言の読み上げは 1 送信につき 1 回だけ(tool イベントは複数回届きうる)
       let searchingAnnounced = false;
@@ -417,6 +423,8 @@ const DestinationAgentScreen = () => {
       );
       // 送信待ちの間にユーザが入力し直していた場合はその内容を優先する
       setInputText((prev) => (prev.length ? prev : text));
+      // 空でない文字列は ref では戻せないため、入力欄を作り直して表示を合わせる
+      setInputResetKey((n) => n + 1);
       showToast({
         type: 'error',
         text1: translate('errorTitle'),
@@ -440,6 +448,7 @@ const DestinationAgentScreen = () => {
             setEntries([]);
             setSuggestionStates({});
             setInputText('');
+            inputRef.current?.clear();
             setRateLimited(false);
           },
         },
@@ -656,6 +665,7 @@ const DestinationAgentScreen = () => {
           ]}
         >
           <AgentInputBar
+            key={inputResetKey}
             value={inputText}
             onChangeText={setInputText}
             onSend={() => handleSend(inputText)}


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

種別絞り込みと同じ「親が入力値を持ち、1 文字ごとに `value` として入力欄へ書き戻す」実装が、AI エージェントのチャット入力欄にも残っていました。日本語で行き先を相談する入力欄で、親（`DestinationAgent`）はチャット履歴とストリーミング表示を抱えており、条件は種別絞り込みと同じです。#6769 と同じ形に揃えます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `AgentInputBar` の `TextInput` を `value` から `defaultValue` に変更し、入力値は入力欄自身が持つようにした。親へは従来どおり `onChangeText` で通知するので、送信可否判定や文字数カウントの挙動は変わらない
- 送信後のクリアと会話リセットは `inputRef.current?.clear()` で行う。`key` を変えないので**キーボードと焦点が残り、続けて質問できる**
- 送信失敗時に入力内容を復元する経路だけは空でない文字列を戻す必要があるため、`inputResetKey` を増やして入力欄を作り直す

**判断の根拠**: iOS は入力欄へ文字列を書き戻すと未確定文字列（marked text）が壊れ、変換候補を出せなくなります。他の `TextInput`（`NewReportModal` / `SavePresetNameModal`）は既に `defaultValue` で書かれており、書き戻しをしているのはこの入力欄だけでした。

**リグレッションリスクと緩和策**: 入力値の保持場所が変わりますが、親の `inputText` は `onChangeText` で従来どおり更新されるため、送信ボタンの活性判定・`handleSend` に渡す本文・文字数カウントは変わりません。親から中身を変える 3 箇所（送信後クリア・会話リセット・送信失敗時の復元）はすべて上記のいずれかで明示的に反映しています。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果: `biome check ./src` → 682 files / 指摘なし、`jest` → 243 スイートすべて成功、`tsc --noEmit` → エラーなし。

**未検証の点**: 作業環境に iOS シミュレータがないため、実際の変換候補の挙動は確認できていません。#6769 と同じ仮説に基づく予防的な修正なので、**#6769 が iOS 実機で効いていることを確認してからマージする**のが安全です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: 差分は入力値の保持場所と、親から中身を変えるときの反映方法だけで、レイアウト・配色・スタイルには触れていません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 入力欄の操作性を改善しました。
  * 送信後もキーボードと入力欄のフォーカスが維持されます。
  * 送信・リセット時には入力内容が正しくクリアされます。
  * エラー発生時などに入力内容を復元した場合も、表示が正しく更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->