### PR TITLE
環状線の行先表示を終着駅ではなく方面にする

### DIFF
--- a/src/hooks/useHeaderStateText.test.tsx
+++ b/src/hooks/useHeaderStateText.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type { Station } from '~/@types/graphql';
+import type { HeaderLangState } from '~/models/HeaderTransitionState';
+import { APP_THEME } from '~/models/Theme';
+import { themeAtom } from '~/store/atoms/theme';
+import { createStation } from '~/utils/test/factories';
+import { headerStateAtom } from '../store/atoms/navigation';
+import { selectedBoundAtom } from '../store/atoms/station';
+import { useHeaderStateText } from './useHeaderStateText';
+import { useLoopLine } from './useLoopLine';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+
+jest.mock('./useLoopLine', () => ({
+  __esModule: true,
+  useLoopLine: jest.fn(),
+}));
+
+const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+  typeof useAtomValue
+>;
+const mockUseLoopLine = useLoopLine as jest.MockedFunction<typeof useLoopLine>;
+
+const osaki = createStation(1, { name: '大崎' });
+
+const setAtomValues = (selectedBound: Station | null) => {
+  mockUseAtomValue.mockImplementation((atom: unknown) => {
+    if (atom === headerStateAtom) return 'CURRENT';
+    if (atom === selectedBoundAtom) return selectedBound;
+    if (atom === themeAtom) return APP_THEME.TOKYO_METRO;
+    return undefined;
+  });
+};
+
+const setLoopLine = (isLoopLine: boolean) => {
+  mockUseLoopLine.mockReturnValue({
+    isLoopLine,
+    isYamanoteLine: isLoopLine,
+    isOsakaLoopLine: false,
+    isMeijoLine: false,
+    isOedoLine: false,
+    isDisneyResortLine: false,
+    isPartiallyLoopLine: false,
+    inboundStationsForLoopLine: [],
+    outboundStationsForLoopLine: [],
+  });
+};
+
+const renderStateTextRight = (headerLangState: HeaderLangState) =>
+  renderHook(() =>
+    useHeaderStateText({ isLast: false, headerLangState, firstStop: true })
+  ).result.current.stateTextRight;
+
+describe('useHeaderStateText', () => {
+  beforeEach(() => {
+    setAtomValues(osaki);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('環状線の乗車直後は行先に続く語を「方面」にする', () => {
+    setLoopLine(true);
+    expect(renderStateTextRight('JA')).toBe('方面');
+    expect(renderStateTextRight('KANA')).toBe('方面');
+    expect(renderStateTextRight('KO')).toBe('방면');
+  });
+
+  it('環状線でない路線の乗車直後は「ゆき」のまま', () => {
+    setLoopLine(false);
+    expect(renderStateTextRight('JA')).toBe('ゆき');
+    expect(renderStateTextRight('KANA')).toBe('ゆき');
+    expect(renderStateTextRight('KO')).toBe('행');
+  });
+
+  it('乗車直後でなければ行先に続く語は出さない', () => {
+    setLoopLine(true);
+    const { result } = renderHook(() =>
+      useHeaderStateText({
+        isLast: false,
+        headerLangState: 'JA',
+        firstStop: false,
+      })
+    );
+    expect(result.current.stateTextRight).toBe('');
+  });
+});

--- a/src/hooks/useHeaderStateText.ts
+++ b/src/hooks/useHeaderStateText.ts
@@ -6,6 +6,7 @@ import type { HeaderLangState } from '../models/HeaderTransitionState';
 import { headerStateAtom } from '../store/atoms/navigation';
 import { selectedBoundAtom } from '../store/atoms/station';
 import { translate } from '../translation';
+import { useLoopLine } from './useLoopLine';
 
 type UseHeaderStateTextOptions = {
   isLast: boolean;
@@ -26,6 +27,7 @@ export const useHeaderStateText = ({
   const headerState = useAtomValue(headerStateAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
   const currentTheme = useAtomValue(themeAtom);
+  const { isLoopLine } = useLoopLine();
 
   const stateText = useMemo<string>(() => {
     if (firstStop && selectedBound) {
@@ -79,18 +81,20 @@ export const useHeaderStateText = ({
 
   const stateTextRight = useMemo<string>(() => {
     if (firstStop && selectedBound) {
+      // 環状線は行先が単一の終着駅ではなく方面(例: 新宿・池袋)なので、
+      // 駅名に続く語も「ゆき」ではなく「方面」にする。
       switch (headerLangState) {
         case 'JA':
         case 'KANA':
-          return 'ゆき';
+          return isLoopLine ? '方面' : 'ゆき';
         case 'KO':
-          return '행';
+          return isLoopLine ? '방면' : '행';
         default:
           return '';
       }
     }
     return '';
-  }, [firstStop, selectedBound, headerLangState]);
+  }, [firstStop, selectedBound, headerLangState, isLoopLine]);
 
   if (
     currentTheme === APP_THEME.YAMANOTE ||

--- a/src/hooks/useHeaderStationText.test.tsx
+++ b/src/hooks/useHeaderStationText.test.tsx
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import type { Station } from '~/@types/graphql';
+import type { HeaderLangState } from '~/models/HeaderTransitionState';
+import { createStation } from '~/utils/test/factories';
+import { headerStateAtom } from '../store/atoms/navigation';
+import {
+  selectedBoundAtom,
+  selectedDirectionAtom,
+} from '../store/atoms/station';
+import { useHeaderStationText } from './useHeaderStationText';
+import { useLoopLine } from './useLoopLine';
+
+jest.mock('jotai', () => ({
+  __esModule: true,
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+
+jest.mock('./useLoopLine', () => ({
+  __esModule: true,
+  useLoopLine: jest.fn(),
+}));
+
+const mockUseAtomValue = useAtomValue as jest.MockedFunction<
+  typeof useAtomValue
+>;
+const mockUseLoopLine = useLoopLine as jest.MockedFunction<typeof useLoopLine>;
+
+const shibuya = createStation(1, {
+  name: '渋谷',
+  nameKatakana: 'シブヤ',
+  nameRoman: 'Shibuya',
+});
+const harajuku = createStation(2, {
+  name: '原宿',
+  nameKatakana: 'ハラジュク',
+  nameRoman: 'Harajuku',
+});
+const osaki = createStation(3, {
+  name: '大崎',
+  nameKatakana: 'オオサキ',
+  nameRoman: 'Osaki',
+});
+const shinjuku = createStation(4, {
+  name: '新宿',
+  nameKatakana: 'シンジュク',
+  nameRoman: 'Shinjuku',
+  nameChinese: '新宿',
+  nameKorean: '신주쿠',
+});
+const ikebukuro = createStation(5, {
+  name: '池袋',
+  nameKatakana: 'イケブクロ',
+  nameRoman: 'Ikebukuro',
+  nameChinese: '池袋',
+  nameKorean: '이케부쿠로',
+});
+
+const setAtomValues = ({
+  headerState,
+  selectedBound,
+  selectedDirection = 'INBOUND',
+}: {
+  headerState: string;
+  selectedBound: Station | null;
+  selectedDirection?: 'INBOUND' | 'OUTBOUND';
+}) => {
+  mockUseAtomValue.mockImplementation((atom: unknown) => {
+    if (atom === headerStateAtom) return headerState;
+    if (atom === selectedBoundAtom) return selectedBound;
+    if (atom === selectedDirectionAtom) return selectedDirection;
+    return undefined;
+  });
+};
+
+const setLoopLine = (
+  isLoopLine: boolean,
+  {
+    inbound = [] as Station[],
+    outbound = [] as Station[],
+  }: { inbound?: Station[]; outbound?: Station[] } = {}
+) => {
+  mockUseLoopLine.mockReturnValue({
+    isLoopLine,
+    isYamanoteLine: isLoopLine,
+    isOsakaLoopLine: false,
+    isMeijoLine: false,
+    isOedoLine: false,
+    isDisneyResortLine: false,
+    isPartiallyLoopLine: false,
+    inboundStationsForLoopLine: inbound,
+    outboundStationsForLoopLine: outbound,
+  });
+};
+
+const renderStationText = (
+  headerLangState: HeaderLangState,
+  firstStop: boolean
+) =>
+  renderHook(() =>
+    useHeaderStationText({
+      currentStation: shibuya,
+      nextStation: harajuku,
+      headerLangState,
+      firstStop,
+    })
+  ).result.current;
+
+describe('useHeaderStationText', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('環状線の乗車直後(firstStop)', () => {
+    beforeEach(() => {
+      setAtomValues({ headerState: 'CURRENT', selectedBound: osaki });
+      setLoopLine(true, { inbound: [shinjuku, ikebukuro] });
+    });
+
+    it('終着駅ではなく方面の主要駅を並べる', () => {
+      expect(renderStationText('JA', true)).toBe('新宿・池袋');
+    });
+
+    it('カナ表示ではひらがなにして並べる', () => {
+      expect(renderStationText('KANA', true)).toBe('しんじゅく・いけぶくろ');
+    });
+
+    it('英語表示では & で並べる', () => {
+      expect(renderStationText('EN', true)).toBe('Shinjuku & Ikebukuro');
+    });
+
+    it('中国語・韓国語表示でも方面の主要駅を並べる', () => {
+      expect(renderStationText('ZH', true)).toBe('新宿・池袋');
+      expect(renderStationText('KO', true)).toBe('신주쿠・이케부쿠로');
+    });
+
+    it('進行方向が外回りなら外回り側の主要駅を使う', () => {
+      setAtomValues({
+        headerState: 'CURRENT',
+        selectedBound: osaki,
+        selectedDirection: 'OUTBOUND',
+      });
+      setLoopLine(true, {
+        inbound: [shinjuku, ikebukuro],
+        outbound: [osaki, shinjuku],
+      });
+      expect(renderStationText('JA', true)).toBe('大崎・新宿');
+    });
+  });
+
+  it('環状線でも firstStop でなければ従来どおり駅名を出す', () => {
+    setAtomValues({ headerState: 'NEXT', selectedBound: osaki });
+    setLoopLine(true, { inbound: [shinjuku, ikebukuro] });
+    expect(renderStationText('JA', false)).toBe('原宿');
+  });
+
+  it('環状線でない路線の firstStop は終着駅を出す', () => {
+    setAtomValues({ headerState: 'CURRENT', selectedBound: osaki });
+    setLoopLine(false);
+    expect(renderStationText('JA', true)).toBe('大崎');
+  });
+
+  it('環状線でも方面の主要駅が取れないときは終着駅に落とす', () => {
+    setAtomValues({ headerState: 'CURRENT', selectedBound: osaki });
+    setLoopLine(true, { inbound: [] });
+    expect(renderStationText('JA', true)).toBe('大崎');
+  });
+});

--- a/src/hooks/useHeaderStationText.ts
+++ b/src/hooks/useHeaderStationText.ts
@@ -4,9 +4,13 @@ import type { Station } from '~/@types/graphql';
 import { parenthesisRegexp } from '~/constants';
 import type { HeaderLangState } from '../models/HeaderTransitionState';
 import { headerStateAtom } from '../store/atoms/navigation';
-import { selectedBoundAtom } from '../store/atoms/station';
+import {
+  selectedBoundAtom,
+  selectedDirectionAtom,
+} from '../store/atoms/station';
 import katakanaToHiragana from '../utils/kanaToHiragana';
 import { isBusLine } from '../utils/line';
+import { useLoopLine } from './useLoopLine';
 
 type UseHeaderStationTextOptions = {
   currentStation: Station | undefined;
@@ -23,8 +27,30 @@ export const useHeaderStationText = ({
 }: UseHeaderStationTextOptions): string => {
   const headerState = useAtomValue(headerStateAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
+  const selectedDirection = useAtomValue(selectedDirectionAtom);
+  const {
+    isLoopLine,
+    inboundStationsForLoopLine,
+    outboundStationsForLoopLine,
+  } = useLoopLine();
 
   const isBus = isBusLine(currentStation?.line);
+
+  // 環状線は一周して起点に戻るため、終着駅を出しても行先の案内にならない。
+  // 行先表示(useBoundText)と同じ主要駅を使い「新宿・池袋」のような方面で見せる。
+  const loopLineBoundStations = useMemo<Station[]>(() => {
+    if (!isLoopLine) {
+      return [];
+    }
+    return selectedDirection === 'INBOUND'
+      ? inboundStationsForLoopLine
+      : outboundStationsForLoopLine;
+  }, [
+    inboundStationsForLoopLine,
+    isLoopLine,
+    outboundStationsForLoopLine,
+    selectedDirection,
+  ]);
 
   const rawText = useMemo<string>(() => {
     if (!selectedBound) {
@@ -32,6 +58,23 @@ export const useHeaderStationText = ({
     }
 
     if (firstStop) {
+      if (loopLineBoundStations.length) {
+        switch (headerLangState) {
+          case 'KANA':
+            return loopLineBoundStations
+              .map((s) => katakanaToHiragana(s.nameKatakana))
+              .join('・');
+          case 'EN':
+            return loopLineBoundStations.map((s) => s.nameRoman).join(' & ');
+          case 'ZH':
+            return loopLineBoundStations.map((s) => s.nameChinese).join('・');
+          case 'KO':
+            return loopLineBoundStations.map((s) => s.nameKorean).join('・');
+          default:
+            return loopLineBoundStations.map((s) => s.name).join('・');
+        }
+      }
+
       switch (headerLangState) {
         case 'JA':
           return selectedBound.name ?? '';
@@ -104,6 +147,7 @@ export const useHeaderStationText = ({
     selectedBound,
     firstStop,
     headerLangState,
+    loopLineBoundStations,
   ]);
 
   return isBus ? rawText.replace(parenthesisRegexp, '') : rawText;

--- a/src/hooks/useNumbering.test.tsx
+++ b/src/hooks/useNumbering.test.tsx
@@ -15,6 +15,7 @@ import { useCurrentLine } from './useCurrentLine';
 import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useDisplayNextStation } from './useDisplayNextStation';
+import { useLoopLine } from './useLoopLine';
 import { useNumbering } from './useNumbering';
 import { useStationNumberIndexFunc } from './useStationNumberIndexFunc';
 
@@ -47,6 +48,11 @@ jest.mock('./useDisplayNextStation', () => ({
 jest.mock('./useStationNumberIndexFunc', () => ({
   __esModule: true,
   useStationNumberIndexFunc: jest.fn(),
+}));
+
+jest.mock('./useLoopLine', () => ({
+  __esModule: true,
+  useLoopLine: jest.fn(),
 }));
 
 const TestComponent: React.FC<{
@@ -92,6 +98,23 @@ describe('useNumbering', () => {
     useStationNumberIndexFunc as jest.MockedFunction<
       typeof useStationNumberIndexFunc
     >;
+  const mockUseLoopLine = useLoopLine as jest.MockedFunction<
+    typeof useLoopLine
+  >;
+
+  const mockLoopLine = (isLoopLine: boolean) => {
+    mockUseLoopLine.mockReturnValue({
+      isLoopLine,
+      isYamanoteLine: isLoopLine,
+      isOsakaLoopLine: false,
+      isMeijoLine: false,
+      isOedoLine: false,
+      isDisneyResortLine: false,
+      isPartiallyLoopLine: false,
+      inboundStationsForLoopLine: [],
+      outboundStationsForLoopLine: [],
+    });
+  };
 
   const mockAtomValues = ({
     arrived,
@@ -115,6 +138,7 @@ describe('useNumbering', () => {
     mockUseStationNumberIndexFunc.mockReturnValue(() => 0);
     mockUseCurrentLine.mockReturnValue(createLine(1));
     mockUseCurrentTrainType.mockReturnValue(null);
+    mockLoopLine(false);
   });
 
   afterEach(() => {
@@ -391,6 +415,53 @@ describe('useNumbering', () => {
 
     await waitFor(() => {
       expect(getByTestId('stationNumber').props.children).toBe('undefined');
+    });
+  });
+
+  describe('環状線の乗車直後(firstStop)', () => {
+    // 行先が方面(複数駅)になるため、そのうち1駅の番号を添えると
+    // その駅ゆきに見えてしまう。番号もスリーレターコードも出さない。
+    const buildLoopLineScenario = () => {
+      const bound = createStation(24, {
+        stationNumbers: [createStationNumber('JY', '24')],
+        stopCondition: StopCondition.All,
+        threeLetterCode: 'OSK',
+      });
+      const currentStation = createStation(20, {
+        stationNumbers: [createStationNumber('JY', '20')],
+        stopCondition: StopCondition.All,
+        threeLetterCode: 'SBY',
+      });
+
+      mockAtomValues({ arrived: true, selectedBound: bound });
+      mockUseCurrentStation.mockReturnValue(currentStation);
+      mockUseNextStation.mockReturnValue(undefined);
+    };
+
+    it('番号もスリーレターコードも出さない', async () => {
+      mockLoopLine(true);
+      buildLoopLineScenario();
+
+      const { getByTestId } = render(<TestComponent firstStop={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe('undefined');
+        expect(getByTestId('threeLetterCode').props.children).toBe('undefined');
+      });
+    });
+
+    it('環状線でなければ従来どおり行先の番号を出す', async () => {
+      mockLoopLine(false);
+      buildLoopLineScenario();
+
+      const { getByTestId } = render(<TestComponent firstStop={true} />);
+
+      await waitFor(() => {
+        expect(getByTestId('stationNumber').props.children).toBe(
+          JSON.stringify({ lineSymbol: 'JY', stationNumber: '24' })
+        );
+        expect(getByTestId('threeLetterCode').props.children).toBe('OSK');
+      });
     });
   });
 });

--- a/src/hooks/useNumbering.ts
+++ b/src/hooks/useNumbering.ts
@@ -8,6 +8,7 @@ import { useCurrentLine } from './useCurrentLine';
 import { useCurrentStation } from './useCurrentStation';
 import { useCurrentTrainType } from './useCurrentTrainType';
 import { useDisplayNextStation } from './useDisplayNextStation';
+import { useLoopLine } from './useLoopLine';
 import { useStationNumberIndexFunc } from './useStationNumberIndexFunc';
 
 export const useNumbering = (
@@ -24,6 +25,7 @@ export const useNumbering = (
 
   const currentLine = useCurrentLine();
   const currentStation = useCurrentStation();
+  const { isLoopLine } = useLoopLine();
   // まもなく表示時は現在地基準で接近している駅の番号を表示する
   const nextStation = useDisplayNextStation();
 
@@ -68,6 +70,14 @@ export const useNumbering = (
 
   useEffect(() => {
     if (!selectedBound || !targetStation) {
+      return;
+    }
+
+    // 環状線の乗車直後は行先が単一の終着駅ではなく方面(複数駅)なので、
+    // そのうち1駅の番号を添えるとその駅ゆきに見えてしまう。番号ごと出さない。
+    if (firstStop && isLoopLine) {
+      setStationNumber(undefined);
+      setThreeLetterCode(undefined);
       return;
     }
 
@@ -125,7 +135,9 @@ export const useNumbering = (
     arrived,
     currentStation,
     currentStationNumberIndex,
+    firstStop,
     isJobanLineRapid,
+    isLoopLine,
     nextStation?.stationNumbers,
     nextStation?.threeLetterCode,
     nextStationNumberIndex,


### PR DESCRIPTION
## 概要

環状線に乗車した直後の行先表示が、方面ではなく単一の終着駅名になっていた問題を修正します。山手線内回りに乗ると、ヘッダー右上の行先が「新宿・池袋 方面」なのに、駅名スロットには終端の「大崎」が出ていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useHeaderStationText`: 乗車直後(`firstStop`)の表示で、環状線のときは `selectedBound` の駅名ではなく `useLoopLine` の方面主要駅を並べる。`useBoundText` が「新宿・池袋 方面」を組み立てるのと同じ主要駅なので、ヘッダー右上と駅名スロットの表示が一致する。言語別の区切りは JA / ZH / KO が `・`、EN が ` & `。KANA はカタカナをひらがなへ変換して並べる。主要駅が取れない場合は従来どおり終着駅へフォールバックする
- `useHeaderStateText`: 駅名に続く語(`stateTextRight`)を環状線では「ゆき」→「方面」、韓国語は `행` → `방면` に切り替える。「新宿・池袋ゆき」という誤った案内を避けるため。EN の `For` / ZH の `开往` は `useBoundText` の表記と揃うためそのまま
- `useNumbering`: 環状線の `firstStop` では駅番号とスリーレターコードを出さない。行先が複数駅の方面になるため、そのうち 1 駅の番号(例: 大崎の JY 24 / OSK)を添えるとその駅ゆきに見えてしまう
- テスト: `useHeaderStationText.test.tsx` / `useHeaderStateText.test.tsx` を新規追加し、`useNumbering.test.tsx` に環状線ケースを追加(既存ケースは `useLoopLine` をモックして従来挙動を維持)

TTS(`useTTSText`)は以前から環状線で方面を読み上げていたため、表示側がそれに追随する形になります。

### 影響範囲とリグレッションリスク

- `useHeaderStationText` / `useHeaderStateText` は `useHeaderCommonData` 経由で全テーマのヘッダーが参照するため、変更は環状線に乗車した直後の表示全体に及ぶ。ただし分岐は `firstStop && isLoopLine` に限定しており、それ以外の経路は既存コードのまま通る
- `isLoopLine` は `useLoopLine` の判定をそのまま使うため、山手線・大阪環状線・名城線・ディズニーリゾートラインが対象。快速など各駅停車以外の種別では `isLoopLine` が false になり、従来どおり終着駅を表示する
- 大江戸線(`isPartiallyLoopLine`)は `isLoopLine` に含まれないため、今回の変更の対象外で挙動は変わらない

## テスト

`npm run lint && npm test && npm run typecheck` をローカルで実行し、すべて成功することを確認しました(255 スイート / 2752 テスト)。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_loop-line-first-stop-bound-a936c65a6beb/cebf00d24184-loop-line-bound-mock.png" width="720" alt="環状線(山手線 内回り)乗車直後の行先表示。左が変更前、右が変更後" />

環状線(山手線 内回り)乗車直後の行先表示。左が変更前、右が変更後。寸法・配色は `PortraitMain` / `NumberingIconSquare` の実装値と実機スクリーンショットの実測値に合わせていますが、実装を動かして得た画像ではありません。

<!-- create-pr:screenshots:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 環状線の乗車直後に、選択方向に応じた主要駅を方面表示できるようになりました。
- 環状線では、日本語・かな・韓国語の案内表現を方面向けに最適化しました。
- 環状線の乗車直後は、駅番号やスリーレターコードを表示しないようにしました。

## テスト
- 環状線・非環状線、多言語表示、進行方向ごとの案内を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->