### PR TITLE
ナンバリングアイコンの表示ズレを修正

### DIFF
--- a/src/components/NumberingIconNankai.test.tsx
+++ b/src/components/NumberingIconNankai.test.tsx
@@ -2,6 +2,9 @@ import { render } from '@testing-library/react-native';
 import { NUMBERING_ICON_SIZE } from '~/constants';
 import NumberingIconNankai from './NumberingIconNankai';
 
+// isTablet=false 時のアイコン外形サイズ
+const ICON_SIZE = 72;
+
 jest.mock('~/utils/isTablet', () => ({
   __esModule: true,
   default: false,
@@ -53,6 +56,65 @@ describe('NumberingIconNankai', () => {
     );
     expect(getByText('NK')).toBeTruthy();
     expect(getByText('01')).toBeTruthy();
+  });
+
+  it.each([
+    ['withOutlineなし', undefined, 1],
+    ['withOutlineあり', true, 2],
+  ])(
+    '%s のとき楕円のフチが描画領域からはみ出さない',
+    (_label, withOutline, expectedStrokeWidth) => {
+      const { getByTestId } = render(
+        <NumberingIconNankai
+          lineColor="#0066cc"
+          stationNumber="NK-01"
+          withOutline={withOutline}
+        />
+      );
+      const ellipse = getByTestId('ellipse');
+      const { cx, cy, rx, ry, strokeWidth } = ellipse.props;
+
+      expect(strokeWidth).toBe(expectedStrokeWidth);
+      // フチはパスの中心から左右に strokeWidth / 2 ずつ広がる
+      expect(cx - rx - strokeWidth / 2).toBeGreaterThanOrEqual(0);
+      expect(cx + rx + strokeWidth / 2).toBeLessThanOrEqual(ICON_SIZE);
+      expect(cy - ry - strokeWidth / 2).toBeGreaterThanOrEqual(0);
+      expect(cy + ry + strokeWidth / 2).toBeLessThanOrEqual(ICON_SIZE);
+    }
+  );
+
+  it('withOutlineの有無でアイコンの占有サイズが変わらない', () => {
+    const withoutOutline = render(
+      <NumberingIconNankai lineColor="#0066cc" stationNumber="NK-01" />
+    ).getByTestId('ellipse');
+    const withOutline = render(
+      <NumberingIconNankai
+        lineColor="#0066cc"
+        stationNumber="NK-01"
+        withOutline={true}
+      />
+    ).getByTestId('ellipse');
+
+    type EllipseProps = { rx: number; ry: number; strokeWidth: number };
+    const outerWidth = (props: EllipseProps) =>
+      props.rx * 2 + props.strokeWidth;
+    const outerHeight = (props: EllipseProps) =>
+      props.ry * 2 + props.strokeWidth;
+
+    expect(outerWidth(withOutline.props as EllipseProps)).toBe(
+      outerWidth(withoutOutline.props as EllipseProps)
+    );
+    expect(outerHeight(withOutline.props as EllipseProps)).toBe(
+      outerHeight(withoutOutline.props as EllipseProps)
+    );
+  });
+
+  it('記号と番号が折り返されない', () => {
+    const { getByText } = render(
+      <NumberingIconNankai lineColor="#0066cc" stationNumber="NK-01" />
+    );
+    expect(getByText('NK').props.numberOfLines).toBe(1);
+    expect(getByText('01').props.numberOfLines).toBe(1);
   });
 
   it('stationNumberが正しく分割される', () => {

--- a/src/components/NumberingIconNankai.tsx
+++ b/src/components/NumberingIconNankai.tsx
@@ -9,6 +9,11 @@ import {
 import isTablet from '../utils/isTablet';
 import Typography from './Typography';
 
+const ICON_SIZE = isTablet ? 72 * 1.5 : 72;
+// 楕円の白フチ。withOutline のときは同じフチを太らせて代用する
+const STROKE_WIDTH = 1;
+const OUTLINE_STROKE_WIDTH = isTablet ? 3 : 2;
+
 type Props = {
   stationNumber: string;
   lineColor: string;
@@ -17,18 +22,21 @@ type Props = {
 };
 
 const styles = StyleSheet.create({
-  optionalBorder: {
-    borderRadius: (isTablet ? 72 * 1.5 : 72) / 2,
-    borderWidth: 2,
-    borderColor: '#fff',
-  },
   root: {
     position: 'relative',
+    width: ICON_SIZE,
+    height: ICON_SIZE,
     justifyContent: 'center',
     alignItems: 'center',
   },
+  // インセットを指定しない絶対配置だと文字の折り返し幅が楕円の幅として解決されず、
+  // 記号が途中で改行されてしまうため SVG と同じ矩形をぴったり覆わせる
   texts: {
     position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -85,24 +93,33 @@ const NumberingIconNankai: React.FC<Props> = ({
     );
   }
 
+  // 白フチは View のボーダーで囲うと真円になり楕円のシンボルと形が合わないため、
+  // 楕円自身のストロークを太らせて表現する
+  const strokeWidth = withOutline ? OUTLINE_STROKE_WIDTH : STROKE_WIDTH;
+  // ストロークはパスの中心から外側にも半分伸びるので、その分だけ半径を詰めないと
+  // 楕円の左右端でフチが SVG の描画領域からはみ出して欠ける
+  const strokeInset = strokeWidth / 2;
+
   return (
-    <View style={withOutline ? styles.optionalBorder : undefined}>
-      <View style={styles.root}>
-        <Svg height={isTablet ? 72 * 1.5 : 72} width={isTablet ? 72 * 1.5 : 72}>
-          <Ellipse
-            cx={(isTablet ? 72 * 1.5 : 72) / 2}
-            cy={(isTablet ? 72 * 1.5 : 72) / 2}
-            rx={(isTablet ? 72 * 1.5 : 72) / 2}
-            ry={(isTablet ? 72 * 1.5 : 72) / 2.5}
-            stroke="white"
-            strokeWidth={1}
-            fill={lineColor}
-          />
-        </Svg>
-        <View style={styles.texts}>
-          <Typography style={styles.lineSymbol}>{lineSymbol}</Typography>
-          <Typography style={styles.stationNumber}>{stationNumber}</Typography>
-        </View>
+    <View style={styles.root}>
+      <Svg height={ICON_SIZE} width={ICON_SIZE}>
+        <Ellipse
+          cx={ICON_SIZE / 2}
+          cy={ICON_SIZE / 2}
+          rx={ICON_SIZE / 2 - strokeInset}
+          ry={ICON_SIZE / 2.5 - strokeInset}
+          stroke="white"
+          strokeWidth={strokeWidth}
+          fill={lineColor}
+        />
+      </Svg>
+      <View style={styles.texts}>
+        <Typography numberOfLines={1} style={styles.lineSymbol}>
+          {lineSymbol}
+        </Typography>
+        <Typography numberOfLines={1} style={styles.stationNumber}>
+          {stationNumber}
+        </Typography>
       </View>
     </View>
   );

--- a/src/components/NumberingIconReversedSquareWest.tsx
+++ b/src/components/NumberingIconReversedSquareWest.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -11,6 +12,9 @@ type Props = {
   darkText?: boolean;
   withOutline?: boolean;
 };
+
+// Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
+const GLYPH_LIFT = numberingGlyphLift(isTablet ? 30 * 1.5 : 30);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -28,6 +32,7 @@ const styles = StyleSheet.create({
   lineSymbol: {
     fontSize: isTablet ? 30 * 1.5 : 30,
     lineHeight: isTablet ? 30 * 1.5 : 30,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: Platform.OS === 'ios' ? 4 : 0,
@@ -36,6 +41,7 @@ const styles = StyleSheet.create({
     marginTop: -4,
     fontSize: isTablet ? 30 * 1.5 : 30,
     lineHeight: isTablet ? 30 * 1.5 : 30,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
   },

--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -6,6 +6,7 @@ import {
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -19,6 +20,16 @@ type Props = {
 };
 
 const TLC_SCALE = 0.7;
+
+// Androidのグリフ下寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// アイコンごとに基準の行高から1つだけ求めて使い回す
+const GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 * 1.5 : 24);
+const TLC_GLYPH_LIFT = numberingGlyphLift(
+  isTablet ? Math.round(24 * 1.5 * TLC_SCALE) : Math.round(24 * TLC_SCALE)
+);
+const TLC_COMPACT_GLYPH_LIFT = numberingGlyphLift(isTablet ? 12 : 8);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 32 : 20);
+const SMALL_GLYPH_LIFT = numberingGlyphLift(10);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -68,14 +79,7 @@ const styles = StyleSheet.create({
     lineHeight: isTablet
       ? Math.round(24 * 1.5 * TLC_SCALE)
       : Math.round(24 * TLC_SCALE),
-    // Androidはグリフが行ボックス下寄りに描画されTLCが下がって見えるため
-    // 上方向に補正して上下中央に揃える(iOSは補正不要)。
-    // 負マージンだと下のアイコンごと動いてバッジ全体が縮むため、
-    // レイアウトに影響しないtransformで文字だけを持ち上げる
-    transform:
-      Platform.OS === 'android'
-        ? [{ translateY: Math.round(-6 * TLC_SCALE) }]
-        : [],
+    transform: TLC_GLYPH_LIFT,
   },
   tlcIconRoot: {
     width: isTablet
@@ -99,6 +103,7 @@ const styles = StyleSheet.create({
     lineHeight: isTablet
       ? Math.round(24 * 1.5 * TLC_SCALE)
       : Math.round(24 * TLC_SCALE),
+    transform: TLC_GLYPH_LIFT,
     fontSize: isTablet
       ? Math.round(24 * 1.5 * TLC_SCALE)
       : Math.round(24 * TLC_SCALE),
@@ -111,6 +116,7 @@ const styles = StyleSheet.create({
     lineHeight: isTablet
       ? Math.round(32 * 1.5 * TLC_SCALE)
       : Math.round(32 * TLC_SCALE),
+    transform: TLC_GLYPH_LIFT,
     fontSize: isTablet
       ? Math.round(32 * 1.5 * TLC_SCALE)
       : Math.round(32 * TLC_SCALE),
@@ -129,6 +135,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: isTablet ? 2 : 1,
   },
   tlcTextCompact: {
+    transform: TLC_COMPACT_GLYPH_LIFT,
     color: 'white',
     textAlign: 'center',
     fontSize: isTablet ? 12 : 8,
@@ -148,6 +155,7 @@ const styles = StyleSheet.create({
   },
   tlcLineSymbolCompact: {
     lineHeight: isTablet ? 12 : 8,
+    transform: TLC_COMPACT_GLYPH_LIFT,
     fontSize: isTablet ? 12 : 8,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
@@ -156,6 +164,7 @@ const styles = StyleSheet.create({
   },
   tlcStationNumberCompact: {
     lineHeight: isTablet ? 15 : 10,
+    transform: TLC_COMPACT_GLYPH_LIFT,
     fontSize: isTablet ? 15 : 10,
     marginTop: isTablet ? -2 : -1,
     textAlign: 'center',
@@ -174,6 +183,7 @@ const styles = StyleSheet.create({
   },
   lineSymbolMedium: {
     lineHeight: isTablet ? 32 : 20,
+    transform: MEDIUM_GLYPH_LIFT,
     fontSize: isTablet ? 32 : 20,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
@@ -195,14 +205,17 @@ const styles = StyleSheet.create({
   },
   lineSymbolSmall: {
     fontSize: 10,
+    transform: SMALL_GLYPH_LIFT,
     lineHeight: 10,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: 2,
+    // 他のサイズと同様、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
     color: '#231e1f',
   },
   lineSymbol: {
     lineHeight: isTablet ? 24 * 1.5 : 24,
+    transform: GLYPH_LIFT,
     fontSize: isTablet ? 24 * 1.5 : 24,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
@@ -211,6 +224,7 @@ const styles = StyleSheet.create({
   },
   stationNumber: {
     lineHeight: isTablet ? 32 * 1.5 : 32,
+    transform: GLYPH_LIFT,
     fontSize: isTablet ? 32 * 1.5 : 32,
     marginTop: -4,
     textAlign: 'center',

--- a/src/utils/numberingGlyphLift.test.ts
+++ b/src/utils/numberingGlyphLift.test.ts
@@ -1,0 +1,45 @@
+import { Platform } from 'react-native';
+import { numberingGlyphLift } from './numberingGlyphLift';
+
+describe('numberingGlyphLift', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS });
+    jest.clearAllMocks();
+  });
+
+  const setOS = (os: typeof Platform.OS) =>
+    Object.defineProperty(Platform, 'OS', { value: os });
+
+  it('iOSでは補正しない', () => {
+    setOS('ios');
+    expect(numberingGlyphLift(24)).toEqual([]);
+  });
+
+  // FrutigerNeueLTPro-Bold のメトリクスから導かれる比率は約 0.084em
+  it('Androidでは行の高さに比例して上方向へ補正する', () => {
+    setOS('android');
+    expect(numberingGlyphLift(8)).toEqual([{ translateY: -1 }]);
+    expect(numberingGlyphLift(24)).toEqual([{ translateY: -2 }]);
+    expect(numberingGlyphLift(36)).toEqual([{ translateY: -3 }]);
+  });
+
+  it('補正量は行の高さに対して単調増加する', () => {
+    setOS('android');
+    const lifts = [8, 12, 20, 24, 32, 48].map(
+      (lh) => -numberingGlyphLift(lh)[0].translateY
+    );
+    for (let i = 1; i < lifts.length; i++) {
+      expect(lifts[i]).toBeGreaterThanOrEqual(lifts[i - 1]);
+    }
+  });
+
+  it('補正量は常に上方向(負)になる', () => {
+    setOS('android');
+    for (const lineHeight of [8, 10, 12, 17, 20, 24, 30, 32, 45, 48]) {
+      const [{ translateY }] = numberingGlyphLift(lineHeight);
+      expect(translateY).toBeLessThan(0);
+    }
+  });
+});

--- a/src/utils/numberingGlyphLift.ts
+++ b/src/utils/numberingGlyphLift.ts
@@ -1,0 +1,45 @@
+import { Platform } from 'react-native';
+
+/**
+ * FrutigerNeueLTPro-Bold の縦メトリクス(unitsPerEm=1000 に対する比率)。
+ * android/app/src/main/assets/fonts/FrutigerNeueLTPro-Bold.ttf の hhea / OS/2 の値。
+ */
+const FONT_ASCENT = 1.13;
+const FONT_DESCENT = 0.264;
+const FONT_CAP_HEIGHT = 0.698;
+
+/**
+ * Android でナンバリングのグリフが行ボックス内で下寄りになる分の比率。
+ *
+ * RN Android の CustomLineHeightSpan は lineHeight とフォントの ascent+descent の差
+ * (leading) を上下へ等分するため、行ボックスの中心はフォントの ascent/descent ボックスの
+ * 中心に一致する。ナンバリングの記号と番号は大文字と数字だけでディセンダを持たないので、
+ * ベースラインより下の descent がそのまま余白として残り、グリフが下寄りに見える。
+ * ズレ量は (ascent - descent) - capHeight で、その半分を引き上げると上下が揃う。
+ * 式から lineHeight が消えることからも分かるとおり、補正量は文字サイズに比例する。
+ *
+ * 端末やOSではなくフォントに依存する値である点に注意:
+ * フォントは APK 同梱で `Typography` も allowFontScaling={false} のため、端末や
+ * フォントサイズ設定では変わらない。一方 myriadpro-bold は -0.087em、FuturaLTPro-Bold は
+ * -0.052em と符号が逆になるので、別フォントのアイコンにそのまま流用してはいけない。
+ * React Native 0.86.2 の CustomLineHeightSpan を前提にしているので、RN のメジャー
+ * アップグレード時は実機で見た目を確認すること。
+ */
+const GLYPH_LIFT_RATIO = (FONT_ASCENT - FONT_DESCENT - FONT_CAP_HEIGHT) / 2;
+
+/**
+ * Android のグリフ下寄り分を打ち消す transform を返す(iOS は行ボックス内で中央に
+ * 描かれるため補正しない)。
+ *
+ * marginTop の負値では兄弟要素ごと動いてアイコン全体が縮むため、レイアウトに影響しない
+ * transform で文字だけを持ち上げる。
+ *
+ * 記号と番号で異なる値を渡すと両者の間隔まで変わってしまうので、1つのアイコンでは
+ * 必ず同じ戻り値を使い回すこと。
+ *
+ * @param baseLineHeight 基準にする行の高さ(本リポジトリでは lineHeight === fontSize)
+ */
+export const numberingGlyphLift = (baseLineHeight: number) =>
+  Platform.OS === 'android'
+    ? [{ translateY: -Math.round(baseLineHeight * GLYPH_LIFT_RATIO) }]
+    : [];


### PR DESCRIPTION
## 概要

Android でナンバリングアイコンの表示がズレていた 2 件を修正します。

- **JR東日本・JR西日本**: 記号と番号が枠内で下にズレる（Android のみ）
- **南海**: 白フチが楕円のシンボルと形が合わず枠だけ浮いて見える／記号が途中で改行される

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### JR東日本 / JR西日本: Android でのグリフ下ズレ

ナンバリングアイコンは `lineHeight` を `fontSize` と同値にしているため、RN Android の `CustomLineHeightSpan` が leading を上下へ等分し、行ボックスの中心がフォントの ascent/descent ボックスの中心に一致します。記号と番号は大文字と数字だけでディセンダを持たないので、ベースラインより下の descent がそのまま余白として残り、グリフが下寄りに描画されていました（iOS は行ボックス内で中央に描かれるため影響なし）。

- `src/utils/numberingGlyphLift.ts` を追加。ズレ量 `((ascent - descent) - capHeight) / 2` を同梱フォントのメトリクスから導出し、Android のみ `transform: translateY` で打ち消します。負マージンだと兄弟要素ごと動いてアイコン全体が縮むため transform を使っています。
- `NumberingIconSquare`（JR東日本）の全バリアント（LARGE / MEDIUM / SMALL / TLC大 / TLCコンパクト）に適用。
- `NumberingIconReversedSquareWest`（JR西日本）に適用。
- TLC ラベルにあった既存の `translateY: Math.round(-6 * TLC_SCALE)` は逆に上げすぎ（上 7px / 下 19px）だったため、共通の補正に差し替え。
- `lineSymbolSmall` の `marginTop: 2` だけがプラットフォーム分岐されておらず iOS 向けの視覚補正が Android にも効いていたため、他サイズと揃えて `Platform.OS === 'ios' ? 2 : 0` に修正。

補正量はフォント依存で、同梱フォントごとに符号まで変わります（FrutigerNeueLTPro-Bold は +0.084em、myriadpro-bold は -0.087em、FuturaLTPro-Bold は -0.052em）。JR東西だけが目立って下ズレしていたのはこのためで、別フォントのアイコンに流用できない旨はヘルパーのコメントに明記しています。

### 南海: 白フチと記号の折り返し

- `withOutline` が真円の View ボーダーで、楕円のシンボルと形が合わず枠だけが浮いていました（`borderWidth` の分だけレイアウト箱も広がり、他社線マークと並んだときに位置がズレる）。楕円自身のストロークを太らせる方式に変更し、外形サイズを 72×72 で一定にしています。
- `rx` が SVG 幅の半分ちょうどで、フチが左右の頂点で欠けていたため `strokeWidth / 2` だけ内側に詰めました。
- インセット未指定の絶対配置により折り返し幅が親の確定幅で解決されず、`NK` が `N` / `K` に割れて改行されていました。`texts` に `top` / `right` / `bottom` / `left: 0` を指定し、保険として `numberOfLines={1}` を追加しています。

### 実機での計測（白地の上余白 / 下余白, px）

| 対象 | 修正前 | 修正後 |
| ---- | ---- | ---- |
| JR東 LARGE（路線一覧） | 12 / 6 | 9 / 10 |
| JR東 MEDIUM | 22 / 12 | 15 / 18 |
| JR東 SMALL | 16 / 5 | 10 / 11 |
| JR東 TLC大（アイコン内側） | 未計測 | 12 / 15 |
| JR東 TLC大（ラベル） | 7 / 19 | 15 / 12 |
| JR東 TLC コンパクト | 10 / 4 | 6 / 8 |
| JR西 | 15 / 8 | 10 / 12 |

Galaxy SCG13（Android 16 / SDK 36）と Android 11 エミュレータ（API 30）の両方で計測し、症状・修正後の結果とも一致しました（OS バージョン非依存）。

### 回帰リスクと緩和

- **iOS には一切影響しません。** `numberingGlyphLift` は Android 以外では空配列を返すため、iOS のスタイルは変わりません。
- **他社線のアイコンには適用していません。** 補正はフォント依存で符号すら変わるため、FrutigerNeueLTPro-Bold を使う JR 東西の 2 コンポーネントに限定しています。
- **RN のバージョンには依存します。** `CustomLineHeightSpan` の実装が変わると前提が崩れるため、React Native 0.86.2 前提であることと、メジャーアップグレード時は実機確認が必要な旨をヘルパーのコメントに残しています。
- 南海アイコンは `withOutline` の有無で外形サイズが変わらないことをテストで固定しました。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 252 suites / 2731 tests。追加したテストは以下のとおりです。

- `numberingGlyphLift`: iOS では補正しないこと、Android では行の高さに比例して上方向へ補正すること
- `NumberingIconNankai`: 楕円のフチが描画領域からはみ出さないこと、`withOutline` の有無で占有サイズが変わらないこと、記号と番号が折り返されないこと

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### Android 11 エミュレータ \(API 30\)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_numbering-icon-glyph-alignment-711502e67ea8/71e805c8f26a-pr-jreast-before-after.png" width="640" alt="修正前は記号と番号が白地の下寄り、修正後は上下中央" />

JR東日本の SQUARE ナンバリング。修正前は記号と番号が白地の下寄り、修正後は上下中央。

JR西・TLC・南海については、計測時の生スクリーンショットがツールサーバの再起動で失われたため画像を添付できていません。数値は上の「実機での計測」表を参照してください。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 南海線の番号アイコンのサイズと白フチ表示を調整し、より安定した外形で表示されるようになりました。
  * Androidで駅番号や記号の位置を補正し、文字がより自然に中央揃えで表示されるようになりました。
  * タブレット表示時のアイコンサイズと文字配置を改善しました。
* **品質向上**
  * 各種画面サイズ・OSにおけるアイコンの外形、文字位置、折り返しを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->