### PR TITLE
ポートレートモードにのりかえ案内を追加してタイマーと画面タップで切り替える

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -2,17 +2,20 @@ import { fireEvent, render, within } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { getLuminance } from 'polished';
 import { StyleSheet } from 'react-native';
-import { type Station, StopCondition } from '~/@types/graphql';
+import { type Line, type Station, StopCondition } from '~/@types/graphql';
 import { DARK_APP_COLORS, LIGHT_APP_COLORS } from '~/constants/colorScheme';
 import {
   useCurrentLine,
   useCurrentStation,
   useCurrentTrainType,
   useHeaderCommonData,
+  useTransferLines,
   useTransferLinesFromStation,
+  useTransferTargetStation,
 } from '~/hooks';
 import { COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
 import { colorSchemePreferenceAtom } from '~/store/atoms/colorScheme';
+import { bottomStateAtom } from '~/store/atoms/navigation';
 import {
   arrivedAtom,
   selectedDirectionAtom,
@@ -43,9 +46,13 @@ jest.mock('~/hooks', () => ({
   useCurrentLine: jest.fn(),
   useCurrentStation: jest.fn(),
   useCurrentTrainType: jest.fn(),
+  useGetLineMark: jest.fn(() => () => null),
   useHeaderCommonData: jest.fn(),
   useStationNumberIndexFunc: jest.fn(() => () => 0),
+  useTransferLines: jest.fn(() => []),
   useTransferLinesFromStation: jest.fn(() => []),
+  useTransferStationNumbers: jest.fn((lines: Line[]) => lines.map(() => null)),
+  useTransferTargetStation: jest.fn(() => undefined),
 }));
 
 const mockedUseHeaderCommonData = useHeaderCommonData as jest.Mock;
@@ -54,6 +61,8 @@ const mockedUseCurrentStation = useCurrentStation as jest.Mock;
 const mockedUseCurrentTrainType = useCurrentTrainType as jest.Mock;
 const mockedUseTransferLinesFromStation =
   useTransferLinesFromStation as jest.Mock;
+const mockedUseTransferLines = useTransferLines as jest.Mock;
+const mockedUseTransferTargetStation = useTransferTargetStation as jest.Mock;
 
 const yamanoteLine = {
   id: 11302,
@@ -101,10 +110,18 @@ const renderWithStations = (
     arrived = true,
     currentStation = stations[0],
     colorScheme = COLOR_SCHEME_PREFERENCE.LIGHT,
+    bottomState = 'LINE' as const,
+    transferStation,
+    onPress,
+    onTransferPress,
   }: {
     arrived?: boolean;
     currentStation?: Station;
     colorScheme?: (typeof COLOR_SCHEME_PREFERENCE)[keyof typeof COLOR_SCHEME_PREFERENCE];
+    bottomState?: 'LINE' | 'TRANSFER' | 'TYPE_CHANGE';
+    transferStation?: Station;
+    onPress?: () => void;
+    onTransferPress?: (station?: Station) => void;
   } = {}
 ) => {
   const store = createStore();
@@ -114,11 +131,13 @@ const renderWithStations = (
   store.set(stationsAtom, stations);
   store.set(selectedDirectionAtom, 'INBOUND');
   store.set(arrivedAtom, arrived);
+  store.set(bottomStateAtom, bottomState);
   mockedUseCurrentStation.mockReturnValue(currentStation);
+  mockedUseTransferTargetStation.mockReturnValue(transferStation);
 
   return render(
     <Provider store={store}>
-      <PortraitMain />
+      <PortraitMain onPress={onPress} onTransferPress={onTransferPress} />
     </Provider>
   );
 };
@@ -133,6 +152,8 @@ describe('PortraitMain', () => {
       color: '#123456',
     });
     mockedUseTransferLinesFromStation.mockReturnValue([]);
+    mockedUseTransferLines.mockReturnValue([]);
+    mockedUseTransferTargetStation.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -578,5 +599,119 @@ describe('PortraitMain', () => {
     );
 
     expect(queryByTestId('portrait-card-meta')).toBeNull();
+  });
+
+  describe('のりかえ案内', () => {
+    const shinjuku = buildStation(100, '新宿', StopCondition.All, 'JC-05');
+    const shinsenShinjuku = buildStation(200, '新線新宿', StopCondition.All);
+
+    const buildTransferLine = (
+      id: number,
+      nameShort: string,
+      color: string,
+      station: Station
+    ): Line =>
+      ({
+        id,
+        nameShort,
+        nameRoman: `${nameShort}-roman`,
+        color,
+        lineSymbols: [],
+        station,
+      }) as unknown as Line;
+
+    const yamanote = buildTransferLine(11302, '山手線', '#80C241', shinjuku);
+    const keioNew = buildTransferLine(
+      99310,
+      '京王新線',
+      '#CA0073',
+      shinsenShinjuku
+    );
+
+    it('下部の表示が TRANSFER のときは停車駅リストに重ねてのりかえ案内を出す', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote]);
+
+      const { getByTestId, getByText } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+      });
+
+      expect(getByTestId('portrait-transfers')).toBeTruthy();
+      // 見出しは translate('transfer') をそのまま使う
+      expect(getByText('transfer')).toBeTruthy();
+      // メタ行にも運転中の路線名が出るので、行に絞って確かめる
+      expect(
+        within(getByTestId('portrait-transfer-row-11302')).getByText('山手線')
+      ).toBeTruthy();
+      // 案内対象の駅は見出しの脇に出す
+      expect(getByTestId('portrait-transfer-station').props.children).toBe(
+        '新宿駅'
+      );
+      // リストは外さずに重ねるだけなので、下のスクロール位置は保たれる
+      expect(getByTestId('portrait-stop-list')).toBeTruthy();
+    });
+
+    it('乗換路線が無いときは TRANSFER でものりかえ案内を出さない', () => {
+      mockedUseTransferLines.mockReturnValue([]);
+
+      const { queryByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+      });
+
+      expect(queryByTestId('portrait-transfers')).toBeNull();
+    });
+
+    it('乗換先が案内中の駅と同じなら駅名を添えず、別の駅のときだけ添える', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote, keioNew]);
+
+      const { getByTestId, getAllByText } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+      });
+
+      // 同じ新宿駅なので、山手線の行には駅名を出さない
+      expect(
+        within(getByTestId('portrait-transfer-row-11302')).queryByText('新宿駅')
+      ).toBeNull();
+      // 新線新宿は別の駅なので添える
+      expect(
+        within(getByTestId('portrait-transfer-row-99310')).getByText(
+          '新線新宿駅'
+        )
+      ).toBeTruthy();
+      // 「新宿駅」は見出しの脇だけ。行に同じ駅名が重ねて出ていないこと
+      expect(getAllByText('新宿駅')).toHaveLength(1);
+    });
+
+    it('画面タップで下部の表示を進める', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderWithStations([shinjuku], { onPress });
+
+      fireEvent.press(getByTestId('portrait-root'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('のりかえ行タップでは路線と駅を渡し、表示は進めない', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote]);
+      const onPress = jest.fn();
+      const onTransferPress = jest.fn();
+
+      const { getByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+        onPress,
+        onTransferPress,
+      });
+
+      fireEvent.press(getByTestId('portrait-transfer-row-11302'));
+
+      expect(onTransferPress).toHaveBeenCalledTimes(1);
+      expect(onTransferPress.mock.calls[0][0]).toMatchObject({
+        groupId: shinjuku.groupId,
+        line: yamanote,
+      });
+      expect(onPress).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -13,9 +13,11 @@ import { memo, useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   type LayoutChangeEvent,
   type NativeSyntheticEvent,
+  Pressable,
   ScrollView,
   StyleSheet,
   type TextLayoutEventData,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import Animated, {
@@ -36,19 +38,27 @@ import {
   Rect,
   Svg,
 } from 'react-native-svg';
-import type { Station } from '~/@types/graphql';
-import { parenthesisRegexp } from '~/constants';
+import type { Line, Station } from '~/@types/graphql';
+import { NUMBERING_ICON_SIZE, parenthesisRegexp } from '~/constants';
 import type { AppColors } from '~/constants/colorScheme';
 import {
   useBoundText,
   useCurrentLine,
   useCurrentStation,
   useCurrentTrainType,
+  useGetLineMark,
   useHeaderCommonData,
   useStationNumberIndexFunc,
+  useTransferLines,
   useTransferLinesFromStation,
+  useTransferStationNumbers,
+  useTransferTargetStation,
 } from '~/hooks';
 import { appColorsAtom } from '~/store/atoms/colorScheme';
+import {
+  bottomStateAtom,
+  enabledLanguagesAtom,
+} from '~/store/atoms/navigation';
 import {
   arrivedAtom,
   selectedDirectionAtom,
@@ -64,6 +74,8 @@ import {
   normalizeTrainTypeColor,
 } from '~/utils/trainTypeTextColor';
 import NumberingIcon from './NumberingIcon';
+import TransferLineDot from './TransferLineDot';
+import TransferLineMark from './TransferLineMark';
 import Typography from './Typography';
 
 // 走行画面は AppColorsProvider の外側で描画されるため useAppColors() は常に
@@ -200,6 +212,17 @@ const MARKER_HEAD_OFFSET = Math.round((14 / 37) * MARKER_HEIGHT);
 
 // 停車駅リストの上下パディング
 const STOP_LIST_PADDING_V = 12;
+
+// のりかえ一覧の行。路線マーク(35)と2〜3行のテキストが収まる高さ
+const TRANSFER_ROW_MIN_HEIGHT = isTablet ? 66 : 46;
+
+// のりかえ一覧に添える駅ナンバリングの枠。アイコン自体は実寸で組まれているので
+// この枠に合わせて縮小する
+const TRANSFER_NUMBERING_SIZE = isTablet ? 48 : 32;
+
+// のりかえへの切り替わり。ふわりと乗るだけの短い動きに留める
+const TRANSFER_FADE_DURATION = 220;
+const TRANSFER_FADE_SHIFT = 10;
 
 // リスト下端のフェード。最終行がホームインジケータへ溶けるようにする
 const LIST_FADE_HEIGHT = 72;
@@ -485,7 +508,85 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     letterSpacing: 0.6,
   },
+  // のりかえ案内。停車駅リストと同じ領域に重ねて出す
+  transferOverlay: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  transferPane: {
+    flex: 1,
+    paddingTop: STOP_LIST_PADDING_V,
+    paddingHorizontal: CONTENT_INSET,
+  },
+  transferListContent: {
+    paddingTop: 10,
+    paddingBottom: STOP_LIST_PADDING_V,
+  },
+  transferRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: TRANSFER_ROW_MIN_HEIGHT,
+  },
+  transferBody: {
+    flex: 1,
+    marginLeft: 5,
+  },
+  transferNameRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
+  transferLineName: {
+    flexShrink: 1,
+    fontSize: RFValue(14),
+    fontWeight: 'bold',
+  },
+  // 乗換先が案内中の駅と別名のときだけ添える駅名
+  transferStationName: {
+    flexShrink: 1,
+    marginLeft: 8,
+    fontSize: RFValue(9),
+    fontWeight: 'bold',
+  },
+  transferSubName: {
+    fontSize: RFValue(10),
+    fontWeight: 'bold',
+  },
+  transferNumberingBox: {
+    width: TRANSFER_NUMBERING_SIZE,
+    height: TRANSFER_NUMBERING_SIZE,
+    marginLeft: 10,
+  },
+  // transform はレイアウトに影響しないため、実寸の枠を絶対配置で中央に重ねてから
+  // 縮小する。こうすると枠の大きさは TRANSFER_NUMBERING_SIZE のまま保たれる。
+  transferNumbering: {
+    position: 'absolute',
+    left: (TRANSFER_NUMBERING_SIZE - NUMBERING_COLUMN_WIDTH) / 2,
+    top: (TRANSFER_NUMBERING_SIZE - NUMBERING_COLUMN_WIDTH) / 2,
+    width: NUMBERING_COLUMN_WIDTH,
+    height: NUMBERING_COLUMN_WIDTH,
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: [{ scale: TRANSFER_NUMBERING_SIZE / NUMBERING_COLUMN_WIDTH }],
+  },
 });
