### PR TITLE
Androidの端末内蔵TTSで識別子順ではなく音声メタデータを基に音声を選ぶ

### DIFF
--- a/docs/spec/tts/remote-tts.md
+++ b/docs/spec/tts/remote-tts.md
@@ -61,6 +61,59 @@ Android のダッキングはオーディオフォーカスの要求でしか起
 このモジュールはネイティブコードを含むため、反映にはネイティブビルドが必要で
 OTA アップデートでは配信されない。
 
+## 端末内蔵 TTS の音声選択
+
+端末内蔵 TTS はどの音声で合成するかで音質が大きく変わる。選択は
+`selectBestVoiceIdentifier()`（`src/utils/nativeTtsVoice.ts`）が行い、言語ごとに
+1 つの音声識別子を決めて `expo-speech` へ渡す。
+
+Android は音声の明示指定が必須である。`expo-speech` の Android 実装は `speak` の
+`language` を `Locale` へ渡すが、音声データが端末に無い言語では `setLanguage` が
+`LANG_MISSING_DATA` となり端末既定言語へフォールバックし、英語文が日本語音声で
+合成されてしまう。`voice` を指定すれば `setVoice` が言語設定ごと上書きするため、
+この不備の影響を受けない。そのため Android では高品質音声が無くても既定品質の
+ローカル音声を明示指定する（`allowDefaultQuality`）。iOS はユーザーが OS 設定で
+選んだ既定音声を尊重し、拡張（Enhanced）/ プレミアム（Premium）音声がある場合だけ
+明示指定する。
+
+`expo-speech` が返す `quality` は `Enhanced` / `Default` の 2 値に丸められており、
+Google TTS の日本語ローカル音声のように `QUALITY_NORMAL` へ横並びになる端末では
+優劣を判定できない。判断材料が尽きると識別子のアルファベット順で決まってしまい、
+品質と無関係に `ja-jp-x-htm-local` が常に選ばれ、ユーザーが端末設定で選んだ音声も
+無視される。これを避けるため `patches/expo-speech+57.0.1.patch` で
+`android.speech.tts.Voice` の生の情報を JS へ渡している。
+
+| フィールド | 由来 | 用途 |
+| --- | --- | --- |
+| `qualityScore` | `Voice.getQuality()`（100〜500） | ローカル音声同士の優劣を判定する |
+| `isDefault` | `TextToSpeech.defaultVoice` と一致するか | 端末設定でのユーザーの選択を尊重する |
+| `networkRequired` | `Voice.isNetworkConnectionRequired()` | 識別子の `network` 判定より正確にローカル音声を選ぶ |
+| `notInstalled` | `Voice.getFeatures()` の `notInstalled` | 音声データ未取得で合成できない音声を避ける |
+
+いずれも iOS では返らないため、iOS では従来どおり識別子と `quality` で判定する。
+
+優先順は次のとおりで、上から順に比較して差がついた時点で決まる。
+
+1. インストール済み — 音声データが無い音声は合成できない
+1. ローカル音声 — 乗車中はトンネル等で接続が切れるため、ネットワーク音声は最後の手段
+1. 地域一致 — `en-US` 要求時に `en-GB` より `en-US` を選ぶ
+1. 端末既定音声 — ユーザーの明示的な選択を機械的な優劣より優先する
+1. `qualityScore` 降順 — Android の生の品質値
+1. 識別子ベースの品質判定 — iOS の `premium` > `enhanced` > その他
+1. 識別子の昇順 — 実行ごとに音声が変わらないようにする最後のタイブレーク
+
+最下段まで差がつかない場合にだけ識別子順に落ちる。ここへ到達するのは判断材料が
+出尽くしたときだけなので、品質と無関係な順序で音声が決まる範囲を最小化している。
+
+選択結果は起動時に 1 度だけ `[useNativeSpeechEngine] Selected voices: ...` として
+ログへ残す。端末ごとに音声のラインナップが違い、音質の問い合わせは実機でどの音声が
+選ばれたかが分からないと切り分けられないため。
+
+生メタデータの露出は `expo-speech` へのネイティブ patch なので、反映には
+ネイティブビルドが必要で OTA アップデートでは配信されない。patch が当たっていない
+バイナリでは各フィールドが `undefined` となり、従来どおり識別子順のタイブレークへ
+フォールバックする。
+
 ## テキストの前処理
 
 TTS テンプレートは SSML 断片を生成するが、Cloud TTS（`input.text`）も `expo-speech` も

