### PR TITLE
ポートレートモードで乗換路線の切り替えが確定しない不具合を修正

### DIFF
--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -778,6 +778,29 @@ const MainScreen: React.FC = () => {
     }
   }, [bottomState, handleTransferPress, hasTerminus, theme, transferStation]);
 
+  // 運転路線の切り替え確認で OK を押すと pendingLine/pendingStations が積まれ、
+  // 方面選択のモーダルで確定させる。どのレイアウトを返しても切り替えが完了する
+  // よう、レイアウトごとの return すべてでこの要素を描画する。
+  const selectBoundModal = (
+    <SelectBoundModal
+      visible={isSelectBoundModalOpen}
+      onClose={handleCloseSelectBoundModal}
+      onBoundSelect={handleCloseSelectBoundModal}
+      onTrainTypeSelect={handleTrainTypeSelect}
+      loading={
+        fetchStationsByLineGroupIdLoading ||
+        fetchStationsByLineIdLoading ||
+        fetchTrainTypesLoading
+      }
+      error={
+        fetchStationsByLineGroupIdError ||
+        fetchStationsByLineIdError ||
+        fetchTrainTypesError ||
+        null
+      }
+    />
+  );
+
   if (pictureInPictureActive) {
     return (
       <>
@@ -799,6 +822,7 @@ const MainScreen: React.FC = () => {
           onTransferPress={handleTransferPress}
         />
         {isDevApp && devOverlayEnabled && <DevOverlay />}
+        {selectBoundModal}
       </>
     );
   }
@@ -863,23 +887,7 @@ const MainScreen: React.FC = () => {
       {/* 回転しているビューの外に置いて正立させる(案A) */}
       <PortraitModePrompt />
 
-      <SelectBoundModal
-        visible={isSelectBoundModalOpen}
-        onClose={handleCloseSelectBoundModal}
-        onBoundSelect={handleCloseSelectBoundModal}
-        onTrainTypeSelect={handleTrainTypeSelect}
-        loading={
-          fetchStationsByLineGroupIdLoading ||
-          fetchStationsByLineIdLoading ||
-          fetchTrainTypesLoading
-        }
-        error={
-          fetchStationsByLineGroupIdError ||
-          fetchStationsByLineIdError ||
-          fetchTrainTypesError ||
-          null
-        }
-      />
+      {selectBoundModal}
     </>
   );
 };


### PR DESCRIPTION
## 概要

ポートレートモードで乗換路線を選び、「◯◯線に切り替えますか？」のモーダルで OK を押しても、走行中の路線が切り替わらない不具合を修正します。

原因は `src/screens/Main.tsx` のレイアウト分岐です。`handleTransferPress` → `changeOperatingLine` は OK 押下時に `pendingLine` / `pendingStations` / `fetchedTrainTypes` を積んで `SelectBoundModal` を開くところまでを担当し、実際の路線切り替えはその方面選択モーダルで確定します。ところが `SelectBoundModal` は横画面用の最終 `return` にしか描画されておらず、ポートレートモードの早期 `return` には含まれていませんでした。そのため OK を押しても方面選択モーダルが出ず、pending 状態が積まれたまま何も確定しない状態になっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `SelectBoundModal` を共有要素 `selectBoundModal` として切り出し、ポートレートモードの早期 `return` と通常レイアウトの `return` の両方で描画するようにした
- どのレイアウトを返しても切り替えが完了する、という意図をコメントで残した

LED テーマ / LOW\_POWER テーマの分岐には引き続き含めていません。これらは下部の乗換案内（`bottomState === 'TRANSFER'`）自体を描画せず `handleTransferPress` に到達しないため、影響がないと判断しました。

## テスト

Galaxy SCG13（実機・dev ビルド）で、ポートレートモード ON・山手線 品川駅の状態から次を確認しました。

1. のりかえ一覧で京浜東北線をタップ → 切り替え確認モーダルが表示される
2. OK を押下 → **行先選択モーダルが表示される**（修正前はここで何も起きなかった）
3. 大宮方面を選択 → 走行中の路線が京浜東北線 各駅停車 大宮ゆきへ切り替わり、ヘッダー・駅ナンバリング（JK-20）・配色が追従する

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 262 suites / 2797 tests すべて通過しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### Galaxy SCG13 \(実機\)

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-transfer-line-change-852e972e7ffe/0cc00979dc31-02-confirm-dialog.png" width="320" alt="乗換路線をタップして表示される切り替え確認モーダル" />

乗換路線をタップして表示される切り替え確認モーダル

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-transfer-line-change-852e972e7ffe/df1bbe859e51-03-select-bound-modal.png" width="320" alt="修正後: OK押下で行先選択モーダルが表示される" />

修正後: OK押下で行先選択モーダルが表示される

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_portrait-transfer-line-change-852e972e7ffe/9a4cbb2673a3-04-after-switch.png" width="320" alt="方面を選ぶと走行中の路線が京浜東北線へ切り替わる" />

方面を選ぶと走行中の路線が京浜東北線へ切り替わる

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iVCWSefqA7Myk3uuQAdv9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ポートレートレイアウトでも、バインド選択モーダルを表示できるようになりました。

- **改善**
  - レイアウトにかかわらず、バインド選択時のローディング中およびエラー発生時の表示が統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->