### PR TITLE
種別選択モーダルのカード路線デザインを全種別で選択中の路線に統一

### DIFF
--- a/src/components/TrainTypeListModal.tsx
+++ b/src/components/TrainTypeListModal.tsx
@@ -278,8 +278,8 @@ export const TrainTypeListModal = ({
   const renderItem = useCallback(
     ({ item }: { item: TrainTypeRow }) => (
       <CommonCard
-        targetStation={item.boardingLineStation ?? undefined}
-        line={item.boardingLine}
+        targetStation={item.cardLineStation ?? undefined}
+        line={item.cardLine}
         title={item.title}
         subtitle={item.subtitle}
         loading={loading}

--- a/src/utils/trainTypeList.test.ts
+++ b/src/utils/trainTypeList.test.ts
@@ -1,5 +1,6 @@
-import type { Line, Station } from '~/@types/graphql';
+import type { Line, Station, TrainType } from '~/@types/graphql';
 import {
+  buildTrainTypeRow,
   formatLineNames,
   getBoardingLine,
   getBoardingLineStation,
@@ -282,5 +283,75 @@ describe('formatLineNames', () => {
       createLine(2, { nameShort: 'B線' }),
     ];
     expect(formatLineNames(lines, true)).toBe('A線 B線');
+  });
+});
+
+describe('buildTrainTypeRow', () => {
+  const seibuChichibu = createLine(6, { nameShort: '西武秩父線' });
+  // 池袋。西武池袋線・東武東上線・副都心線が乗り入れる
+  const ikebukuro = createBoardingStation([
+    { id: seibuIkebukuro.id, station: createNestedStation('SI-01', 'SI') },
+    { id: tobuTojo.id, station: createNestedStation('TJ-01', 'TJ') },
+    { id: fukutoshin.id, station: createNestedStation('F-09', 'F') },
+  ]);
+  const minatomiraiStation = { line: minatomirai } as Station;
+
+  const createTrainType = (
+    id: number,
+    name: string,
+    lines: Line[]
+  ): TrainType =>
+    ({
+      __typename: 'TrainType',
+      id,
+      name,
+      nameRoman: name,
+      lines,
+    }) as unknown as TrainType;
+
+  // 西武池袋線経由と東武東上線経由。従来は行ごとに乗車路線が変わっていた
+  const viaSeibu = createTrainType(1, '快速急行', [
+    seibuChichibu,
+    seibuIkebukuro,
+    fukutoshin,
+    tokyu,
+    minatomirai,
+  ]);
+  const viaTobu = createTrainType(2, '急行', [
+    tobuTojo,
+    fukutoshin,
+    tokyu,
+    minatomirai,
+  ]);
+
+  it('カードの路線は経由が違っても全種別で選択中の路線に揃う', () => {
+    const rows = [viaSeibu, viaTobu].map((tt) =>
+      buildTrainTypeRow(tt, seibuIkebukuro, ikebukuro, minatomiraiStation, true)
+    );
+    expect(rows.map((r) => r.cardLine.id)).toEqual([
+      seibuIkebukuro.id,
+      seibuIkebukuro.id,
+    ]);
+  });
+
+  it('ナンバリングも選択中の路線の乗車駅基準で揃う', () => {
+    const rows = [viaSeibu, viaTobu].map((tt) =>
+      buildTrainTypeRow(tt, seibuIkebukuro, ikebukuro, minatomiraiStation, true)
+    );
+    expect(
+      rows.map((r) => r.cardLineStation?.stationNumbers?.[0]?.stationNumber)
+    ).toEqual(['SI-01', 'SI-01']);
+  });
+
+  it('経由路線は種別ごとの乗車路線を起点に切り出したままにする', () => {
+    const row = buildTrainTypeRow(
+      viaTobu,
+      seibuIkebukuro,
+      ikebukuro,
+      minatomiraiStation,
+      true
+    );
+    // 乗車路線(東武東上線)は経由に含めず、そこから行先までの間だけを出す
+    expect(row.viaLines.map((l) => l.id)).toEqual([fukutoshin.id, tokyu.id]);
   });
 });

--- a/src/utils/trainTypeList.ts
+++ b/src/utils/trainTypeList.ts
@@ -33,8 +33,7 @@ export const getOriginLine = (
  * 経路順に並ぶ lines のうち、乗車駅を通る最初の路線がその駅で乗車する路線になる。
  * getOriginLine が返す始発側の終端路線は、乗車駅が経路の途中にある場合（例: 池袋から
  * S-TRAIN に乗ると終端は西武秩父線だが乗車するのは西武池袋線）に一致しない。
- * カードの配色・路線記号・ナンバリングはこの乗車路線で統一することで、乗車駅に必ず
- * 存在する駅番号を使ってナンバリングを安定して表示できる。
+ * 経由路線は「その駅で乗ってから先」を出したいので、この乗車路線を起点に切り出す。
  * 乗車駅情報が無い場合（在来アプリ内利用など）は getOriginLine にフォールバックする。
  */
 export const getBoardingLine = (
@@ -153,10 +152,10 @@ export const formatLineNames = (lines: Line[], ja: boolean): string => {
 /** 種別一覧の 1 行分。表示に必要な値と、絞り込みに使う値をまとめて持つ */
 export type TrainTypeRow = {
   trainType: TrainType;
-  /** カードの配色・路線記号・ナンバリングに使う乗車路線 */
-  boardingLine: Line;
-  /** ナンバリング表示に使う乗車路線側の駅 */
-  boardingLineStation: StationNested | null;
+  /** カードの配色・路線記号・ナンバリングに使う路線。全種別で共通 */
+  cardLine: Line;
+  /** ナンバリング表示に使うカード路線側の駅。全種別で共通 */
+  cardLineStation: StationNested | null;
   /** カードの見出し（＝種別名）。種別での絞り込みのキーも兼ねる */
   title: string;
   /** カードの補足（経由・直通路線） */
@@ -189,10 +188,8 @@ export const buildTrainTypeRow = (
 ): TrainTypeRow => {
   const lines = uniqBy(trainType.lines ?? [], 'id');
 
-  // カードの配色・路線シンボル・ナンバリングは、種別ごとに乗車駅で実際に乗車する
-  // 路線で統一する（選択中の line で固定すると東武東上線経由の種別に西武池袋線の
-  // デザインが当たってしまう）。経路の途中駅から乗る場合は終端路線ではなく乗車路線
-  // を使うことで、乗車駅に必ず存在する駅番号でナンバリングを安定表示できる。
+  // 経由路線は乗車駅で実際に乗車する路線から先を出したいので、種別ごとに乗車路線を
+  // 求めて起点にする（経路の途中駅から乗る場合、終端路線は乗車路線と一致しない）。
   const boardingLine = getBoardingLine(
     lines,
     boardingStation,
@@ -235,12 +232,14 @@ export const buildTrainTypeRow = (
         })
         .join('\n');
 
-  // 駅番号（ナンバリング）は乗車路線の乗車駅基準で表示する。乗車路線はカードの
-  // デザインと同一なので CommonCard の路線記号一致が必ず成立し、番号が安定して
-  // 描画される。
-  const boardingLineStation = getBoardingLineStation(
+  // カードの配色・路線記号・ナンバリングは全種別で選択中の路線に揃える。行ごとに
+  // 乗車路線を推定して切り替えると、同じ駅から同じように乗るのに種別ごとに色と記号が
+  // 変わり、一覧として並べたときに種別の違いが読み取りづらくなるため。
+  // 駅番号も同じ路線を基準に引くので CommonCard の路線記号一致が必ず成立する。
+  const cardLine = selectedLine;
+  const cardLineStation = getBoardingLineStation(
     boardingStation,
-    boardingLine,
+    cardLine,
     selectedLine
   );
 
@@ -256,8 +255,8 @@ export const buildTrainTypeRow = (
 
   return {
     trainType,
-    boardingLine,
-    boardingLineStation,
+    cardLine,
+    cardLineStation,
     title,
     subtitle,
     viaLines,


### PR DESCRIPTION
## 概要

種別選択モーダルで、各種別カードの配色・路線記号・ナンバリングが行ごとに別々の路線基準で描かれていたのを、全種別で選択中の路線に統一しました。

これまでは行ごとに「その種別が乗車駅で実際に乗車する路線」を推定してカードのデザインに当てていたため、同じ駅から同じように乗るのに種別ごとに色と路線記号が変わり、一覧として並べたときに種別の違いが読み取りづらくなっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `buildTrainTypeRow` のカード用路線を `selectedLine`（モーダルに渡している選択中の路線）に固定。駅番号（ナンバリング）も同じ路線を基準に引くため、`CommonCard` の路線記号一致は従来どおり成立する
- `TrainTypeRow` の `boardingLine` / `boardingLineStation` を `cardLine` / `cardLineStation` にリネーム。行ごとの乗車路線ではなく全種別共通のカード用路線になったため、名前と JSDoc を実態に合わせた
- 経由路線（サブタイトル）の算出は従来のまま。種別ごとの乗車路線を `getBoardingLine` で求めて起点にする処理は残しているので、「〇〇線 直通」「〇〇線 急行」といった文言は変わらない
- 用途が経由路線の起点算出だけになった `getBoardingLine` の JSDoc を更新
- `TrainTypeListModal` が `CommonCard` へ渡す prop をリネーム後のフィールドに差し替え
- `buildTrainTypeRow` のユニットテストを新規追加（カード路線とナンバリングが全行で揃うこと、経由路線は従来どおり種別ごとの乗車路線起点であること）

### リグレッションリスク

- カードの配色・路線記号・ナンバリングの出どころが変わるため、これらの見た目は全種別で変化する（意図した変更）
- サブタイトルの経由路線テキストと絞り込み（`viaLines` 起点）のロジックは触っていないため、種別の絞り込み結果と表示文言は変化しない
- `TrainTypeRow` のフィールド名変更は参照元が `TrainTypeListModal` のみで、`npm run typecheck` で網羅的に確認済み

## テスト

実機（SCG13 / Android 16）で渋谷駅の東京メトロ副都心線の種別一覧を開き、西武池袋線経由・東武東上線経由・S-TRAIN が同じ副都心線の配色と路線記号で並ぶことを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（244 suites / 2643 tests）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### Android 実機 \(SCG13\)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_unify-train-type-card-line-8a7f7250092c/e612ca7da09b-before-scrolled.png" width="320" alt="変更前: 経由が違う種別だけ東急東横線(TY 01)の配色になっている" />

変更前: 経由が違う種別だけ東急東横線\(TY 01\)の配色になっている

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_unify-train-type-card-line-8a7f7250092c/7cbff66b9837-after-scrolled.png" width="320" alt="変更後: 全種別が選択中の東京メトロ副都心線(F 16)の配色に揃う" />

変更後: 全種別が選択中の東京メトロ副都心線\(F 16\)の配色に揃う

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 列車種別カードの路線情報を、選択中の路線に統一しました。
  - 経由路線の一覧は、各列車種別の乗車路線を起点として正しく表示されます。
  - 路線カラー・路線記号・駅ナンバリングが、選択中の路線に基づいて表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->