### PR TITLE
現在駅が未確定のときAIチャットのエントリーバナーを押せないようにして直通で行けない駅の提案を防ぐ

### DIFF
--- a/src/screens/DestinationAgent/AgentEntryBanner.test.tsx
+++ b/src/screens/DestinationAgent/AgentEntryBanner.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import { stationAtom } from '~/store/atoms/station';
+import { createStation } from '~/utils/test/factories';
+import { AgentEntryBanner } from './AgentEntryBanner';
+
+// 実体はフォント読み込みで非同期 setState するため、act 警告を避けて素の View に差し替える
+jest.mock('@expo/vector-icons', () => {
+  const { View } = require('react-native');
+  return { Ionicons: View };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockIsAIAgentFeatureEnabled = jest.fn<boolean, []>();
+jest.mock('~/lib/remoteConfig', () => ({
+  isAIAgentFeatureEnabled: () => mockIsAIAgentFeatureEnabled(),
+  subscribeRemoteConfig: () => () => undefined,
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: true,
+}));
+
+const BANNER_LABEL = 'destinationAgentEntryTitle destinationAgentEntrySubtitle';
+
+const renderBanner = (station: ReturnType<typeof createStation> | null) => {
+  const store = createStore();
+  store.set(stationAtom, station);
+  return render(
+    <Provider store={store}>
+      <AgentEntryBanner />
+    </Provider>
+  );
+};
+
+describe('AgentEntryBanner', () => {
+  beforeEach(() => {
+    mockIsAIAgentFeatureEnabled.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('現在駅が確定していればタップでAIチャットへ遷移する', () => {
+    const { getByLabelText } = renderBanner(createStation(1130205));
+
+    fireEvent.press(getByLabelText(BANNER_LABEL));
+
+    expect(mockNavigate).toHaveBeenCalledWith('DestinationAgent');
+  });
+
+  it('現在駅が未確定ならタップしても遷移しない', () => {
+    const { getByLabelText } = renderBanner(null);
+
+    fireEvent.press(getByLabelText(BANNER_LABEL));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('現在駅が未確定なら無効状態として読み上げられる', () => {
+    const { getByLabelText } = renderBanner(null);
+
+    expect(getByLabelText(BANNER_LABEL)).toBeDisabled();
+  });
+
+  it('フィーチャーフラグがoffならバナー自体を描画しない', () => {
+    mockIsAIAgentFeatureEnabled.mockReturnValue(false);
+
+    const { queryByLabelText } = renderBanner(createStation(1130205));
+
+    expect(queryByLabelText(BANNER_LABEL)).toBeNull();
+  });
+});

--- a/src/screens/DestinationAgent/AgentEntryBanner.tsx
+++ b/src/screens/DestinationAgent/AgentEntryBanner.tsx
@@ -13,6 +13,7 @@ import { CardChevron } from '~/components/CardChevron';
 import Typography from '~/components/Typography';
 import { useAIAgentFeatureEnabled } from '~/hooks/useAIAgentFeatureEnabled';
 import { useAppColors } from '~/providers/AppColorsProvider';
+import { stationAtom } from '~/store/atoms/station';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 
@@ -33,6 +34,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#212121',
     borderColor: '#fff',
     borderWidth: 1,
+  },
+  // Button/CommonCard の無効表現と同じ不透明度
+  disabled: {
+    opacity: 0.5,
   },
   texts: {
     flex: 1,
@@ -59,6 +64,13 @@ export const AgentEntryBanner = ({ style }: Props) => {
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const colors = useAppColors();
   const enabled = useAIAgentFeatureEnabled();
+  const station = useAtomValue(stationAtom);
+
+  // 現在駅が未確定のままチャットを始めると currentStationGroupId を送れず、
+  // 最寄り駅から直通で行けない駅が提案されてしまう。同じ画面の駅名検索が
+  // station.groupId 無しでは検索しない(RouteSearchScreen の handleSearch)のと
+  // 同じ理由で、現在駅が確定するまでは押せない見た目にして無反応にする。
+  const disabled = !station?.groupId;
 
   const handlePress = useCallback(() => {
     navigation.navigate('DestinationAgent' as never);
@@ -73,12 +85,15 @@ export const AgentEntryBanner = ({ style }: Props) => {
       activeOpacity={0.8}
       accessibilityRole="button"
       accessibilityLabel={`${translate('destinationAgentEntryTitle')} ${translate('destinationAgentEntrySubtitle')}`}
-      onPress={handlePress}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={disabled ? undefined : handlePress}
       style={[
         styles.root,
         isLEDTheme
           ? styles.ledBg
           : [styles.bg, { backgroundColor: colors.card }],
+        disabled && styles.disabled,
         style,
       ]}
     >


### PR DESCRIPTION
## 概要

現在駅が確定していない状態で AI チャット（行き先相談）を開始すると、実際の最寄り駅から直通で行けない駅が提案される不具合を修正します。行き先検索画面の AI 相談バナーを、現在駅が確定するまで押せない見た目にして無反応にします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AgentEntryBanner` が `stationAtom` を購読し、`station?.groupId` が無いときを無効状態として扱うようにした
- 無効時は不透明度 0.5（`Button` / `CommonCard` の無効表現と同値）、`disabled` と `onPress={undefined}` で無反応、`accessibilityState={{ disabled }}` でスクリーンリーダーにも伝える
- `AgentEntryBanner.test.tsx` を新規追加（遷移する / しない・無効状態の読み上げ・フィーチャーフラグ off の 4 ケース）

### 背景

`useDestinationAgent` は現在駅を `stationAtom` から読み、null のときはリクエストボディから `currentStationGroupId` を丸ごと省きます。サーバーは `stationsByName` を `fromStationGroupId` 無しで引くため、現在地との関係が無い駅が候補に混ざります。

同じ画面の駅名検索は `RouteSearchScreen` の `handleSearch` 冒頭で `if (!station?.groupId) return;` として現在駅未確定なら検索させません。AI チャットだけこのガードが無いという非対称が原因だったので、駅名検索と同じ扱いに揃えました。

`DestinationAgent` へのディープリンク設定は無く、このバナーが唯一の入口のため、ここを塞げば現在駅未確定でのチャット開始は起きません。

### 本 PR で対応していないこと

- 現在駅が確定していても `fromStationGroupId` は近接優先のヒントであり直通性を保証しないため、乗り換えが必要な駅は引き続き提案されうる
- チャットを開いた後に現在駅が失われた場合はガードされない（入口のみを塞いでいるため）

## テスト

実機（Galaxy SCG13 / Android dev build）で位置情報サービスをオフにして現在駅が未確定の状態を再現し、バナーが薄く表示されタップしても遷移しないことを確認しました。アクセシビリティツリー上も `[clickable,disabled]` として公開されています。位置情報あり（現在駅確定）の状態では従来どおり押せることも確認済みです。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。 -->

<!-- create-pr:screenshots:start -->

### Galaxy SCG13 (Android dev build)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_agent-entry-banner-current-station-guard-4d922c978aef/04720f61d5db-banner-disabled.png" width="320" alt="現在駅が未確定のとき（バナーが薄く表示され、押しても無反応）" />

現在駅が未確定のとき（バナーが薄く表示され、押しても無反応）

現在駅が確定しているときの通常表示は、撮影画像に実際の現在地（駅名）が写るため添付していません。従来どおりの見た目で、この PR による変更はありません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 駅が確定している場合のみ、目的地エージェントへ遷移できるようになりました。
  * 駅未確定時はバナーが無効状態になり、押下や画面遷移が発生しません。
  * AIエージェント機能が無効な場合、バナーは表示されません。

* **テスト**
  * 駅の確定状態や機能の有効・無効に応じた表示・操作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->