### PR TITLE
既存UIのモックで路線ごとに出し分かる要素を実データで確認する規約を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Command mapping — the skills under `.claude/skills/` follow this table:
   - Commands executed locally (e.g., `npm run lint && npm test && npm run typecheck`).
   - Linked issues or tickets.
   - Visual evidence for UI/UX deltas, each labeled with where the image came from. Any method is acceptable — a device or simulator capture (label it with the device name, e.g., Pixel 8, iPhone 15 Pro), a React Native Web rendering (`npm run web`), or a mockup / generated image. An image that is not a rendering of the implementation must say so in its label, so a reviewer never mistakes an illustration for observed behavior. If no image is attached, state the reason in that section instead of leaving it blank.
+- Mockups and illustrations of existing UI must reproduce whatever the real screen branches on. A mockup is read as the spec, so an inaccurate one manufactures a wrong agreement even when the implementation is correct. Before drawing an element that varies by line, theme, or train type — station numbering shape, palette, train-type badge, pass/stop treatment — trace what decides it and take the value for the case you are depicting, instead of reusing the appearance of whichever component file you happened to read for its dimensions. Station numbering shape comes from the API's `lineSymbolShape`, and `src/__fixtures__/station.ts` lists the symbol-to-shape pairs (JR East `JA` / `JB` / `JC` / `JO` / `JS` / `JY` are `SQUARE`; Tokyo Metro and Toei lines are `ROUND`). If you cannot confirm a value, choose a case that does not include that element.
 - If CI fails, pause reviews until you add root-cause notes plus reproduction steps or open an issue for blocking infrastructure problems.
 - **Keep PR metadata in sync with the bookmark state.** Whenever you push new commits to an open PR, refresh both the PR title and the body:
   - **Title**: re-evaluate whether the current title still describes the full scope of the bookmark. If new commits introduce a subject that the title does not cover, propose an updated title and, once approved by the user, apply it via `gh pr edit --title`.
@@ -178,6 +179,7 @@ Command mapping — the skills under `.claude/skills/` follow this table:
 - [ ] Run `npm run lint`, `npm test`, and `npm run typecheck`; record summaries.
 - [ ] Update documentation (README, docs/, inline comments) if behaviors shift.
 - [ ] Attach visual evidence for UI changes, each labeled with its source (device name, React Native Web, or an explicit 'not a rendering of the implementation' note for mockups); when no image is attached, state why instead of leaving the section blank.
+- [ ] For a mockup or illustration of existing UI, confirm the depicted case's real values for anything that branches by line, theme, or train type (e.g., `lineSymbolShape`) rather than reusing another component's appearance.
 
 **For documentation-only tasks**
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

既存 UI のモックを作るときに、路線ごとに出し分かる要素を実データで確かめることを `AGENTS.md`（= `CLAUDE.md`）へ規約として追記します。

#6800 のレビューで、PR に添付したイメージ図の駅ナンバリングが JR 中央線（`JC`）にもかかわらず丸で描かれていた指摘を受けたことへの再発防止です。実装は `shape={lineSymbolShape}` で API の値に従うので正しく、誤っていたのはモックだけでした。寸法を写すために `NumberingIconRound.tsx` を読み、その見た目をそのまま採用したのが原因です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

`AGENTS.md` に 2 箇所追記しました（`CLAUDE.md` は `AGENTS.md` へのシンボリックリンクなので同時に反映されます）。

- `Commit & Pull Request Protocol`: 既存 UI のモック・イメージ図は、実画面が分岐している要素を再現すること。モックは仕様として読まれるので、実装が正しくても不正確なモックは誤った合意を作る。路線・テーマ・種別で変わる要素（ナンバリング記号の形、配色、種別バッジ、通過/停車の表現）は、何が決めているかを辿って対象ケースの値を取る。ナンバリング形状は API の `lineSymbolShape` 由来で、`src/__fixtures__/station.ts` に記号と形の対応がある旨も添えました
- `Automation Checklists` の `Before submitting code changes`: 同じ内容をチェック項目として 1 行追加

回帰リスク: ドキュメントのみの変更で、アプリの挙動・ビルド・CI には影響しません。既存の節構成は変えず、既存の箇条書きの間に項目を足しただけです。`markdownlint-cli2` の指摘件数は追記した 2 行ぶんの MD013（行長）が増えるだけで、これはファイル全体の既存 75 件と同じ扱いです（新しい種類の指摘は増えていません）。

## テスト

<!-- どのようにテストしたかを記述してください -->

ドキュメントのみの変更のためスキップしました（`src/**` などのコード本体に変更が無く、これらのコマンドを実行する意味がないため）。代わりに `npx markdownlint-cli2 AGENTS.md` を変更前後で比較し、指摘の種類が増えていないことを確認しています。

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6800

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `AGENTS.md` のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * UIモックアップやイラストで、路線・テーマ・列車種別などの実装上の分岐に一致するケースを確認する手順を追加しました。
  * `lineSymbolShape` の確認方法と、値を確認できない場合の対応をチェックリストに明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->