### PR TITLE
LEDテーマでウォークスルーが白いカードで表示される不具合を修正

### DIFF
--- a/src/components/WalkthroughOverlay.test.tsx
+++ b/src/components/WalkthroughOverlay.test.tsx
@@ -170,12 +170,69 @@ describe('WalkthroughOverlay', () => {
     );
   });
 
-  it('LEDテーマではツールチップも角丸なしになる', () => {
-    const { getByLabelText } = renderOverlay(true);
+  it('通常テーマではツールチップがライト配色のカードになる', () => {
+    const { getByTestId, getByText, getByLabelText } = renderOverlay(false);
 
-    const nextButton = getByLabelText('walkthroughNext');
+    expect(getByTestId('walkthrough-tooltip')).toHaveStyle({
+      backgroundColor: '#FFFFFF',
+      borderRadius: 12,
+    });
+    expect(getByText('settingsWalkthroughTitle2')).toHaveStyle({
+      color: '#03a9f4',
+    });
+    expect(getByText('settingsWalkthroughDescription2')).toHaveStyle({
+      color: '#333333',
+    });
+    expect(getByText('walkthroughSkip')).toHaveStyle({ color: '#666666' });
+    expect(getByTestId('walkthrough-dot-0')).toHaveStyle({
+      backgroundColor: '#03a9f4',
+      borderRadius: 4,
+    });
+    expect(getByTestId('walkthrough-dot-1')).toHaveStyle({
+      backgroundColor: '#DDDDDD',
+    });
+    expect(getByLabelText('walkthroughNext')).toHaveStyle({
+      backgroundColor: '#03a9f4',
+      borderRadius: 6,
+    });
+  });
 
-    expect(nextButton).toHaveStyle({ borderRadius: 0 });
+  it('LEDテーマではツールチップが黒地・白枠・角丸なしになる', () => {
+    const { getByTestId, getByLabelText } = renderOverlay(true);
+
+    expect(getByTestId('walkthrough-tooltip')).toHaveStyle({
+      backgroundColor: '#212121',
+      borderColor: '#fff',
+      borderWidth: 1,
+      borderRadius: 0,
+    });
+    expect(getByLabelText('walkthroughNext')).toHaveStyle({
+      backgroundColor: '#212121',
+      borderColor: '#fff',
+      borderWidth: 1,
+      borderRadius: 0,
+    });
+  });
+
+  it('LEDテーマでは文字とドットも白系の配色になる', () => {
+    const { getByTestId, getByText } = renderOverlay(true);
+
+    expect(getByText('settingsWalkthroughTitle2')).toHaveStyle({
+      color: '#fff',
+    });
+    expect(getByText('settingsWalkthroughDescription2')).toHaveStyle({
+      color: '#fff',
+    });
+    expect(getByText('walkthroughSkip')).toHaveStyle({ color: '#CCCCCC' });
+    expect(getByText('walkthroughNext')).toHaveStyle({ color: '#fff' });
+    expect(getByTestId('walkthrough-dot-0')).toHaveStyle({
+      backgroundColor: '#fff',
+      borderRadius: 0,
+    });
+    expect(getByTestId('walkthrough-dot-1')).toHaveStyle({
+      backgroundColor: '#444',
+      borderRadius: 0,
+    });
   });
 });
 

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, { Defs, Mask, Path, Rect } from 'react-native-svg';
+import { LED_THEME_BG_COLOR } from '~/constants';
 import { useAppColors } from '~/providers/AppColorsProvider';
 import { isLEDThemeAtom } from '../store/atoms/theme';
 import { translate } from '../translation';
@@ -82,6 +83,12 @@ const ANIMATION_DURATION = 300;
 // spotlightArea.borderRadius が指定されていない場合の切り抜き半径
 const DEFAULT_SPOTLIGHT_BORDER_RADIUS = 8;
 
+// LEDテーマは appColorsAtom がライト配色を返すため colors.* をそのまま使うと白いカードになる。
+// 他のダイアログ(DialogModalLayout / Button)と同じ黒地・白枠・白文字の規則をここで持つ
+const LED_TEXT_COLOR = '#fff';
+const LED_MUTED_TEXT_COLOR = '#CCCCCC';
+const LED_INACTIVE_DOT_COLOR = '#444';
+
 const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFill,
@@ -148,6 +155,24 @@ const styles = StyleSheet.create({
   },
   // LEDテーマは角丸を使わないため、角丸を持つ要素すべてに重ねて直角化する
   squareCorners: {
+    borderRadius: 0,
+  },
+  tooltipContainerLED: {
+    backgroundColor: LED_THEME_BG_COLOR,
+    borderWidth: 1,
+    borderColor: LED_TEXT_COLOR,
+    borderRadius: 0,
+  },
+  titleLED: {
+    color: LED_TEXT_COLOR,
+  },
+  dotActiveLED: {
+    backgroundColor: LED_TEXT_COLOR,
+  },
+  nextButtonLED: {
+    backgroundColor: LED_THEME_BG_COLOR,
+    borderWidth: 1,
+    borderColor: LED_TEXT_COLOR,
     borderRadius: 0,
   },
 });
