### PR TITLE
LineBoardの斜め書き駅名の折り返し幅を文字サイズ基準にして改行を防ぐ

### DIFF
--- a/src/components/LineBoard/shared/components/StationName.test.tsx
+++ b/src/components/LineBoard/shared/components/StationName.test.tsx
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/react-native';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
-import { HORIZONTAL_STATION_NAME_FONT_SIZE } from '../styles/commonStyles';
+import {
+  getHorizontalStationNameOffset,
+  getHorizontalStationNameWidth,
+  HORIZONTAL_STATION_NAME_FONT_SIZE,
+  HORIZONTAL_STATION_NAME_MAX_CHARS,
+} from '../styles/commonStyles';
 import { StationName } from './StationName';
 
 // モック設定
@@ -14,6 +19,29 @@ jest.mock('~/utils/isTablet', () => ({
   __esModule: true,
   default: false,
 }));
+
+const WINDOW_HEIGHT = 375;
+
+jest.mock('~/hooks', () => ({
+  useLandscapeWindowDimensions: jest.fn(() => ({
+    width: 812,
+    height: 375,
+    isPortrait: false,
+  })),
+}));
+
+/** 従来の折り返し幅(画面短辺基準)。位置補正の基準値 */
+const LEGACY_HORIZONTAL_WIDTH = WINDOW_HEIGHT / 2.5;
+
+const expectedOffset = getHorizontalStationNameOffset(
+  LEGACY_HORIZONTAL_WIDTH,
+  getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS)
+);
+
+const flattenStyle = (style: unknown): Record<string, unknown>[] =>
+  (Array.isArray(style) ? style.flat() : [style]).filter(
+    (s): s is Record<string, unknown> => !!s && typeof s === 'object'
+  );
 
 jest.mock('../../../Typography', () => {
   const _React = require('react');
@@ -114,12 +142,13 @@ describe('StationName', () => {
     const flattenedStyles = Array.isArray(textElement.props.style)
       ? textElement.props.style.flat()
       : [textElement.props.style];
+    // 折り返し幅を広げたぶんの位置補正が指定値に加算される
     const hasMarginBottom = flattenedStyles.some(
       (s: unknown) =>
         s &&
         typeof s === 'object' &&
         'marginBottom' in s &&
-        s.marginBottom === customMargin
+        s.marginBottom === customMargin + expectedOffset.marginBottom
     );
     expect(hasMarginBottom).toBe(true);
   });
@@ -216,6 +245,26 @@ describe('StationName', () => {
     // 文字数ぶんの幅が確保できていれば改行されない
     expect(widthStyle?.width).toBeGreaterThanOrEqual(
       HORIZONTAL_STATION_NAME_FONT_SIZE * stationName.length
+    );
+  });
+
+  it('horizontal=true の場合、折り返し幅を広げたぶんの位置ずれが補正される', () => {
+    const { getAllByTestId } = render(
+      <StationName station={mockStation} horizontal={true} />
+    );
+
+    const style = Object.assign(
+      {},
+      ...flattenStyle(getAllByTestId('typography-text')[0].props.style)
+    );
+
+    // -55deg 回転の中心は要素の中心なので、幅を広げると回転後の駅名が
+    // 右下へずれる。marginLeft を負に、marginBottom を正に振って打ち消す
+    expect(expectedOffset.marginLeft).toBeLessThan(0);
+    expect(expectedOffset.marginBottom).toBeGreaterThan(0);
+    expect(style.marginLeft).toBeCloseTo(expectedOffset.marginLeft);
+    expect(style.marginBottom).toBeCloseTo(
+      WINDOW_HEIGHT / 6 + expectedOffset.marginBottom
     );
   });
 });

--- a/src/components/LineBoard/shared/components/StationName.test.tsx
+++ b/src/components/LineBoard/shared/components/StationName.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react-native';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
+import { HORIZONTAL_STATION_NAME_FONT_SIZE } from '../styles/commonStyles';
 import { StationName } from './StationName';
 
 // モック設定