--- a/patches/expo-speech+57.0.1.patch
+++ b/patches/expo-speech+57.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt b/node_modules/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
-index 9ca869c..81d37ec 100644
+index 9ca869c..077cb21 100644
 --- a/node_modules/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
 +++ b/node_modules/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
 @@ -4,6 +4,7 @@ import android.os.Bundle
@@ -20,7 +20,52 @@ index 9ca869c..81d37ec 100644
  class SpeechModule : Module() {
    private val delayedUtterances: Queue<Utterance> = ArrayDeque()
    private val delayedGetVoices: Queue<Promise> = ArrayDeque()
-@@ -103,24 +107,48 @@ class SpeechModule : Module() {
+@@ -83,6 +87,14 @@ class SpeechModule : Module() {
+       throw SpeechUnableToGetVoicesException(err)
+     }
+ 
++    // TrainLCD patch: 端末設定で選ばれているエンジン既定音声を JS 側へ伝える。
++    // 一部エンジンは defaultVoice の取得で例外を投げるため防御する。
++    val defaultVoiceName = try {
++      textToSpeech.defaultVoice?.name
++    } catch (_: Exception) {
++      null
++    }
++
+     return nativeVoices.map {
+       val quality = if (it.quality > Voice.QUALITY_NORMAL) {
+         VoiceQuality.ENHANCED
+@@ -90,11 +102,28 @@ class SpeechModule : Module() {
+         VoiceQuality.DEFAULT
+       }
+ 
++      // TrainLCD patch: features / isNetworkConnectionRequired はエンジン実装に
++      // よっては例外を投げうるため、取得できない場合は保守的な既定値へ倒す。
++      val networkRequired = try {
++        it.isNetworkConnectionRequired
++      } catch (_: Exception) {
++        false
++      }
++      val notInstalled = try {
++        it.features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) == true
++      } catch (_: Exception) {
++        false
++      }
++
+       VoiceRecord(
+         identifier = it.name,
+         name = it.name,
+         quality = quality,
+-        language = LanguageUtils.getISOCode(it.locale)
++        language = LanguageUtils.getISOCode(it.locale),
++        qualityScore = it.quality,
++        isDefault = defaultVoiceName != null && it.name == defaultVoiceName,
++        networkRequired = networkRequired,
++        notInstalled = notInstalled
+       )
+     }
+   }
+@@ -103,24 +132,48 @@ class SpeechModule : Module() {
      options.pitch?.let(textToSpeech::setPitch)
      options.rate?.let(textToSpeech::setSpeechRate)
  
@@ -48,11 +93,7 @@ index 9ca869c..81d37ec 100644
        }
 -    } ?: Locale.getDefault()
 +    }
