### PR TITLE
R8の最適化パスを有効化してDEXサイズを削減

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -129,7 +129,11 @@ android {
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            // proguard-android.txt は -dontoptimize を含むため R8 の最適化パスが動かず、
+            // 収縮と難読化しか効かない。Google Play の技術品質要件 (2027年2月施行) は
+            // DEX に最適化・圧縮・難読化で最低25%のカバレッジを求めるため、最適化を有効にする。
+            // wearable モジュールは元から optimize 版を使っており、そちらへ揃える形になる
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             def enablePngCrunchInRelease = findProperty('android.enablePngCrunchInReleaseBuilds') ?: 'true'
             crunchPngs enablePngCrunchInRelease.toBoolean()
         }


### PR DESCRIPTION
## 概要

Google Play の技術品質要件（[2026年8月の Android Developers Blog](https://android-developers.googleblog.com/2026/08/app-quality-memory-optimization-secure-onboarding.html) で告知、2027年2月施行）のうち、**DEX コード最適化**への対応です。要件は最適化・圧縮・難読化の組み合わせで最低 25% のカバレッジを求めています。

`android/app/build.gradle` が `getDefaultProguardFile("proguard-android.txt")` を参照していましたが、**このファイルは `-dontoptimize` を含んでおり、R8 の最適化パスが動いていませんでした**。収縮と難読化しか効いていない状態です。

```text
# AGP 同梱の proguard-android.txt より
# Optimization is turned off by default. ...
# instead you will need to point to the
# "proguard-android-optimize.txt" file instead of this one
-dontoptimize
```

`android/wearable/build.gradle.kts:71` は元から `proguard-android-optimize.txt` を使っており、**`app` モジュールだけが取り残されていた**形です。そちらへ揃えます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

ビルド構成の変更です。アプリのソースコードには一切手を入れていません（差分は `android/app/build.gradle` の 1 ファイルのみ）。

## 変更内容

```diff
-proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
```

### DEX サイズの実測（prodRelease / R8 適用後）

`:app:minifyProdReleaseWithR8` の出力を実測した結果です。

| | 変更前 | 変更後 | 差 |
| ---- | ---- | ---- | ---- |
| `classes.dex` | 7,305,104 B | 9,520,488 B | |
| `classes2.dex` | 7,832,988 B | 2,307,520 B | |
| `classes3.dex` | 781,672 B | — | |
| **合計** | **15,919,764 B (15.18 MiB)** | **11,828,008 B (11.28 MiB)** | **−4,091,756 B (−25.7%)** |

DEX ファイル数も 3 → 2 に減っています。`mapping/prodRelease/configuration.txt` から `-dontoptimize` が消えたことも確認済みです。

なお合計 11.28 MiB なので、**10MB の閾値は変更後も超えています**。最適化を入れても DEX 要件の適用対象からは外れないため、カバレッジを満たしにいく方針で対応しています。25.7% はサイズ削減率であって要件の「25% カバレッジ」とは別指標なので、実際の判定は Play Console 側の表示で確認が必要です。

### R8 の各パスの状態（変更後）

| 項目 | 状態 |
| ---- | ---- |
| 収縮（shrink） | 有効（17,583 クラスを削除） |
| 難読化（obfuscate） | 有効（20,884 クラス中 16,094 = 77.1% を改名） |
| 最適化（optimize） | **有効化（本 PR）** |

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 252 suites / 2731 tests。JS 側に変更がないため、テストは既存の回帰確認としての実行です。

### 実機スモークテスト（Galaxy SCG13 / Android 16 / SDK 36）

R8 の最適化はインライン化とコード削除を伴うため、リフレクション経由の参照が壊れていないかを実機で確認しました。`release` ビルドタイプに debug キーストアを Gradle プロパティで注入した devRelease APK を使っています（`build.gradle` は変更していません）。

| 動線 | 結果 |
| ---- | ---- |
| 起動・位置情報取得 | OK |
| GraphQL 経由の路線取得（鉄道・バス） | OK |
| 行先選択モーダル・ナンバリングアイコン描画 | OK |
| 乗車画面（停車駅一覧・所要時間・ヘッダー切り替え） | OK |
| TTS 音声選択（`ja-JP` / `en-US` を 474 音声から解決） | OK |
| 設定画面 | OK |
| テーマプレビュー（`ThemeConfirmModal` / expo-image） | OK |

**致命的な例外（FATAL / `E AndroidRuntime`）は発生しませんでした。**

## 回帰リスクと緩和

### 検出した警告 1 件

logcat に以下が 1 件出ます（`W System.err`、クラッシュには至らず）。

```text
java.lang.NoSuchMethodException: i2.a.newBuilder [class android.content.Context]
    at com.learnium.RNDeviceInfo.RNDeviceModule.<init>(...)
```

`react-native-device-info` の `RNInstallReferrerClient` が Play の InstallReferrer API をリフレクションで呼んでいる箇所です。

```java
// node_modules/react-native-device-info/.../RNInstallReferrerClient.java:45
Method newBuilderMethod = InstallReferrerClientClazz.getMethod("newBuilder", Context.class);
```

`mapping.txt` を見ると、原因は `Builder` クラスが未使用として削除されていることでした。

```text
com.android.installreferrer.api.InstallReferrerClient         -> i2.a:
com.android.installreferrer.api.InstallReferrerClient$Builder -> R8$$REMOVED$$CLASS$$283:
```

`Class.forName` の文字列リテラルは R8 が難読化後の名前へ書き換えるためクラス解決は成功しますが、`getMethod("newBuilder", ...)` の文字列は書き換え対象外で、かつ戻り値の `Builder` が消えているため失敗します。

**影響はありません。** ライブラリ側が例外を catch して当該 API を無効化するだけで、`getInstallReferrer` はアプリのコードから一切呼ばれていません（`src/` に参照なし）。

**この警告は本 PR 由来ではなく、変更前から発生している既存の挙動です。** 変更前（`-dontoptimize` あり）の `mapping.txt` と比較して確認しました。

```text
# 変更前: Builder は残るが、newBuilder が c へ改名されている
com.android.installreferrer.api.InstallReferrerClient         -> X1.a:
    ...InstallReferrerClient$Builder newBuilder(android.content.Context) -> c
com.android.installreferrer.api.InstallReferrerClient$Builder -> X1.a$b:

# 変更後: Builder ごと未使用として削除されている
com.android.installreferrer.api.InstallReferrerClient         -> i2.a:
com.android.installreferrer.api.InstallReferrerClient$Builder -> R8$$REMOVED$$CLASS$$283:
```

変更前は難読化により `newBuilder` が `c` へ改名されているため、`getMethod("newBuilder", ...)` は同じく `NoSuchMethodException` になります。本 PR は失敗の理由を「改名」から「クラスごと削除」に変えているだけで、結果は変わりません。

### その他

- **iOS には影響しません。** 変更は `android/app/build.gradle` のみです。
- **`wearable` モジュールには影響しません。** 元から `proguard-android-optimize.txt` を使っています。
- **debug ビルドには影響しません。** `minifyEnabled` は release ビルドタイプのみです。
- R8 の最適化は単体テストでは検出できない実行時の破損を招きうるため、**Canary で実機確認を行ってから本番へ載せる想定**です。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: ビルド構成のみの変更で、画面の見た目やレイアウトには影響しません。実機での表示確認は上記「実機スモークテスト」の表に記載しています。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Androidのリリースビルドでコード最適化を有効化し、アプリのパフォーマンスとサイズ効率を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->