### PR TITLE
iOSの権限説明画面で本文末尾が欠ける不具合を行送り固定の解除で修正

### DIFF
--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -25,22 +25,21 @@ const styles = StyleSheet.create({
   text: {
     fontSize: RFValue(14),
     marginBottom: 12,
-    // NOTE: Text 自身に paddingHorizontal を持たせたまま親の alignItems: 'center' で
-    // 内在幅に任せると、iOS では高さ計測時の折り返し幅が描画時より広くなり、
-    // 末尾の行が欠ける。余白は root 側へ移し、幅は親いっぱいに固定する。
+    // NOTE: 余白は root 側へ持たせ、Text の幅は親いっぱいに固定する。Text 自身に
+    // paddingHorizontal を持たせて親の alignItems: 'center' で内在幅に任せると、
+    // 折り返し幅が計測時と描画時でずれる余地が残る。
     alignSelf: 'stretch',
-    lineHeight: Platform.select({
-      ios: RFValue(18),
-    }),
+    // NOTE: iOS で lineHeight を指定すると NSParagraphStyle の min/max lineHeight が
+    // 固定される。RN は高さ計測を高さ無制限の NSTextContainer で行い、描画は計測結果
+    // ちょうどの高さの NSTextContainer で行うため、行送りを固定して両者がわずかでも
+    // ずれると収まらない行が丸ごと捨てられ、末尾が欠ける。行送りはフォント本来の値に
+    // 任せる。
   },
   headingText: {
     color: '#03a9f4',
     fontSize: RFValue(21),
     fontWeight: 'bold',
     textAlign: 'center',
-    lineHeight: Platform.select({
-      ios: RFValue(24),
-    }),
   },
   buttons: {
     flexDirection: 'row',


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

iPhone の権限説明画面（`PrivacyScreen`）で説明文の末尾（日本語で「けます。」の 1 行分）が表示されない不具合を、iOS 固有の `lineHeight` 固定を解除することで修正します。

#6850 で余白の持たせ方を変更しましたが、カナリアビルド（#6857 マージ後）で撮影したキャプチャでも症状が再現したため、原因の見立てを変えた対処です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `styles.text` の `lineHeight: Platform.select({ ios: RFValue(18) })` を削除
- `styles.headingText` の `lineHeight: Platform.select({ ios: RFValue(24) })` を削除
- 経緯が非自明なため NOTE コメントを追加（`alignSelf: 'stretch'` を残している理由もあわせて明記）

`#6850` で入れた `root` 側の `paddingHorizontal: 24` と `styles.text` の `alignSelf: 'stretch'` はそのまま残しています。折り返し幅を計測時・描画時ともに確定させる意味では正しい形のためです。

### 原因

報告いただいたキャプチャ（1179x2556 = 393x852pt @3x、カナリアビルド）を実寸で計測した結果は以下のとおりです。

| 観測項目 | 値 |
| ---- | ---- |
| 本文の折り返し幅 | 左端 24.3pt / 右端 368.7pt ＝ 内容幅 345pt（`393 - 24*2`、#6850 適用後の想定どおり） |
| 行送り | 23pt（`RFValue(18)`） |
| 本文 `Text` の枠の高さ | 約 230pt ＝ `23 * 10 行`（下線の下端 567.0pt と 1 行目のベースラインから逆算） |
| 内容幅 345pt で折り返した場合に必要な行数 | 11 行（最終行「けます。」が枠外） |

つまり **描画は 345pt 幅で 11 行に折り返しているのに、`Text` の高さは 10 行分しか確保されていない**状態でした。折り返し幅は #6850 の想定どおり 345pt に確定していたため、幅ではなく高さ側の問題です。

React Native の iOS 実装では、`lineHeight` を指定すると `NSParagraphStyle` の `minimumLineHeight` / `maximumLineHeight` が固定値になります（`RCTAttributedTextUtils.mm`）。そのうえで

- 高さ計測は **高さ無制限**の `NSTextContainer` で行う（`RCTTextLayoutManager.mm` の `measureNSAttributedString` は `CGSize{width, CGFLOAT_MAX}`）
- 描画は **計測結果ちょうどの高さ**の `NSTextContainer` で行う（`drawAttributedString` は `frame.size`）

という非対称があり、行送りを固定して計測値と実際の行ボックス合計がわずかでもずれると、収まらない行が丸ごと 1 行捨てられます。本文は `fontSize: RFValue(14)` = 18pt に対し `lineHeight` = 23pt で、Roboto 本来の行送り 21.09pt（1.1719em）を超えていました。指定していた値が本来値を下回る見出し（`lineHeight` 30pt < 30.47pt）が無事だったこととも整合します。

### リグレッションリスク

- 影響範囲は `src/screens/Privacy.tsx` のみで、他画面から参照されるスタイルではありません。
- Android は `Platform.select({ ios: ... })` により元々 `lineHeight` 未指定だったため、表示は一切変わりません。
- iOS では行送りがフォント本来の値になります。本文が 23pt → 21.09pt、見出しが 30pt → 30.47pt と変化しますが、レイアウトは中央揃えで十分な余白があり、はみ出しは発生しません。
- 同じ `lineHeight: Platform.select({ ios: ... })` のパターンは `PortraitModePrompt` / `WalkthroughOverlay` / `TypeChangeNotify` にもあり、いずれも fontSize に対する行送りが本来値を上回っています。本 PR では触れていません。原因が実機で確定したうえで、まとめて見直す想定です。

### 未確認事項

作業環境（Linux）に iOS シミュレータが無く、実機での確認ができていません。上記は計測値と React Native の実装から立てた仮説で、#6850 に続く 2 本目の仮説です。**カナリアビルドでの実機確認をお願いします。**

これで解消しない場合は、当該 `Text` に `onLayout` / `onTextLayout` を一時的に仕込み、確定した高さと React Native が保持している行数をログに出して、幅の問題か高さの問題かを切り分ける方針です。

## テスト

<!-- どのようにテストしたかを記述してください -->

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint       Checked 719 files in 1079ms. No fixes applied.
npm run typecheck  エラーなし
npm test           Test Suites: 262 passed, 262 total / Tests: 2797 passed, 2797 total
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6850

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: 本事象は iOS 固有のテキスト計測差に起因するもので、実装を動かした画像を用意できなかったためです。作業環境は Linux で iOS シミュレータが使えず、React Native Web（`npm run web`）では `Platform.OS` が `'web'` となり今回削除した `Platform.select({ ios: ... })` の分岐自体が適用されないため、修正の前後で差が出ません。修正前の見切れの状態は「原因」節のとおり、報告時のキャプチャを実寸で解析して数値で示しています。iOS 実機での目視確認をお願いします。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoEyFhop3QN6ZARNyre9Dk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * iOSでプライバシー画面の本文と見出しの行間表示を調整しました。
  * 本文の折り返しと高さ計測に関する表示動作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->