- 
--    options.voice?.let { voiceName ->
--      textToSpeech.voices
--        .firstOrNull { it.name == voiceName }
--        ?.let(textToSpeech::setVoice)
++
 +    if (matchedVoice != null) {
 +      textToSpeech.setVoice(matchedVoice)
 +    } else {
@@ -70,7 +111,11 @@ index 9ca869c..81d37ec 100644
 +          availability != TextToSpeech.LANG_MISSING_DATA &&
 +            availability != TextToSpeech.LANG_NOT_SUPPORTED
 +        }
-+
+ 
+-    options.voice?.let { voiceName ->
+-      textToSpeech.voices
+-        .firstOrNull { it.name == voiceName }
+-        ?.let(textToSpeech::setVoice)
 +        when {
 +          isUsable(exactLocale) -> exactLocale
 +          isUsable(languageOnlyLocale) -> languageOnlyLocale
@@ -85,3 +130,28 @@ index 9ca869c..81d37ec 100644
      }
  
      val params = Bundle().apply {
+diff --git a/node_modules/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt b/node_modules/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt
+index 480ce46..e85ad12 100644
+--- a/node_modules/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt
++++ b/node_modules/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt
+@@ -15,5 +15,19 @@ data class VoiceRecord(
+   @Field val identifier: String,
+   @Field val name: String,
+   @Field val quality: VoiceQuality,
+-  @Field val language: String
++  @Field val language: String,
++  // TrainLCD patch: 音声選択の精度を上げるための Android 固有メタデータ。
++  // quality は ENHANCED / DEFAULT の 2 値へ丸められており、ローカル音声同士の
++  // 優劣を判定できない（Google TTS の日本語ローカル音声は軒並み QUALITY_NORMAL
++  // に並ぶ）。android.speech.tts.Voice が持つ生の情報を併せて渡すことで、
++  // JS 側が識別子のアルファベット順という無根拠なタイブレークに頼らずに済む。
++  //
++  // - qualityScore: Voice.getQuality() の生値 (QUALITY_VERY_LOW=100 〜 VERY_HIGH=500)
++  // - isDefault: 端末設定で選ばれているエンジン既定音声か
++  // - networkRequired: 合成にネットワーク接続が必要か（識別子の 'network' 判定より正確）
++  // - notInstalled: 音声データが未ダウンロードで、指定しても合成できない状態か
++  @Field val qualityScore: Int,
++  @Field val isDefault: Boolean,
++  @Field val networkRequired: Boolean,
++  @Field val notInstalled: Boolean
+ ) : Record

--- a/src/hooks/tts/useNativeSpeechEngine.ts
+++ b/src/hooks/tts/useNativeSpeechEngine.ts
@@ -21,6 +21,9 @@ const EN_SPEECH_LANGUAGE = 'en-US';
 
 // expo-speech は volume 未指定時の既定値が機種・OSバージョンにより最大音量
 // より低くなることがあるため、常に最大値を明示指定して音量が下がる余地を無くす。
+// Android の KEY_PARAM_VOLUME は既定値が 1.0 なので指定しても挙動は変わらない
+// （効くのは iOS 側）。音量ではなく音質の問題は音声選択で解く。
+// src/utils/nativeTtsVoice.ts を参照。
 const MAX_SPEECH_VOLUME = 1.0;
 
 // 発話開始前に音声選択（getAvailableVoicesAsync）の完了を待つ上限（ミリ秒）。
@@ -75,6 +78,12 @@ export const useNativeSpeechEngine = (): SpeechEngine => {
         );
         if (Platform.OS === 'android' && voices.length > 0) {
           androidVoicesLoadedRef.current = true;
+          // 端末ごとに音声のラインナップが違い、音質の当たり外れもここで決まる。
+          // 実機で「どの音声が選ばれたか」を追えないと音質の切り分けができない
+          // ため、起動時の選択結果を 1 度だけ残す。
+          console.warn(
+            `[useNativeSpeechEngine] Selected voices: ja=${jaVoiceIdRef.current ?? 'none'} en=${enVoiceIdRef.current ?? 'none'} (from ${voices.length} voices)`
+          );
           if (!jaVoiceIdRef.current) {
             console.warn(
               '[useNativeSpeechEngine] No Japanese voice found on this device; Japanese announcements will be skipped'

--- a/src/utils/nativeTtsVoice.test.ts
+++ b/src/utils/nativeTtsVoice.test.ts
@@ -1,5 +1,9 @@
 import { type Voice, VoiceQuality } from 'expo-speech';
-import { scoreVoiceQuality, selectBestVoiceIdentifier } from './nativeTtsVoice';
+import {
+  type NativeVoice,
+  scoreVoiceQuality,
+  selectBestVoiceIdentifier,
+} from './nativeTtsVoice';
 
 const voice = (
   identifier: string,
@@ -7,6 +11,30 @@ const voice = (
   quality: VoiceQuality = VoiceQuality.Default,
   name = identifier
 ): Voice => ({ identifier, name, quality, language });
+
+// patch 済み expo-speech の Android が返す拡張メタデータ付きの音声。
+// 実機の Google TTS ローカル音声は quality が軒並み QUALITY_NORMAL(300) に
+// 並ぶため、識別子順以外のタイブレークが効くかどうかをここで検証する。
+const androidVoice = (
+  identifier: string,
+  language: string,
+  extras: Partial<
+    Pick<
+      NativeVoice,
+      'qualityScore' | 'isDefault' | 'networkRequired' | 'notInstalled'
+    >
+  > = {}
+): NativeVoice => ({
+  identifier,
+  name: identifier,
+  quality: VoiceQuality.Default,
+  language,
+  qualityScore: 300,
+  isDefault: false,
+  networkRequired: false,
+  notInstalled: false,
+  ...extras,
+});
 
 describe('scoreVoiceQuality', () => {
   it('premium識別子を最高スコアにする', () => {
@@ -174,6 +202,89 @@ describe('selectBestVoiceIdentifier', () => {
     ];
     expect(selectBestVoiceIdentifier(voices, 'en-US')).toBe(
       'com.apple.voice.premium.en-US.Ava'
+    );
+  });
+});
+
+describe('selectBestVoiceIdentifier (Android拡張メタデータ)', () => {
+  const options = { allowDefaultQuality: true };
+
+  it('品質が同点なら端末既定音声を選ぶ', () => {
+    // ユーザーが端末設定で選んだ音声を尊重する。識別子順では 'htm' が勝つ並び
+    const voices = [
+      androidVoice('ja-jp-x-htm-local', 'ja-JP'),
+      androidVoice('ja-jp-x-jad-local', 'ja-JP', { isDefault: true }),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP', options)).toBe(
+      'ja-jp-x-jad-local'
+    );
+  });
+
+  it('生の品質値が高い音声を識別子順より優先する', () => {
+    const voices = [
+      androidVoice('ja-jp-x-htm-local', 'ja-JP', { qualityScore: 300 }),
+      androidVoice('ja-jp-x-jad-local', 'ja-JP', { qualityScore: 400 }),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP', options)).toBe(
+      'ja-jp-x-jad-local'
+    );
+  });
+
+  it('端末既定音声より地域一致を優先する', () => {
+    const voices = [
+      androidVoice('en-gb-x-gba-local', 'en-GB', { isDefault: true }),
+      androidVoice('en-us-x-iob-local', 'en-US'),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'en-US', options)).toBe(
+      'en-us-x-iob-local'
+    );
+  });
+
+  it('未インストールの音声は他に候補があれば選ばない', () => {
+    // 品質値が高くても音声データが無ければ合成できない
+    const voices = [
+      androidVoice('ja-jp-x-jab-local', 'ja-JP', {
+        qualityScore: 500,
+        notInstalled: true,
+      }),
+      androidVoice('ja-jp-x-jad-local', 'ja-JP', { qualityScore: 300 }),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP', options)).toBe(
+      'ja-jp-x-jad-local'
+    );
+  });
+
+  it('未インストールの音声しか無ければ最後の手段として選ぶ', () => {
+    // 音声未指定のまま進めると端末既定言語で合成されてしまうため、
+    // 合成できない可能性があっても明示指定する方がマシ
+    const voices = [
+      androidVoice('ja-jp-x-jad-local', 'ja-JP', { notInstalled: true }),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP', options)).toBe(
+      'ja-jp-x-jad-local'
+    );
+  });
+
+  it('識別子にnetworkを含まなくてもnetworkRequiredでローカルを優先する', () => {
+    const voices = [
+      androidVoice('ja-jp-x-jab-cloud', 'ja-JP', {
+        qualityScore: 500,
+        networkRequired: true,
+      }),
+      androidVoice('ja-jp-x-jad-local', 'ja-JP', { qualityScore: 300 }),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP', options)).toBe(
+      'ja-jp-x-jad-local'
+    );
+  });
+
+  it('拡張メタデータが無いiOSの音声では従来の判定を維持する', () => {
+    const voices = [
+      voice('com.apple.voice.compact.ja-JP.Kyoko', 'ja-JP'),
+      voice('com.apple.voice.premium.ja-JP.Kyoko', 'ja-JP'),
+    ];
+    expect(selectBestVoiceIdentifier(voices, 'ja-JP')).toBe(
+      'com.apple.voice.premium.ja-JP.Kyoko'
     );
   });
 });

--- a/src/utils/nativeTtsVoice.ts
+++ b/src/utils/nativeTtsVoice.ts
@@ -17,11 +17,33 @@ import { type Voice, VoiceQuality } from 'expo-speech';
 // オプションを用意し、地域違い（en-GB 等）やネットワーク必須音声も
 // フォールバック候補に含める。
 //
+// Android のローカル音声は Google TTS の日本語のように quality が軒並み
+// QUALITY_NORMAL へ並ぶため、expo-speech が返す 2 値の quality だけでは優劣を
+// 判定できず、識別子のアルファベット順という無根拠なタイブレークで音声が決まって
+// しまう（'ja-jp-x-htm-local' が常に勝ち、ユーザーが端末設定で選んだ音声も無視
+// される）。そのため expo-speech の Android 実装へ patch を当てて生の
+// Voice メタデータ（qualityScore / isDefault / networkRequired / notInstalled）
+// を受け取り、それらを優先順の判断材料にする。iOS ではこれらのフィールドは
+// 返らないため、従来どおり識別子と quality で判定する。
+//
 // 注意: expo-speech の iOS 実装は AVSpeechSynthesisVoiceQuality.premium を
 // "Default" として報告する（native 側が enhanced 以外を一律 Default に落とす）ため、
 // quality フィールドだけでは Premium 音声を検出できない。iOS の音声識別子は
 // `com.apple.voice.premium.ja-JP.Kyoko` / `com.apple.ttsbundle.Kyoko-premium` の
 // ように品質を含む命名になっているので、識別子でも判定して補完する。
+
+// expo-speech の Voice 型は Android patch で追加したフィールドを含まないため、
+// アプリ側で拡張して扱う。iOS ではいずれも返らないので optional にしている。
+export type NativeVoice = Voice & {
+  // android.speech.tts.Voice.getQuality() の生値 (VERY_LOW=100 〜 VERY_HIGH=500)
+  qualityScore?: number;
+  // 端末設定で選ばれているエンジン既定音声か
+  isDefault?: boolean;
+  // 合成にネットワーク接続が必要か
+  networkRequired?: boolean;
+  // 音声データが未ダウンロードで、指定しても合成できない状態か
+  notInstalled?: boolean;
+};
 
 const normalizeLanguageTag = (tag: string): string =>
   tag.toLowerCase().replace(/_/g, '-');
@@ -30,7 +52,7 @@ const primarySubtag = (tag: string): string =>
   normalizeLanguageTag(tag).split('-')[0] ?? '';
 
 // 品質スコア。premium > enhanced > その他。
-export const scoreVoiceQuality = (voice: Voice): number => {
+export const scoreVoiceQuality = (voice: NativeVoice): number => {
   const id = (voice.identifier ?? '').toLowerCase();
   if (id.includes('premium')) {
     return 3;
@@ -51,14 +73,32 @@ export interface SelectBestVoiceOptions {
 
 // Android の '-network' 音声はネットワーク接続必須。乗車中はトンネル等で接続が
 // 切れやすく読み上げが失敗しうるため、ローカル音声を優先し最後の手段としてのみ使う。
-const isNetworkVoice = (voice: Voice): boolean =>
+// patch 済みの Android は Voice.isNetworkConnectionRequired() を返すのでそれを使い、
+// 返らない環境では従来どおり識別子の 'network' で判定する。
+const isNetworkVoice = (voice: NativeVoice): boolean =>
+  voice.networkRequired ??
   (voice.identifier ?? '').toLowerCase().includes('network');
+
+// 音声データ未ダウンロードの音声は指定しても合成できない。候補が他に無いときの
+// 保険として残したいので、除外はせず優先順の最劣後へ回す。
+const isNotInstalledVoice = (voice: NativeVoice): boolean =>
+  voice.notInstalled === true;
+
+// Android の生の品質値。iOS では返らないため、その場合は同点として扱い
+// 後続の識別子ベースの品質判定へ委ねる。
+const nativeQualityScore = (voice: NativeVoice): number =>
+  voice.qualityScore ?? 0;
+
+// 端末設定で選ばれているエンジン既定音声か。ユーザーの明示的な選択なので、
+// 同じ地域の候補が並んだときは機械的な優劣より優先する。
+const isDefaultVoice = (voice: NativeVoice): boolean =>
+  voice.isDefault === true;
 
 // 指定言語で最適な音声識別子を返す。地域まで一致する音声を優先しつつ、
 // 無ければ同一言語の別地域（en-US が無い端末の en-GB 等）も候補にする。
 // 条件を満たす音声が無い場合は undefined を返してシステム既定に任せる。
 export const selectBestVoiceIdentifier = (
-  voices: Voice[],
+  voices: NativeVoice[],
   language: string,
   options?: SelectBestVoiceOptions
 ): string | undefined => {
@@ -71,12 +111,17 @@ export const selectBestVoiceIdentifier = (
   const best = voices
     .filter((v) => primarySubtag(v.language ?? '') === targetPrimary)
     .filter((v) => scoreVoiceQuality(v) >= minScore)
-    // ローカル > 地域一致 > 品質 の優先順。同点は識別子順で決定的に選ぶ
-    // （実行ごとに音声が変わらないように）
+    // インストール済み > ローカル > 地域一致 > 端末既定 > 品質 の優先順。
+    // 最後まで差がつかない場合のみ識別子順で決定的に選ぶ（実行ごとに音声が
+    // 変わらないように）。識別子順は品質と無関係なので、その手前で判断材料を
+    // 出し切るのが狙い。
     .sort(
       (a, b) =>
+        Number(isNotInstalledVoice(a)) - Number(isNotInstalledVoice(b)) ||
         Number(isNetworkVoice(a)) - Number(isNetworkVoice(b)) ||
         Number(isExactRegion(b)) - Number(isExactRegion(a)) ||
+        Number(isDefaultVoice(b)) - Number(isDefaultVoice(a)) ||
+        nativeQualityScore(b) - nativeQualityScore(a) ||
         scoreVoiceQuality(b) - scoreVoiceQuality(a) ||
         (a.identifier ?? '').localeCompare(b.identifier ?? '')
     )


### PR DESCRIPTION
## 概要

Android の端末内蔵 TTS で、音声の選択が識別子のアルファベット順という品質と無関係な基準で決まっていた問題を修正します。

`expo-speech` が返す `quality` は `Enhanced` / `Default` の 2 値へ丸められており、Google TTS の日本語ローカル音声のように `QUALITY_NORMAL` へ横並びになる端末では優劣を判定できません。その結果、最終タイブレークである識別子の昇順が実質的な決定要因になり、`ja-jp-x-htm-local` が常に選ばれてユーザーが端末設定で選んだ音声も無視されていました。iOS はリモート TTS（Cloud TTS）を使うため、この差が音質差として体感されます。

`android.speech.tts.Voice` が持つ生の情報を JS へ渡し、それを優先順の判断材料にすることで、識別子順に落ちる範囲を最小化します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `patches/expo-speech+57.0.1.patch`: `VoiceRecord` に Android 固有のメタデータ 4 種（`qualityScore` / `isDefault` / `networkRequired` / `notInstalled`）を追加し、`getVoices()` で `android.speech.tts.Voice` と `TextToSpeech.defaultVoice` から埋める
- `src/utils/nativeTtsVoice.ts`: 拡張型 `NativeVoice` を追加し、優先順を「インストール済み → ローカル音声 → 地域一致 → 端末既定音声 → `qualityScore` 降順 → 識別子ベースの品質判定 → 識別子順」へ変更
- `src/utils/nativeTtsVoice.test.ts`: 拡張メタデータ経路のテストを 7 件追加（既存 17 件はそのまま通過）
- `src/hooks/tts/useNativeSpeechEngine.ts`: 起動時に選択された音声識別子を 1 度だけログへ残す。あわせて `volume` 指定のコメントを修正（Android の `KEY_PARAM_VOLUME` は既定値が 1.0 なので、この指定が効くのは iOS のみ）
- `docs/spec/tts/remote-tts.md`: 「端末内蔵 TTS の音声選択」節を追加

### 実装上の判断

エンジン実装によっては例外を投げうる `defaultVoice` / `isNetworkConnectionRequired` / `getFeatures` の呼び出しは、すべて try/catch で保守的な既定値へ倒しています。

未インストールの音声は除外せず優先順の最劣後へ回しました。Android では音声を指定しないと言語フォールバックの不備で端末既定言語の音声が使われるため、候補が 1 つも無い状態を作るより「合成できない可能性はあるが明示指定する」方が安全なためです。

トンネル等での接続断を避けるためのローカル音声優先は維持しているので、Google TTS の WaveNet 系（ネットワーク音声）は引き続き使いません。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は TTS 関連へ絞って実行しました（`src/utils/nativeTtsVoice.test.ts` と `src/hooks/tts` で 5 suite / 93 件通過）。

ネイティブ patch を含むため、`./gradlew :expo:compileDevDebugKotlin --rerun-tasks` で強制再コンパイルし、patch 済み Kotlin がビルドできることを確認しています（BUILD SUCCESSFUL）。

### レビュー時の注意

**この変更はネイティブ patch を含むため OTA では配信されず、反映にはネイティブビルドが必要です。**

効果は端末に依存します。既定音声も `qualityScore` も横並びの端末では選ばれる音声が変わらない可能性があります。実機で `[useNativeSpeechEngine] Selected voices: ja=... en=...` のログを確認すると、どの音声が選ばれたか追跡できます。

patch が当たっていないバイナリでは各フィールドが `undefined` となり、従来どおり識別子順のタイブレークへフォールバックします。iOS は拡張フィールドが返らないため、判定ロジックは従来のままです。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: 変更は TTS の音声選択ロジックと `expo-speech` のネイティブ patch のみで、画面表示に変化はありません。差分は読み上げに使われる音声であり、静止画では示せません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Android・iOSの内蔵音声選択を改善し、地域、端末の既定音声、音声品質を考慮して最適な音声を選択するようになりました。
  - 未インストールの音声やネットワーク接続が必要な音声を優先的に避け、より安定した読み上げを実現します。
  - 音声情報を取得できない環境でも、従来の選択方式へ自動的に切り替わります。
  - 起動時に選択された音声情報を記録し、音声設定の確認や問題調査がしやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->