@@ -189,5 +190,32 @@ describe('StationName', () => {
       (s: unknown) => s && typeof s === 'object' && 'color' in s
     );
     expect(hasColorStyle).toBe(true);
+  });
+
+  it('horizontal=true の場合、折り返し幅が「東京テレポート」を1行に収められる', () => {
+    const stationName = '東京テレポート';
+    const longNameStation: Station = {
+      ...mockStation,
+      name: stationName,
+    };
+
+    const { getAllByTestId } = render(
+      <StationName station={longNameStation} horizontal={true} />
+    );
+
+    const textElement = getAllByTestId('typography-text')[0];
+    const flattenedStyles = Array.isArray(textElement.props.style)
+      ? textElement.props.style.flat()
+      : [textElement.props.style];
+    const widthStyle = flattenedStyles.find(
+      (s: unknown): s is { width: number } =>
+        !!s && typeof s === 'object' && 'width' in s
+    );
+
+    // 全角1文字の幅はフォントサイズとほぼ等しいので、
+    // 文字数ぶんの幅が確保できていれば改行されない
+    expect(widthStyle?.width).toBeGreaterThanOrEqual(
+      HORIZONTAL_STATION_NAME_FONT_SIZE * stationName.length
+    );
   });
 });

--- a/src/components/LineBoard/shared/components/StationName.tsx
+++ b/src/components/LineBoard/shared/components/StationName.tsx
@@ -6,6 +6,7 @@ import getStationNameR from '~/utils/getStationNameR';
 import isTablet from '~/utils/isTablet';
 import Typography from '../../../Typography';
 import {
+  getHorizontalStationNameOffset,
   getHorizontalStationNameWidth,
   HORIZONTAL_STATION_NAME_MAX_CHARS,
   commonLineBoardStyles as styles,
@@ -37,14 +38,22 @@ export const StationName: React.FC<StationNameProps> = React.memo(
     );
     const dim = useLandscapeWindowDimensions();
 
-    const horizontalAdditionalStyle = useMemo(
-      () => ({
-        width: getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS),
+    const horizontalAdditionalStyle = useMemo(() => {
+      // 従来の折り返し幅(画面短辺基準)。回転後の見た目をこの幅のときと揃えるための基準
+      const previousWidth = isTablet ? dim.height / 3.5 : dim.height / 2.5;
+      const width = getHorizontalStationNameWidth(
+        HORIZONTAL_STATION_NAME_MAX_CHARS
+      );
+      const offset = getHorizontalStationNameOffset(previousWidth, width);
+
+      return {
+        width,
+        marginLeft: offset.marginLeft,
         marginBottom:
-          marginBottom ?? (isTablet ? dim.height / 8 : dim.height / 6),
-      }),
-      [dim.height, marginBottom]
-    );
+          (marginBottom ?? (isTablet ? dim.height / 8 : dim.height / 6)) +
+          offset.marginBottom,
+      };
+    }, [dim.height, marginBottom]);
 
     if (en) {
       return (

--- a/src/components/LineBoard/shared/components/StationName.tsx
+++ b/src/components/LineBoard/shared/components/StationName.tsx
@@ -5,7 +5,11 @@ import { useLandscapeWindowDimensions } from '~/hooks';
 import getStationNameR from '~/utils/getStationNameR';
 import isTablet from '~/utils/isTablet';
 import Typography from '../../../Typography';
-import { commonLineBoardStyles as styles } from '../styles/commonStyles';
+import {
+  getHorizontalStationNameWidth,
+  HORIZONTAL_STATION_NAME_MAX_CHARS,
+  commonLineBoardStyles as styles,
+} from '../styles/commonStyles';
 
 export interface StationNameProps {
   station: Station;
@@ -35,7 +39,7 @@ export const StationName: React.FC<StationNameProps> = React.memo(
 
     const horizontalAdditionalStyle = useMemo(
       () => ({
-        width: isTablet ? dim.height / 3.5 : dim.height / 2.5,
+        width: getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS),
         marginBottom:
           marginBottom ?? (isTablet ? dim.height / 8 : dim.height / 6),
       }),

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -30,6 +30,29 @@ export const HORIZONTAL_STATION_NAME_MAX_CHARS = 8.5;
 export const getHorizontalStationNameWidth = (maxChars: number): number =>
   HORIZONTAL_STATION_NAME_FONT_SIZE * maxChars;
 
+/** 斜め書き駅名の回転角(度)。折り返し幅を変えたときの位置補正にも使う */
+const HORIZONTAL_STATION_NAME_ROTATION_DEG = 55;
+
+/**
+ * 折り返し幅を変えたときに必要な位置補正を返す。
+ * 斜め書きは要素の中心を軸に -55° 回転するため、幅を w0 から w1 へ広げると
+ * 回転中心が右へ動き、回転後の駅名は横に (w1-w0)×(1-cos55°)/2、
+ * 縦に (w1-w0)×sin55°/2 だけずれて路線バーに寄ってしまう。
+ * ずれた分を marginLeft / marginBottom へ戻し、見た目の位置を従来の幅の
+ * ときと揃える。
+ */
+export const getHorizontalStationNameOffset = (
+  previousWidth: number,
+  nextWidth: number
+): { marginLeft: number; marginBottom: number } => {
+  const delta = nextWidth - previousWidth;
+  const rad = (HORIZONTAL_STATION_NAME_ROTATION_DEG * Math.PI) / 180;
+  return {
+    marginLeft: -(delta * (1 - Math.cos(rad))) / 2,
+    marginBottom: (delta * Math.sin(rad)) / 2,
+  };
+};
+
 export const commonLineBoardStyles = StyleSheet.create({
   root: {
     height: '100%',

--- a/src/components/LineBoard/shared/styles/commonStyles.ts
+++ b/src/components/LineBoard/shared/styles/commonStyles.ts
@@ -14,6 +14,22 @@ export const STATION_NAME_CONTAINER_BOTTOM: number | undefined = isTablet
   ? Platform.select({ android: 64, default: 84 })
   : undefined;
 
+// 斜め書き駅名のフォントサイズ。1行に収まる文字数を決めるため折り返し幅の算出にも使う
+export const HORIZONTAL_STATION_NAME_FONT_SIZE = RFValue(18);
+
+/** 斜め書きで1行に収める全角文字数の既定値 */
+export const HORIZONTAL_STATION_NAME_MAX_CHARS = 8.5;
+
+/**
+ * 斜め書き駅名の折り返し幅を、1行に収めたい全角文字数から求める。
+ * 画面短辺(dim.height)基準だと、フォントサイズを決める RFValue が画面長辺で
+ * スケールするぶん縦長端末ほど1行に入る文字数が減ってしまい、iPhone 17 では
+ * 7文字の「東京テレポート」が改行されていた。全角1文字の幅はフォントサイズと
+ * ほぼ等しいので、文字サイズ基準にして端末によらず同じ文字数を保証する。
+ */
+export const getHorizontalStationNameWidth = (maxChars: number): number =>
+  HORIZONTAL_STATION_NAME_FONT_SIZE * maxChars;
+
 export const commonLineBoardStyles = StyleSheet.create({
   root: {
     height: '100%',
@@ -140,7 +156,7 @@ export const commonLineBoardStyles = StyleSheet.create({
     marginBottom: Platform.select({ android: isTablet ? -8 : -6, ios: 0 }),
   },
   stationNameHorizontal: {
-    fontSize: RFValue(18),
+    fontSize: HORIZONTAL_STATION_NAME_FONT_SIZE,
     fontWeight: 'bold',
     transform: [{ rotate: '-55deg' }],
   },

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -1,5 +1,10 @@
 import { render } from '@testing-library/react-native';
 import type { Line, Station } from '~/@types/graphql';
+import {
+  getHorizontalStationNameOffset,
+  getHorizontalStationNameWidth,
+  HORIZONTAL_STATION_NAME_MAX_CHARS,
+} from './LineBoard/shared/styles/commonStyles';
 import LineBoardToei from './LineBoardToei';
 
 // モック設定
@@ -345,5 +350,89 @@ describe('LineBoardToei', () => {
       />
     );
     expect(getByText('新桥')).toBeTruthy();
+  });
+
+  describe('斜め書き駅名(横書き)の折り返し幅と位置補正', () => {
+    // useLandscapeWindowDimensions のモックが返す短辺
+    const WINDOW_HEIGHT = 375;
+
+    const flattenStyle = (style: unknown): Record<string, unknown> =>
+      Object.assign(
+        {},
+        ...(Array.isArray(style) ? style.flat() : [style]).filter(
+          (s: unknown): s is Record<string, unknown> =>
+            !!s && typeof s === 'object'
+        )
+      );
+
+    const renderStationName = (stations: Station[]) => {
+      const { getByText } = render(
+        <LineBoardToei
+          stations={stations}
+          lineColors={['#ed6d00', '#ed6d00']}
+          hasTerminus={false}
+        />
+      );
+      return flattenStyle(getByText('新橋').props.style);
+    };
+
+    beforeEach(() => {
+      const {
+        useIncludesLongStationName,
+      } = require('./LineBoard/shared/hooks/useBarStyles');
+      useIncludesLongStationName.mockReturnValue(true);
+      // 韓国語の入れ子表示を切って駅名の Text を一意に取得する
+      useAtomValue.mockImplementation(
+        createUseAtomValueMock({ enabledLanguages: ['JA'] })
+      );
+    });
+
+    afterEach(() => {
+      const {
+        useIncludesLongStationName,
+      } = require('./LineBoard/shared/hooks/useBarStyles');
+      useIncludesLongStationName.mockReturnValue(false);
+    });
+
+    it('ナンバリングありの場合、既定より広い幅と対応する位置補正が適用される', () => {
+      const style = renderStationName(mockStations);
+
+      const expectedWidth = getHorizontalStationNameWidth(
+        HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5
+      );
+      const expectedOffset = getHorizontalStationNameOffset(
+        WINDOW_HEIGHT / 2,
+        expectedWidth
+      );
+
+      expect(style.width).toBeCloseTo(expectedWidth);
+      expect(style.marginLeft).toBeCloseTo(expectedOffset.marginLeft);
+      expect(style.marginBottom).toBeCloseTo(
+        WINDOW_HEIGHT / 6 + expectedOffset.marginBottom
+      );
+    });
+
+    it('ナンバリングなしの場合、既定の幅と対応する位置補正が適用される', () => {
+      const stationsWithoutNumbering = mockStations.map((s) => ({
+        ...s,
+        stationNumbers: [],
+      })) as Station[];
+
+      const style = renderStationName(stationsWithoutNumbering);
+
+      const expectedWidth = getHorizontalStationNameWidth(
+        HORIZONTAL_STATION_NAME_MAX_CHARS
+      );
+      const expectedOffset = getHorizontalStationNameOffset(
+        WINDOW_HEIGHT / 2.5,
+        expectedWidth
+      );
+
+      expect(style.width).toBeCloseTo(expectedWidth);
+      expect(style.marginLeft).toBeCloseTo(expectedOffset.marginLeft);
+      expect(style.marginBottom).toBeCloseTo(
+        WINDOW_HEIGHT / 10 + expectedOffset.marginBottom
+      );
+    });
   });
 });

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -5,7 +5,7 @@ import {
   getHorizontalStationNameWidth,
   HORIZONTAL_STATION_NAME_MAX_CHARS,
 } from './LineBoard/shared/styles/commonStyles';
-import LineBoardToei from './LineBoardToei';
+import LineBoardToei, { EN_STATION_NAME_MAX_CHARS } from './LineBoardToei';
 
 // モック設定
 jest.mock('jotai', () => ({
@@ -433,6 +433,37 @@ describe('LineBoardToei', () => {
       expect(style.marginBottom).toBeCloseTo(
         WINDOW_HEIGHT / 10 + expectedOffset.marginBottom
       );
+    });
+
+    it('英語表記の場合、中国語の併記ぶん行が増えるので日本語より狭い幅になる', () => {
+      useAtomValue.mockImplementation(
+        createUseAtomValueMock({ isEn: true, enabledLanguages: ['JA', 'EN'] })
+      );
+
+      const { getAllByText } = render(
+        <LineBoardToei
+          stations={mockStations}
+          lineColors={['#ed6d00', '#ed6d00']}
+          hasTerminus={false}
+        />
+      );
+      const style = flattenStyle(getAllByText('Tokyo')[0].props.style);
+
+      const expectedWidth = getHorizontalStationNameWidth(
+        EN_STATION_NAME_MAX_CHARS
+      );
+      const expectedOffset = getHorizontalStationNameOffset(
+        WINDOW_HEIGHT / 2,
+        expectedWidth
+      );
+
+      expect(style.width).toBeCloseTo(expectedWidth);
+      // 斜め書きの外接矩形は (幅 × sin55°) が支配的なので、
+      // 日本語と同じ広い幅にすると回転後に親からはみ出して併記が切れる
+      expect(style.width).toBeLessThan(
+        getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5)
+      );
+      expect(style.marginLeft).toBeCloseTo(expectedOffset.marginLeft);
     });
   });
 });

--- a/src/components/LineBoardToei.test.tsx
+++ b/src/components/LineBoardToei.test.tsx
@@ -464,6 +464,9 @@ describe('LineBoardToei', () => {
         getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5)
       );
       expect(style.marginLeft).toBeCloseTo(expectedOffset.marginLeft);
+      expect(style.marginBottom).toBeCloseTo(
+        WINDOW_HEIGHT / 6 + expectedOffset.marginBottom
+      );
     });
   });
 });

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -34,6 +34,8 @@ import {
 } from './LineBoard/shared/hooks/useBarStyles';
 import {
   commonLineBoardStyles,
+  getHorizontalStationNameWidth,
+  HORIZONTAL_STATION_NAME_MAX_CHARS,
   STATION_NAME_CONTAINER_BOTTOM,
 } from './LineBoard/shared/styles/commonStyles';
 import Typography from './Typography';
