### PR TITLE
ポートレートのタップ領域をScrollViewの内側へ移して駅一覧のスクロールを戻す

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -746,8 +746,10 @@ describe('PortraitMain', () => {
         transferStation: shinjuku,
       });
 
+      // 行の直接の親はタップ領域の Pressable。ScrollView の
+      // contentContainerStyle に置いても行間には入らない。
       const style = StyleSheet.flatten(
-        getByTestId('portrait-transfer-list').props.contentContainerStyle
+        getByTestId('portrait-transfer-list-tap').props.style
       );
       expect(style.rowGap).toBeGreaterThan(0);
     });

--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -683,13 +683,37 @@ describe('PortraitMain', () => {
       expect(getAllByText('新宿駅')).toHaveLength(1);
     });
 
-    it('画面タップで下部の表示を進める', () => {
+    it('上部の路線情報・カードのタップで下部の表示を進める', () => {
       const onPress = jest.fn();
       const { getByTestId } = renderWithStations([shinjuku], { onPress });
 
-      fireEvent.press(getByTestId('portrait-root'));
+      fireEvent.press(getByTestId('portrait-header-tap'));
 
       expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('停車駅リストのタップでも下部の表示を進める', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderWithStations([shinjuku], { onPress });
+
+      fireEvent.press(getByTestId('portrait-stop-list-tap'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('のりかえ一覧の余白タップは駅なしで渡す(横画面と同じく表示が進む)', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote]);
+      const onTransferPress = jest.fn();
+      const { getByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+        onTransferPress,
+      });
+
+      fireEvent.press(getByTestId('portrait-transfer-list-tap'));
+
+      expect(onTransferPress).toHaveBeenCalledTimes(1);
+      expect(onTransferPress).toHaveBeenCalledWith(undefined);
     });
 
     it('のりかえ行タップでは路線と駅を渡し、表示は進めない', () => {
@@ -712,6 +736,76 @@ describe('PortraitMain', () => {
         line: yamanote,
       });
       expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('路線と路線の間に余白を取る', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote, keioNew]);
+
+      const { getByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+      });
+
+      const style = StyleSheet.flatten(
+        getByTestId('portrait-transfer-list').props.contentContainerStyle
+      );
+      expect(style.rowGap).toBeGreaterThan(0);
+    });
+
+    it('のりかえ一覧をスクロールした指では表示を進めない', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote]);
+      const onTransferPress = jest.fn();
+
+      const { getByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+        onTransferPress,
+      });
+
+      fireEvent(getByTestId('portrait-transfer-list'), 'scrollBeginDrag');
+      fireEvent.press(getByTestId('portrait-transfer-list-tap'));
+
+      expect(onTransferPress).not.toHaveBeenCalled();
+    });
+
+    it('のりかえ一覧をスクロールした指では路線変更へ渡さない', () => {
+      mockedUseTransferLines.mockReturnValue([yamanote]);
+      const onTransferPress = jest.fn();
+
+      const { getByTestId } = renderWithStations([shinjuku], {
+        bottomState: 'TRANSFER',
+        transferStation: shinjuku,
+        onTransferPress,
+      });
+
+      fireEvent(getByTestId('portrait-transfer-list'), 'scrollBeginDrag');
+      fireEvent.press(getByTestId('portrait-transfer-row-11302'));
+
+      expect(onTransferPress).not.toHaveBeenCalled();
+    });
+
+    it('停車駅リストをスクロールした指でも表示を進めない', () => {
+      const onPress = jest.fn();
+
+      const { getByTestId } = renderWithStations([shinjuku], { onPress });
+
+      fireEvent(getByTestId('portrait-stop-list'), 'scrollBeginDrag');
+      fireEvent.press(getByTestId('portrait-stop-list-tap'));
+
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('指を置き直せばスクロール後でもタップは効く', () => {
+      const onPress = jest.fn();
+
+      const { getByTestId } = renderWithStations([shinjuku], { onPress });
+
+      fireEvent(getByTestId('portrait-stop-list'), 'scrollBeginDrag');
+      // 指を離して置き直したところからは、また普通のタップとして扱う
+      fireEvent(getByTestId('portrait-root'), 'touchStart');
+      fireEvent.press(getByTestId('portrait-stop-list-tap'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -536,6 +536,10 @@ const styles = StyleSheet.create({
   transferListContent: {
     paddingTop: 10,
     paddingBottom: STOP_LIST_PADDING_V,
+  },
+  // rowGap は直接の子の間にしか入らない。行の親はタップ領域の Pressable なので、
+  // ここに置かないと路線と路線の間が空かない。
+  transferRows: {
     rowGap: TRANSFER_ROW_GAP,
   },
   transferRow: {
@@ -1095,6 +1099,7 @@ const PortraitTransfers = ({
         {/* 停車駅リストと同じ理由で、タップ領域は ScrollView の中に置く */}
         <Pressable
           testID="portrait-transfer-list-tap"
+          style={styles.transferRows}
           onPress={() => onPress?.()}
         >
           {lines.map((line, index) => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -9,7 +9,15 @@ import {
   setLightness,
 } from 'polished';
 import type React from 'react';
-import { memo, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   type LayoutChangeEvent,
   type NativeSyntheticEvent,
@@ -215,6 +223,10 @@ const STOP_LIST_PADDING_V = 12;
 
 // のりかえ一覧の行。路線マーク(35)と2〜3行のテキストが収まる高さ
 const TRANSFER_ROW_MIN_HEIGHT = isTablet ? 66 : 46;
+
+// 路線と路線の間隔。間隔が無いと路線名と次の路線名が地続きに見えて、
+// どこまでが1つの路線の情報なのか読み取れないため、行間で区切りを作る
+const TRANSFER_ROW_GAP = isTablet ? 16 : 12;
 
 // のりかえ一覧に添える駅ナンバリングの枠。アイコン自体は実寸で組まれているので
 // この枠に合わせて縮小する
@@ -524,6 +536,7 @@ const styles = StyleSheet.create({
   transferListContent: {
     paddingTop: 10,
     paddingBottom: STOP_LIST_PADDING_V,
+    rowGap: TRANSFER_ROW_GAP,
   },
   transferRow: {
     flexDirection: 'row',
@@ -1016,6 +1029,7 @@ const PortraitTransfers = ({
   accentColor,
   bottomInset,
   onPress,
+  onScrollBeginDrag,
 }: {
   lines: Line[];
   transferStation: Station | null;
@@ -1023,6 +1037,7 @@ const PortraitTransfers = ({
   accentColor: string;
   bottomInset: number;
   onPress?: (station?: Station) => void;
+  onScrollBeginDrag?: () => void;
 }) => {
   const getLineMarkFunc = useGetLineMark();
   const stationNumbers = useTransferStationNumbers(lines);
@@ -1038,7 +1053,11 @@ const PortraitTransfers = ({
   return (
     <View style={styles.transferPane}>
       {/* 見出しは現在駅カードの頭と同じ組み方にして、画面内の調子を揃える */}
-      <View style={styles.cardHeadRow}>
+      <Pressable
+        testID="portrait-transfer-heading-tap"
+        style={styles.cardHeadRow}
+        onPress={() => onPress?.()}
+      >
         <Typography
           numberOfLines={1}
           style={[styles.stateText, { color: accentColor }]}
@@ -1057,7 +1076,7 @@ const PortraitTransfers = ({
             {stationLabel(transferStation)}
           </Typography>
         ) : null}
-      </View>
+      </Pressable>
 
       <ScrollView
         testID="portrait-transfer-list"
@@ -1071,117 +1090,133 @@ const PortraitTransfers = ({
           },
         ]}
         showsVerticalScrollIndicator={false}
+        onScrollBeginDrag={onScrollBeginDrag}
       >
-        {lines.map((line, index) => {
-          const lineMark = getLineMarkFunc({
-            line,
-            stationNumbers: line.station?.stationNumbers,
-          });
-          const numbering = stationNumbers[index];
+        {/* 停車駅リストと同じ理由で、タップ領域は ScrollView の中に置く */}
+        <Pressable
+          testID="portrait-transfer-list-tap"
+          onPress={() => onPress?.()}
+        >
+          {lines.map((line, index) => {
+            const lineMark = getLineMarkFunc({
+              line,
+              stationNumbers: line.station?.stationNumbers,
+            });
+            const numbering = stationNumbers[index];
 
-          // 乗換先が案内中の駅と別の駅のときだけ駅名を添える(新線新宿など)。
-          // 幅の狭い縦画面で同じ駅名を全行に並べても情報が増えないため。
-          const showStationName =
-            !!line.station && line.station.groupId !== transferStation?.groupId;
+            // 乗換先が案内中の駅と別の駅のときだけ駅名を添える(新線新宿など)。
+            // 幅の狭い縦画面で同じ駅名を全行に並べても情報が増えないため。
+            const showStationName =
+              !!line.station &&
+              line.station.groupId !== transferStation?.groupId;
 
-          const cjkLineName = [
-            isZhEnabled ? line.nameChinese : null,
-            isKoEnabled ? line.nameKorean : null,
-          ]
-            .filter((t): t is string => !!t?.length)
-            .map((t) => t.replace(parenthesisRegexp, ''))
-            .join(' / ');
+            const cjkLineName = [
+              isZhEnabled ? line.nameChinese : null,
+              isKoEnabled ? line.nameKorean : null,
+            ]
+              .filter((t): t is string => !!t?.length)
+              .map((t) => t.replace(parenthesisRegexp, ''))
+              .join(' / ');
 
-          return (
-            <TouchableOpacity
-              key={line.id}
-              activeOpacity={1}
-              testID={`portrait-transfer-row-${line.id}`}
-              style={styles.transferRow}
-              onPress={() => {
-                if (!line.station) {
-                  return;
-                }
-                onPress?.({
-                  ...line.station,
-                  __typename: 'Station',
-                  line,
-                  lines,
-                } as Station);
-              }}
-            >
-              {lineMark ? (
-                <TransferLineMark
-                  line={line}
-                  mark={lineMark}
-                  size={NUMBERING_ICON_SIZE.MEDIUM}
-                />
-              ) : (
-                <TransferLineDot line={line} />
-              )}
+            return (
+              <TouchableOpacity
+                key={line.id}
+                activeOpacity={1}
+                testID={`portrait-transfer-row-${line.id}`}
+                style={styles.transferRow}
+                onPress={() => {
+                  if (!line.station) {
+                    return;
+                  }
+                  onPress?.({
+                    ...line.station,
+                    __typename: 'Station',
+                    line,
+                    lines,
+                  } as Station);
+                }}
+              >
+                {lineMark ? (
+                  <TransferLineMark
+                    line={line}
+                    mark={lineMark}
+                    size={NUMBERING_ICON_SIZE.MEDIUM}
+                  />
+                ) : (
+                  <TransferLineDot line={line} />
+                )}
 
-              <View style={styles.transferBody}>
-                <View style={styles.transferNameRow}>
-                  {isJaEnabled && line.nameShort ? (
-                    <Typography
-                      numberOfLines={1}
-                      style={[styles.transferLineName, { color: colors.text }]}
-                    >
-                      {line.nameShort.replace(parenthesisRegexp, '')}
-                    </Typography>
-                  ) : null}
-                  {showStationName ? (
-                    <Typography
-                      numberOfLines={1}
-                      style={[styles.transferStationName, { color: passColor }]}
-                    >
-                      {stationLabel(line.station)}
-                    </Typography>
-                  ) : null}
-                </View>
-                {isEnEnabled && line.nameRoman ? (
-                  <Typography
-                    numberOfLines={1}
-                    style={[
-                      isJaEnabled
-                        ? styles.transferSubName
-                        : styles.transferLineName,
-                      {
-                        color: isJaEnabled ? colors.secondaryText : colors.text,
-                      },
-                    ]}
-                  >
-                    {line.nameRoman.replace(parenthesisRegexp, '')}
-                  </Typography>
-                ) : null}
-                {cjkLineName ? (
-                  <Typography
-                    numberOfLines={1}
-                    style={[
-                      styles.transferSubName,
-                      { color: colors.secondaryText },
-                    ]}
-                  >
-                    {cjkLineName}
-                  </Typography>
-                ) : null}
-              </View>
-
-              {numbering?.stationNumber ? (
-                <View style={styles.transferNumberingBox}>
-                  <View style={styles.transferNumbering}>
-                    <NumberingIcon
-                      shape={numbering.lineSymbolShape ?? 'NOOP'}
-                      lineColor={numbering.lineSymbolColor ?? '#000000'}
-                      stationNumber={numbering.stationNumber}
-                      allowScaling={false}
-                    />
+                <View style={styles.transferBody}>
+                  <View style={styles.transferNameRow}>
+                    {isJaEnabled && line.nameShort ? (
+                      <Typography
+                        numberOfLines={1}
+                        style={[
+                          styles.transferLineName,
+                          { color: colors.text },
+                        ]}
+                      >
+                        {line.nameShort.replace(parenthesisRegexp, '')}
+                      </Typography>
+                    ) : null}
+                    {showStationName ? (
+                      <Typography
+                        numberOfLines={1}
+                        style={[
+                          styles.transferStationName,
+                          { color: passColor },
+                        ]}
+                      >
+                        {stationLabel(line.station)}
+                      </Typography>
+                    ) : null}
                   </View>
+                  {isEnEnabled && line.nameRoman ? (
+                    <Typography
+                      numberOfLines={1}
+                      style={[
+                        isJaEnabled
+                          ? styles.transferSubName
+                          : styles.transferLineName,
+                        {
+                          color: isJaEnabled
+                            ? colors.secondaryText
+                            : colors.text,
+                        },
+                      ]}
+                    >
+                      {line.nameRoman.replace(parenthesisRegexp, '')}
+                    </Typography>
+                  ) : null}
+                  {cjkLineName ? (
+                    <Typography
+                      numberOfLines={1}
+                      style={[
+                        styles.transferSubName,
+                        { color: colors.secondaryText },
+                      ]}
+                    >
+                      {cjkLineName}
+                    </Typography>
+                  ) : null}
                 </View>
-              ) : null}
-            </TouchableOpacity>
-          );
-        })}
+
+                {numbering?.stationNumber ? (
+                  <View style={styles.transferNumberingBox}>
+                    <View style={styles.transferNumbering}>
+                      <NumberingIcon
+                        shape={numbering.lineSymbolShape ?? 'NOOP'}
+                        lineColor={numbering.lineSymbolColor ?? '#000000'}
+                        stationNumber={numbering.stationNumber}
+                        allowScaling={false}
+                      />
+                    </View>
+                  </View>
+                ) : null}
+              </TouchableOpacity>
+            );
+          })}
+        </Pressable>
       </ScrollView>
     </View>
   );
@@ -1361,6 +1396,34 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
     transform: [{ translateY: transferShift.value }],
   }));
 
+  // スクロールで指を離したときの press をタップと誤認しないようにする。
+  // 1回のジェスチャの間にスクロールが始まったかどうかだけを覚えておき、
+  // 指を置いた時点で倒す。ScrollView がドラッグを始めたら立てる。
+  // (TouchableOpacity 側の取り消しはリスト内の行にしか効かず、画面全体の
+  //  Pressable には届かないため、ここで明示的に区別する)
+  const draggedRef = useRef(false);
+  const handleTouchStart = useCallback(() => {
+    draggedRef.current = false;
+  }, []);
+  const handleScrollBeginDrag = useCallback(() => {
+    draggedRef.current = true;
+  }, []);
+  const handlePress = useCallback(() => {
+    if (draggedRef.current) {
+      return;
+    }
+    onPress?.();
+  }, [onPress]);
+  const handleTransferPress = useCallback(
+    (station?: Station) => {
+      if (draggedRef.current) {
+        return;
+      }
+      onTransferPress?.(station);
+    },
+    [onTransferPress]
+  );
+
   // rowYs は各行の上端 y を記録する(onLayout は行のレイアウト時にしか発火しないので、
   // currentIndex 変更でコールバックが別行に移っても再取得できない。全行を記録して
   // index で引く)。
@@ -1401,9 +1464,9 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
     // ステータスバーは非表示のため SafeAreaView は使わず素の View を使う。
     // 上端は Dynamic Island / ノッチと路線情報が被らないよう、
     // セーフエリア上端ぶんの padding を確保する。
-    <Pressable
+    <View
       testID="portrait-root"
-      onPress={onPress}
+      onTouchStart={handleTouchStart}
       style={[
         styles.root,
         { backgroundColor: colors.background, paddingTop: insets.top },
@@ -1414,108 +1477,117 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
         opacity={colors.isDark ? WASH_OPACITY_DARK : WASH_OPACITY_LIGHT}
       />
 
-      {/* 路線・種別・行き先 */}
-      <View style={styles.metaRow}>
-        <View style={[styles.lineColorBar, { backgroundColor: accentColor }]} />
-        <Typography
-          numberOfLines={1}
-          style={[styles.lineName, { color: colors.text }]}
-        >
-          {lineName}
-        </Typography>
-        {trainTypeName ? (
+      {/* 上部はスクロールしない領域なので、そのままタップ領域にしてよい */}
+      <Pressable testID="portrait-header-tap" onPress={handlePress}>
+        {/* 路線・種別・行き先 */}
+        <View style={styles.metaRow}>
           <View
-            style={[styles.trainTypeBadge, { backgroundColor: trainTypeColor }]}
-          >
-            <Typography
-              style={[styles.trainTypeText, { color: trainTypeTextColor }]}
-            >
-              {trainTypeName}
-            </Typography>
-          </View>
-        ) : null}
-        <View style={styles.metaSpacer} />
-        <Typography
-          numberOfLines={1}
-          style={[styles.boundText, { color: colors.secondaryText }]}
-        >
-          {boundText}
-        </Typography>
-      </View>
-
-      {/* 現在駅カード */}
-      <View
-        testID="portrait-station-card"
-        style={[
-          styles.card,
-          { backgroundColor: colors.card, borderColor: colors.border },
-        ]}
-      >
-        <View style={styles.cardHeadRow}>
+            style={[styles.lineColorBar, { backgroundColor: accentColor }]}
+          />
           <Typography
             numberOfLines={1}
-            style={[styles.stateText, { color: accentColor }]}
+            style={[styles.lineName, { color: colors.text }]}
           >
-            {displayStateText}
+            {lineName}
           </Typography>
-          <View
-            style={[styles.cardHeadRule, { backgroundColor: colors.border }]}
-          />
-          {cardMetaText ? (
-            // 起点と次駅の駅名が両方入るため、長い駅名同士だと1行に収まらない
-            // ことがある。末尾を削ると肝心の次駅が消えるので先頭側を省略する。
-            <Typography
-              numberOfLines={1}
-              ellipsizeMode="head"
-              testID="portrait-card-meta"
-              style={[styles.cardHeadMeta, { color: passTextColor(colors) }]}
+          {trainTypeName ? (
+            <View
+              style={[
+                styles.trainTypeBadge,
+                { backgroundColor: trainTypeColor },
+              ]}
             >
-              {cardMetaText}
-            </Typography>
-          ) : null}
-        </View>
-
-        <View style={styles.stationNameRow}>
-          {currentStationNumber ? (
-            <View style={styles.numberingColumn} testID="numbering-column">
-              <NumberingIcon
-                shape={currentStationNumber.lineSymbolShape || ''}
-                lineColor={accentColorFor(numberingColor, colors.isDark)}
-                stationNumber={currentStationNumber.stationNumber || ''}
-                threeLetterCode={commonData.threeLetterCode}
-              />
+              <Typography
+                style={[styles.trainTypeText, { color: trainTypeTextColor }]}
+              >
+                {trainTypeName}
+              </Typography>
             </View>
           ) : null}
-          <StationName
-            text={stationText}
-            color={colors.text}
-            withNumbering={!!currentStationNumber}
-          />
+          <View style={styles.metaSpacer} />
+          <Typography
+            numberOfLines={1}
+            style={[styles.boundText, { color: colors.secondaryText }]}
+          >
+            {boundText}
+          </Typography>
         </View>
 
-        {/* 駅間の進み具合。到着すると満ちる */}
+        {/* 現在駅カード */}
         <View
-          testID="portrait-progress-track"
-          style={[styles.progressTrack, { backgroundColor: colors.border }]}
+          testID="portrait-station-card"
+          style={[
+            styles.card,
+            { backgroundColor: colors.card, borderColor: colors.border },
+          ]}
         >
+          <View style={styles.cardHeadRow}>
+            <Typography
+              numberOfLines={1}
+              style={[styles.stateText, { color: accentColor }]}
+            >
+              {displayStateText}
+            </Typography>
+            <View
+              style={[styles.cardHeadRule, { backgroundColor: colors.border }]}
+            />
+            {cardMetaText ? (
+              // 起点と次駅の駅名が両方入るため、長い駅名同士だと1行に収まらない
+              // ことがある。末尾を削ると肝心の次駅が消えるので先頭側を省略する。
+              <Typography
+                numberOfLines={1}
+                ellipsizeMode="head"
+                testID="portrait-card-meta"
+                style={[styles.cardHeadMeta, { color: passTextColor(colors) }]}
+              >
+                {cardMetaText}
+              </Typography>
+            ) : null}
+          </View>
+
+          <View style={styles.stationNameRow}>
+            {currentStationNumber ? (
+              <View style={styles.numberingColumn} testID="numbering-column">
+                <NumberingIcon
+                  shape={currentStationNumber.lineSymbolShape || ''}
+                  lineColor={accentColorFor(numberingColor, colors.isDark)}
+                  stationNumber={currentStationNumber.stationNumber || ''}
+                  threeLetterCode={commonData.threeLetterCode}
+                />
+              </View>
+            ) : null}
+            <StationName
+              text={stationText}
+              color={colors.text}
+              withNumbering={!!currentStationNumber}
+            />
+          </View>
+
+          {/* 駅間の進み具合。到着すると満ちる */}
           <View
-            testID="portrait-progress-fill"
-            style={[
-              styles.progressFill,
-              {
-                width: `${progress * 100}%`,
-                backgroundColor: accentColor,
-              },
-            ]}
-          />
+            testID="portrait-progress-track"
+            style={[styles.progressTrack, { backgroundColor: colors.border }]}
+          >
+            <View
+              testID="portrait-progress-fill"
+              style={[
+                styles.progressFill,
+                {
+                  width: `${progress * 100}%`,
+                  backgroundColor: accentColor,
+                },
+              ]}
+            />
+          </View>
         </View>
-      </View>
+      </Pressable>
 
       {/* 停車駅リスト */}
       <View style={styles.stopList}>
         <ScrollView
           ref={scrollRef}
           testID="portrait-stop-list"
+          onScrollBeginDrag={handleScrollBeginDrag}
           contentContainerStyle={[
             styles.stopListContent,
             // スクロール末尾でも最終駅がホームインジケータに被って
@@ -1523,31 +1595,36 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
             { paddingBottom: STOP_LIST_PADDING_V + insets.bottom },
           ]}
         >
-          {stops.map((station, index) => {
-            // 列車位置のピンより前の行(過ぎた線路)を淡色にする。停車中・
-            // 走行中とも、ピンの行とそれ以降は通常色のまま。
-            const departed = index < markerRowIndex;
-            return (
-              <StopRow
-                key={station.id}
-                station={station}
-                colors={colors}
-                isFirst={index === 0}
-                isLast={index === stops.length - 1}
-                isFocused={index === currentStopIndex}
-                departed={departed}
-                marker={index === markerRowIndex ? markerPosition : null}
-                markerMoving={markerMoving}
-                fallbackLineColor={lineColor}
-                elevated={index === markerRowIndex}
-                onLayoutTop={(y) =>
-                  setRowYs((prev) =>
-                    prev[index] === y ? prev : { ...prev, [index]: y }
-                  )
-                }
-              />
-            );
-          })}
+          {/* タップ領域は ScrollView の中に置く。こうするとスクロールが
+              始まった時点で RN 側が press を取り消すので、スクロールと
+              タップが競合しない。 */}
+          <Pressable testID="portrait-stop-list-tap" onPress={handlePress}>
+            {stops.map((station, index) => {
+              // 列車位置のピンより前の行(過ぎた線路)を淡色にする。停車中・
+              // 走行中とも、ピンの行とそれ以降は通常色のまま。
+              const departed = index < markerRowIndex;
+              return (
+                <StopRow
+                  key={station.id}
+                  station={station}
+                  colors={colors}
+                  isFirst={index === 0}
+                  isLast={index === stops.length - 1}
+                  isFocused={index === currentStopIndex}
+                  departed={departed}
+                  marker={index === markerRowIndex ? markerPosition : null}
+                  markerMoving={markerMoving}
+                  fallbackLineColor={lineColor}
+                  elevated={index === markerRowIndex}
+                  onLayoutTop={(y) =>
+                    setRowYs((prev) =>
+                      prev[index] === y ? prev : { ...prev, [index]: y }
+                    )
+                  }
+                />
+              );
+            })}
+          </Pressable>
         </ScrollView>
         {showTransfer ? (
           <Animated.View
@@ -1564,7 +1641,8 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
               colors={colors}
               accentColor={accentColor}
               bottomInset={insets.bottom}
-              onPress={onTransferPress}
+              onPress={handleTransferPress}
+              onScrollBeginDrag={handleScrollBeginDrag}
             />
           </Animated.View>
         ) : null}
@@ -1576,7 +1654,7 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
           style={styles.listFade}
         />
       </View>
-    </Pressable>
+    </View>
   );
 };
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6794 で入れたポートレートのりかえ案内の不具合を 2 件直します。

1. **駅一覧がスクロールできなくなっていた**（#6794 のリグレッション。canary #6795 にも入っています）
2. のりかえ一覧で路線と路線の間に余白が無く、どこまでが 1 つの路線の情報か読み取れない

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

### 駅一覧のスクロールが効かない問題

原因は #6794 で画面全体を `Pressable` で包んだことです。React Native では JS レスポンダを取った時点でネイティブ `UIScrollView` のパンジェスチャが止まるため、`ScrollView` を `Touchable` / `Pressable` の子孫にするとスクロールできなくなります。

タップ領域を `ScrollView` の外から内へ移して直しました。

- ルートは素の `View` へ戻す（`onTouchStart` はレスポンダを取らないのでルートに残せる）
- 上部の路線情報・現在駅カードはスクロールしない領域なので、そのまま `Pressable` で包む
- 停車駅リストとのりかえ一覧は、`ScrollView` の**中**に `Pressable` を置いて行を包む。この形なら、スクロールが始まった時点で RN 側が press を取り消すため、スクロールとタップが競合しない

あわせて、1 回のジェスチャ中に `onScrollBeginDrag` が来たかどうかを覚えておく判定も入れています（指を置いた時点でリセット）。スクロールしてから指を離した押下をタップと取り違えないためです。

なお、のりかえ一覧の余白タップは横画面と同じく駅なしで `handleTransferPress` へ渡します（`Main` 側で `updateBottomState` に倒れます）。

### 路線間の余白

のりかえ一覧の行に `rowGap`（スマホ 12 / タブレット 16）を入れました。言語設定に依らず、常に路線と路線の間が空きます。

`rowGap` は直接の子同士にしか効かないため、上のタップ領域の変更で行の親が `Pressable` になったぶん、`rowGap` はその `Pressable` に置いています。`ScrollView` の `contentContainerStyle` に置くと直接の子が `Pressable` 1 つだけになり、行間には入りません。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 249 suites / 2692 tests が通過。`src/components/PortraitMain.test.tsx` に 6 件追加しました。

- 路線と路線の間に余白を取る（行の直接の親のスタイルを検証）
- 上部の路線情報・カードのタップで表示を進める
- 停車駅リストのタップでも表示を進める
- のりかえ一覧の余白タップは駅なしで渡す
- のりかえ一覧・停車駅リストをスクロールした指では表示を進めない / 路線変更へ渡さない
- 指を置き直せばスクロール後でもタップは効く

実機・シミュレータでの動作確認は未実施です。スクロールの回復は実機で確認していただく必要があります。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

実装した React Native のコードを動かして撮ったものではなく、レビュー用に組んだ HTML/CSS を Chrome でレンダリングしたものです。寸法・配色は実装と同じ値を使い、路線名・ローマ字・中国語 / 韓国語・駅ナンバリングは実機のスクリーンショットから起こしています。スクロールの回復はこの静止画では示せません。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-transfer-scroll-and-spacing-db5038f4c732/cc4b35dd944e-shot-gap-before.png" width="320" alt="余白なし(修正前)" />

余白なし（修正前）。路線名と次の路線の行が地続きに見える

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-transfer-scroll-and-spacing-db5038f4c732/5d0dd32d4932-shot-gap-after.png" width="320" alt="余白あり(修正後)" />

余白あり（修正後）。`rowGap` 12 で路線ごとの区切りがつく

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ヘッダー、停車駅リスト、乗換案内をそれぞれ独立してタップできるようになりました。
  * 乗換案内の見出しや各行をタップして操作できます。
  * 乗換案内の余白部分をタップした際の動作を整理しました。
  * スクロール開始後の誤タップを防止し、指を置き直すとタップ操作を再開できます。
  * 乗換行間のスペースを調整し、一覧を見やすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->