### PR TITLE
ポートレートの駅リストが環状線で進行方向と逆に並ぶ問題を修正

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -10,6 +10,7 @@ import {
   useCurrentTrainType,
   useEstimatedMinutesByStationId,
   useHeaderCommonData,
+  useLoopLine,
   useTransferLines,
   useTransferLinesFromStation,
   useTransferTargetStation,
@@ -59,6 +60,7 @@ jest.mock('~/hooks', () => ({
   useEstimatedMinutesByStationId: jest.fn(() => new Map<number, number>()),
   useGetLineMark: jest.fn(() => () => null),
   useHeaderCommonData: jest.fn(),
+  useLoopLine: jest.fn(() => ({ isLoopLine: false })),
   useStationNumberIndexFunc: jest.fn(() => () => 0),
   useTransferLines: jest.fn(() => []),
   useTransferLinesFromStation: jest.fn(() => []),
@@ -70,6 +72,7 @@ const mockedUseHeaderCommonData = useHeaderCommonData as jest.Mock;
 const mockedUseCurrentLine = useCurrentLine as jest.Mock;
 const mockedUseCurrentStation = useCurrentStation as jest.Mock;
 const mockedUseCurrentTrainType = useCurrentTrainType as jest.Mock;
+const mockedUseLoopLine = useLoopLine as unknown as jest.Mock;
 const mockedUseTransferLinesFromStation =
   useTransferLinesFromStation as jest.Mock;
 const mockedUseTransferLines = useTransferLines as jest.Mock;
@@ -124,6 +127,7 @@ const renderWithStations = (
     currentStation = stations[0],
     colorScheme = COLOR_SCHEME_PREFERENCE.LIGHT,
     bottomState = 'LINE' as const,
+    direction = 'INBOUND' as const,
     transferStation,
     onPress,
     onTransferPress,
@@ -132,6 +136,7 @@ const renderWithStations = (
     currentStation?: Station;
     colorScheme?: (typeof COLOR_SCHEME_PREFERENCE)[keyof typeof COLOR_SCHEME_PREFERENCE];
     bottomState?: 'LINE' | 'TRANSFER' | 'TYPE_CHANGE';
+    direction?: 'INBOUND' | 'OUTBOUND';
     transferStation?: Station;
     onPress?: () => void;
     onTransferPress?: (station?: Station) => void;
@@ -140,9 +145,9 @@ const renderWithStations = (
   const store = createStore();
   // 端末のダークモード状態に左右されないよう、配色は常に明示して固定する
   store.set(colorSchemePreferenceAtom, colorScheme);
-  // 全駅表示。INBOUND は反転しないので渡した順がそのまま表示順になる。
+  // 全駅表示。非環状線の INBOUND は反転しないので渡した順がそのまま表示順になる。
   store.set(stationsAtom, stations);
-  store.set(selectedDirectionAtom, 'INBOUND');
+  store.set(selectedDirectionAtom, direction);
   store.set(arrivedAtom, arrived);
   store.set(bottomStateAtom, bottomState);
   mockedUseCurrentStation.mockReturnValue(currentStation);
@@ -164,6 +169,7 @@ describe('PortraitMain', () => {
       nameRoman: 'Local',
       color: '#123456',
     });
+    mockedUseLoopLine.mockReturnValue({ isLoopLine: false });
     mockedUseTransferLinesFromStation.mockReturnValue([]);
     mockedUseTransferLines.mockReturnValue([]);
     mockedUseTransferTargetStation.mockReturnValue(undefined);
@@ -324,6 +330,56 @@ describe('PortraitMain', () => {
     ).not.toBe(yamanoteLine.color);
     expect(
       StyleSheet.flatten(getByTestId('stop-dot-2').props.style).borderColor
+    ).toBe(yamanoteLine.color);
+  });
+
+  it('環状線のOUTBOUNDは駅順が進行方向なので反転しない', () => {
+    mockedUseLoopLine.mockReturnValue({ isLoopLine: true });
+
+    const { getByTestId } = renderWithStations(
+      [
+        buildStation(1, '品川', StopCondition.All, 'JY-25'),
+        buildStation(2, '田町', StopCondition.All, 'JY-27'),
+        buildStation(3, '浜松町', StopCondition.All, 'JY-28'),
+      ],
+      {
+        arrived: true,
+        currentStation: buildStation(2, '田町', StopCondition.All),
+        direction: 'OUTBOUND',
+      }
+    );
+
+    // 進行方向は index 増加方向。現在駅より手前の品川が淡色、先の浜松町は通常色
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-1').props.style).borderColor
+    ).not.toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-3').props.style).borderColor
+    ).toBe(yamanoteLine.color);
+  });
+
+  it('環状線のINBOUNDは駅順と進行方向が逆なので反転する', () => {
+    mockedUseLoopLine.mockReturnValue({ isLoopLine: true });
+
+    const { getByTestId } = renderWithStations(
+      [
+        buildStation(1, '品川', StopCondition.All, 'JY-25'),
+        buildStation(2, '田町', StopCondition.All, 'JY-27'),
+        buildStation(3, '浜松町', StopCondition.All, 'JY-28'),
+      ],
+      {
+        arrived: true,
+        currentStation: buildStation(2, '田町', StopCondition.All),
+        direction: 'INBOUND',
+      }
+    );
+
+    // 進行方向は index 減少方向。現在駅より手前の浜松町が淡色、先の品川は通常色
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-3').props.style).borderColor
+    ).not.toBe(yamanoteLine.color);
+    expect(
+      StyleSheet.flatten(getByTestId('stop-dot-1').props.style).borderColor
     ).toBe(yamanoteLine.color);
   });
 

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -58,6 +58,7 @@ import {
   useEstimatedMinutesByStationId,
   useGetLineMark,
   useHeaderCommonData,
+  useLoopLine,
   useStationNumberIndexFunc,
   useTransferLines,
   useTransferLinesFromStation,
@@ -1358,6 +1359,7 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
   const arrived = useAtomValue(arrivedAtom);
   const currentLine = useCurrentLine();
   const trainType = useCurrentTrainType();
+  const { isLoopLine } = useLoopLine();
   const bottomState = useAtomValue(bottomStateAtom);
   const transferLines = useTransferLines();
   // 案内する乗換路線と対象駅がずれないよう、路線側と同じフックから引く
@@ -1408,13 +1410,19 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
 
   // ポートレートでは路線の全駅を進行方向順(上から下)に表示する。
   // 2路線の接続駅の重複を dropEitherJunctionStation で除いたうえで、
-  // INBOUND は index 増加方向へ進むので昇順のまま、OUTBOUND は index 減少
-  // 方向へ進むので反転する(useRefreshLeftStations と同じ向き)。
+  // 進行方向が index 減少方向のときだけ反転する。
+  // 通常の路線は INBOUND が index 増加方向だが、環状線(山手線・大阪環状線の
+  // 各駅停車・名城線・ディズニーリゾートライン)は向きが逆で、INBOUND が index
+  // 減少方向、OUTBOUND が増加方向になる(useSlicedStations / useNextStation /
+  // useRefreshLeftStations のループ線分岐と同じ向き)。
   const stops = useMemo(() => {
     const list = allStations.filter((s): s is Station => !!s);
     const dropped = dropEitherJunctionStation(list, selectedDirection);
-    return selectedDirection === 'OUTBOUND' ? [...dropped].reverse() : dropped;
-  }, [allStations, selectedDirection]);
+    const shouldReverse = isLoopLine
+      ? selectedDirection === 'INBOUND'
+      : selectedDirection === 'OUTBOUND';
+    return shouldReverse ? [...dropped].reverse() : dropped;
+  }, [allStations, selectedDirection, isLoopLine]);
 
   // 現在の最寄り駅(列車位置)の index。
   const currentIndex = useMemo(


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

ポートレート表示の駅リストが、環状線（山手線・大阪環状線の各駅停車・名城線・ディズニーリゾートライン）で進行方向と逆順に並んでいたのを修正します。

`PortraitMain` は駅配列を「INBOUND なら昇順のまま、OUTBOUND なら反転」で並べていましたが、このリポジトリでは INBOUND / OUTBOUND と駅配列 index の対応が路線種別で逆になります。

| | INBOUND | OUTBOUND |
| ---- | ---- | ---- |
| 通常の路線 | index 増加 | index 減少 |
| 環状線 | index 減少 | index 増加 |

環状線側の向きは `useSlicedStations` / `useNextStation` / `useRefreshLeftStations` のループ線分岐、および `useLoopLine` の行先算出がすべてこの規約で書かれていますが、`PortraitMain` だけが通常路線の規約しか見ていませんでした。

その結果、山手線「池袋・新宿 方面」（環状線の OUTBOUND = index 増加）で JY-14 → JY-04 の降順に描画され、実際の進行方向とリストが逆になっていました。発車済み／これから向かう駅の判定も同じ index を根拠にしているため、後方の上野・御徒町が「これから向かう駅」の見た目（強調表示・ETA 列のプレースホルダ）になっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/components/PortraitMain.tsx`: `useLoopLine()` の `isLoopLine` を参照し、反転条件を `isLoopLine ? selectedDirection === 'INBOUND' : selectedDirection === 'OUTBOUND'` に変更。あわせて、なぜ環状線だけ向きが逆なのかと参照実装（`useSlicedStations` / `useNextStation` / `useRefreshLeftStations`）をコメントに明記。
- `src/components/PortraitMain.test.tsx`: 環状線の INBOUND / OUTBOUND それぞれで並び順が正しいことを確かめるテストを追加。テストハーネスに `direction` オプションと `useLoopLine` のモックを追加。

### 回帰リスクと緩和策

- **影響範囲はポートレート表示の駅リストのみ**。変更したのは `PortraitMain` 内の `stops` の並び順を決める 1 か所で、横画面 LineBoard・ヘッダー・TTS・ETA 取得はいずれも別のフックを経由しており触れていません。
- **非環状線の挙動は不変**。`isLoopLine` が false のときは従来と同じ `selectedDirection === 'OUTBOUND'` 判定になります。既存テスト（`selectedDirectionAtom` が `INBOUND` のケース）はすべてそのまま通っています。
- **判定基準を新設していない**。`useLoopLine().isLoopLine` は大阪環状線の非各停を除外する条件を内包しており、既に他フックが同じフラグで分岐しています。独自の路線 ID 判定を持ち込んでいないため、対象路線の定義がここで二重管理になることはありません。
- 追加した 2 件のテストは、修正前のロジックに戻すと両方とも失敗することを確認済みです。

## テスト

<!-- どのようにテストしたかを記述してください -->

ローカルで以下を実行し、すべて成功しています。

- `npm run lint` — Checked 704 files、修正なし
- `npm test` — 253 suites / 2737 tests すべて成功
- `npm run typecheck` — エラーなし

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### ユーザー提供の実機スクリーンショット（端末名不明）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-loop-line-station-order-ad1da6a22/b93beae85b48-portrait-yamanote-before.png" width="320" alt="修正前: 山手線「池袋・新宿 方面」。JY-14→JY-04 の降順に並び、進行方向と逆になっている" />

修正前: 山手線「池袋・新宿 方面」。JY-14→JY-04 の降順に並び、進行方向と逆になっている

**修正後の画像は未添付**: 実機・シミュレータを起動できない環境のため。修正後の並び順（同じ状況で 鶯谷 JY-06 の下に 日暮里 JY-07 → 西日暮里 JY-08 → … と続く）は、追加した 2 件のユニットテストで担保しています。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 環状線の停車駅表示が、進行方向に応じた正しい順序で表示されるようになりました。
  * 通常路線を含め、列車の方向に合わせて駅順が適切に反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->