### PR TITLE
ライトウェイトテーマの乗換表記を「他N線」にして2行に収まる件数だけ並べる

### DIFF
--- a/src/components/HeaderLowPower.test.tsx
+++ b/src/components/HeaderLowPower.test.tsx
@@ -153,7 +153,7 @@ describe('HeaderLowPower', () => {
     expect(getByText('東急大井町線')).toBeTruthy();
   });
 
-  it('乗換路線が上限を超えたら残りを「他N線」に畳む', () => {
+  it('2行に収まる乗換路線はすべて並べる', () => {
     setEstimatedMinutes(2);
     useTransferLines.mockReturnValue(
       ['A線', 'B線', 'C線', 'D線', 'E線'].map((nameShort) => ({
@@ -166,7 +166,28 @@ describe('HeaderLowPower', () => {
       <HeaderLowPower {...createMockHeaderProps({ headerState: 'NEXT' })} />
     );
 
-    expect(getByText('A線・B線・C線 他2線')).toBeTruthy();
+    expect(getByText('A線・B線・C線・D線・E線')).toBeTruthy();
+  });
+
+  it('2行に収まらない乗換路線は収まる件数まで減らして「他N線」に畳む', () => {
+    setEstimatedMinutes(2);
+    useTransferLines.mockReturnValue(
+      [
+        '東京メトロ丸ノ内線',
+        '東京メトロ千代田線',
+        '東京メトロ半蔵門線',
+        '東京メトロ東西線',
+        '都営三田線',
+      ].map((nameShort) => ({ nameShort, nameRoman: nameShort }))
+    );
+
+    const { getByText } = render(
+      <HeaderLowPower {...createMockHeaderProps({ headerState: 'NEXT' })} />
+    );
+
+    expect(
+      getByText('東京メトロ丸ノ内線・東京メトロ千代田線 他3線')
+    ).toBeTruthy();
   });
 
   it('セーフエリアぶんを外周の余白として確保する', () => {

--- a/src/components/HeaderLowPower.test.tsx
+++ b/src/components/HeaderLowPower.test.tsx
@@ -153,7 +153,7 @@ describe('HeaderLowPower', () => {
     expect(getByText('東急大井町線')).toBeTruthy();
   });
 
-  it('乗換路線が上限を超えたら残りを「他N」に畳む', () => {
+  it('乗換路線が上限を超えたら残りを「他N線」に畳む', () => {
     setEstimatedMinutes(2);
     useTransferLines.mockReturnValue(
       ['A線', 'B線', 'C線', 'D線', 'E線'].map((nameShort) => ({
@@ -166,7 +166,7 @@ describe('HeaderLowPower', () => {
       <HeaderLowPower {...createMockHeaderProps({ headerState: 'NEXT' })} />
     );
 
-    expect(getByText('A線・B線・C線 他2')).toBeTruthy();
+    expect(getByText('A線・B線・C線 他2線')).toBeTruthy();
   });
 
   it('セーフエリアぶんを外周の余白として確保する', () => {

--- a/src/components/HeaderLowPower.tsx
+++ b/src/components/HeaderLowPower.tsx
@@ -145,7 +145,7 @@ const HeaderLowPower: React.FC<CommonHeaderProps> = ({
     if (!rest) {
       return joined;
     }
-    return isJapaneseState ? `${joined} 他${rest}` : `${joined} +${rest}`;
+    return isJapaneseState ? `${joined} 他${rest}線` : `${joined} +${rest}`;
   }, [isJapaneseState, transferLines]);
 
   return (

--- a/src/components/HeaderLowPower.tsx
+++ b/src/components/HeaderLowPower.tsx
@@ -14,8 +14,23 @@ import Typography from './Typography';
 const { background, primary, secondary, muted, accent } =
   LOW_POWER_THEME_COLORS;
 
-/** 乗換路線名を並べる上限。これを超えた分は「他N」に畳む */
-const MAX_TRANSFER_LINE_NAMES = 3;
+/** 乗換路線名に割ける行数。ヘッダー右カラムの取り分がこれで決まる */
+const TRANSFER_TEXT_LINES = 2;
+/** 乗換路線名のフォントサイズ(拡大率を掛ける前)。表示と文字数見積もりで共有する */
+const TRANSFER_TEXT_FONT_SIZE = 15;
+
+/**
+ * 全角1文字ぶんを1カラムとして数える。ASCII は半角なので 0.5 で見積もる。
+ * 行送りを実測せずに「何件まで並べられるか」を決めるための近似で、
+ * 日本語は任意位置で折り返せるため合計カラム数がそのまま行数の目安になる。
+ */
+const measureColumns = (text: string): number => {
+  let columns = 0;
+  for (const char of text) {
+    columns += (char.codePointAt(0) ?? 0) < 0x100 ? 0.5 : 1;
+  }
+  return columns;
+};
 
 /**
  * 低消費電力テーマ(#3697)のヘッダー。
@@ -132,7 +147,6 @@ const HeaderLowPower: React.FC<CommonHeaderProps> = ({
       return '';
     }
     const names = transferLines
-      .slice(0, MAX_TRANSFER_LINE_NAMES)
       .map((line) =>
         ((isJapaneseState ? line.nameShort : line.nameRoman) ?? '').replace(
           parenthesisRegexp,
@@ -140,13 +154,34 @@ const HeaderLowPower: React.FC<CommonHeaderProps> = ({
         )
       )
       .filter((name) => name.length);
-    const rest = transferLines.length - names.length;
-    const joined = names.join(isJapaneseState ? '・' : ', ');
-    if (!rest) {
-      return joined;
+    if (!names.length) {
+      return '';
     }
-    return isJapaneseState ? `${joined} 他${rest}線` : `${joined} +${rest}`;
-  }, [isJapaneseState, transferLines]);
+
+    const separator = isJapaneseState ? '・' : ', ';
+    const buildText = (count: number) => {
+      const joined = names.slice(0, count).join(separator);
+      const rest = names.length - count;
+      if (!rest) {
+        return joined;
+      }
+      return isJapaneseState ? `${joined} 他${rest}線` : `${joined} +${rest}`;
+    };
+
+    // 並べる件数は固定せず、右カラム2行に収まる文字数から決める。あふれた分は
+    // 必ず「他N線」へ畳まれるので、末尾が三点リーダーで切れることがない
+    const budget =
+      (metrics.sideColumnWidth / (TRANSFER_TEXT_FONT_SIZE * scale)) *
+      TRANSFER_TEXT_LINES;
+    for (let count = names.length; count > 1; count--) {
+      const text = buildText(count);
+      if (measureColumns(text) <= budget) {
+        return text;
+      }
+    }
+    // 1件でも溢れる駅はこれ以上畳みようがないので、そのまま返して省略に委ねる
+    return buildText(1);
+  }, [isJapaneseState, metrics.sideColumnWidth, scale, transferLines]);
 
   return (
     <View
@@ -337,10 +372,10 @@ const HeaderLowPower: React.FC<CommonHeaderProps> = ({
                 )}
               </Typography>
               <Typography
-                numberOfLines={2}
+                numberOfLines={TRANSFER_TEXT_LINES}
                 style={{
                   color: primary,
-                  fontSize: 15 * scale,
+                  fontSize: TRANSFER_TEXT_FONT_SIZE * scale,
                   lineHeight: 19 * scale,
                   fontWeight: 'bold',
                 }}


### PR DESCRIPTION
## 概要

ライトウェイトテーマのヘッダーにある「のりかえ」欄の表記を 2 点直しました。

1. 畳んだ残数の表記が `他N` で単位が無く日本語として不自然だったので `他N線` にしました。
2. 路線名を常に 3 件並べていたため、`東京メトロ丸ノ内線` のように長い名前の駅では 2 行に収まらず、末尾が三点リーダーで切れて `他N線` ごと読めなくなっていました。並べる件数を固定せず「右カラム 2 行に収まる文字数」から決めるようにして、あふれた分は必ず `他N線` へ畳まれるようにしています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/components/HeaderLowPower.tsx`
  - 日本語表示の残数表記を `他${rest}` → `他${rest}線` に変更（英語表示の `+N` は据え置き）
  - 固定上限 `MAX_TRANSFER_LINE_NAMES = 3` を廃止し、`TRANSFER_TEXT_LINES`（2 行）と `TRANSFER_TEXT_FONT_SIZE`（15dp）と右カラム幅から文字数予算を出して、収まる件数まで減らしながら `他N線` を組み立てるように変更
  - 文字幅の見積もりは `measureColumns`（ASCII は 0.5 カラム、それ以外は 1 カラム）で近似。日本語は任意位置で折り返せるため、合計カラム数がそのまま行数の目安になる
  - `numberOfLines` とフォントサイズを新しい定数から参照するようにして、見積もりと実表示がずれないようにした
- `src/components/HeaderLowPower.test.tsx`
  - 「2 行に収まる乗換路線はすべて並べる」ケースを追加
  - 「2 行に収まらない乗換路線は収まる件数まで減らして `他N線` に畳む」ケースへ差し替え

### 回帰リスクと緩和

- 影響範囲はライトウェイトテーマ（`APP_THEME.LOW_POWER`）のヘッダーの乗換表示のみで、他テーマのヘッダー・停車駅ストリップ（`LineBoardLowPower` の記号チップは `+N` のまま）には触れていません。
- 件数が固定 3 件でなくなるため、短い路線名の駅では従来より多く並ぶことがあります。これは「2 行に収まる範囲で並べる」という意図どおりの挙動で、収まらない場合は必ず `他N線` へ畳まれます。
- 文字幅は実測ではなく近似のため、極端に幅の広い字形では 1 文字ぶん溢れる可能性があります。その場合も `numberOfLines={2}` が従来どおり効くため、レイアウトが崩れることはありません。
- 路線名が 1 件でも 2 行に収まらない駅では畳みようがないので、従来どおり省略表示に委ねます。

## テスト

ローカルで以下を実行し、いずれも成功しています。

- `npm run lint` — 704 files checked, no fixes applied
- `npm test` — 253 suites / 2739 tests passed
- `npm run typecheck` — エラーなし

加えて、Galaxy SCG13（実機・devDebug ビルド）で京浜東北線・東京駅のライトウェイトテーマ走行画面を表示し、`のりかえ` が 2 行に収まり三点リーダーが出ないことを目視で確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy SCG13（実機・devDebug ビルド）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_low-power-transfer-line-suffix-0ed3868d3d44/2f80dbd29b60-after-transfer.png" width="640" alt="変更後: のりかえが2行に収まる件数だけ並び、末尾が「他10線」で三点リーダーが出ない" />

変更後: のりかえが 2 行に収まる件数だけ並び、末尾が「他10線」で三点リーダーが出ない

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 乗換路線名の表示が、画面幅や文字サイズに応じて最適化されました。
  * 2行に収まる場合は、より多くの路線を表示できるようになりました。
  * 収まりきらない路線は「他N線」や「+N」にまとめ、表示が見やすくなりました。
  * 路線名が長い場合も、限られた表示領域に合わせて適切に省略されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->