### PR TITLE
タブレットのポートレートモードで上端の余白を下端と揃える

### DIFF
--- a/src/components/PortraitMain.tablet.test.tsx
+++ b/src/components/PortraitMain.tablet.test.tsx
@@ -1,0 +1,129 @@
+import { render } from '@testing-library/react-native';
+import { createStore, Provider } from 'jotai';
+import { StyleSheet } from 'react-native';
+import { type Line, type Station, StopCondition } from '~/@types/graphql';
+import { useCurrentStation, useHeaderCommonData } from '~/hooks';
+import { COLOR_SCHEME_PREFERENCE } from '~/models/ColorScheme';
+import { colorSchemePreferenceAtom } from '~/store/atoms/colorScheme';
+import { bottomStateAtom } from '~/store/atoms/navigation';
+import {
+  arrivedAtom,
+  selectedDirectionAtom,
+  stationsAtom,
+} from '~/store/atoms/station';
+import PortraitMain from './PortraitMain';
+
+jest.mock('~/translation', () => ({
+  isJapanese: true,
+  translate: jest.fn((key: string) => key),
+}));
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: true,
+}));
+
+// タブレットはノッチがないぶん上端のセーフエリアが 0 になる
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: jest.fn(() => ({
+    top: 0,
+    right: 0,
+    bottom: 20,
+    left: 0,
+  })),
+}));
+
+jest.mock('./NumberingIcon', () => () => null);
+
+jest.mock('~/hooks', () => ({
+  useBoundText: jest.fn(() => ({ JA: '品川・大崎方面' })),
+  useCurrentLine: jest.fn(() => ({
+    id: 11302,
+    color: '#80C241',
+    nameShort: '山手線',
+    nameRoman: 'Yamanote Line',
+  })),
+  useCurrentStation: jest.fn(),
+  useCurrentTrainType: jest.fn(() => null),
+  useEstimateArrivalTimesAllStops: jest.fn(() => ({
+    route: null,
+    loading: false,
+    error: null,
+  })),
+  useEstimatedMinutesByStationId: jest.fn(() => new Map<number, number>()),
+  useGetLineMark: jest.fn(() => () => null),
+  useHeaderCommonData: jest.fn(),
+  useLoopLine: jest.fn(() => ({ isLoopLine: false })),
+  useStationNumberIndexFunc: jest.fn(() => () => 0),
+  useTransferLines: jest.fn(() => []),
+  useTransferLinesFromStation: jest.fn(() => []),
+  useTransferStationNumbers: jest.fn((lines: Line[]) => lines.map(() => null)),
+  useTransferTargetStation: jest.fn(() => undefined),
+}));
+
+const station = {
+  id: 1,
+  groupId: 1,
+  name: '品川',
+  nameRoman: 'Shinagawa',
+  stopCondition: StopCondition.All,
+  stationNumbers: [{ stationNumber: 'JY-25' }],
+  line: {
+    id: 11302,
+    color: '#80C241',
+    nameShort: '山手線',
+    nameRoman: 'Yamanote Line',
+  },
+  lines: [],
+} as unknown as Station;
+
+describe('PortraitMain - tablet', () => {
+  beforeEach(() => {
+    (useHeaderCommonData as jest.Mock).mockReturnValue({
+      stateText: 'nextKana',
+      stationText: '高輪ゲートウェイ',
+      boundText: '品川・大崎方面',
+      currentStationNumber: {
+        lineSymbol: 'JY',
+        lineSymbolColor: '#80C241',
+        lineSymbolShape: 'ROUND',
+        stationNumber: 'JY-26',
+      },
+      threeLetterCode: undefined,
+      numberingColor: '#80C241',
+      headerState: 'NEXT_KANA',
+    });
+    (useCurrentStation as jest.Mock).mockReturnValue(station);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('セーフエリア上端が 0 でも下端と同じだけの余白を上端に確保する', () => {
+    const store = createStore();
+    store.set(colorSchemePreferenceAtom, COLOR_SCHEME_PREFERENCE.LIGHT);
+    store.set(stationsAtom, [station]);
+    store.set(selectedDirectionAtom, 'INBOUND');
+    store.set(arrivedAtom, true);
+    store.set(bottomStateAtom, 'LINE');
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <PortraitMain />
+      </Provider>
+    );
+
+    const paddingTop = StyleSheet.flatten(
+      getByTestId('portrait-root').props.style
+    ).paddingTop;
+    const paddingBottom = StyleSheet.flatten(
+      getByTestId('portrait-stop-list').props.contentContainerStyle
+    ).paddingBottom;
+
+    // 下端: リストの下パディング 12 + セーフエリア下端 20
+    expect(paddingBottom).toBe(12 + 20);
+    // 上端も同じ量を敷き、路線情報が画面の縁に貼り付かないようにする
+    expect(paddingTop).toBe(paddingBottom);
+  });
+});

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -1347,6 +1347,12 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
   // Dynamic Island / ノッチやホームインジケータと表示が被らないよう、
   // 上下のセーフエリア分を padding として確保する。
   const insets = useSafeAreaInsets();
+  // タブレットはノッチもホームインジケータもないぶんセーフエリアがほぼ 0 になり、
+  // 上端だけ余白が消えて路線情報が画面の縁に貼り付いて見える。下端に確保している
+  // 余白と同じ量を最低限敷いて、上下の重さを揃える。
+  const topInset = isTablet
+    ? Math.max(insets.top, STOP_LIST_PADDING_V + insets.bottom)
+    : insets.top;
   const colors = useAtomValue(appColorsAtom);
   const commonData = useHeaderCommonData();
   const allStations = useAtomValue(stationsAtom);
@@ -1596,13 +1602,13 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
   return (
     // ステータスバーは非表示のため SafeAreaView は使わず素の View を使う。
     // 上端は Dynamic Island / ノッチと路線情報が被らないよう、
-    // セーフエリア上端ぶんの padding を確保する。
+    // セーフエリア上端ぶん(タブレットでは下端の余白と同量)の padding を確保する。
     <View
       testID="portrait-root"
       onTouchStart={handleTouchStart}
       style={[
         styles.root,
-        { backgroundColor: colors.background, paddingTop: insets.top },
+        { backgroundColor: colors.background, paddingTop: topInset },
       ]}
     >
       <AccentWash


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

タブレットでポートレートモードを使うと画面上端に余白がなく、路線名・種別・行き先が画面の縁に接していました。下端に確保している余白と同量を上端の下限として敷き、上下の余白を揃えます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/components/PortraitMain.tsx`: ルート `View` の `paddingTop` を、タブレットのときだけ下端と同量（`STOP_LIST_PADDING_V (12) + insets.bottom`）を下限とする値に変更した。
- `src/components/PortraitMain.tablet.test.tsx`: `isTablet` を `true`、セーフエリアを `top: 0 / bottom: 20` にモックし、上端の `paddingTop` が停車駅リストの `paddingBottom` と一致することを検証するテストを追加した。

### 背景

ルート `View` は `paddingTop: insets.top` だけを敷いていた。iPhone は Dynamic Island / ノッチのぶん `insets.top` が 47〜59 あるため余白として成立するが、タブレットはノッチがないので `insets.top` がほぼ 0 になり、上端だけ余白が消えていた。一方の下端は `STOP_LIST_PADDING_V (12) + insets.bottom` を確保しているため、上下で余白量が食い違っていた。

### 回帰リスクと緩和

- 変更は `isTablet` が真のときの `paddingTop` のみ。スマートフォンは分岐に入らないため描画は変わらない。
- タブレットでも `Math.max(insets.top, ...)` なので従来値を下回ることはなく、上端が今より詰まる方向の変化は起きない。
- 上端の余白が増えるぶん停車駅リストの表示可能高さが 32pt 分縮む。リストはスクロール領域なので表示自体は破綻しないが、1 画面あたりの表示駅数がタブレットで 1 駅程度減る可能性がある。
- 追加したテストで、セーフエリア上端が 0 の条件下での余白量を固定した。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果:

- `npm run lint`: Checked 707 files, no fixes applied
- `npm test`: 256 suites / 2753 tests passed
- `npm run typecheck`: エラーなし

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### イメージ図（実装のレンダリング結果ではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-tablet-top-inset-a42b9464765f/bcb55053775e-portrait-tablet-inset.png" width="640" alt="修正前(上端0)と修正後(上端32)の比較" />

修正前\(上端0\)と修正後\(上端32\)の比較。縦方向の余白とスタイル値は実装値どおりだが、横幅は図の都合で圧縮しており、実機のレンダリング結果ではない。isTablet が true になるタブレット実機・エミュレータが手元にないため、実レンダリングのキャプチャは撮れていない。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDo6eiy4pbHnA355qcokfF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * タブレット表示で、画面上部のセーフエリアと最小余白を考慮したレイアウト調整を行いました。
  * 上部の余白がない端末でも、停止リスト周辺の余白が適切に保たれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->