### PR TITLE
ポートレートモードの走行画面で広すぎた文字送りを解除

### DIFF
--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -324,7 +324,6 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     fontSize: RFValue(11),
     fontWeight: 'bold',
-    letterSpacing: 1.4,
     height: RFValue(17),
     lineHeight: RFValue(17),
   },
@@ -514,7 +513,6 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     fontSize: RFValue(8),
     fontWeight: 'bold',
-    letterSpacing: 0.8,
   },
   transferDots: {
     flexDirection: 'row',
@@ -531,7 +529,6 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     fontSize: RFValue(10),
     fontWeight: 'bold',
-    letterSpacing: 0.6,
   },
   // 到着予測。数字と単位のベースラインを揃えたうえで右寄せの固定幅に置く
   etaColumn: {
@@ -560,7 +557,6 @@ const styles = StyleSheet.create({
   etaSoon: {
     fontSize: RFValue(10),
     fontWeight: 'bold',
-    letterSpacing: 0.4,
   },
   // のりかえ案内。停車駅リストと同じ領域に重ねて出す
   transferOverlay: {


### PR DESCRIPTION
## 概要

ポートレートモードの走行画面で、字間が広すぎた 4 箇所の `letterSpacing` を外します。不具合の修正ではなく、見た目の調整です。

対象はいずれも横幅に制約のある行に置かれたテキストで、文字送りの分だけ実効幅が広がっていました。

| スタイル | 用途 | 削除した値 |
| ---- | ---- | ---- |
| `stateText` | カード見出しの状態表示（「次は」「ただいま」「のりかえ」など）。`flexShrink: 1` + `numberOfLines={1}` で罫線と並ぶ | `1.4` |
| `passLabel` | 通過駅ラベル。駅名の直後にインラインで並ぶ | `0.8` |
| `stopNumber` | 停車駅リストの駅ナンバリング | `0.6` |
| `etaSoon` | 到着予測の「まもなく」。固定幅の ETA 列に収める | `0.4` |

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `src/components/PortraitMain.tsx` のスタイル定義から `letterSpacing` を 4 件削除（`stateText` / `passLabel` / `stopNumber` / `etaSoon`）
- 削除のみで、コンポーネント構造・条件分岐・props には一切手を入れていない

### リグレッションリスクと緩和

| リスク | 評価 | 緩和 |
| ---- | ---- | ---- |
| 他画面への波及 | なし | 変更は `PortraitMain.tsx` 内のローカルな `StyleSheet` のみで、他のコンポーネントからは参照されない |
| 縦書き・多言語表示での崩れ | 低 | 走行画面は日本語・英語・中国語・韓国語をローテーション表示するが、いずれも字間を詰める方向の変更で、行幅が広がる方向には動かない |
| テストへの影響 | なし | スタイル定数の削除のみで、既存のテストは全て通過（253 suites / 2737 tests） |

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint      → Checked 704 files. No fixes applied.
npm test          → Test Suites: 253 passed / Tests: 2737 passed
npm run typecheck → エラーなし
```

実機（Galaxy SCG13 / Android 16）に dev ビルドを入れ直して Metro 経由で読み込ませ、変更あり・なしの両方を同一の表示内容で撮影して差分を確認しました。両画像は MD5 が異なることを確認済みです（`0b23fc6f…` / `830c4eed…`）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy SCG13 \(Android 16\) 実機キャプチャの該当箇所を切り出して並べたもの

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-main-letter-spacing-aecbd2e305a2/ab4986f1f7d0-compare-letterspacing.png" width="640" alt="「次は」「のりかえ」の字間比較（上: 修正前 / 下: 修正後）" />

「次は」「のりかえ」の字間比較（上: 修正前 / 下: 修正後）

### Galaxy SCG13 \(Android 16\)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-main-letter-spacing-aecbd2e305a2/3d5a8332f31c-before-transfer.png" width="320" alt="修正前の走行画面（全体）" />

修正前の走行画面（全体）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-main-letter-spacing-aecbd2e305a2/13ebbf5ffa31-after-transfer.png" width="320" alt="修正後の走行画面（同一表示内容・全体）" />

修正後の走行画面（同一表示内容・全体）

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 状態テキスト、通過ラベル、駅番号、短時間の到着予測表示における文字間隔を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->