@@ -315,15 +340,23 @@ const WalkthroughOverlay: React.FC<Props> = ({
       </Pressable>
 
       <RNAnimated.View
+        testID="walkthrough-tooltip"
         style={[
           styles.tooltipContainer,
           { backgroundColor: colors.card },
           animatedTooltipStyle,
-          isLEDTheme && styles.squareCorners,
+          isLEDTheme && styles.tooltipContainerLED,
         ]}
       >
-        <Typography style={styles.title}>{translate(step.titleKey)}</Typography>
-        <Typography style={[styles.description, { color: colors.text }]}>
+        <Typography style={[styles.title, isLEDTheme && styles.titleLED]}>
+          {translate(step.titleKey)}
+        </Typography>
+        <Typography
+          style={[
+            styles.description,
+            { color: isLEDTheme ? LED_TEXT_COLOR : colors.text },
+          ]}
+        >
           {translate(step.descriptionKey)}
         </Typography>
 
@@ -334,7 +367,14 @@ const WalkthroughOverlay: React.FC<Props> = ({
             accessibilityLabel={skipText}
             accessibilityHint={translate('walkthroughSkipHint')}
           >
-            <Typography style={[styles.skipText, { color: colors.mutedText }]}>
+            <Typography
+              style={[
+                styles.skipText,
+                {
+                  color: isLEDTheme ? LED_MUTED_TEXT_COLOR : colors.mutedText,
+                },
+              ]}
+            >
               {skipText}
             </Typography>
           </Pressable>
@@ -354,10 +394,16 @@ const WalkthroughOverlay: React.FC<Props> = ({
                   accessibilityHint={translate('walkthroughGoToStepHint')}
                 >
                   <View
+                    testID={`walkthrough-dot-${index}`}
                     style={[
                       styles.dot,
-                      { backgroundColor: colors.border },
-                      index === currentStepIndex && styles.dotActive,
+                      {
+                        backgroundColor: isLEDTheme
+                          ? LED_INACTIVE_DOT_COLOR
+                          : colors.border,
+                      },
+                      index === currentStepIndex &&
+                        (isLEDTheme ? styles.dotActiveLED : styles.dotActive),
                       isLEDTheme && styles.squareCorners,
                     ]}
                   />
@@ -367,7 +413,7 @@ const WalkthroughOverlay: React.FC<Props> = ({
           ) : null}
 
           <Pressable
-            style={[styles.nextButton, isLEDTheme && styles.squareCorners]}
+            style={[styles.nextButton, isLEDTheme && styles.nextButtonLED]}
             onPress={onNext}
             accessibilityRole="button"
             accessibilityLabel={nextText}


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

LEDテーマ（電光掲示板風）でウォークスルーのツールチップがライト配色の白いカードで表示されていた不具合を修正します。`appColorsAtom` は LED テーマ中もライトの配色を返す設計のため、ツールチップ側で `colors.card` などをそのまま使うと白くなっていました。`DialogModalLayout` / `Button` と同じ LED 専用の見た目（黒地 `#212121`・白 1px 枠・白文字・角丸 0）をツールチップにも持たせています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `WalkthroughOverlay`: LED テーマ時の配色を LED 規則に変更。カードと「次へ」ボタンは `LED_THEME_BG_COLOR`（`#212121`）＋白 1px 枠、タイトル・本文は白、スキップは `#CCCCCC`（`PresetCard` の LED 時の補助文字色と同じ）、ドットは現在ページ `#FFFFFF`／それ以外 `#444`。角丸 0 は従来どおり
- 通常テーマ（ライト／ダーク）の見た目は変更なし
- `WalkthroughOverlay.test.tsx`: 通常テーマ／LED テーマの配色検証を 3 件追加。要素特定用に `testID`（`walkthrough-tooltip`、`walkthrough-dot-<n>`）を付与
- Figma（v10 / 👣 ウォークスルー）の `Tooltip / LEDテーマ` と仕様表の LED 行も同じ配色に更新済み（リポジトリ外）

回帰リスク: `isLEDTheme` が真のときだけ追加スタイルを重ねる構成なので、通常テーマへの影響はありません。LED テーマは `Typography` が文字色を白に固定する既存挙動と整合します。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は全 255 スイート・2754 件 pass。Android エミュレータ（TrainLCD_API30, API 30）で LED テーマにしてウォークスルーを再表示し、黒地・白枠・白文字で描画されることを確認しました。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### Android エミュレータ TrainLCD\_API30 \(API 30\)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_led-walkthrough-colors-e9b47ea57203/5edd6cf144a5-led_real_crop.png" width="320" alt="変更前: LEDテーマでもライト配色の白いカードになっていた" />

変更前: LEDテーマでもライト配色の白いカードになっていた

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_led-walkthrough-colors-e9b47ea57203/714b06028ff9-led_new_crop.png" width="320" alt="変更後: 黒地 #212121・白 1px 枠・白文字（他の LED ダイアログと同じ規則）" />

変更後: 黒地 \#212121・白 1px 枠・白文字（他の LED ダイアログと同じ規則）

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC5xE24kmtTs5Za67XYg9p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ウォークスルーで主ボタン、スキップラベル、背景タップ時の動作をカスタマイズできるようになりました。
  * 背景タップ時は、指定された処理を優先して実行します。未指定の場合は次のステップへ進みます。
  * 1ステップ בלבדの場合、ページドットを表示しないようにしました。

* **スタイル改善**
  * LEDテーマの表示を黒背景・白い境界線・白系文字・角丸なしで統一しました。
  * その他のテーマの表示は従来どおりです。

* **テスト**
  * 各テーマの表示スタイルと背景タップ時の動作に関する検証を拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->