### PR TITLE
ポートレートモードの列車種別バッジに上下の余白を追加

### DIFF
--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -286,7 +286,7 @@ const styles = StyleSheet.create({
   trainTypeBadge: {
     marginLeft: 8,
     paddingHorizontal: 6,
-    paddingVertical: 1,
+    paddingVertical: 3,
     borderRadius: 2,
   },
   trainTypeText: {


### PR DESCRIPTION
## 概要

ポートレートモードの上部に出る列車種別バッジ（路線名の右隣）が、文字の上下ぎりぎりまで背景色で詰まっていて窮屈に見えていたため、上下の余白を広げました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `src/components/PortraitMain.tsx` の `trainTypeBadge.paddingVertical` を `1` → `3` に変更。
- 横方向（`paddingHorizontal: 6`）・`marginLeft: 8`・`trainTypeText` のフォントサイズは据え置き。バッジは `metaRow`（`alignItems: 'center'`）配下なので、高さが増えても中央揃えのまま上部の行がわずかに高くなるだけで、路線名・行き先の横並びには影響しません。

## テスト

`npm run lint` / `npm test` / `npm run typecheck` をローカルで実行し、すべて成功することを確認しました（`npm test`: 251 suites / 2720 tests all passed）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### React Native Web (Chrome)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-train-type-badge-padding-a8a93fad/b56572edd1b9-badge-compare.png" width="480" alt="列車種別バッジの変更前後を4倍拡大して比較" />

列車種別バッジの変更前後（4倍拡大）。上が `paddingVertical: 1`、下が `paddingVertical: 3`。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-train-type-badge-padding-a8a93fad/9aef56b08942-after-full.png" width="320" alt="変更後のポートレート画面全体" />

変更後のポートレート画面全体。

いずれも `npm run web` の React Native Web レンダリングをヘッドレス Chrome でキャプチャしたものです。ロケーション権限や API を伴わずに走行画面を出すため、`PortraitMain` だけを一時ハーネスで単体描画し、都営新宿線のフィクスチャ（種別は「急行」相当、ロケール都合で英語表示）を流し込んでいます。ハーネスとその Metro 設定はコミットに含めていません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 列車種別バッジの縦方向の余白を調整し、表示バランスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->