### PR TITLE
権限説明画面の行間を末尾が欠けない上限まで戻す

### DIFF
--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -29,17 +29,25 @@ const styles = StyleSheet.create({
     // paddingHorizontal を持たせて親の alignItems: 'center' で内在幅に任せると、
     // 折り返し幅が計測時と描画時でずれる余地が残る。
     alignSelf: 'stretch',
-    // NOTE: iOS で lineHeight を指定すると NSParagraphStyle の min/max lineHeight が
-    // 固定される。RN は高さ計測を高さ無制限の NSTextContainer で行い、描画は計測結果
-    // ちょうどの高さの NSTextContainer で行うため、行送りを固定して両者がわずかでも
-    // ずれると収まらない行が丸ごと捨てられ、末尾が欠ける。行送りはフォント本来の値に
-    // 任せる。
+    // NOTE: iOS の lineHeight は fontSize の 1.1719 倍(Roboto 本来の行送り)を超えて
+    // はいけない。RN は Text の高さ計測に指定フォント(Roboto)の行送りを使う一方、
+    // 描画は lineHeight と実際に使われるフォント(和文はフォールバックされ 1.0em)に
+    // 従うため、これを超えると枠に収まらない行が丸ごと捨てられて末尾が欠ける。
+    // RFValue(16)/RFValue(14) は端末サイズによらず 1.11〜1.16em に収まる。
+    lineHeight: Platform.select({
+      ios: RFValue(16),
+    }),
   },
   headingText: {
     color: '#03a9f4',
     fontSize: RFValue(21),
     fontWeight: 'bold',
     textAlign: 'center',
+    // NOTE: RFValue(24)/RFValue(21) は 1.14〜1.15em で上記の上限内。見出しが元から
+    // 欠けていなかったのはこのため。
+    lineHeight: Platform.select({
+      ios: RFValue(24),
+    }),
   },
   buttons: {
     flexDirection: 'row',

--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -15,6 +15,19 @@ import { isJapanese, translate } from '../translation';
 import { showDialog } from '../utils/dialogPresentation';
 import { RFValue } from '../utils/rfValue';
 
+// NOTE: iOS の lineHeight は fontSize の 1.1719 倍(= Roboto 本来の行送り)を超えては
+// いけない。RN は Text の高さ計測に指定フォント(Roboto)の行送りを使う一方、描画は
+// lineHeight と実際に使われるフォント(和文は Roboto にグリフが無くフォールバックされ
+// 1.0em)に従うため、これを超えると確定した枠に収まらない行が丸ごと捨てられ、末尾が
+// 欠ける。RFValue は値ごとに Math.round するため RFValue(16)/RFValue(14) のような比は
+// 画面高で変動し(画面高 844 では 20/17 = 1.18em で上限超過)、安全域を保証できない。
+// fontSize から直接算出して比率を固定する。
+const IOS_LINE_HEIGHT_RATIO = 1.15;
+const DESCRIPTION_FONT_SIZE = RFValue(14);
+const HEADING_FONT_SIZE = RFValue(21);
+const iosLineHeight = (fontSize: number) =>
+  Platform.select({ ios: Math.floor(fontSize * IOS_LINE_HEIGHT_RATIO) });
+
 const styles = StyleSheet.create({
   root: {
     flex: 1,
@@ -23,31 +36,20 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   text: {
-    fontSize: RFValue(14),
+    fontSize: DESCRIPTION_FONT_SIZE,
     marginBottom: 12,
     // NOTE: 余白は root 側へ持たせ、Text の幅は親いっぱいに固定する。Text 自身に
     // paddingHorizontal を持たせて親の alignItems: 'center' で内在幅に任せると、
     // 折り返し幅が計測時と描画時でずれる余地が残る。
     alignSelf: 'stretch',
-    // NOTE: iOS の lineHeight は fontSize の 1.1719 倍(Roboto 本来の行送り)を超えて
-    // はいけない。RN は Text の高さ計測に指定フォント(Roboto)の行送りを使う一方、
-    // 描画は lineHeight と実際に使われるフォント(和文はフォールバックされ 1.0em)に
-    // 従うため、これを超えると枠に収まらない行が丸ごと捨てられて末尾が欠ける。
-    // RFValue(16)/RFValue(14) は端末サイズによらず 1.11〜1.16em に収まる。
-    lineHeight: Platform.select({
-      ios: RFValue(16),
-    }),
+    lineHeight: iosLineHeight(DESCRIPTION_FONT_SIZE),
   },
   headingText: {
     color: '#03a9f4',
-    fontSize: RFValue(21),
+    fontSize: HEADING_FONT_SIZE,
     fontWeight: 'bold',
     textAlign: 'center',
-    // NOTE: RFValue(24)/RFValue(21) は 1.14〜1.15em で上記の上限内。見出しが元から
-    // 欠けていなかったのはこのため。
-    lineHeight: Platform.select({
-      ios: RFValue(24),
-    }),
+    lineHeight: iosLineHeight(HEADING_FONT_SIZE),
   },
   buttons: {
     flexDirection: 'row',


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

権限説明画面（`PrivacyScreen`）の行間を、末尾が欠けない上限まで戻します。

#6859 で本文末尾の見切れは解消しましたが、`lineHeight` を丸ごと外したため行間が詰まって可読性が落ちていました。実機キャプチャ 2 枚（修正前・修正後）を実寸で突き合わせた結果、iOS 側の上限が数値で確定したので、その範囲内で行間を戻します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `lineHeight` を `fontSize` から直接算出する `iosLineHeight()` を追加し、`styles.text` と `styles.headingText` に適用
- 比率の上限を `IOS_LINE_HEIGHT_RATIO = 1.15` として定数化し、`Math.floor(fontSize * 1.15)` で算出
- 上限の根拠が非自明なため NOTE コメントを追加

画面高 852pt（393x852、iPhone 15 / 16 など）での実効値:

| | #6859 以前 | #6859 | 本 PR | 計測側の上限 |
| ---- | ---- | ---- | ---- | ---- |
| 本文（fontSize 18pt） | 23pt（欠ける） | 18pt | **20pt** | 21.09pt |
| 見出し（fontSize 26pt） | 30pt | 26pt | **29pt** | 30.47pt |

### 上限の根拠

報告いただいた実機キャプチャ 2 枚（いずれも 1179x2556 = 393x852pt @3x、カナリアビルド）を実寸で計測し、レイアウトの中央揃えから各 `Text` の枠の高さを逆算しました。

| 要素 | 描画（実測の行送り） | 枠の高さ（逆算） | 枠 ÷ fontSize |
| ---- | ---- | ---- | ---- |
| ボタンの文字「続ける」（18pt・和文のみ・`lineHeight` 指定なし） | 18.0pt（1.0em） | 21.3pt | **1.18** |
| 本文（#6859 以前・`lineHeight` 23pt・11 行） | 23pt × 11 = 253pt | 約 231pt | **1.17** |
| 見出し（#6859 以前・`lineHeight` 30pt・2 行） | 30pt × 2 = 60pt | 約 60pt | 1.17 以内 |

**iOS は `Text` の高さ計測に指定フォント（Roboto）の行送り 1.1719em を使う一方、描画は `lineHeight` と実際に使われるフォント（和文は Roboto にグリフが無くフォールバックされ 1.0em）に従います。** `lineHeight` が計測側の 1.1719em を超えると、確定した枠に収まらない行が丸ごと捨てられ、末尾が欠けます。

- 本文: `RFValue(18)` / `RFValue(14)` = 23 / 18 = **1.278em** → 上限超過。11 行で 253pt 必要なところ枠が約 231pt しかなく、11 行目が欠けていた
- 見出し: `RFValue(24)` / `RFValue(21)` = 30 / 26 = **1.154em** → 上限内。**見出しだけ欠けていなかったのはこのため**

### なぜ `RFValue` 同士の比ではなく `fontSize` から算出するか

`RFValue` は値ごとに `Math.round` するため、`RFValue(16)` / `RFValue(14)` のような比は画面高によって変動します。全画面高（400〜2000pt）で総当たりしたところ、**166 通りの画面高で上限 1.1719em を超えました**。

| 画面高 | `RFValue(14)` | `RFValue(16)` | 比 | 判定 |
| ---- | ---- | ---- | ---- | ---- |
| 852（iPhone 15 / 16） | 18 | 20 | 1.111em | OK |
| **844（iPhone 12 / 13 / 14）** | **17** | **20** | **1.176em** | **上限超過** |
| 568 | 12 | 13 | 1.083em | OK |

`RFValue(24)` / `RFValue(21)`（見出し）も同様に一部の画面高で超過します。

`Math.floor(fontSize * 1.15)` で算出すれば比は必ず 1.15em 以下になり（`floor` は比を下げる方向にしか働かない）、画面高によらず上限を下回ることを同じ総当たりで確認しました。

| 画面高 | 本文 fontSize / lineHeight | 比 | 見出し fontSize / lineHeight | 比 |
| ---- | ---- | ---- | ---- | ---- |
| 568 | 12 / 13 | 1.083em | 18 / 20 | 1.111em |
| 667 | 14 / 16 | 1.143em | 21 / 24 | 1.143em |
| 844 | 17 / 19 | 1.118em | 26 / 29 | 1.115em |
| 852 | 18 / 20 | 1.111em | 26 / 29 | 1.115em |
| 932 | 19 / 21 | 1.105em | 29 / 33 | 1.138em |

本文 11 行で 11 × 20 = 220pt に対し計測値は約 232pt なので 12pt の余裕があります。1 行あたりで不等式が成立するため、行数が増える英語ロケール（14 行）でも成立します。

### リグレッションリスク

- 影響範囲は `src/screens/Privacy.tsx` のみで、他画面から参照されるスタイルではありません。
- Android は `Platform.select({ ios: ... })` により `lineHeight` 未指定のままなので、表示は一切変わりません。
- iOS の見出しは #6859 以前の 30pt に対し 29pt となり、1pt 詰まります。上限を画面高によらず保証するためのトレードオフです。本文は 18pt → 20pt となり、#6859 以前の 23pt よりは詰まります。上限が 21.09pt である以上 23pt には戻せません。
- 同じ `lineHeight: Platform.select({ ios: ... })` のパターンは `PortraitModePrompt` / `WalkthroughOverlay` / `TypeChangeNotify` にもあり、いずれも fontSize に対する行送りが 1.1719em を超えています（`RFValue(18)`/`RFValue(14)` = 1.28em など）。同じ理由で末尾が欠けている可能性がありますが、本 PR では触れていません。別途まとめて確認する想定です。

## テスト

<!-- どのようにテストしたかを記述してください -->

ローカルで以下を実行し、すべて成功することを確認しました。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint       Checked 719 files in 4s. No fixes applied.
npm run typecheck  エラーなし
npm test           Test Suites: 262 passed, 262 total / Tests: 2797 passed, 2797 total
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6859

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: 行間の差は iOS のみに出るもので、実装を動かした画像を用意できなかったためです。作業環境は Linux で iOS シミュレータが使えず、React Native Web（`npm run web`）では `Platform.OS` が `'web'` となり今回追加した `Platform.select({ ios: ... })` の分岐自体が適用されないため、修正の前後で差が出ません。行送りの変化は「上限の根拠」節のとおり、報告時のキャプチャを実寸で解析した数値で示しています。iOS 実機での目視確認をお願いします。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoEyFhop3QN6ZARNyre9Dk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * iOS版のプライバシー画面で、本文と見出しの行間をフォントサイズに応じて調整しました。
  * テキストの可読性と表示の一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->