@@ -104,12 +106,15 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
     if (!hasNumbering) {
       return {
         marginBottom: dim.height / 10,
-        width: isTablet ? dim.height / 3 : dim.height / 2.5,
+        width: getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS),
       };
     }
     return {
       marginBottom: isTablet ? dim.height / 10 : dim.height / 6,
-      width: isTablet ? dim.height / 3.5 : dim.height / 2,
+      // ナンバリングを駅名の下に置くぶん斜め書きを長く伸ばせるので既定より広く取る
+      width: getHorizontalStationNameWidth(
+        HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5
+      ),
     };
   }, [dim.height, hasNumbering]);
 

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -34,6 +34,7 @@ import {
 } from './LineBoard/shared/hooks/useBarStyles';
 import {
   commonLineBoardStyles,
+  getHorizontalStationNameOffset,
   getHorizontalStationNameWidth,
   HORIZONTAL_STATION_NAME_MAX_CHARS,
   STATION_NAME_CONTAINER_BOTTOM,
@@ -104,17 +105,32 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
 
   const horizontalAdditionalStyle = useMemo(() => {
     if (!hasNumbering) {
+      // 従来の折り返し幅(画面短辺基準)。回転後の見た目をこの幅のときと揃えるための基準
+      const previousWidth = isTablet ? dim.height / 3 : dim.height / 2.5;
+      const width = getHorizontalStationNameWidth(
+        HORIZONTAL_STATION_NAME_MAX_CHARS
+      );
+      const offset = getHorizontalStationNameOffset(previousWidth, width);
+
       return {
-        marginBottom: dim.height / 10,
-        width: getHorizontalStationNameWidth(HORIZONTAL_STATION_NAME_MAX_CHARS),
+        width,
+        marginLeft: offset.marginLeft,
+        marginBottom: dim.height / 10 + offset.marginBottom,
       };
     }
+
+    const previousWidth = isTablet ? dim.height / 3.5 : dim.height / 2;
+    // ナンバリングを駅名の下に置くぶん斜め書きを長く伸ばせるので既定より広く取る
+    const width = getHorizontalStationNameWidth(
+      HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5
+    );
+    const offset = getHorizontalStationNameOffset(previousWidth, width);
+
     return {
-      marginBottom: isTablet ? dim.height / 10 : dim.height / 6,
-      // ナンバリングを駅名の下に置くぶん斜め書きを長く伸ばせるので既定より広く取る
-      width: getHorizontalStationNameWidth(
-        HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5
-      ),
+      width,
+      marginLeft: offset.marginLeft,
+      marginBottom:
+        (isTablet ? dim.height / 10 : dim.height / 6) + offset.marginBottom,
     };
   }, [dim.height, hasNumbering]);
 

--- a/src/components/LineBoardToei.tsx
+++ b/src/components/LineBoardToei.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import type { Line, Station, StationNumber } from '~/@types/graphql';
 import {
   useCurrentLine,
@@ -47,6 +47,9 @@ type Props = {
   hasTerminus: boolean;
 };
 
+/** 英語表記の斜め書きが1行に収める幅(全角文字数換算) */
+export const EN_STATION_NAME_MAX_CHARS = 7.5;
+
 const localStyles = StyleSheet.create({
   splittedStationName: {
     marginLeft: 1,
@@ -54,6 +57,14 @@ const localStyles = StyleSheet.create({
   stationNameExtra: {
     fontSize: RFValue(10),
     fontWeight: 'bold',
+  },
+  // 縦書きの併記は1文字ずつ Text を並べるため、Android では行の余白ぶん字間が
+  // 開いて日本語の駅名よりはるかに縦長になる。日本語側(stationName)と同じ考え方で
+  // 負のマージンを当てて詰める。
+  splittedStationNameExtraChar: {
+    fontSize: RFValue(10),
+    fontWeight: 'bold',
+    marginBottom: Platform.select({ android: isTablet ? -5 : -4, ios: 0 }),
   },
   splittedStationNameWithExtraLang: {
     position: 'relative',
@@ -104,35 +115,35 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
   const dim = useLandscapeWindowDimensions();
 
   const horizontalAdditionalStyle = useMemo(() => {
-    if (!hasNumbering) {
-      // 従来の折り返し幅(画面短辺基準)。回転後の見た目をこの幅のときと揃えるための基準
-      const previousWidth = isTablet ? dim.height / 3 : dim.height / 2.5;
-      const width = getHorizontalStationNameWidth(
-        HORIZONTAL_STATION_NAME_MAX_CHARS
-      );
-      const offset = getHorizontalStationNameOffset(previousWidth, width);
+    // 従来の折り返し幅(画面短辺基準)。回転後の見た目をこの幅のときと揃えるための基準
+    const previousWidth = hasNumbering
+      ? isTablet
+        ? dim.height / 3.5
+        : dim.height / 2
+      : isTablet
+        ? dim.height / 3
+        : dim.height / 2.5;
+    const baseMarginBottom =
+      hasNumbering && !isTablet ? dim.height / 6 : dim.height / 10;
 
-      return {
-        width,
-        marginLeft: offset.marginLeft,
-        marginBottom: dim.height / 10 + offset.marginBottom,
-      };
-    }
-
-    const previousWidth = isTablet ? dim.height / 3.5 : dim.height / 2;
-    // ナンバリングを駅名の下に置くぶん斜め書きを長く伸ばせるので既定より広く取る
-    const width = getHorizontalStationNameWidth(
-      HORIZONTAL_STATION_NAME_MAX_CHARS + 0.5
-    );
+    // 英語表記は中国語の併記が次の行に付くぶん行数が増える。斜め書きの外接矩形の
+    // 高さは (幅 × sin55°) が支配的なので、幅を広げると回転後に親の高さを超え、
+    // はみ出した分が Android 側で切り取られてしまう(併記が消える)。英語は単語
+    // 単位で折り返されるため幅を詰めても行数が増えにくく、日本語より狭く取る。
+    // 日本語側はナンバリングを駅名の下に置くぶん斜め書きを長く伸ばせるので広く取る。
+    const width = en
+      ? getHorizontalStationNameWidth(EN_STATION_NAME_MAX_CHARS)
+      : getHorizontalStationNameWidth(
+          HORIZONTAL_STATION_NAME_MAX_CHARS + (hasNumbering ? 0.5 : 0)
+        );
     const offset = getHorizontalStationNameOffset(previousWidth, width);
 
     return {
       width,
       marginLeft: offset.marginLeft,
-      marginBottom:
-        (isTablet ? dim.height / 10 : dim.height / 6) + offset.marginBottom,
+      marginBottom: baseMarginBottom + offset.marginBottom,
     };
-  }, [dim.height, hasNumbering]);
+  }, [dim.height, hasNumbering, en]);
 
   if (en) {
     return (
@@ -205,7 +216,7 @@ const StationNameToeiBase: React.FC<StationNameToeiProps> = ({
           {station.nameKorean.split('').map((c, j) => (
             <Typography
               style={[
-                styles.stationNameExtra,
+                styles.splittedStationNameExtraChar,
                 passed ? styles.grayColor : null,
               ]}
               key={`${station.id}-ko-${j}`}


### PR DESCRIPTION
## 概要

LineBoard の斜め書き駅名が、iPhone 17 のような縦長端末で「東京テレポート」のような 7 文字の駅名を 1 行に収めきれず改行される問題を修正します。

折り返し幅の基準が**画面短辺**（`dim.height / 2.5`）だったのに対し、フォントサイズを決める `RFValue` は**画面長辺**でスケールするため、端末が縦長になるほど 1 行に入る文字数が減っていました。iPhone 17 では折り返し幅 160.8pt に対し「東京テレポート」が 7 文字 × 23pt = 161.0pt となり、**0.2pt 足りずに改行**されていました。

あわせて、実機（Galaxy S22 Ultra）で確認できた都営テーマの多言語併記の表示崩れ 2 件も修正します。うち中国語の見切れは、**本 PR で英語表記の折り返し幅を広げたことが引き金**になっていたため、同じ PR で塞ぎます。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 斜め書き駅名の折り返し幅を、画面短辺基準から**文字サイズ基準**（`RFValue(18) × 8.5`）へ変更。端末によらず 8.5 文字ぶんの幅を保証する
- 幅を広げると `transform: rotate(-55deg)` の回転中心（要素の中心）が移動し、回転後の駅名が右 7.4pt・下 14.2pt ずれて路線バーに寄るため、`marginLeft` / `marginBottom` で打ち消す位置補正を追加
- 共通 `StationName`（東京メトロ / TY / 小田急 / 埼京 / E231 / JR九州テーマ）と `LineBoardToei` に適用
- 折り返し幅・位置補正それぞれの回帰テストを追加。共通 `StationName` に加え、`LineBoardToei` のナンバリングあり / なしの 2 分岐も検証する

### 都営テーマの多言語併記の修正（Android・実機で確認）

**1. 英語表記で中国語の併記が見切れる**

斜め書きが画面上で占める高さは `幅 × sin55° + テキスト高さ × cos55°` です。英語名がハイフンで折り返されて行数が増えると膨らみ、**回転後の外接矩形が親 View の高さを超えた分を Android が切り抜いて**いました。

| 駅 | 行数 | 外接矩形 | 親 239dp |
| --- | --- | --- | --- |
| `Nakai` + 中井 | 2行 | 210dp | 収まる |
| `Ochiai-minami-nagasaki` + 落合南长崎 | 4行 | 244dp | **超過 → 切れる** |

外接矩形の高さは `幅 × sin55°`（0.82）が支配的な一方、**英語は単語単位で折り返されるため幅を詰めても行数が増えません**。そこで英語表記のときだけ折り返し幅を 216dp → 180dp に詰め、高さを 244dp → 214dp に抑えました。駅名の位置は動きません。

なお本 PR の変更前は `dim.height / 2` = 205.5dp で外接矩形 235dp に収まっていたため、これは本 PR が引き起こしたリグレッションです。

**2. 縦書きの韓国語併記の字間が開きすぎる**

縦書きの併記は 1 文字ずつ Text を並べる実装で、Android では行の余白ぶん字間が開きます。日本語の駅名（`stationName`）には `marginBottom: Platform.select({ android: -6 })` の調整が入っている一方、**併記側には同じ調整がありませんでした**。「落合南長崎」5 文字に対し `오치아이미나미나가사키` 11 文字が枠外へはみ出していたため、縦書き併記専用のスタイルを分けてフォントサイズ比でスケールした負のマージンを当てました。横書きの併記はネストされた Text で仕組みが異なるため対象外です。

### 端末別の効果

| 端末 | フォント | 従来の幅 | 変更後 | 文字数換算 |
| --- | --- | --- | --- | --- |
| iPhone 17 (874×402) | 23pt | 160.8pt (7.0字) | **195.5pt** | 8.5字 |
| iPhone SE3 (667×375) | 18pt | 150.0pt (8.3字) | **153.0pt** | 8.5字 |
| iPad 10.9 (1194×834) | 32pt | 238.3pt (7.4字) | **272.0pt** | 8.5字 |
| iPad Pro 12.9 (1366×1024) | 36pt | 292.6pt (8.1字) | **306.0pt** | 8.5字 |

端末によって 7.0〜8.3 字とばらついていた実効文字数が 8.5 字に揃います。

### リグレッションリスクと緩和

| リスク | 評価 | 緩和 |
| --- | --- | --- |
| 既存端末で表示可能文字数が減る | **なし**。上表のとおりどの端末でも従来より広い幅になる | 折り返し幅の回帰テストを追加 |
| 回転による位置ずれで駅名がバーに重なる | 幅の増分に比例して発生する。iPhone 17 で下 14.2pt | 幅の増分から補正量を算出して打ち消し、縦位置を従来どおりに保つ |
| 斜め書きが縦方向へはみ出しヘッダーに食い込む | iPhone 17 で縦方向の占有は約 175pt、駅名セルが使える高さは約 183pt と試算 | **実機での目視確認が必要**（下記の未対応事項を参照） |

### 未対応（同種の問題を抱えるが今回は触っていない）

- **JR西テーマ** — 折り返し幅が固定値（端末 180pt / タブレット 250pt）。iPhone 17 では 7.8 字ぶんあり「東京テレポート」は収まるが、iPad Pro では 6.9 字ぶんで同種の改行が起きる
- **JO / 山手テーマ** — `stationNameEnJO` の幅 250pt 固定。iPad Pro では 6.9 字ぶん

いずれもヘッダーが厚く（JR西 150pt / JO 128pt、東京メトロ系は 88pt）縦方向の余白が少ないため、実機確認なしに幅を広げるとヘッダーへ食い込むリスクが高いと判断し、今回のスコープから外しています。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果: 244 suites / 2640 tests すべて成功。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy S22 Ultra (SCG13) 実機

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_horizontal-station-name-wrap-width-5d83dc1c3b9f/031492cf5ffe-zh-compare.png" width="720" alt="中国語併記の見切れ: 修正前後" />

中国語併記の見切れ: 修正前後（都営大江戸線 E-33 落合南長崎）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_horizontal-station-name-wrap-width-5d83dc1c3b9f/c033c90d3565-ko-compare2.png" width="480" alt="韓国語併記の字間: 修正前後" />

韓国語併記の字間: 修正前後（同上）

### イメージ図（実装のレンダリング結果ではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_horizontal-station-name-wrap-width-4727b9f3740f/6781dd422994-lineboard-wrap-width.png" width="720" alt="従来と修正後の折り返し幅の比較" />

従来と修正後の折り返し幅の比較

<!-- create-pr:screenshots:end -->

都営テーマの多言語併記の 2 件は Android 実機（Galaxy S22 Ultra）で修正前後を確認済みです。イメージ図の 1 枚は折り返し幅の考え方を示す模式図で、**実装を動かして得た画像ではありません**。

iOS 側は実機・シミュレータでの確認ができていません（この環境は Linux）。折り返し幅の変更はどの端末でも従来より広い幅になるため後退はしませんが、斜め書きの縦方向のはみ出しについては iOS 実機での目視確認をお願いします。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 横向き画面で、長い駅名をより自然に1行表示できるようになりました。
  * 駅名の長さ、言語、駅番号の有無に応じて表示幅を調整します。
  * 回転表示時の左右・上下位置を自動補正し、配置を安定させました。
  * カスタム余白にも横向き表示用の補正を適用します。
  * 韓国語併記を含む縦書き表示の端末別レイアウトを改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