+
+// 乗換先の駅名。横画面の Transfers と同じ体裁で出す
+const stationLabel = (station: Station | null | undefined): string => {
+  if (!station) {
+    return '';
+  }
+  const name = isJapanese
+    ? (station.name ?? '')
+    : (station.nameRoman ?? station.name ?? '');
+  const stripped = name.replace(parenthesisRegexp, '');
+  if (!stripped) {
+    return '';
+  }
+  return isJapanese ? `${stripped}駅` : `${stripped} Sta.`;
+};
 
 type MarkerPosition = 'above-dot' | 'segment-top' | null;
 
@@ -906,7 +1007,184 @@ const AccentWash = ({ color, opacity }: { color: string; opacity: number }) => {
   );
 };
 
-const PortraitMain: React.FC = () => {
+// のりかえ案内。停車駅リストと同じ領域を占めて、下部の表示状態が TRANSFER の
+// 間だけ上に重なる。行をタップすると横画面と同じく運転路線の切り替え確認へ渡す。
+const PortraitTransfers = ({
+  lines,
+  transferStation,
+  colors,
+  accentColor,
+  onPress,
+}: {
+  lines: Line[];
+  transferStation: Station | null;
+  colors: AppColors;
+  accentColor: string;
+  onPress?: (station?: Station) => void;
+}) => {
+  const getLineMarkFunc = useGetLineMark();
+  const stationNumbers = useTransferStationNumbers(lines);
+  const enabledLanguages = useAtomValue(enabledLanguagesAtom);
+
+  const isJaEnabled = enabledLanguages.includes('JA');
+  const isEnEnabled = enabledLanguages.includes('EN');
+  const isZhEnabled = enabledLanguages.includes('ZH');
+  const isKoEnabled = enabledLanguages.includes('KO');
+
+  const passColor = passTextColor(colors);
+
+  return (
+    <View style={styles.transferPane}>
+      {/* 見出しは現在駅カードの頭と同じ組み方にして、画面内の調子を揃える */}
+      <View style={styles.cardHeadRow}>
+        <Typography
+          numberOfLines={1}
+          style={[styles.stateText, { color: accentColor }]}
+        >
+          {translate('transfer')}
+        </Typography>
+        <View
+          style={[styles.cardHeadRule, { backgroundColor: colors.border }]}
+        />
+        {transferStation ? (
+          <Typography
+            numberOfLines={1}
+            testID="portrait-transfer-station"
+            style={[styles.cardHeadMeta, { color: passColor }]}
+          >
+            {stationLabel(transferStation)}
+          </Typography>
+        ) : null}
+      </View>
+
+      <ScrollView
+        testID="portrait-transfer-list"
+        contentContainerStyle={styles.transferListContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {lines.map((line, index) => {
+          const lineMark = getLineMarkFunc({
+            line,
+            stationNumbers: line.station?.stationNumbers,
+          });
+          const numbering = stationNumbers[index];
+
+          // 乗換先が案内中の駅と別の駅のときだけ駅名を添える(新線新宿など)。
+          // 幅の狭い縦画面で同じ駅名を全行に並べても情報が増えないため。
+          const showStationName =
+            !!line.station && line.station.groupId !== transferStation?.groupId;
+
+          const cjkLineName = [
+            isZhEnabled ? line.nameChinese : null,
+            isKoEnabled ? line.nameKorean : null,
+          ]
+            .filter((t): t is string => !!t?.length)
+            .map((t) => t.replace(parenthesisRegexp, ''))
+            .join(' / ');
+
+          return (
+            <TouchableOpacity
+              key={line.id}
+              activeOpacity={1}
+              testID={`portrait-transfer-row-${line.id}`}
+              style={styles.transferRow}
+              onPress={() => {
+                if (!line.station) {
+                  return;
+                }
+                onPress?.({
+                  ...line.station,
+                  __typename: 'Station',
+                  line,
+                  lines,
+                } as Station);
+              }}
+            >
+              {lineMark ? (
+                <TransferLineMark
+                  line={line}
+                  mark={lineMark}
+                  size={NUMBERING_ICON_SIZE.MEDIUM}
+                />
+              ) : (
+                <TransferLineDot line={line} />
+              )}
+
+              <View style={styles.transferBody}>
+                <View style={styles.transferNameRow}>
+                  {isJaEnabled && line.nameShort ? (
+                    <Typography
+                      numberOfLines={1}
+                      style={[styles.transferLineName, { color: colors.text }]}
+                    >
+                      {line.nameShort.replace(parenthesisRegexp, '')}
+                    </Typography>
+                  ) : null}
+                  {showStationName ? (
+                    <Typography
+                      numberOfLines={1}
+                      style={[styles.transferStationName, { color: passColor }]}
+                    >
+                      {stationLabel(line.station)}
+                    </Typography>
+                  ) : null}
+                </View>
+                {isEnEnabled && line.nameRoman ? (
+                  <Typography
+                    numberOfLines={1}
+                    style={[
+                      isJaEnabled
+                        ? styles.transferSubName
+                        : styles.transferLineName,
+                      {
+                        color: isJaEnabled ? colors.secondaryText : colors.text,
+                      },
+                    ]}
+                  >
+                    {line.nameRoman.replace(parenthesisRegexp, '')}
+                  </Typography>
+                ) : null}
+                {cjkLineName ? (
+                  <Typography
+                    numberOfLines={1}
+                    style={[
+                      styles.transferSubName,
+                      { color: colors.secondaryText },
+                    ]}
+                  >
+                    {cjkLineName}
+                  </Typography>
+                ) : null}
+              </View>
+
+              {numbering?.stationNumber ? (
+                <View style={styles.transferNumberingBox}>
+                  <View style={styles.transferNumbering}>
+                    <NumberingIcon
+                      shape={numbering.lineSymbolShape ?? 'NOOP'}
+                      lineColor={numbering.lineSymbolColor ?? '#000000'}
+                      stationNumber={numbering.stationNumber}
+                      allowScaling={false}
+                    />
+                  </View>
+                </View>
+              ) : null}
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+};
+
+type Props = {
+  /** 画面タップ。横画面と同じく下部の表示を次へ進める */
+  onPress?: () => void;
+  /** のりかえ行タップ。運転路線の切り替え確認へ渡す */
+  onTransferPress?: (station?: Station) => void;
+};
+
+const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
   // ステータスバー非表示で全画面描画するため SafeAreaView は使わないが、
   // Dynamic Island / ノッチやホームインジケータと表示が被らないよう、
   // 上下のセーフエリア分を padding として確保する。
@@ -919,6 +1197,10 @@ const PortraitMain: React.FC = () => {
   const arrived = useAtomValue(arrivedAtom);
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
+  const bottomState = useAtomValue(bottomStateAtom);
+  const transferLines = useTransferLines();
+  // 案内する乗換路線と対象駅がずれないよう、路線側と同じフックから引く
+  const transferStation = useTransferTargetStation() ?? null;
   // 行先は言語切り替えタイマーで多言語化せず日本語固定で表示する
   const boundText = useBoundText().JA;
 
@@ -1041,6 +1323,30 @@ const PortraitMain: React.FC = () => {
   const markerMoving =
     !stoppedHere || getIsPass(stops[currentIndex] ?? undefined);
 
+  // 乗換路線が無いときは useUpdateBottomState 側でも LINE へ戻されるが、
+  // 戻るまでの間に空の案内が出ないようここでも見る。
+  const showTransfer = bottomState === 'TRANSFER' && transferLines.length > 0;
+
+  // のりかえは停車駅リストの上に重ねて出す。リストを外さないので、
+  // 戻ってきたときもスクロール位置がそのまま保たれる。
+  const transferOpacity = useSharedValue(0);
+  const transferShift = useSharedValue(0);
+  useEffect(() => {
+    if (!showTransfer) {
+      return;
+    }
+    transferOpacity.value = 0;
+    transferShift.value = TRANSFER_FADE_SHIFT;
+    transferOpacity.value = withTiming(1, {
+      duration: TRANSFER_FADE_DURATION,
+    });
+    transferShift.value = withTiming(0, { duration: TRANSFER_FADE_DURATION });
+  }, [showTransfer, transferOpacity, transferShift]);
+  const transferStyle = useAnimatedStyle(() => ({
+    opacity: transferOpacity.value,
+    transform: [{ translateY: transferShift.value }],
+  }));
+
   // rowYs は各行の上端 y を記録する(onLayout は行のレイアウト時にしか発火しないので、
   // currentIndex 変更でコールバックが別行に移っても再取得できない。全行を記録して
   // index で引く)。
@@ -1081,8 +1387,9 @@ const PortraitMain: React.FC = () => {
     // ステータスバーは非表示のため SafeAreaView は使わず素の View を使う。
     // 上端は Dynamic Island / ノッチと路線情報が被らないよう、
     // セーフエリア上端ぶんの padding を確保する。
-    <View
+    <Pressable
       testID="portrait-root"
+      onPress={onPress}
       style={[
         styles.root,
         { backgroundColor: colors.background, paddingTop: insets.top },
@@ -1228,6 +1535,25 @@ const PortraitMain: React.FC = () => {
             );
           })}
         </ScrollView>
+        {showTransfer ? (
+          <Animated.View
+            testID="portrait-transfers"
+            style={[
+              styles.transferOverlay,
+              { backgroundColor: colors.background },
+              transferStyle,
+            ]}
+          >
+            <PortraitTransfers
+              lines={transferLines}
+              transferStation={transferStation}
+              colors={colors}
+              accentColor={accentColor}
+              onPress={onTransferPress}
+            />
+          </Animated.View>
+        ) : null}
+
         {/* 最終行がホームインジケータへ溶けるよう下端をぼかす */}
         <LinearGradient
           pointerEvents="none"
@@ -1235,7 +1561,7 @@ const PortraitMain: React.FC = () => {
           style={styles.listFade}
         />
       </View>
-    </View>
+    </Pressable>
   );
 };
 

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1014,12 +1014,14 @@ const PortraitTransfers = ({
   transferStation,
   colors,
   accentColor,
+  bottomInset,
   onPress,
 }: {
   lines: Line[];
   transferStation: Station | null;
   colors: AppColors;
   accentColor: string;
+  bottomInset: number;
   onPress?: (station?: Station) => void;
 }) => {
   const getLineMarkFunc = useGetLineMark();
@@ -1059,7 +1061,15 @@ const PortraitTransfers = ({
 
       <ScrollView
         testID="portrait-transfer-list"
-        contentContainerStyle={styles.transferListContent}
+        contentContainerStyle={[
+          styles.transferListContent,
+          // 停車駅リストと同じ領域を占めるので下端のセーフエリアを足す。
+          // さらに下端のぼかし(listFade)がこのオーバーレイの上に描かれるため、
+          // 最終行がぼかしへ潜らないようその分も空ける。
+          {
+            paddingBottom: STOP_LIST_PADDING_V + LIST_FADE_HEIGHT + bottomInset,
+          },
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {lines.map((line, index) => {
@@ -1341,6 +1351,10 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
       duration: TRANSFER_FADE_DURATION,
     });
     transferShift.value = withTiming(0, { duration: TRANSFER_FADE_DURATION });
+    return () => {
+      cancelAnimation(transferOpacity);
+      cancelAnimation(transferShift);
+    };
   }, [showTransfer, transferOpacity, transferShift]);
   const transferStyle = useAnimatedStyle(() => ({
     opacity: transferOpacity.value,
@@ -1549,6 +1563,7 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
               transferStation={transferStation}
               colors={colors}
               accentColor={accentColor}
+              bottomInset={insets.bottom}
               onPress={onTransferPress}
             />
           </Animated.View>

--- a/src/components/Transfers.tsx
+++ b/src/components/Transfers.tsx
@@ -1,9 +1,13 @@
 import { useAtomValue } from 'jotai';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 import type { Line, Station } from '~/@types/graphql';
 import { NUMBERING_ICON_SIZE, parenthesisRegexp } from '../constants';
-import { useGetLineMark, useTransferLines } from '../hooks';
+import {
+  useGetLineMark,
+  useTransferLines,
+  useTransferStationNumbers,
+} from '../hooks';
 import type { AppTheme } from '../models/Theme';
 import { enabledLanguagesAtom } from '../store/atoms/navigation';
 import { isLEDThemeAtom } from '../store/atoms/theme';
@@ -76,49 +80,7 @@ const Transfers: React.FC<Props> = ({ onPress, theme }: Props) => {
   const isZhEnabled = enabledLanguages.includes('ZH');
   const isKoEnabled = enabledLanguages.includes('KO');
 
-  const stationNumbers = useMemo(
-    () =>
-      lines?.map((l) => {
-        const stationNumberData = l.station?.stationNumbers?.find((sn) =>
-          l.lineSymbols?.some((sym) => sym.symbol === sn.lineSymbol)
-        );
-        const lineSymbol = stationNumberData?.lineSymbol ?? '';
-        const lineSymbolColor = stationNumberData?.lineSymbolColor ?? '';
-        const stationNumber = stationNumberData?.stationNumber ?? '';
-        const lineSymbolShape = stationNumberData?.lineSymbolShape ?? 'NOOP';
-
-        if (!lineSymbol.length || !stationNumber.length) {
-          const stationNumberWhenEmptySymbol =
-            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
-              ?.stationNumber ?? '';
-          const lineSymbolWhenEmptySymbol = l.lineSymbols?.[0]?.symbol ?? '';
-          const lineSymbolColorWhenEmptySymbol =
-            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
-              ?.lineSymbolColor ?? '#000000';
-          const lineSymbolShapeWhenEmptySymbol =
-            l.station?.stationNumbers?.find(
-              (sn) => !sn.lineSymbol?.length
-            )?.lineSymbolShape;
-
-          return {
-            __typename: 'StationNumber' as const,
-            lineSymbol: lineSymbolWhenEmptySymbol,
-            lineSymbolColor: lineSymbolColorWhenEmptySymbol,
-            stationNumber: stationNumberWhenEmptySymbol,
-            lineSymbolShape: lineSymbolShapeWhenEmptySymbol,
-          };
-        }
-
-        return {
-          __typename: 'StationNumber' as const,
-          lineSymbol,
-          lineSymbolColor,
-          stationNumber,
-          lineSymbolShape,
-        };
-      }),
-    [lines]
-  );
+  const stationNumbers = useTransferStationNumbers(lines);
 
   const renderTransferLine = useCallback(
     ({ item: line, index }: { item: Line; index: number }) => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -87,6 +87,8 @@ export { useThreshold } from './useThreshold';
 export { useTrainTypeStations } from './useTrainTypeStations';
 export { useTransferLines } from './useTransferLines';
 export { useTransferLinesFromStation } from './useTransferLinesFromStation';
+export { useTransferStationNumbers } from './useTransferStationNumbers';
+export { useTransferTargetStation } from './useTransferTargetStation';
 export { useTransitionHeaderState } from './useTransitionHeaderState';
 export { useTTS } from './useTTS';
 export { useTTSFeatureEnabled } from './useTTSFeatureEnabled';

--- a/src/hooks/useTransferLines.ts
+++ b/src/hooks/useTransferLines.ts
@@ -1,11 +1,6 @@
-import { useAtomValue } from 'jotai';
-import { useMemo } from 'react';
 import type { Line } from '~/@types/graphql';
-import { arrivedAtom } from '../store/atoms/station';
-import getIsPass from '../utils/isPass';
-import { useCurrentStation } from './useCurrentStation';
-import { useDisplayNextStation } from './useDisplayNextStation';
 import { useTransferLinesFromStation } from './useTransferLinesFromStation';
+import { useTransferTargetStation } from './useTransferTargetStation';
 
 type Option = {
   omitRepeatingLine?: boolean;
@@ -13,20 +8,7 @@ type Option = {
 };
 
 export const useTransferLines = (options?: Option): Line[] => {
-  const arrived = useAtomValue(arrivedAtom);
-  const currentStation = useCurrentStation(false, true);
-  // ヘッダー・TTS が「まもなく」で読み上げる駅 (接近中はGPS基準の接近駅) と
-  // 乗換案内の対象駅を一致させる。useNextStation 起点のままだと、到着判定の
-  // 取りこぼしで stationState が古い場合に「まもなくA、B駅の乗換路線をご案内」
-  // という不整合が起きる。
-  const nextStation = useDisplayNextStation();
-  const targetStation = useMemo(
-    () =>
-      arrived && currentStation && !getIsPass(currentStation)
-        ? currentStation
-        : nextStation,
-    [arrived, currentStation, nextStation]
-  );
+  const targetStation = useTransferTargetStation();
 
   const { omitRepeatingLine, omitJR } = options ?? {
     omitRepeatingLine: false,

--- a/src/hooks/useTransferStationNumbers.ts
+++ b/src/hooks/useTransferStationNumbers.ts
@@ -7,6 +7,7 @@ import type { Line } from '~/@types/graphql';
  * 駅側の stationNumbers に路線のシンボルと一致するものが無い場合は、
  * シンボルを持たない駅ナンバリングと路線側の先頭シンボルを組み合わせて
  * フォールバックする(シンボル未設定の路線でもナンバリングを出すため)。
+ * どちらの経路でも lineSymbolShape は 'NOOP' で埋めて型を揃える。
  */
 export const useTransferStationNumbers = (lines: Line[]) =>
   useMemo(
@@ -38,7 +39,7 @@ export const useTransferStationNumbers = (lines: Line[]) =>
             lineSymbol: lineSymbolWhenEmptySymbol,
             lineSymbolColor: lineSymbolColorWhenEmptySymbol,
             stationNumber: stationNumberWhenEmptySymbol,
-            lineSymbolShape: lineSymbolShapeWhenEmptySymbol,
+            lineSymbolShape: lineSymbolShapeWhenEmptySymbol ?? 'NOOP',
           };
         }
 

--- a/src/hooks/useTransferStationNumbers.ts
+++ b/src/hooks/useTransferStationNumbers.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import type { Line } from '~/@types/graphql';
+
+/**
+ * 乗換路線ごとに、その路線のシンボルと対応する駅ナンバリングを取り出す。
+ *
+ * 駅側の stationNumbers に路線のシンボルと一致するものが無い場合は、
+ * シンボルを持たない駅ナンバリングと路線側の先頭シンボルを組み合わせて
+ * フォールバックする(シンボル未設定の路線でもナンバリングを出すため)。
+ */
+export const useTransferStationNumbers = (lines: Line[]) =>
+  useMemo(
+    () =>
+      lines.map((l) => {
+        const stationNumberData = l.station?.stationNumbers?.find((sn) =>
+          l.lineSymbols?.some((sym) => sym.symbol === sn.lineSymbol)
+        );
+        const lineSymbol = stationNumberData?.lineSymbol ?? '';
+        const lineSymbolColor = stationNumberData?.lineSymbolColor ?? '';
+        const stationNumber = stationNumberData?.stationNumber ?? '';
+        const lineSymbolShape = stationNumberData?.lineSymbolShape ?? 'NOOP';
+
+        if (!lineSymbol.length || !stationNumber.length) {
+          const stationNumberWhenEmptySymbol =
+            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
+              ?.stationNumber ?? '';
+          const lineSymbolWhenEmptySymbol = l.lineSymbols?.[0]?.symbol ?? '';
+          const lineSymbolColorWhenEmptySymbol =
+            l.station?.stationNumbers?.find((sn) => !sn.lineSymbol?.length)
+              ?.lineSymbolColor ?? '#000000';
+          const lineSymbolShapeWhenEmptySymbol =
+            l.station?.stationNumbers?.find(
+              (sn) => !sn.lineSymbol?.length
+            )?.lineSymbolShape;
+
+          return {
+            __typename: 'StationNumber' as const,
+            lineSymbol: lineSymbolWhenEmptySymbol,
+            lineSymbolColor: lineSymbolColorWhenEmptySymbol,
+            stationNumber: stationNumberWhenEmptySymbol,
+            lineSymbolShape: lineSymbolShapeWhenEmptySymbol,
+          };
+        }
+
+        return {
+          __typename: 'StationNumber' as const,
+          lineSymbol,
+          lineSymbolColor,
+          stationNumber,
+          lineSymbolShape,
+        };
+      }),
+    [lines]
+  );

--- a/src/hooks/useTransferTargetStation.test.tsx
+++ b/src/hooks/useTransferTargetStation.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import { type Station, StopCondition } from '~/@types/graphql';
+import { arrivedAtom } from '~/store/atoms/station';
+import { useCurrentStation } from './useCurrentStation';
+import { useDisplayNextStation } from './useDisplayNextStation';
+import { useTransferTargetStation } from './useTransferTargetStation';
+
+jest.mock('./useCurrentStation', () => ({
+  useCurrentStation: jest.fn(),
+}));
+jest.mock('./useDisplayNextStation', () => ({
+  useDisplayNextStation: jest.fn(),
+}));
+
+const mockedUseCurrentStation = useCurrentStation as jest.Mock;
+const mockedUseDisplayNextStation = useDisplayNextStation as jest.Mock;
+
+const buildStation = (
+  id: number,
+  name: string,
+  stopCondition: StopCondition
+): Station => ({ id, groupId: id, name, stopCondition }) as unknown as Station;
+
+const shinjuku = buildStation(1, '新宿', StopCondition.All);
+const koenji = buildStation(2, '高円寺', StopCondition.Not);
+const nakano = buildStation(3, '中野', StopCondition.All);
+
+const renderWith = ({
+  arrived,
+  currentStation,
+  nextStation,
+}: {
+  arrived: boolean;
+  currentStation: Station | undefined;
+  nextStation: Station | undefined;
+}) => {
+  const store = createStore();
+  store.set(arrivedAtom, arrived);
+  mockedUseCurrentStation.mockReturnValue(currentStation);
+  mockedUseDisplayNextStation.mockReturnValue(nextStation);
+
+  return renderHook(() => useTransferTargetStation(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    ),
+  });
+};
+
+describe('useTransferTargetStation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('停車中で現在駅が停車駅なら現在駅を対象にする', () => {
+    const { result } = renderWith({
+      arrived: true,
+      currentStation: shinjuku,
+      nextStation: nakano,
+    });
+
+    expect(result.current).toBe(shinjuku);
+  });
+
+  it('到着扱いでも現在駅が通過駅なら次の駅を対象にする', () => {
+    // 通過中の駅の乗換路線を案内してしまわないこと
+    const { result } = renderWith({
+      arrived: true,
+      currentStation: koenji,
+      nextStation: nakano,
+    });
+
+    expect(result.current).toBe(nakano);
+  });
+
+  it('未到着なら表示用の次駅(接近中はGPS基準の接近駅)を対象にする', () => {
+    const { result } = renderWith({
+      arrived: false,
+      currentStation: shinjuku,
+      nextStation: nakano,
+    });
+
+    expect(result.current).toBe(nakano);
+  });
+
+  it('現在駅が取れないときは次の駅へ倒す', () => {
+    const { result } = renderWith({
+      arrived: true,
+      currentStation: undefined,
+      nextStation: nakano,
+    });
+
+    expect(result.current).toBe(nakano);
+  });
+});

--- a/src/hooks/useTransferTargetStation.ts
+++ b/src/hooks/useTransferTargetStation.ts
@@ -1,0 +1,29 @@
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import type { Station } from '~/@types/graphql';
+import { arrivedAtom } from '../store/atoms/station';
+import getIsPass from '../utils/isPass';
+import { useCurrentStation } from './useCurrentStation';
+import { useDisplayNextStation } from './useDisplayNextStation';
+
+/**
+ * 乗換案内の対象駅。
+ *
+ * ヘッダー・TTS が「まもなく」で読み上げる駅 (接近中はGPS基準の接近駅) と
+ * 乗換案内の対象駅を一致させる。useNextStation 起点のままだと、到着判定の
+ * 取りこぼしで stationState が古い場合に「まもなくA、B駅の乗換路線をご案内」
+ * という不整合が起きる。
+ */
+export const useTransferTargetStation = (): Station | undefined => {
+  const arrived = useAtomValue(arrivedAtom);
+  const currentStation = useCurrentStation(false, true);
+  const nextStation = useDisplayNextStation();
+
+  return useMemo(
+    () =>
+      arrived && currentStation && !getIsPass(currentStation)
+        ? currentStation
+        : nextStation,
+    [arrived, currentStation, nextStation]
+  );
+};

--- a/src/hooks/useUpdateBottomState.test.tsx
+++ b/src/hooks/useUpdateBottomState.test.tsx
@@ -63,6 +63,7 @@ describe('useUpdateBottomState', () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
     jest.useRealTimers();
     mockLayout.isPortrait = false;
   });

--- a/src/hooks/useUpdateBottomState.test.tsx
+++ b/src/hooks/useUpdateBottomState.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import type React from 'react';
+import { DEFAULT_BOTTOM_TRANSITION_INTERVAL } from '~/constants';
+import { THEME_PREFERENCE, type ThemePreference } from '~/models/Theme';
+import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import { bottomStateAtom } from '~/store/atoms/navigation';
+import { themePreferenceAtom } from '~/store/atoms/theme';
+import { useUpdateBottomState } from './useUpdateBottomState';
+
+// 乗換路線が1件でもあれば LINE -> TRANSFER へ進む
+jest.mock('./useTransferLines', () => ({
+  useTransferLines: () => [{ id: 1 }],
+}));
+jest.mock('./useTypeWillChange', () => ({
+  useTypeWillChange: () => false,
+}));
+jest.mock('./useShouldHideTypeChange', () => ({
+  useShouldHideTypeChange: () => false,
+}));
+
+const mockLayout = { isPortrait: false };
+jest.mock('./useLandscapeWindowDimensions', () => ({
+  useLandscapeWindowDimensions: () => ({
+    width: 800,
+    height: 400,
+    isPortrait: mockLayout.isPortrait,
+  }),
+}));
+
+const renderWithStore = (store: ReturnType<typeof createStore>) =>
+  renderHook(() => useUpdateBottomState(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    ),
+  });
+
+const buildStore = ({
+  theme,
+  portraitModeEnabled,
+  isPortrait,
+}: {
+  theme: ThemePreference;
+  portraitModeEnabled: boolean;
+  isPortrait: boolean;
+}) => {
+  const store = createStore();
+  store.set(themePreferenceAtom, theme);
+  store.set(portraitModeEnabledAtom, portraitModeEnabled);
+  mockLayout.isPortrait = isPortrait;
+  return store;
+};
+
+const advanceOneInterval = () => {
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_BOTTOM_TRANSITION_INTERVAL);
+  });
+};
+
+describe('useUpdateBottomState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    mockLayout.isPortrait = false;
+  });
+
+  it('通常のテーマでは一定間隔でのりかえ案内へ進む', () => {
+    const store = buildStore({
+      theme: THEME_PREFERENCE.TOKYO_METRO,
+      portraitModeEnabled: false,
+      isPortrait: false,
+    });
+    renderWithStore(store);
+
+    advanceOneInterval();
+
+    expect(store.get(bottomStateAtom)).toBe('TRANSFER');
+  });
+
+  it('横画面の電光掲示板風テーマは下部の領域を持たないので切り替えない', () => {
+    const store = buildStore({
+      theme: THEME_PREFERENCE.LED,
+      portraitModeEnabled: false,
+      isPortrait: false,
+    });
+    renderWithStore(store);
+
+    advanceOneInterval();
+
+    expect(store.get(bottomStateAtom)).toBe('LINE');
+  });
+
+  it('ポートレートレイアウト中は電光掲示板風テーマでも切り替える', () => {
+    // ポートレートは路線テーマに依存しない独自の画面なので、
+    // 電光掲示板風テーマを選んでいてものりかえ案内は出す
+    const store = buildStore({
+      theme: THEME_PREFERENCE.LED,
+      portraitModeEnabled: true,
+      isPortrait: true,
+    });
+    renderWithStore(store);
+
+    advanceOneInterval();
+
+    expect(store.get(bottomStateAtom)).toBe('TRANSFER');
+  });
+
+  it('ポートレートモードが有効でも端末が横向きなら従来どおり切り替えない', () => {
+    const store = buildStore({
+      theme: THEME_PREFERENCE.LED,
+      portraitModeEnabled: true,
+      isPortrait: false,
+    });
+    renderWithStore(store);
+
+    advanceOneInterval();
+
+    expect(store.get(bottomStateAtom)).toBe('LINE');
+  });
+});

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -1,9 +1,11 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect } from 'react';
+import { portraitModeEnabledAtom } from '../store/atoms/experimental';
 import navigationState, { bottomStateAtom } from '../store/atoms/navigation';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import tuningState from '../store/atoms/tuning';
 import { useInterval } from './useInterval';
+import { useLandscapeWindowDimensions } from './useLandscapeWindowDimensions';
 import { useShouldHideTypeChange } from './useShouldHideTypeChange';
 import { useTransferLines } from './useTransferLines';
 import { useTypeWillChange } from './useTypeWillChange';
@@ -15,11 +17,18 @@ export const useUpdateBottomState = () => {
   const { bottomTransitionInterval } = useAtomValue(tuningState);
   const bottomStateRef = useValueRef(bottomState);
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const portraitModeEnabled = useAtomValue(portraitModeEnabledAtom);
+  const { isPortrait } = useLandscapeWindowDimensions();
+  // ポートレートレイアウトは路線テーマに依存しない独自の画面なので、電光掲示板風
+  // テーマを選んでいても下部の表示は切り替える。横画面の電光掲示板風テーマは
+  // 下部の領域自体を持たないため、そちらは従来どおり止めたままにする。
+  const isPortraitLayout = portraitModeEnabled && isPortrait;
 
   const isTypeWillChange = useTypeWillChange();
   const isTypeWillChangeRef = useValueRef(isTypeWillChange);
   const transferLines = useTransferLines();
   const isLEDThemeRef = useValueRef(isLEDTheme);
+  const isPortraitLayoutRef = useValueRef(isPortraitLayout);
   const shouldHideTypeChange = useShouldHideTypeChange();
   const shouldHideTypeChangeRef = useValueRef(shouldHideTypeChange);
 
@@ -31,7 +40,7 @@ export const useUpdateBottomState = () => {
 
   const { pause } = useInterval(
     useCallback(() => {
-      if (isLEDThemeRef.current) {
+      if (isLEDThemeRef.current && !isPortraitLayoutRef.current) {
         return;
       }
 
@@ -75,6 +84,7 @@ export const useUpdateBottomState = () => {
       bottomStateRef,
       isTypeWillChangeRef,
       isLEDThemeRef,
+      isPortraitLayoutRef,
       shouldHideTypeChangeRef,
       setNavigation,
       transferLines.length,

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -793,7 +793,10 @@ const MainScreen: React.FC = () => {
     return (
       <>
         <MainScreenEffects />
-        <PortraitMain />
+        <PortraitMain
+          onPress={updateBottomState}
+          onTransferPress={handleTransferPress}
+        />
         {isDevApp && devOverlayEnabled && <DevOverlay />}
       </>
     );


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ポートレートモードの走行画面に、横画面と同じのりかえ案内を追加します。停車駅リストの領域が一定間隔で「のりかえ」と入れ替わり、画面タップでも進みます。のりかえの行をタップすると、横画面と同じ運転路線の切り替え確認が出ます。

これまでポートレートは `bottomState` を見ておらず、のりかえ案内が存在しませんでした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `PortraitMain` にのりかえ案内 (`PortraitTransfers`) を追加。`bottomState` が `TRANSFER` の間だけ停車駅リストの**上に重ねて**出す。リストを外さないので、のりかえから戻ったときもスクロール位置と列車ピンの位置が保たれる
- オーバーレイの下端には `insets.bottom` に加えて `LIST_FADE_HEIGHT` 分の余白を取る。ぼかし (`listFade`) がオーバーレイより後に描かれるため、乗換路線が多いときに最終行が潜らないようにする
- 見出しは現在駅カードの頭 (`cardHeadRow`) と同じ組み方にして画面内の調子を揃える。ポートレートは路線テーマに依存しないため、テーマ別の `TransfersHeading` は使わない
- 画面全体を `Pressable` にし、横画面と同じ `updateBottomState` で表示を進める。のりかえの行タップは `handleTransferPress` にそのまま渡すので、確認ダイアログも `changeOperatingLine` も既存コードが動く（ポートレート側に同等の処理は書いていない）
- **`useUpdateBottomState` の不整合を修正**: 電光掲示板風テーマを選んでいると早期 return するため、ポートレートでも自動切り替えが一切起きない一方、画面タップ側 (`updateBottomState`) にはそのガードが無く、タップだけ効く状態だった。ポートレートは路線テーマに依存しない独自の画面なので、ポートレートレイアウト中はガードを外す。**横画面の挙動は変えていない**
- 乗換案内の対象駅の算出を `useTransferTargetStation` へ抽出し、`useTransferLines` と `PortraitMain` で共有。案内する路線と見出しの駅名がずれないようにするため
- 乗換路線ごとの駅ナンバリング抽出を `useTransferStationNumbers` へ抽出し、`Transfers.tsx` と共有。フォールバック経路の `lineSymbolShape` も `'NOOP'` で埋めて、経路によって戻り値の型が揺れないようにする
- 乗換先の駅名は、案内中の駅と別の駅のときだけ添える（新線新宿など）。幅の狭い縦画面で全行に同じ駅名を並べても情報が増えないため

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 249 suites / 2685 tests が通過。追加したテストは以下です。

- `src/components/PortraitMain.test.tsx` に 5 件: リストへ重ねて表示する / 乗換路線ゼロなら出さない / 駅名を添える条件 / 画面タップ / 行タップで路線と駅を渡し表示は進めない
- `src/hooks/useUpdateBottomState.test.tsx` を新規追加 4 件: 通常テーマの切り替え、横画面の電光掲示板風テーマは止めたまま、ポートレートレイアウト中は切り替える、ポートレートモード有効でも横向きなら止めたまま
- `src/hooks/useTransferTargetStation.test.tsx` を新規追加 4 件: 停車中は現在駅、到着扱いでも通過駅なら次駅、未到着は表示用の次駅、現在駅が取れないときは次駅へ倒す

実機・シミュレータでの動作確認は未実施です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

実装した React Native のコードを動かして撮ったものではなく、レビュー用に用意したデザインの HTML/CSS を Chrome でレンダリングしたものです。寸法・配色は実装と同じ値（`colorScheme.ts` のトークン、`PortraitMain.tsx` の定数、`accentColorFor()` の算出結果）を使っていますが、実機の見え方とは差異が残っている可能性があります。題材は中央線快速・新宿停車中で、路線色と路線マークは `src/__fixtures__/station.ts` と `assets/marks/` の実データです。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-transfers-eaa692425488/27cc0d87e73a-shot-transfer-light.png" width="320" alt="のりかえ表示・ライト" />

のりかえ表示・ライト

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-transfers-eaa692425488/d7493ce4d7a4-shot-transfer-dark.png" width="320" alt="のりかえ表示・ダーク" />

のりかえ表示・ダーク

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-transfers-eaa692425488/274b2abc67fb-shot-dialog-light.png" width="320" alt="のりかえ行タップ時の路線変更確認" />

のりかえ行タップ時の路線変更確認

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 縦画面で、停車駅一覧に乗換路線を重ねて表示できるようになりました。
  * 路線名、駅名、駅ナンバリングを表示し、乗換項目をタップして対象駅を選択できます。
  * 通常の画面タップと乗換項目タップに対応しました。
* **改善**
  * 乗換対象駅と駅ナンバリングを適切に表示できるようになりました。
  * 乗換一覧が画面下部の安全領域に重ならないよう改善しました。
  * 縦画面の電光掲示板テーマでも、乗換案内へ自動的に切り替わるようになりました。
* **テスト**
  * 乗換案内の表示条件、表示内容、操作結果を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->