### PR TITLE
ポートレートモードの停車駅リストに各駅の到着予測を残り分で追加

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -302,6 +302,8 @@
   "portraitNextStop": "Next %{station}",
   "portraitNextStopFrom": "After %{current}: %{station}",
   "portraitPassThrough": "Passing %{station}",
+  "portraitEtaUnit": "min.",
+  "portraitEtaSoon": "Soon",
   "telemetryDescription": "Your device's geographic coordinates are sent to our analytics server. The information is used only for analytics.",
   "batterySettings": "Battery",
   "powerSavingLocationTitle": "Power-saving location mode",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -303,6 +303,8 @@
   "portraitNextStop": "つぎは%{station}",
   "portraitNextStopFrom": "%{current}のつぎは%{station}",
   "portraitPassThrough": "%{station}を通過中",
+  "portraitEtaUnit": "分",
+  "portraitEtaSoon": "まもなく",
   "telemetryDescription": "お使いの端末の地理的座標を解析用サーバに送信します。送信された情報は解析以外に使用されません。",
   "batterySettings": "バッテリー",
   "powerSavingLocationTitle": "省電力測位モード",

--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -681,6 +681,40 @@ describe('PortraitMain', () => {
       expect(queryByTestId('stop-eta-2')).toBeNull();
     });
 
