### PR TITLE
ポートレートモードのナンバリングを配色スキームで加工せず路線色のまま表示

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -40,7 +40,11 @@ jest.mock('react-native-safe-area-context', () => ({
   })),
 }));
 
-jest.mock('./NumberingIcon', () => () => null);
+const mockNumberingIcon = jest.fn();
+jest.mock('./NumberingIcon', () => (props: { lineColor: string }) => {
+  mockNumberingIcon(props);
+  return null;
+});
 
 jest.mock('~/hooks', () => ({
   useBoundText: jest.fn(() => ({ JA: '品川・大崎方面' })),
@@ -354,6 +358,17 @@ describe('PortraitMain', () => {
       StyleSheet.flatten(getByTestId('portrait-station-name-slot').props.style)
         .paddingLeft
     ).toBe(8);
+  });
+
+  it('ナンバリングには配色スキームで加工していない路線色をそのまま渡す', () => {
+    renderWithStations([buildStation(1, '品川', StopCondition.All, 'JY-25')], {
+      colorScheme: COLOR_SCHEME_PREFERENCE.DARK,
+    });
+
+    // ダークでも明度を持ち上げず、API 由来の路線色をそのまま描く
+    expect(mockNumberingIcon).toHaveBeenCalledWith(
+      expect.objectContaining({ lineColor: commonData.numberingColor })
+    );
   });
 
   it('現在駅にナンバリングがないときは枠を確保せず駅名表示に充てる', () => {

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1677,9 +1677,11 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
           <View style={styles.stationNameRow}>
             {currentStationNumber ? (
               <View style={styles.numberingColumn} testID="numbering-column">
+                {/* ナンバリングは地の上の文字ではなく独立した記号なので、
+                    他のヘッダーと同じく路線色をそのまま渡して加工しない。 */}
                 <NumberingIcon
                   shape={currentStationNumber.lineSymbolShape || ''}
-                  lineColor={accentColorFor(numberingColor, colors.isDark)}
+                  lineColor={numberingColor}
                   stationNumber={currentStationNumber.stationNumber || ''}
                   threeLetterCode={commonData.threeLetterCode}
                 />


### PR DESCRIPTION
## 概要

ポートレートモードの現在駅カードで、ナンバリング記号だけが配色スキームに合わせて路線色を加工されていました。ダークでは HSL の明度を `0.62` まで持ち上げる `luminousAccentColor` が適用されるため、記号に明るいオーバレイが掛かったように見えます。ナンバリングは地の上に置く文字ではなく独立した記号なので、他のヘッダーと同じく API 由来の路線色をそのまま描くようにします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `PortraitMain` の現在駅ナンバリングに渡す色を `accentColorFor(numberingColor, colors.isDark)` から `numberingColor` へ変更し、配色スキームによる加工をやめた
- なぜ加工しないのかを `NumberingIcon` の直上にコメントで残した
- 線路・状態テキストなど「地の上に載る要素」の `accentColorFor` は従来どおり据え置き（暗い地で路線色が沈むのを防ぐ役割は残す）
- `PortraitMain.test.tsx` の `NumberingIcon` モックを props 記録型に変え、ダークでも加工していない路線色が渡ることを検証するテストを追加

他のヘッダー（`HeaderJL` / `HeaderSaikyo` / `HeaderJRKyushu` など）は元から `numberingColor` を素通ししており、今回の変更でポートレートもそれらと揃います。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` はスコープを絞って `npx jest src/components/PortraitMain.test.tsx` を実行し、45 件すべて通過しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### React Native Web (Chrome)

各画像とも左がダーク、右がライトです。塗りつぶしで差が見える `REVERSED_SQUARE` の路線として、本番 API の `lineStations` から取得した東急田園都市線の実データ（`DT-01` 渋谷、路線色 `#018D54`）を `PortraitMain` に流し込んで描画しました。RN Web で動かしている都合上、状態テキストが `[missing "en.portrait…"]` になりますが、これは本 PR の変更とは無関係な web レンダリング側の差異です。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-numbering-raw-line-color-4d2e72ed350c/1dd0922576e5-numbering-rs-before.png" width="640" alt="修正前: ダーク(左)のナンバリングが明るいミント #3FFEB0 に持ち上がり、ライト(右)の路線色 #018D54 と食い違う" />

修正前: ダーク（左）のナンバリングが明るいミント `#3FFEB0` に持ち上がり、ライト（右）の路線色 `#018D54` と食い違う

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-numbering-raw-line-color-4d2e72ed350c/57e96f5b9615-numbering-rs-after.png" width="640" alt="修正後: ダーク(左)もライト(右)と同じ路線色 #018D54 で描かれる" />

修正後: ダーク（左）もライト（右）と同じ路線色 `#018D54` で描かれる

<!-- create-pr:screenshots:end -->
