### PR TITLE
ポートレートモードを試験的機能から外観設定へ移設して本番でも利用可能にする

### DIFF
--- a/src/components/Permitted.tsx
+++ b/src/components/Permitted.tsx
@@ -46,7 +46,7 @@ import {
 import { useTrainTypeModal } from '../hooks/useTrainTypeModal';
 import { storage } from '../lib/storage';
 import { THEME_PREFERENCE, type ThemePreference } from '../models/Theme';
-import { portraitModeEnabledAtom } from '../store/atoms/experimental';
+import { portraitModeEnabledAtom } from '../store/atoms/display';
 import navigationState, {
   autoModeEnabledAtom,
   isAppLatestAtom,

--- a/src/hooks/useUpdateBottomState.test.tsx
+++ b/src/hooks/useUpdateBottomState.test.tsx
@@ -3,7 +3,7 @@ import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import { DEFAULT_BOTTOM_TRANSITION_INTERVAL } from '~/constants';
 import { THEME_PREFERENCE, type ThemePreference } from '~/models/Theme';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import { portraitModeEnabledAtom } from '~/store/atoms/display';
 import { bottomStateAtom } from '~/store/atoms/navigation';
 import { themePreferenceAtom } from '~/store/atoms/theme';
 import { useUpdateBottomState } from './useUpdateBottomState';

--- a/src/hooks/useUpdateBottomState.ts
+++ b/src/hooks/useUpdateBottomState.ts
@@ -1,6 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect } from 'react';
-import { portraitModeEnabledAtom } from '../store/atoms/experimental';
+import { portraitModeEnabledAtom } from '../store/atoms/display';
 import navigationState, { bottomStateAtom } from '../store/atoms/navigation';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import tuningState from '../store/atoms/tuning';

--- a/src/screens/ColorSchemeSettings.test.tsx
+++ b/src/screens/ColorSchemeSettings.test.tsx
@@ -4,6 +4,7 @@ import { STORAGE_KEYS } from '~/constants';
 import { storage } from '~/lib/storage';
 import { COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
 import { colorSchemePreferenceAtom } from '~/store/atoms/colorScheme';
+import { portraitModeEnabledAtom } from '~/store/atoms/display';
 import {
   getDialogPresentationSnapshot,
   resetDialogPresentationForTests,
@@ -26,10 +27,12 @@ jest.mock('~/translation', () => ({
 }));
 
 const renderWithStore = (
-  preference = COLOR_SCHEME_PREFERENCE.AUTO as (typeof COLOR_SCHEME_PREFERENCE)[keyof typeof COLOR_SCHEME_PREFERENCE]
+  preference = COLOR_SCHEME_PREFERENCE.AUTO as (typeof COLOR_SCHEME_PREFERENCE)[keyof typeof COLOR_SCHEME_PREFERENCE],
+  portraitModeEnabled = false
 ) => {
   const store = createStore();
   store.set(colorSchemePreferenceAtom, preference);
+  store.set(portraitModeEnabledAtom, portraitModeEnabled);
 
   const screen = render(
     <Provider store={store}>
@@ -76,6 +79,52 @@ describe('ColorSchemeSettingsScreen', () => {
     expect(storage.getString(STORAGE_KEYS.COLOR_SCHEME_PREFERENCE)).toBe(
       COLOR_SCHEME_PREFERENCE.DARK
     );
+  });
+
+  it('ポートレートモードをONにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore();
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    expect(store.get(portraitModeEnabledAtom)).toBe(true);
+    expect(storage.getString(STORAGE_KEYS.PORTRAIT_MODE_ENABLED)).toBe('true');
+  });
+
+  it('ポートレートモードをOFFにするとatomとストレージへ保存される', () => {
+    const { getByLabelText, store } = renderWithStore(
+      COLOR_SCHEME_PREFERENCE.AUTO,
+      true
+    );
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    expect(store.get(portraitModeEnabledAtom)).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.PORTRAIT_MODE_ENABLED)).toBe('false');
+  });
+
+  it('ポートレートモードの保存に失敗した場合はatom状態をロールバックしエラーを通知する', () => {
+    const setSpy = jest.spyOn(storage, 'set').mockImplementationOnce(() => {
+      throw new Error('storage failure');
+    });
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { getByLabelText, store } = renderWithStore();
+
+    fireEvent.press(getByLabelText('portraitModeTitle'));
+
+    expect(store.get(portraitModeEnabledAtom)).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to save portrait mode setting',
+      expect.any(Error)
+    );
+    expect(getDialogPresentationSnapshot().request).toMatchObject({
+      title: 'errorTitle',
+      message: 'failedToSavePreference',
+    });
+
+    setSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   it('ストレージへの保存に失敗した場合はatom状態をロールバックしエラーを通知する', () => {

--- a/src/screens/ColorSchemeSettings.tsx
+++ b/src/screens/ColorSchemeSettings.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { lighten } from 'polished';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
@@ -21,6 +21,7 @@ import {
 } from '~/models/ColorScheme';
 import { useAppColors } from '~/providers/AppColorsProvider';
 import { colorSchemePreferenceAtom } from '~/store/atoms/colorScheme';
+import { portraitModeEnabledAtom } from '~/store/atoms/display';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { showDialog } from '~/utils/dialogPresentation';
@@ -49,6 +50,10 @@ const styles = StyleSheet.create({
   description: {
     marginTop: 16,
     lineHeight: 21,
+  },
+  // 配色グループと画面レイアウトグループの区切りを視覚的に分かるようにする
+  toggleSpacer: {
+    marginTop: 32,
   },
   okButton: {
     width: 128,
@@ -122,6 +127,40 @@ const SettingsItem = ({
   );
 };
 
+const ToggleItem = ({
+  title,
+  state,
+  onToggle,
+}: {
+  title: string;
+  state: boolean;
+  onToggle: () => void;
+}) => {
+  const isLEDTheme = useAtomValue(isLEDThemeAtom);
+  const colors = useAppColors();
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityLabel={title}
+      accessibilityState={{ checked: state }}
+      onPress={onToggle}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 24,
+        paddingVertical: 16,
+        backgroundColor: isLEDTheme ? '#333' : colors.card,
+        borderRadius: isLEDTheme ? 0 : 12,
+      }}
+    >
+      <Typography style={styles.title}>{title}</Typography>
+
+      <StatePanel state={state} />
+    </Pressable>
+  );
+};
+
 const ColorSchemeSettingsScreen: React.FC = () => {
   const [headerHeight, setHeaderHeight] = useState(0);
 
@@ -131,6 +170,9 @@ const ColorSchemeSettingsScreen: React.FC = () => {
   const colors = useAppColors();
   const currentPreference = useAtomValue(colorSchemePreferenceAtom);
   const setColorSchemePreference = useSetAtom(colorSchemePreferenceAtom);
+  const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
+    portraitModeEnabledAtom
+  );
 
   const navigation = useNavigation();
 
@@ -178,6 +220,20 @@ const ColorSchemeSettingsScreen: React.FC = () => {
     [currentPreference, setColorSchemePreference]
   );
 
+  const handleTogglePortraitMode = useCallback(() => {
+    const flag = !portraitModeEnabled;
+    setPortraitModeEnabled(flag);
+    try {
+      storage.set(STORAGE_KEYS.PORTRAIT_MODE_ENABLED, flag ? 'true' : 'false');
+    } catch (error) {
+      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
+      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
+      setPortraitModeEnabled(!flag);
+      console.error('Failed to save portrait mode setting', error);
+      showDialog(translate('errorTitle'), translate('failedToSavePreference'));
+    }
+  }, [portraitModeEnabled, setPortraitModeEnabled]);
+
   const handleScroll = useRef(
     RNAnimated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
       useNativeDriver: true,
@@ -215,6 +271,18 @@ const ColorSchemeSettingsScreen: React.FC = () => {
             style={[styles.description, { color: colors.secondaryText }]}
           >
             {translate('colorSchemeDescription')}
+          </Typography>
+          <View style={styles.toggleSpacer}>
+            <ToggleItem
+              title={translate('portraitModeTitle')}
+              state={portraitModeEnabled}
+              onToggle={handleTogglePortraitMode}
+            />
+          </View>
+          <Typography
+            style={[styles.description, { color: colors.secondaryText }]}
+          >
+            {translate('portraitModeDescription')}
           </Typography>
           <Button
             style={styles.okButton}

--- a/src/screens/ExperimentalSettings.test.tsx
+++ b/src/screens/ExperimentalSettings.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { createStore, Provider } from 'jotai';
 import { STORAGE_KEYS } from '~/constants';
 import { storage } from '~/lib/storage';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import tuningState from '~/store/atoms/tuning';
 import {
   getDialogPresentationSnapshot,
@@ -26,12 +25,10 @@ jest.mock('~/translation', () => ({
 }));
 
 const renderWithStore = (
-  portraitModeEnabled: boolean,
   telemetryEnabled = false,
   untouchableModeEnabled = false
 ) => {
   const store = createStore();
-  store.set(portraitModeEnabledAtom, portraitModeEnabled);
   store.set(tuningState, (prev) => ({
     ...prev,
     telemetryEnabled,
@@ -56,60 +53,20 @@ describe('ExperimentalSettingsScreen', () => {
     resetDialogPresentationForTests();
   });
 
-  it('ポートレートモードをONにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false);
+  it('ポートレートモードのトグルは外観設定へ移設され表示されない', () => {
+    const { queryByLabelText } = renderWithStore();
 
-    fireEvent.press(getByLabelText('portraitModeTitle'));
-
-    expect(store.get(portraitModeEnabledAtom)).toBe(true);
-    expect(storage.getString(STORAGE_KEYS.PORTRAIT_MODE_ENABLED)).toBe('true');
-  });
-
-  it('ポートレートモードをOFFにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(true);
-
-    fireEvent.press(getByLabelText('portraitModeTitle'));
-
-    expect(store.get(portraitModeEnabledAtom)).toBe(false);
-    expect(storage.getString(STORAGE_KEYS.PORTRAIT_MODE_ENABLED)).toBe('false');
-  });
-
-  it('ストレージへの保存に失敗した場合はatom状態をロールバックしエラーを通知する', () => {
-    jest.spyOn(storage, 'set').mockImplementationOnce(() => {
-      throw new Error('storage failure');
-    });
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    const { getByLabelText, store } = renderWithStore(false);
-
-    fireEvent.press(getByLabelText('portraitModeTitle'));
-
-    // 保存失敗後にロールバックされる（MMKVは同期APIのため即時）
-    expect(store.get(portraitModeEnabledAtom)).toBe(false);
-
-    // エラーログとユーザーへのダイアログ表示を検証
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to save portrait mode setting',
-      expect.any(Error)
-    );
-    expect(getDialogPresentationSnapshot()).toMatchObject({
-      visible: true,
-      request: {
-        title: 'errorTitle',
-        message: 'failedToSavePreference',
-      },
-    });
+    expect(queryByLabelText('portraitModeTitle')).toBeNull();
   });
 
   it('ETA補助トグルは廃止され表示されない(自動有効化)', () => {
-    const { queryByLabelText } = renderWithStore(false);
+    const { queryByLabelText } = renderWithStore();
 
     expect(queryByLabelText('etaAssistTitle')).toBeNull();
   });
 
   it('テレメトリをONにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false);
+    const { getByLabelText, store } = renderWithStore();
 
     fireEvent.press(getByLabelText('optInTelemetryTitle'));
 
@@ -118,7 +75,7 @@ describe('ExperimentalSettingsScreen', () => {
   });
 
   it('テレメトリをOFFにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false, true);
+    const { getByLabelText, store } = renderWithStore(true);
 
     fireEvent.press(getByLabelText('optInTelemetryTitle'));
 
@@ -133,7 +90,7 @@ describe('ExperimentalSettingsScreen', () => {
     const consoleErrorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    const { getByLabelText, store } = renderWithStore(false);
+    const { getByLabelText, store } = renderWithStore();
 
     fireEvent.press(getByLabelText('optInTelemetryTitle'));
 
@@ -153,7 +110,7 @@ describe('ExperimentalSettingsScreen', () => {
   });
 
   it('タッチ不可モードをONにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false);
+    const { getByLabelText, store } = renderWithStore();
 
     fireEvent.press(getByLabelText('untouchableModeTitle'));
 
@@ -164,7 +121,7 @@ describe('ExperimentalSettingsScreen', () => {
   });
 
   it('タッチ不可モードをOFFにするとatomとストレージへ保存される', () => {
-    const { getByLabelText, store } = renderWithStore(false, false, true);
+    const { getByLabelText, store } = renderWithStore(false, true);
 
     fireEvent.press(getByLabelText('untouchableModeTitle'));
 
@@ -181,7 +138,7 @@ describe('ExperimentalSettingsScreen', () => {
     const consoleErrorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    const { getByLabelText, store } = renderWithStore(false);
+    const { getByLabelText, store } = renderWithStore();
 
     fireEvent.press(getByLabelText('untouchableModeTitle'));
 

--- a/src/screens/ExperimentalSettings.tsx
+++ b/src/screens/ExperimentalSettings.tsx
@@ -13,7 +13,6 @@ import { SettingsHeader } from '~/components/SettingsHeader';
 import { StatePanel } from '~/components/ToggleButton';
 import Typography from '~/components/Typography';
 import { useAppColors } from '~/providers/AppColorsProvider';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';
 import { translate } from '~/translation';
@@ -92,26 +91,9 @@ const ExperimentalSettingsScreen: React.FC = () => {
 
   const isLEDTheme = useAtomValue(isLEDThemeAtom);
   const colors = useAppColors();
-  const [portraitModeEnabled, setPortraitModeEnabled] = useAtom(
-    portraitModeEnabledAtom
-  );
   const [tuning, setTuning] = useAtom(tuningState);
 
   const navigation = useNavigation();
-
-  const handleTogglePortraitMode = useCallback(() => {
-    const flag = !portraitModeEnabled;
-    setPortraitModeEnabled(flag);
-    try {
-      storage.set(STORAGE_KEYS.PORTRAIT_MODE_ENABLED, flag ? 'true' : 'false');
-    } catch (error) {
-      // 保存に失敗したままだと次回起動時に設定が巻き戻るため、
-      // UIと永続値の不整合を防ぐべくatom状態をロールバックする
-      setPortraitModeEnabled(!flag);
-      console.error('Failed to save portrait mode setting', error);
-      showDialog(translate('errorTitle'), translate('failedToSavePreference'));
-    }
-  }, [portraitModeEnabled, setPortraitModeEnabled]);
 
   const handleToggleUntouchableMode = useCallback(() => {
     const flag = !tuning.untouchableModeEnabled;
@@ -163,22 +145,10 @@ const ExperimentalSettingsScreen: React.FC = () => {
           scrollEventThrottle={16}
         >
           <ToggleItem
-            title={translate('portraitModeTitle')}
-            state={portraitModeEnabled}
-            onToggle={handleTogglePortraitMode}
+            title={translate('optInTelemetryTitle')}
+            state={tuning.telemetryEnabled}
+            onToggle={handleToggleTelemetry}
           />
-          <Typography
-            style={[styles.description, { color: colors.secondaryText }]}
-          >
-            {translate('portraitModeDescription')}
-          </Typography>
-          <View style={styles.toggleSpacer}>
-            <ToggleItem
-              title={translate('optInTelemetryTitle')}
-              state={tuning.telemetryEnabled}
-              onToggle={handleToggleTelemetry}
-            />
-          </View>
           <Typography
             style={[styles.description, { color: colors.secondaryText }]}
           >

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -71,7 +71,7 @@ import {
 import { storage } from '~/lib/storage';
 import { getLineSymbolImage } from '~/lineSymbolImage';
 import { APP_THEME } from '~/models/Theme';
-import { portraitModeEnabledAtom } from '~/store/atoms/experimental';
+import { portraitModeEnabledAtom } from '~/store/atoms/display';
 import lineState from '~/store/atoms/line';
 import { isLEDThemeAtom, themeAtom } from '~/store/atoms/theme';
 import tuningState from '~/store/atoms/tuning';

--- a/src/store/atoms/display.ts
+++ b/src/store/atoms/display.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
 
-// 試験的機能のオンオフ。フィールド単位のプリミティブatomとして公開し、
+// 画面表示に関する設定。フィールド単位のプリミティブatomとして公開し、
 // 読み取りは必ずこちらを購読する(docs/state-management.md 参照)。
 export const portraitModeEnabledAtom = atom(false);


### PR DESCRIPTION
## 概要

ポートレートモードを試験的機能から卒業させ、本番ビルドでも利用できるようにします。設定画面では「試験的機能」カテゴリから外し、既存の「外観」カテゴリへ移設しました。

「試験的機能」への導線は `AppSettings` で `isDevApp` ガードがかかっており、canary ビルドでしか到達できません。トグルの置き場所を「外観」へ移すことで、ガードに手を入れることなく本番ビルドから設定できるようになります。ポートレートモードの実装側（`PortraitMain` / `useLandscapeWindowDimensions` / 画面向きロック）には元々 dev 限定の分岐はなく、機能そのものへの変更はありません。

移設先に「外観」を選んだのは、既存の説明文がすでに両者の関係を案内しているためです。

> 設定や路線選択などの操作画面の配色を変更します。（中略）走行中の画面はテーマ設定の配色のままですが、**ポートレートモードの表示だけはこの設定に追従します。**

ポートレートレイアウトは路線テーマではなくライト/ダーク設定に従う仕様なので、同じ画面に置くことで設定と説明が一致します。単一項目のカテゴリを新設せずに済む点も理由です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `ExperimentalSettings`: ポートレートモードのトグル・説明文・保存処理を削除（残るのはテレメトリとタッチ不可モード）
- `ColorSchemeSettings`: 配色ラジオ群の下に区切り余白を挟んでトグルを追加。保存失敗時の atom ロールバックとエラーダイアログは移設元と同じ挙動を維持
- `src/store/atoms/experimental.ts` を `src/store/atoms/display.ts` にリネーム（試験的機能ではなくなったため）。`Main.tsx` / `Permitted.tsx` / `useUpdateBottomState.ts` の import を追従
- ストレージキー `@TrainLCD:portraitModeEnabled` は変更なし。既存ユーザーの設定はそのまま引き継がれる

### リグレッションリスクと緩和

| リスク | 評価 | 緩和 |
| ---- | ---- | ---- |
| 既存ユーザーの設定が飛ぶ | 低 | MMKV のキーを変更していないため、`Permitted` の復元経路も含めて従来どおり動作する |
| atom のリネームによる参照漏れ | 低 | 旧モジュールを削除しているので、参照漏れがあれば `npm run typecheck` が失敗する。実行して通ることを確認済み |
| 「外観」画面のラジオ群への影響 | 低 | 既存の配色選択部分には手を入れず、下に独立したトグルを追加しただけ。既存テストもそのまま通る |
| canary の「試験的機能」画面の崩れ | 低 | 先頭項目だったポートレートモードを外したため、テレメトリの余白ラッパーを外して詰めた。スクリーンショットで確認済み |

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint      → Checked 704 files. No fixes applied.
npm test          → Test Suites: 253 passed / Tests: 2738 passed
npm run typecheck → エラーなし
```

テストの増減:

- `ColorSchemeSettings.test.tsx`: ポートレートモードの ON/OFF 保存・保存失敗時のロールバックの 3 件を追加
- `ExperimentalSettings.test.tsx`: ポートレートモード関連の 3 件を削除し、「移設され表示されない」ことの確認に置換

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Android エミュレータ (TrainLCD\_API30 / API 30)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-mode-general-availability-e68c75db05ed/ce2c2d42bb05-appearance-portrait-off.png" width="320" alt="「外観」設定に追加したポートレートモードのトグル（OFF）" />

「外観」設定に追加したポートレートモードのトグル（OFF）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-mode-general-availability-e68c75db05ed/1495980443b9-appearance-portrait-on.png" width="320" alt="トグルをONにした状態" />

トグルをONにした状態

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_portrait-mode-general-availability-e68c75db05ed/0e7a2a2df27c-experimental-after.png" width="320" alt="「試験的機能」からポートレートモードが外れた状態" />

「試験的機能」からポートレートモードが外れた状態（canary ビルドのみ表示される画面）

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 設定画面に縦向きモードの切り替えを追加しました。
  * 設定変更を保存し、保存に失敗した場合は状態を元に戻してエラーを表示します。
  * 実験設定から縦向きモードを移動し、テレメトリー設定を独立した項目として整理しました。

* **テスト**
  * 縦向きモードの切り替え、保存成功・失敗時の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->