### PR TITLE
走行画面のテーマ一覧で未公開テーマが本番ビルドにも出る不具合を修正

### DIFF
--- a/src/components/ThemeListModal.test.tsx
+++ b/src/components/ThemeListModal.test.tsx
@@ -21,6 +21,9 @@ jest.mock('react-native-app-clip', () => ({
   isClip: jest.fn(() => false),
 }));
 
+// 本番ビルド相当。未公開テーマがこのモーダルから選べないことを担保する
+jest.mock('~/utils/isDevApp', () => ({ isDevApp: false }));
+
 jest.mock('../translation', () => ({
   translate: (key: string) => key,
   isJapanese: false,
@@ -71,6 +74,11 @@ describe('ThemeListModal', () => {
     fireEvent.press(getByText('tokyoMetroLike'));
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(THEME_PREFERENCE.TOKYO_METRO);
+  });
+
+  it('本番ビルドでは devOnly なテーマが一覧に表示されない', () => {
+    const { queryByText } = render(<ThemeListModal {...defaultProps} />);
+    expect(queryByText('lowPowerTheme')).toBeNull();
   });
 
   it('閉じるボタンを押すと onClose が呼ばれる', () => {

--- a/src/screens/ThemeSettings.tsx
+++ b/src/screens/ThemeSettings.tsx
@@ -22,7 +22,6 @@ import { useAppColors } from '~/providers/AppColorsProvider';
 import { isLEDThemeAtom, themePreferenceAtom } from '~/store/atoms/theme';
 import { translate } from '~/translation';
 import { showDialog } from '~/utils/dialogPresentation';
-import { isDevApp } from '~/utils/isDevApp';
 import isTablet from '~/utils/isTablet';
 import { RFValue } from '~/utils/rfValue';
 import { getSettingsThemes } from '~/utils/theme';
@@ -36,7 +35,6 @@ import { storage } from '../lib/storage';
 type SettingItem = {
   id: ThemePreference;
   title: string;
-  hidden: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -147,18 +145,14 @@ const ThemeSettingsScreen: React.FC = () => {
 
   const navigation = useNavigation();
 
-  const SETTING_ITEMS: SettingItem[] = useMemo(() => {
-    const themes = getSettingsThemes();
-    return themes.map((theme) => ({
-      id: theme.value,
-      title: theme.label,
-      hidden: !isDevApp && theme.devOnly,
-    }));
-  }, []);
-
-  const visibleItems = useMemo(
-    () => SETTING_ITEMS.filter((item) => !item.hidden),
-    [SETTING_ITEMS]
+  // getSettingsThemes() が未公開テーマを既に落としているため、ここでの再除外は不要
+  const visibleItems: SettingItem[] = useMemo(
+    () =>
+      getSettingsThemes().map((theme) => ({
+        id: theme.value,
+        title: theme.label,
+      })),
+    []
   );
 
   const handleApplyTheme = useCallback(

--- a/src/utils/theme.test.ts
+++ b/src/utils/theme.test.ts
@@ -1,0 +1,57 @@
+import { isClip } from 'react-native-app-clip';
+import { APP_THEME } from '~/models/Theme';
+
+jest.mock('react-native-app-clip', () => ({
+  isClip: jest.fn(() => false),
+}));
+
+jest.mock('~/translation', () => ({
+  translate: (key: string) => key,
+  isJapanese: false,
+}));
+
+const mockedIsClip = jest.mocked(isClip);
+
+// isDevApp は import 時に評価される定数のため、テストごとにモック値を変えて
+// モジュールを読み直す
+const loadThemes = (isDevApp: boolean) => {
+  let themes: ReturnType<typeof import('./theme').getSettingsThemes> = [];
+  jest.isolateModules(() => {
+    jest.doMock('./isDevApp', () => ({ isDevApp }));
+    themes = require('./theme').getSettingsThemes();
+  });
+  return themes;
+};
+
+describe('getSettingsThemes', () => {
+  beforeEach(() => {
+    mockedIsClip.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('本番ビルドでは devOnly なテーマを一覧に含めない', () => {
+    const themes = loadThemes(false);
+    expect(themes.some((t) => t.devOnly)).toBe(false);
+    expect(themes.some((t) => t.value === APP_THEME.LOW_POWER)).toBe(false);
+  });
+
+  it('カナリア版では devOnly なテーマも一覧に含める', () => {
+    const themes = loadThemes(true);
+    expect(themes.some((t) => t.value === APP_THEME.LOW_POWER)).toBe(true);
+  });
+
+  it('本番ビルドでも devOnly でないテーマは一覧に残る', () => {
+    const themes = loadThemes(false);
+    expect(themes.some((t) => t.value === APP_THEME.TOKYO_METRO)).toBe(true);
+    expect(themes.some((t) => t.value === APP_THEME.LED)).toBe(true);
+  });
+
+  it('App Clip では LED テーマを一覧に含めない', () => {
+    mockedIsClip.mockReturnValue(true);
+    const themes = loadThemes(false);
+    expect(themes.some((t) => t.value === APP_THEME.LED)).toBe(false);
+  });
+});

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -5,6 +5,7 @@ import {
   type ThemePreference,
 } from '~/models/Theme';
 import { translate } from '~/translation';
+import { isDevApp } from './isDevApp';
 
 export interface SettingsTheme {
   label: string;
@@ -85,4 +86,12 @@ export const getSettingsThemes = (): SettingsTheme[] =>
       // コードネームは低消費電力テーマ(#3697)。まずカナリア版だけで様子を見る
       devOnly: true,
     },
-  ].filter((t) => (isClip() ? t.value !== APP_THEME.LED : t)); // App Clip では LED テーマを非表示
+  ].filter((t) => {
+    // App Clip では LED テーマを非表示
+    if (isClip() && t.value === APP_THEME.LED) {
+      return false;
+    }
+    // 未公開テーマはカナリア版でのみ選べるようにする。
+    // 呼び出し側ごとに除外すると片方だけ漏れるため、一覧を組み立てるここで一元的に落とす
+    return isDevApp || !t.devOnly;
+  });


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

走行画面の設定モーダルから開くテーマ一覧（`ThemeListModal`）が `SettingsTheme.devOnly` を見ておらず、カナリア版限定のはずの未公開テーマが本番ビルドでも選択できる状態だったため、除外処理を一覧の生成元へ集約して塞ぐ。

テーマピッカーは 2 経路あり、`ThemeSettings` 画面だけが `devOnly` を除外していた。

| 経路 | 実装 | 修正前の `devOnly` |
| ---- | ---- | ---- |
| 設定画面 → テーマ | `src/screens/ThemeSettings.tsx` | 除外していた |
| 走行画面の設定モーダル → テーマ | `src/components/ThemeListModal.tsx` | **除外していなかった** |

`ThemeListModal` は `getSettingsThemes()` の戻り値をそのまま `FlatList` の `data` に渡していたため、`devOnly: true` のテーマがそのまま並んでいた。呼び出し側ごとに除外していたことが漏れの原因なので、呼び出し側で塞ぐのではなく `getSettingsThemes()` 側で落とす。

現時点で `devOnly: true` なのはライトウェイトテーマ（`APP_THEME.LOW_POWER`）のみ。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/theme.ts`: `getSettingsThemes()` の最終 `filter` に `isDevApp || !t.devOnly` を追加し、未公開テーマの除外を一覧生成の一箇所へ集約。既存の App Clip 向け LED 除外は挙動を変えずに同じ `filter` へ統合
- `src/screens/ThemeSettings.tsx`: 上記により不要になった `hidden: !isDevApp && theme.devOnly` と `SettingItem.hidden`、`visibleItems` の再フィルタを削除（未使用になった `isDevApp` の import も除去）。表示結果は修正前と同一
- `src/utils/theme.test.ts`: 新規。本番ビルド（`isDevApp: false`）で `devOnly` なテーマが落ちること、カナリア版（`isDevApp: true`）では残ること、`devOnly` でないテーマは本番でも残ること、App Clip で LED が落ちることを検証
- `src/components/ThemeListModal.test.tsx`: `~/utils/isDevApp` を `false` に固定して本番ビルド相当にし、`lowPowerTheme` が一覧に出ないことを検証するケースを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

ローカルで以下を実行し、いずれも成功。実行環境は Node 24.15.0 / npm 11.17.0。

- `npm run lint`: 719 ファイル、指摘なし
- `npm run typecheck`: エラーなし
- `npm test`: 262 suites / 2797 tests すべて成功

追加テストが回帰を実際に検出することも確認済み。`src/utils/theme.ts` のゲート（`return isDevApp || !t.devOnly;`）を一時的に `return true;` へ戻すと、`src/utils/theme.test.ts` と `src/components/ThemeListModal.test.tsx` の該当ケース計 2 件が失敗する。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->
未添付: 本番ビルドでのみ現れる差分（走行画面の設定モーダル → テーマ一覧からライトウェイトテーマの行が消える）で、開発ビルドのシミュレータでは再現しないため。カナリア版の見た目は修正前後で変わりません。挙動は `src/utils/theme.test.ts` と `src/components/ThemeListModal.test.tsx` で担保しています。
<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NNj7B5mf9DvKu6EBga3Ty


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - テーマ設定一覧で、アプリの公開環境に応じて未公開テーマを適切に表示・非表示にするよう改善しました。
  - カナリア版では対象テーマを表示し、本番版では開発用テーマを表示しません。
  - App Clipでは従来どおりLEDテーマを表示対象外としています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->