+    it('停車中の駅と発車済みの駅には列を出さない', () => {
+      // これらの駅は相対値が0以下になり変換側で落ちるため、列を出すと
+      // 「--」だけが並ぶ。品川を発車済みなので品川・新橋には出さない。
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(
+        new Map([
+          [3, 4],
+          [4, 11],
+        ])
+      );
+
+      const { queryByTestId } = renderWithStations(etaStations(), {
+        arrived: false,
+      });
+
+      expect(queryByTestId('stop-eta-1')).toBeNull();
+      expect(queryByTestId('stop-eta-3')).toBeTruthy();
+    });
+
+    it('ETAの値がすべて null のときは列ごと出さない', () => {
+      // stops は揃っていても cumulativeMinutes が全部 null の応答がある。
+      // 件数だけで判定すると「--」だけの列が出てしまう。
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(
+        new Map<number, number | null>([
+          [3, null],
+          [4, null],
+        ])
+      );
+
+      const { queryByTestId } = renderWithStations(etaStations());
+
+      expect(queryByTestId('stop-eta-3')).toBeNull();
+      expect(queryByTestId('stop-eta-4')).toBeNull();
+    });
+
     it('ETAが1駅も取れないときは列ごと出さない', () => {
       // 全行に「--」が並び続けるより、右端を今までどおり空けておく
       mockedUseEstimatedMinutesByStationId.mockReturnValue(

--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -8,6 +8,7 @@ import {
   useCurrentLine,
   useCurrentStation,
   useCurrentTrainType,
+  useEstimatedMinutesByStationId,
   useHeaderCommonData,
   useTransferLines,
   useTransferLinesFromStation,
@@ -46,6 +47,12 @@ jest.mock('~/hooks', () => ({
   useCurrentLine: jest.fn(),
   useCurrentStation: jest.fn(),
   useCurrentTrainType: jest.fn(),
+  useEstimateArrivalTimesAllStops: jest.fn(() => ({
+    route: null,
+    loading: false,
+    error: null,
+  })),
+  useEstimatedMinutesByStationId: jest.fn(() => new Map<number, number>()),
   useGetLineMark: jest.fn(() => () => null),
   useHeaderCommonData: jest.fn(),
   useStationNumberIndexFunc: jest.fn(() => () => 0),
@@ -63,6 +70,8 @@ const mockedUseTransferLinesFromStation =
   useTransferLinesFromStation as jest.Mock;
 const mockedUseTransferLines = useTransferLines as jest.Mock;
 const mockedUseTransferTargetStation = useTransferTargetStation as jest.Mock;
+const mockedUseEstimatedMinutesByStationId =
+  useEstimatedMinutesByStationId as jest.Mock;
 
 const yamanoteLine = {
   id: 11302,
@@ -154,6 +163,9 @@ describe('PortraitMain', () => {
     mockedUseTransferLinesFromStation.mockReturnValue([]);
     mockedUseTransferLines.mockReturnValue([]);
     mockedUseTransferTargetStation.mockReturnValue(undefined);
+    mockedUseEstimatedMinutesByStationId.mockReturnValue(
+      new Map<number, number>()
+    );
   });
 
   afterEach(() => {
@@ -599,6 +611,113 @@ describe('PortraitMain', () => {
     );
 
     expect(queryByTestId('portrait-card-meta')).toBeNull();
+  });
+
+  describe('各駅のETA', () => {
+    // 品川(現在駅) → 新橋(通過) → 田町 → 浜松町
+    const etaStations = () => [
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+      buildStation(2, '新橋', StopCondition.Not, 'JY-26'),
+      buildStation(3, '田町', StopCondition.All, 'JY-27'),
+      buildStation(4, '浜松町', StopCondition.All, 'JY-28'),
+    ];
+
+    it('ETAのある停車駅に残り分と単位を出す', () => {
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(
+        new Map([
+          [3, 4],
+          [4, 11],
+        ])
+      );
+
+      const { getByTestId } = renderWithStations(etaStations());
+
+      expect(within(getByTestId('stop-eta-3')).getByText('4')).toBeTruthy();
+      expect(within(getByTestId('stop-eta-4')).getByText('11')).toBeTruthy();
+      // 単位は全行に添える
+      expect(
+        within(getByTestId('stop-eta-3')).getByText('portraitEtaUnit')
+      ).toBeTruthy();
+      expect(
+        within(getByTestId('stop-eta-4')).getByText('portraitEtaUnit')
+      ).toBeTruthy();
+    });
+
+    it('小数のETAは分に丸めて出す', () => {
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(new Map([[3, 4.6]]));
+
+      const { getByTestId } = renderWithStations(etaStations());
+
+      expect(within(getByTestId('stop-eta-3')).getByText('5')).toBeTruthy();
+    });
+
+    it('丸めて0分になる駅は数字ではなく「まもなく」を出す', () => {
+      // 0分と出すと「もう着いた」と読めてしまうため
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(new Map([[3, 0.4]]));
+
+      const { getByTestId } = renderWithStations(etaStations());
+
+      expect(
+        within(getByTestId('stop-eta-3')).getByText('portraitEtaSoon')
+      ).toBeTruthy();
+      expect(
+        within(getByTestId('stop-eta-3')).queryByText('portraitEtaUnit')
+      ).toBeNull();
+    });
+
+    it('ETAが取れている路線では、値の無い停車駅にもプレースホルダを出して桁位置を揃える', () => {
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(new Map([[3, 4]]));
+
+      const { getByTestId } = renderWithStations(etaStations());
+
+      expect(within(getByTestId('stop-eta-4')).getByText('--')).toBeTruthy();
+    });
+
+    it('通過駅にはETAを出さない', () => {
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(new Map([[3, 4]]));
+
+      const { queryByTestId } = renderWithStations(etaStations());
+
+      expect(queryByTestId('stop-eta-2')).toBeNull();
+    });
+
+    it('ETAが1駅も取れないときは列ごと出さない', () => {
+      // 全行に「--」が並び続けるより、右端を今までどおり空けておく
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(
+        new Map<number, number>()
+      );
+
+      const { queryByTestId } = renderWithStations(etaStations());
+
+      expect(queryByTestId('stop-eta-3')).toBeNull();
+      expect(queryByTestId('stop-eta-4')).toBeNull();
+    });
+
+    it('次の停車駅のETAだけ路線色で一回り大きく出す', () => {
+      mockedUseEstimatedMinutesByStationId.mockReturnValue(
+        new Map([
+          [3, 4],
+          [4, 11],
+        ])
+      );
+
+      // 品川を発車済みなので、次の停車駅は通過駅の新橋を挟んだ田町になる
+      const { getByTestId } = renderWithStations(etaStations(), {
+        arrived: false,
+      });
+
+      const focused = StyleSheet.flatten(
+        within(getByTestId('stop-eta-3')).getByText('4').props.style
+      );
+      expect(focused.fontSize).toBe(RFValue(15));
+      expect(focused.color).toBe('#80C241');
+
+      const rest = StyleSheet.flatten(
+        within(getByTestId('stop-eta-4')).getByText('11').props.style
+      );
+      expect(rest.fontSize).toBe(RFValue(13));
+      expect(rest.color).toBe(LIGHT_APP_COLORS.secondaryText);
+    });
   });
 
   describe('のりかえ案内', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -54,6 +54,8 @@ import {
   useCurrentLine,
   useCurrentStation,
   useCurrentTrainType,
+  useEstimateArrivalTimesAllStops,
+  useEstimatedMinutesByStationId,
   useGetLineMark,
   useHeaderCommonData,
   useStationNumberIndexFunc,
@@ -238,6 +240,16 @@ const TRANSFER_FADE_SHIFT = 10;
 
 // リスト下端のフェード。最終行がホームインジケータへ溶けるようにする
 const LIST_FADE_HEIGHT = 72;
+
+// 各駅の到着予測を出す列の幅。3桁+単位が収まる固定幅を確保し、値の桁数で
+// 右端が動かないようにして数字を縦に読める列にする。
+const ETA_COLUMN_WIDTH = isTablet ? 46 * 1.5 : 46;
+
+// 1分未満に丸まった駅。0分と出すと「もう着いた」と読めてしまうので語で出す
+const ETA_SOON_THRESHOLD_MIN = 1;
+
+// ETAが取れていない駅のプレースホルダ。値のある駅と桁位置を揃えて置く
+const ETA_PLACEHOLDER = '--';
 
 // 現在地まわりに敷く路線色のにじみ。ダークでは発光、ライトでは淡い染みに見える
 const WASH_WIDTH = 430;
@@ -520,6 +532,35 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     letterSpacing: 0.6,
   },
+  // 到着予測。数字と単位のベースラインを揃えたうえで右寄せの固定幅に置く
+  etaColumn: {
+    minWidth: ETA_COLUMN_WIDTH,
+    marginLeft: 10,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'flex-end',
+  },
+  etaValue: {
+    fontSize: RFValue(13),
+    fontWeight: 'bold',
+  },
+  etaValueFocused: {
+    fontSize: RFValue(15),
+  },
+  etaUnit: {
+    marginLeft: 2,
+    fontSize: RFValue(8),
+    fontWeight: 'bold',
+  },
+  etaUnitFocused: {
+    fontSize: RFValue(9),
+  },
+  // 「まもなく」は数字より字数が多いので一段小さくして列の幅に収める
+  etaSoon: {
+    fontSize: RFValue(10),
+    fontWeight: 'bold',
+    letterSpacing: 0.4,
+  },
   // のりかえ案内。停車駅リストと同じ領域に重ねて出す
   transferOverlay: {
     position: 'absolute',
@@ -740,6 +781,59 @@ const TrackSegment = ({
   </View>
 );
 
+// 各駅の到着予測。横画面の LineBoard と同じく「現在駅を0分とした残り分」を出す。
+// 単位を全行に添えるのは、LineBoard が最後のドットにだけ「分」を置くのは数字を
+// ドットの中へ入れる都合で場所が無いからで、縦の列には置く場所があるため。
+// スクロールで単位だけ画面外に出ることもない。
+const EtaValue = ({
+  minutes,
+  isFocused,
+  color,
+  placeholderColor,
+}: {
+  minutes?: number | null;
+  isFocused: boolean;
+  color: string;
+  placeholderColor: string;
+}) => {
+  if (minutes == null) {
+    return (
+      <Typography style={[styles.etaValue, { color: placeholderColor }]}>
+        {ETA_PLACEHOLDER}
+      </Typography>
+    );
+  }
+
+  // 0分と出すと「もう着いた」と読めてしまうので、丸めて0になる駅は語で出す
+  const rounded = Math.round(minutes);
+  if (rounded < ETA_SOON_THRESHOLD_MIN) {
+    return (
+      <Typography style={[styles.etaSoon, { color }]}>
+        {translate('portraitEtaSoon')}
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      <Typography
+        style={[
+          styles.etaValue,
+          isFocused && styles.etaValueFocused,
+          { color },
+        ]}
+      >
+        {rounded}
+      </Typography>
+      <Typography
+        style={[styles.etaUnit, isFocused && styles.etaUnitFocused, { color }]}
+      >
+        {translate('portraitEtaUnit')}
+      </Typography>
+    </>
+  );
+};
+
 const StopRow = ({
   station,
   colors,
@@ -752,6 +846,8 @@ const StopRow = ({
   fallbackLineColor,
   elevated,
   onLayoutTop,
+  showEta,
+  estimatedMinutes,
 }: {
   station: Station;
   colors: AppColors;
@@ -764,6 +860,9 @@ const StopRow = ({
   fallbackLineColor: string;
   elevated?: boolean;
   onLayoutTop?: (y: number) => void;
+  /** ETAが1駅でも取れているか。取れていない路線では列ごと出さない */
+  showEta: boolean;
+  estimatedMinutes?: number | null;
 }) => {
   const isPass = getIsPass(station);
   // 直通運転で路線が変わったら縦棒も直通先のラインカラーで塗る
@@ -885,6 +984,18 @@ const StopRow = ({
           <Typography style={[styles.stopNumber, { color: numberColor }]}>
             {stationNumber}
           </Typography>
+        ) : null}
+        {/* 通過駅は停車しないので出さない。値の無い停車駅でも列は残して、
+            取得が届いたときに行の右端が動かないようにする。 */}
+        {showEta && !isPass ? (
+          <View style={styles.etaColumn} testID={`stop-eta-${station.id}`}>
+            <EtaValue
+              minutes={estimatedMinutes}
+              isFocused={isFocused}
+              color={isFocused ? accentColor : colors.secondaryText}
+              placeholderColor={passColor}
+            />
+          </View>
         ) : null}
       </View>
     </View>
@@ -1253,6 +1364,13 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
   const transferStation = useTransferTargetStation() ?? null;
   // 行先は言語切り替えタイマーで多言語化せず日本語固定で表示する
   const boundText = useBoundText().JA;
+  // 全駅を出すので leftStations で絞られない方のフックを使う
+  const { route: estimatedRoute } = useEstimateArrivalTimesAllStops();
+  const estimatedMinutesByStationId =
+    useEstimatedMinutesByStationId(estimatedRoute);
+  // ETAが1駅も取れない路線(未取得・エラー・データなし)では列ごと出さない。
+  // 全行に「--」が並び続けるより、右端を今までどおり空けておく方が素直。
+  const showEta = estimatedMinutesByStationId.size > 0;
 
   const lineColor = currentLine?.color ?? FALLBACK_ACCENT;
   const accentColor = useMemo(
@@ -1621,6 +1739,12 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
                   markerMoving={markerMoving}
                   fallbackLineColor={lineColor}
                   elevated={index === markerRowIndex}
+                  showEta={showEta}
+                  estimatedMinutes={
+                    station.id != null
+                      ? estimatedMinutesByStationId.get(station.id)
+                      : null
+                  }
                   onLayoutTop={(y) =>
                     setRowYs((prev) =>
                       prev[index] === y ? prev : { ...prev, [index]: y }

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1370,7 +1370,13 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
     useEstimatedMinutesByStationId(estimatedRoute);
   // ETAが1駅も取れない路線(未取得・エラー・データなし)では列ごと出さない。
   // 全行に「--」が並び続けるより、右端を今までどおり空けておく方が素直。
-  const showEta = estimatedMinutesByStationId.size > 0;
+  // 件数ではなく実値の有無で見る。stops は揃っていても cumulativeMinutes が
+  // すべて null の応答があり、件数だけでは「--」だけの列を出してしまう。
+  const hasEta = useMemo(
+    () =>
+      Array.from(estimatedMinutesByStationId.values()).some((m) => m != null),
+    [estimatedMinutesByStationId]
+  );
 
   const lineColor = currentLine?.color ?? FALLBACK_ACCENT;
   const accentColor = useMemo(
@@ -1739,7 +1745,10 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
                   markerMoving={markerMoving}
                   fallbackLineColor={lineColor}
                   elevated={index === markerRowIndex}
-                  showEta={showEta}
+                  // 現在駅とそれより手前の駅は ETA を持たない(相対値が0以下に
+                  // なるので変換側で落ちる)。列を出すと「--」だけが並ぶので、
+                  // 現在駅より先の駅に限って出す。
+                  showEta={hasEta && index > currentIndex}
                   estimatedMinutes={
                     station.id != null
                       ? estimatedMinutesByStationId.get(station.id)

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,6 +23,7 @@ export { useDisplayNextStation } from './useDisplayNextStation';
 export { useDistanceToNextStation } from './useDistanceToNextStation';
 export { useEnsureSelectLineInHistory } from './useEnsureSelectLineInHistory';
 export { useEstimateArrivalTimes } from './useEstimateArrivalTimes';
+export { useEstimateArrivalTimesAllStops } from './useEstimateArrivalTimesAllStops';
 export { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
 export { useEstimatedMinutesByStationId } from './useEstimatedMinutesByStationId';
 export { useEtaAnchor } from './useEtaAnchor';

--- a/src/hooks/useEstimateArrivalTimes.ts
+++ b/src/hooks/useEstimateArrivalTimes.ts
@@ -1,5 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
+import { toRelativeEtaStops } from '~/utils/relativeEtaStops';
 import { leftStationsAtom } from '../store/atoms/navigation';
 import { useDisplayCurrentStation } from './useDisplayCurrentStation';
 import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
@@ -9,6 +10,9 @@ import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
  * ここでは表示都合の整形だけを行う薄いラッパー。
  * 返す route.stops は LineBoard に表示中の駅（leftStations）に限定し、
  * 現在駅の到着時刻を基準（0分）とした相対時間に変換する。
+ *
+ * 全駅ぶんの ETA が要る画面(ポートレート)は leftStations で絞られると大半の駅が
+ * 欠けるため、絞り込みを持たない useEstimateArrivalTimesAllStops を使う。
  */
 export const useEstimateArrivalTimes = (options?: { skip?: boolean }) => {
   const leftStations = useAtomValue(leftStationsAtom);
@@ -25,39 +29,14 @@ export const useEstimateArrivalTimes = (options?: { skip?: boolean }) => {
       return null;
     }
 
-    const allStops = route.stops ?? [];
-
-    // 大江戸線の都庁前のように、環状区間(6の字運転)では同じ駅が全stops中に
-    // 複数回出現する。ただしこれらは stationGroupId(同一駅を束ねる論理グループ)
-    // こそ共通だが、stationId は出現ごとに別々に採番されている(例: 都庁前の
-    // 外回り/内回りはそれぞれ別の stationId を持つ)。そのため stationGroupId
-    // で突き合わせると無関係な出現まで拾ってしまうが、stationId なら出現ごとに
-    // 一意なので誤って混同することがない。
-    const baseMinutes =
-      allStops.find((s) => s.stationId === currentStation?.id)
-        ?.departureCumulativeMinutes ?? 0;
-
     const visibleStationIds = new Set(leftStations.map((ls) => ls.id));
 
-    // 現在駅自身は cumulativeMinutes - baseMinutes が0以下になり通常は下のfilterで
-    // 除外されるが、区間内に現在駅のエントリが見つからずbaseMinutesが0に
-    // フォールバックするケースでは生の値が残ってしまう。停車中の駅にはETAを出さない
-    // という表示上の不変条件を計算結果に依存せず保証するため、ここで明示的に除く。
-    const relativeStops = allStops
-      .filter(
-        (s) =>
-          s.stationId != null &&
-          visibleStationIds.has(s.stationId) &&
-          s.stationId !== currentStation?.id
-      )
-      .map((s) => ({
-        ...s,
-        cumulativeMinutes:
-          s.cumulativeMinutes == null
-            ? null
-            : s.cumulativeMinutes - baseMinutes,
-      }))
-      .filter((s) => s.cumulativeMinutes == null || s.cumulativeMinutes > 0);
+    // 相対値への変換は全 stops を見てから行う。先に leftStations で絞ると、
+    // 表示区間の外に出た現在駅を見失って基準が 0 にフォールバックしてしまう。
+    const relativeStops = toRelativeEtaStops(
+      route.stops ?? [],
+      currentStation?.id
+    ).filter((s) => s.stationId != null && visibleStationIds.has(s.stationId));
 
     return { ...route, stops: relativeStops };
   }, [route, leftStations, currentStation?.id]);

--- a/src/hooks/useEstimateArrivalTimesAllStops.test.tsx
+++ b/src/hooks/useEstimateArrivalTimesAllStops.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react-native';
+import { useDisplayCurrentStation } from './useDisplayCurrentStation';
+import { useEstimateArrivalTimesAllStops } from './useEstimateArrivalTimesAllStops';
+import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
+
+jest.mock('./useDisplayCurrentStation', () => ({
+  useDisplayCurrentStation: jest.fn(),
+}));
+jest.mock('./useEstimateArrivalTimesRoute', () => ({
+  useEstimateArrivalTimesRoute: jest.fn(),
+}));
+
+const mockedUseDisplayCurrentStation = useDisplayCurrentStation as jest.Mock;
+const mockedUseEstimateArrivalTimesRoute =
+  useEstimateArrivalTimesRoute as jest.Mock;
+
+const setRoute = (route: unknown) => {
+  mockedUseEstimateArrivalTimesRoute.mockReturnValue({
+    route,
+    loading: false,
+    error: null,
+  });
+};
+
+describe('useEstimateArrivalTimesAllStops', () => {
+  beforeEach(() => {
+    mockedUseDisplayCurrentStation.mockReturnValue({ id: 2 });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ルートが無いときは null を返す', () => {
+    setRoute(null);
+
+    const { result } = renderHook(() => useEstimateArrivalTimesAllStops());
+
+    expect(result.current.route).toBeNull();
+  });
+
+  it('leftStations で絞らず、全 stops を相対時間にして返す', () => {
+    // 横画面 LineBoard に出ていない駅も落とさないことがこのフックの存在理由
+    setRoute({
+      id: 1,
+      stops: [
+        { stationId: 1, cumulativeMinutes: 0, departureCumulativeMinutes: 1 },
+        { stationId: 2, cumulativeMinutes: 5, departureCumulativeMinutes: 6 },
+        { stationId: 3, cumulativeMinutes: 12, departureCumulativeMinutes: 13 },
+        { stationId: 4, cumulativeMinutes: 20, departureCumulativeMinutes: 21 },
+        { stationId: 5, cumulativeMinutes: 31, departureCumulativeMinutes: 32 },
+      ],
+    });
+
+    const { result } = renderHook(() => useEstimateArrivalTimesAllStops());
+
+    expect(
+      result.current.route?.stops.map((s) => [s.stationId, s.cumulativeMinutes])
+    ).toEqual([
+      [3, 6],
+      [4, 14],
+      [5, 25],
+    ]);
+  });
+
+  it('ルートの他のフィールドはそのまま持ち越す', () => {
+    setRoute({ id: 42, stops: [] });
+
+    const { result } = renderHook(() => useEstimateArrivalTimesAllStops());
+
+    expect(result.current.route?.id).toBe(42);
+  });
+
+  it('skip オプションをルート取得へそのまま渡す', () => {
+    setRoute(null);
+
+    renderHook(() => useEstimateArrivalTimesAllStops({ skip: true }));
+
+    expect(mockedUseEstimateArrivalTimesRoute).toHaveBeenCalledWith({
+      skip: true,
+    });
+  });
+});

--- a/src/hooks/useEstimateArrivalTimesAllStops.ts
+++ b/src/hooks/useEstimateArrivalTimesAllStops.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { toRelativeEtaStops } from '~/utils/relativeEtaStops';
+import { useDisplayCurrentStation } from './useDisplayCurrentStation';
+import { useEstimateArrivalTimesRoute } from './useEstimateArrivalTimesRoute';
+
+/**
+ * useEstimateArrivalTimes と同じ相対時間への変換を、leftStations による絞り込み
+ * 抜きで行う。ポートレートは路線の全駅を出すため、横画面 LineBoard の表示都合で
+ * 絞られた stops では画面に出ている駅の大半で ETA が欠ける。
+ *
+ * 絞り込みを useEstimateArrivalTimes 側から外して共用すると LineBoard の表示条件が
+ * 変わってしまうので、共通する変換だけを toRelativeEtaStops に切り出したうえで
+ * フックは分けている。
+ */
+export const useEstimateArrivalTimesAllStops = (options?: {
+  skip?: boolean;
+}) => {
+  // 基準駅は useEstimateArrivalTimes と揃える。GPS の取りこぼしを前方補正した
+  // ときに基準がずれて、発車済みの駅に ETA が残るのを防ぐ。
+  const currentStation = useDisplayCurrentStation();
+
+  const { route, loading, error } = useEstimateArrivalTimesRoute(options);
+
+  const matchedRoute = useMemo(() => {
+    if (!route) {
+      return null;
+    }
+
+    return {
+      ...route,
+      stops: toRelativeEtaStops(route.stops ?? [], currentStation?.id),
+    };
+  }, [route, currentStation?.id]);
+
+  return { route: matchedRoute, loading, error };
+};

--- a/src/utils/relativeEtaStops.test.ts
+++ b/src/utils/relativeEtaStops.test.ts
@@ -50,6 +50,30 @@ describe('toRelativeEtaStops', () => {
     ]);
   });
 
+  it('現在駅が未確定のときは id 無しの stop を基準に取らない', () => {
+    // currentStationId が undefined だと stationId 未設定の stop と
+    // undefined 同士で一致してしまい、無関係な出発時刻が基準に入る。
+    const stops = [
+      {
+        stationId: undefined,
+        cumulativeMinutes: 4,
+        departureCumulativeMinutes: 30,
+      },
+      stop(2, 5),
+      stop(3, 12),
+    ];
+
+    expect(
+      toRelativeEtaStops(stops, undefined).map((s) => [
+        s.stationId,
+        s.cumulativeMinutes,
+      ])
+    ).toEqual([
+      [2, 5],
+      [3, 12],
+    ]);
+  });
+
   it('stationId が無い stop は除外する', () => {
     const stops = [stop(null, 5), stop(3, 12)];
 

--- a/src/utils/relativeEtaStops.test.ts
+++ b/src/utils/relativeEtaStops.test.ts
@@ -1,0 +1,80 @@
+import { toRelativeEtaStops } from './relativeEtaStops';
+
+const stop = (
+  stationId: number | null,
+  cumulativeMinutes: number | null,
+  departureCumulativeMinutes: number | null = cumulativeMinutes
+) => ({ stationId, cumulativeMinutes, departureCumulativeMinutes });
+
+describe('toRelativeEtaStops', () => {
+  it('現在駅の出発時刻を基準(0分)とした相対値に変換する', () => {
+    const stops = [stop(1, 0), stop(2, 5, 6), stop(3, 12), stop(4, 20)];
+
+    expect(toRelativeEtaStops(stops, 2)).toEqual([
+      expect.objectContaining({ stationId: 3, cumulativeMinutes: 6 }),
+      expect.objectContaining({ stationId: 4, cumulativeMinutes: 14 }),
+    ]);
+  });
+
+  it('現在駅自身とそれより前の駅を除外する', () => {
+    const stops = [stop(1, 0), stop(2, 5), stop(3, 12)];
+
+    expect(toRelativeEtaStops(stops, 2).map((s) => s.stationId)).toEqual([3]);
+  });
+
+  it('現在駅の出発時刻が欠けて基準が0に落ちても、現在駅自身にはETAを付けない', () => {
+    // 基準が 0 にフォールバックすると現在駅の相対値は生の値のまま正になり、
+    // 相対値のフィルタだけでは残ってしまう。station id で明示的に除いて
+    // 「停車中の駅には ETA を出さない」不変条件を計算結果に依存せず保つ。
+    const stops = [stop(1, 0), stop(2, 5, null), stop(3, 12)];
+
+    expect(
+      toRelativeEtaStops(stops, 2).map((s) => [
+        s.stationId,
+        s.cumulativeMinutes,
+      ])
+    ).toEqual([[3, 12]]);
+  });
+
+  it('区間内に現在駅が見つからないときは基準を0として扱う', () => {
+    const stops = [stop(1, 0), stop(2, 5), stop(3, 12)];
+
+    expect(
+      toRelativeEtaStops(stops, 99).map((s) => [
+        s.stationId,
+        s.cumulativeMinutes,
+      ])
+    ).toEqual([
+      [2, 5],
+      [3, 12],
+    ]);
+  });
+
+  it('stationId が無い stop は除外する', () => {
+    const stops = [stop(null, 5), stop(3, 12)];
+
+    expect(toRelativeEtaStops(stops, 1).map((s) => s.stationId)).toEqual([3]);
+  });
+
+  it('cumulativeMinutes が null の stop は相対値を持たないまま残す', () => {
+    const stops = [stop(2, 5), stop(3, null, 12)];
+
+    expect(toRelativeEtaStops(stops, 2)).toEqual([
+      expect.objectContaining({ stationId: 3, cumulativeMinutes: null }),
+    ]);
+  });
+
+  it('元の stop の他のフィールドを保つ', () => {
+    const stops = [
+      { ...stop(2, 5), stopsHere: true },
+      { ...stop(3, 12), stopsHere: false },
+    ];
+
+    expect(toRelativeEtaStops(stops, 2)[0]).toEqual({
+      stationId: 3,
+      cumulativeMinutes: 7,
+      departureCumulativeMinutes: 12,
+      stopsHere: false,
+    });
+  });
+});

--- a/src/utils/relativeEtaStops.ts
+++ b/src/utils/relativeEtaStops.ts
@@ -28,9 +28,14 @@ export const toRelativeEtaStops = <T extends EtaStopLike>(
   // 別々に採番されている(例: 都営大江戸線 都庁前の外回り/内回りはそれぞれ別の
   // stationId を持つ)。そのため stationGroupId で突き合わせると無関係な出現まで
   // 拾ってしまうが、stationId なら出現ごとに一意なので誤って混同することがない。
+  // 現在駅が分からないときは探しに行かない。id 無しの stop は stationId が
+  // undefined になりうるので、undefined 同士で一致してしまい、無関係な stop の
+  // 出発時刻を基準に据えてしまう。
   const baseMinutes =
-    stops.find((s) => s.stationId === currentStationId)
-      ?.departureCumulativeMinutes ?? 0;
+    currentStationId == null
+      ? 0
+      : (stops.find((s) => s.stationId === currentStationId)
+          ?.departureCumulativeMinutes ?? 0);
 
   return stops
     .filter((s) => s.stationId != null && s.stationId !== currentStationId)

--- a/src/utils/relativeEtaStops.ts
+++ b/src/utils/relativeEtaStops.ts
@@ -1,0 +1,43 @@
+/** estimateArrivalTimes の stop のうち、相対時間への変換に必要な部分だけ。 */
+export type EtaStopLike = {
+  stationId?: number | null;
+  cumulativeMinutes?: number | null;
+  departureCumulativeMinutes?: number | null;
+};
+
+/**
+ * 絶対累積分を持つ stops を、現在駅の出発時刻を基準(0分)とした相対時間に変換する。
+ *
+ * 表示側で絞り込む前の全 stops を渡す。基準となる現在駅の出発時刻は絞り込みの
+ * 有無に依らず全 stops から引く必要があるため、絞り込みは呼び出し側でこの関数の
+ * 後に行う(先に絞ると区間外に出た現在駅を見失って基準が 0 にフォールバックする)。
+ *
+ * 除外する stop は2種類:
+ * - 現在駅自身。相対値は通常 0 以下になり下の条件で落ちるが、区間内に現在駅の
+ *   エントリが見つからず基準が 0 にフォールバックしたときは生の値が残ってしまう。
+ *   「停車中の駅には ETA を出さない」という表示上の不変条件を計算結果に依存せず
+ *   保証するため、station id で明示的に除く。
+ * - 相対値が 0 以下になった stop(= すでに通り過ぎた駅)。
+ */
+export const toRelativeEtaStops = <T extends EtaStopLike>(
+  stops: readonly T[],
+  currentStationId: number | null | undefined
+): (T & { cumulativeMinutes: number | null })[] => {
+  // 環状区間(6の字運転)では同じ駅が全stops中に複数回出現する。ただしこれらは
+  // stationGroupId(同一駅を束ねる論理グループ)こそ共通だが、stationId は出現ごとに
+  // 別々に採番されている(例: 都営大江戸線 都庁前の外回り/内回りはそれぞれ別の
+  // stationId を持つ)。そのため stationGroupId で突き合わせると無関係な出現まで
+  // 拾ってしまうが、stationId なら出現ごとに一意なので誤って混同することがない。
+  const baseMinutes =
+    stops.find((s) => s.stationId === currentStationId)
+      ?.departureCumulativeMinutes ?? 0;
+
+  return stops
+    .filter((s) => s.stationId != null && s.stationId !== currentStationId)
+    .map((s) => ({
+      ...s,
+      cumulativeMinutes:
+        s.cumulativeMinutes == null ? null : s.cumulativeMinutes - baseMinutes,
+    }))
+    .filter((s) => s.cumulativeMinutes == null || s.cumulativeMinutes > 0);
+};


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ポートレートモードの停車駅リストで、各駅に到着予測（ETA）を残り分で表示します。横画面の LineBoard が既にドット内へ残り分数を出しているので、アプリ内の ETA の語彙を相対分に揃えました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/relativeEtaStops.ts`（新規）: 現在駅の出発時刻を 0 分とした相対分への変換を純関数に切り出し
- `src/hooks/useEstimateArrivalTimes.ts`: 上記の共通関数を使う形に整理。`leftStations` での絞り込みは残し、相対分の計算を絞り込みより前に行う順序も変えていない
- `src/hooks/useEstimateArrivalTimesAllStops.ts`（新規）: `leftStations` で絞らない全駅版。ポートレートは路線の全駅を出すため、既存フックのままでは画面に出ている駅の大半で ETA が欠ける
- `src/components/PortraitMain.tsx`: 停車駅リストの行右端に ETA 列を追加
- `assets/translations/{ja,en}.json`: `portraitEtaUnit` / `portraitEtaSoon` を追加

表示ルール:

- 現在駅より先の停車駅にだけ出す。通過駅・停車中の駅・発車済みの駅には列ごと出さない（これらは相対値が 0 以下になって変換側で落ちるため、列を出すと `--` だけが並ぶ）
- 丸めて 0 分になる駅は数字ではなく「まもなく」（0 分と出すと「もう着いた」と読めるため）
- 次の停車駅だけ路線色で一回り大きく出し、列の起点だと分かるようにする
- 実値がまったく無い応答（`cumulativeMinutes` が全部 `null`、未取得、エラー）では列ごと出さない。1 駅でも実値があれば、値の無い停車駅には `--` を置いて行の右端が駅ごとに動かないようにする
- 単位は全行に添える。横画面の LineBoard が最後のドットにだけ「分」を置くのは数字をドット内へ入れる都合で場所が無いためで、縦の列には場所があり、スクロールで単位だけ画面外へ出ることもない

判断メモ: ETA の表示自体は `isEtaAssistEnabled()` で塞いでいません。あのフラグが切り替えるのは GPS 補助（`useEtaFallback`）の可否であって表示ではなく、横画面 LineBoard も無関係に ETA を出しているためです。

回帰リスクと緩和:

- 既存の `useEstimateArrivalTimes` に手を入れているため、横画面 LineBoard 8 テーマと `HeaderLowPower` に影響が及びうる。変換ロジックを純関数へ移しただけで入出力は変えておらず、既存テスト（`useEstimateArrivalTimes.test.tsx` の 19 ケース）はそのまま通っている。切り出した純関数にも 8 ケースを追加した
- 切り出しにあたり、`currentStationId` が未確定のときに `stationId` 未設定の stop と `undefined` 同士で一致して無関係な出発時刻を基準に据えてしまう経路を塞いだ（未確定時は基準を 0 にする）。実データの `stationId` は `null` なので現状は踏まないが、共有する純関数なので閉じてある
- ETA ルートの GraphQL は 1 本増える。ETA アシストが有効な間は `Main.tsx` の `useEtaFallback` が同じ変数で同じクエリを走らせるためキャッシュに相乗りし、追加のフェッチにはならない。無効な間はこの 1 本ぶん増える
- 行の右端が 56px（列 46 ＋ marginLeft 10）狭くなる。`stopName` は `flexShrink` 済みなので、長い駅名は省略で吸収される

## テスト

<!-- どのようにテストしたかを記述してください -->

ローカルで `npm run lint && npm test && npm run typecheck` を実行し、いずれも成功（251 suites / 2713 tests）。ETA 列のレンダリング 9 ケース、`toRelativeEtaStops` 8 ケース、`useEstimateArrivalTimesAllStops` 4 ケースを追加しています。停車中・発車済みの駅に `--` が出ないこと、実値の無い応答で空の列が出ないことの回帰テストを含みます。

実機・シミュレータでの動作確認はまだ行っていません。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-eta-c67c99158c98/c019c0613a5c-portrait-eta-mock.png" width="640" alt="ETA列を足した停車駅リストのライト・ダーク" />

実装前に合意したデザイン案を HTML で組んでレンダリングしたものです。寸法・色は `PortraitMain.tsx` と `colorScheme.ts` の実値から起こしていますが、アプリを動かして撮ったものではありません。中央線快速・新宿を発車して中野へ向かっている場面。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ポートレートモードで、各停車駅までの到着予定時間を表示できるようになりました。
  - 到着予定時間は分単位で表示され、1分未満の場合は「まもなく」と表示します。
  - 到着予定時間を取得できない駅は「--」で表示します。
  - 通過駅では表示せず、到着予定がない場合は時間表示欄を非表示にします。
  - 次に停車する駅を強調表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->