### PR TITLE
iOSの権限説明画面で本文の末尾が見切れる不具合を修正

### DIFF
--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -20,11 +20,15 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    paddingHorizontal: 24,
   },
   text: {
     fontSize: RFValue(14),
     marginBottom: 12,
-    paddingHorizontal: 24,
+    // NOTE: Text 自身に paddingHorizontal を持たせたまま親の alignItems: 'center' で
+    // 内在幅に任せると、iOS では高さ計測時の折り返し幅が描画時より広くなり、
+    // 末尾の行が欠ける。余白は root 側へ移し、幅は親いっぱいに固定する。
+    alignSelf: 'stretch',
     lineHeight: Platform.select({
       ios: RFValue(18),
     }),
@@ -33,7 +37,6 @@ const styles = StyleSheet.create({
     color: '#03a9f4',
     fontSize: RFValue(21),
     fontWeight: 'bold',
-    width: '100%',
     textAlign: 'center',
     lineHeight: Platform.select({
       ios: RFValue(24),


### PR DESCRIPTION
## 概要

iPhone の権限説明画面（`PrivacyScreen`）で、説明文の末尾（日本語で「ます。」の 1 行分）が表示されずに見切れていた不具合を修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `styles.text` が持っていた `paddingHorizontal: 24` を `styles.root` へ移動
- `styles.text` に `alignSelf: 'stretch'` を追加し、`Text` の幅を親に固定
- 冗長になった `styles.headingText` の `width: '100%'` を削除
- 経緯が非自明なため NOTE コメントを追加

### 原因

`styles.text` が `Text` 自身に `paddingHorizontal: 24` を持ち、かつ親の `styles.root` が `alignItems: 'center'` で幅を内在幅に任せていました。この組み合わせだと iOS で **高さ計測時の折り返し幅と描画時の折り返し幅がずれ**、1 行分足りない高さで `Text` が確定して末尾がクリップされます。見出しだけ無事だったのは `headingText` に `width: '100%'` が付いていたためです。

報告いただいた画面キャプチャ（1179x2556 = 393x852pt @3x）を解析した根拠は以下のとおりです。

| 観測項目 | 値 |
| ---- | ---- |
| 本文の行送り | 69px = 23pt（`RFValue(18)` と一致） |
| 1〜9 行目の右端 | 約 362pt（内容幅 345pt = 393 - 24*2 で折り返し） |
| **10 行目の右端** | **382pt（内容幅を超えて padding へはみ出し、以降クリップ）** |
| 見出し上端〜ボタン下端 | 231〜645pt（セーフエリア 759pt に対して中央配置）＝ 画面はみ出しではない |

折り返し幅を変えたシミュレーションでも一致しました。

- 日本語: 幅 345pt → 11 行 / 幅 369pt → 10 行（実際の描画は 10 行で 11 行目が欠落）
- 英語: 幅 345pt → 14 行 / 幅 369pt → 13 行

そのため英語ロケールでも同様に末尾が欠けていたはずで、本修正で両方とも解消します。

### リグレッションリスク

- 影響範囲は `src/screens/Privacy.tsx` のみで、他画面から参照されるスタイルではありません。
- 横方向の余白（24pt）と中央揃えのレイアウトは従来と同一です。`paddingHorizontal` の適用先が `Text` から親 `SafeAreaView` に移るだけで、テキストの左右位置は変わりません。
- `headingText` の `width: '100%'` 削除は `alignSelf: 'stretch'` で等価に置き換わるため、見出しの中央揃えに変化はありません。
- Android は元々 `lineHeight` が未指定で本事象が出ていませんでしたが、今回の変更はプラットフォーム分岐を含まないため Android でも余白・折り返しは従来どおりです。

## テスト

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint       Checked 718 files in 797ms. No fixes applied.
npm run typecheck  エラーなし
npm test           Test Suites: 261 passed, 261 total / Tests: 2792 passed, 2792 total
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

未添付: 本事象は iOS 固有のテキスト計測差に起因するもので、実装を動かした画像を用意できなかったためです。作業環境は Linux で iOS シミュレータが使えず、React Native Web（`npm run web`）では `Platform.OS` が `'web'` となり `lineHeight` の分岐も padding 由来の計測差も再現しないため、修正の前後で差が出ません。修正前の見切れの状態は上表のとおり報告時のキャプチャを解析して数値で示しています。iOS 実機での目視確認をお願いします。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvKm2WSwmmE6eWDz15uBaB
