### PR TITLE
英語TTSで「Keisei」が「かいせい」と読まれる誤読を読み上げ直前の表記置換で修正

### DIFF
--- a/src/utils/englishReading.test.ts
+++ b/src/utils/englishReading.test.ts
@@ -1,0 +1,37 @@
+import { fixEnglishReading } from './englishReading';
+
+describe('fixEnglishReading', () => {
+  it('路線名の「Keisei」を英語 TTS が「けいせい」と読む表記へ置換する', () => {
+    expect(fixEnglishReading('Change here for the Keisei Main Line.')).toBe(
+      'Change here for the Kay-say Main Line.'
+    );
+  });
+
+  it('ハイフン連結の駅名でも語単位で置換する', () => {
+    expect(fixEnglishReading('The next station is Keisei-Ueno.')).toBe(
+      'The next station is Kay-say-Ueno.'
+    );
+  });
+
+  it('会社名など 1 文中の複数箇所をすべて置換する', () => {
+    expect(
+      fixEnglishReading('Keisei Electric Railway operates the Keisei Line.')
+    ).toBe('Kay-say Electric Railway operates the Kay-say Line.');
+  });
+
+  it('大文字小文字を問わず置換する', () => {
+    expect(fixEnglishReading('KEISEI SKYLINER and keisei bus')).toBe(
+      'Kay-say SKYLINER and Kay-say bus'
+    );
+  });
+
+  it('別語の一部は置換しない', () => {
+    expect(fixEnglishReading('Keiseibus')).toBe('Keiseibus');
+  });
+
+  it('対象を含まないテキストはそのまま返す', () => {
+    expect(fixEnglishReading('The next station is Osaki.')).toBe(
+      'The next station is Osaki.'
+    );
+  });
+});

--- a/src/utils/englishReading.ts
+++ b/src/utils/englishReading.ts
@@ -1,0 +1,29 @@
+// 英語音声の TTS エンジンが日本語由来の固有名詞を誤読するケースを、読み上げ
+// 直前のプレーンテキストに対する表記置換で補正する。旧外部 TTS 向けの
+// `<phoneme>` (IPA) は OS ネイティブ TTS (expo-speech) もリモート TTS も解釈
+// しないため、エンジンが確実に読める英単語の綴りへ倒すしかない。
+// 表示用テキストには適用しないこと (TTS 生成時専用)。
+
+type EnglishReadingRule = {
+  // 置換対象。ASCII 英字の単語境界 (`\b`) で囲み、`Keisei-Ueno` のような
+  // ハイフン連結の駅名でも語単位で一致させる。
+  pattern: RegExp;
+  reading: string;
+};
+
+// NOTE: 読み替え先は必ず英語の辞書語 (か、辞書語のハイフン連結) にする。
+// 未知語の綴りを与えると G2P の推定に戻ってしまい、エンジンごとに結果がぶれる。
+const ENGLISH_READING_RULES: readonly EnglishReadingRule[] = [
+  // 「Keisei (京成)」は英語 TTS が "ei" を /aɪ/ と推定して「かいせい」と読む
+  // ため、英単語 "Kay" + "say" で /keɪ.seɪ/ (けいせい) を確定させる。
+  { pattern: /\bKeisei\b/gi, reading: 'Kay-say' },
+];
+
+/**
+ * 英語の読み上げ用テキスト内の固有名詞を、TTS エンジンが正しく読める表記へ置換する。
+ */
+export const fixEnglishReading = (text: string): string =>
+  ENGLISH_READING_RULES.reduce(
+    (acc, { pattern, reading }) => acc.replace(pattern, reading),
+    text
+  );

--- a/src/utils/speakableText.test.ts
+++ b/src/utils/speakableText.test.ts
@@ -38,6 +38,19 @@ describe('toSpeakableText', () => {
     expect(toSpeakableText('the JR Kobe Line', 'EN')).toBe('the J-R Kobe Line');
   });
 
+  it('英語文の「Keisei」を英語 TTS が「けいせい」と読む表記へ置換する', () => {
+    expect(
+      toSpeakableText(
+        'The next station is Keisei-Ueno,<break time="200ms"/> KS 1.',
+        'EN'
+      )
+    ).toBe('The next station is Kay-say-Ueno, KS 1.');
+    // 日本語文はカタカナ読み (sub alias) がそのまま使われるので対象外
+    expect(
+      toSpeakableText('<sub alias="ケイセイウエノ">京成上野</sub>', 'JA')
+    ).toBe('ケイセイウエノ');
+  });
+
   it('英語文に混入した日本語を除去する', () => {
     // nameRoman 欠落データ等で英語文に日本語が残ると、エンジンが言語を誤判定して
     // 全文を日本語音声で読んでしまうため最終防衛線として除去する

--- a/src/utils/speakableText.ts
+++ b/src/utils/speakableText.ts
@@ -1,3 +1,4 @@
+import { fixEnglishReading } from './englishReading';
 import { fixJrReading } from './jrReading';
 import { containsJapaneseCharacters, stripJapaneseCharacters } from './phoneme';
 import { ssmlToPlainText } from './ssmlToPlainText';
@@ -15,6 +16,8 @@ import getStringBytes from './stringBytes';
  *   含まれるため半角スペースへ置き換える。
  * - 「JR」は TTS エンジンが "Jr."（ジュニア）と誤読するため、読み方が確定する
  *   表記へ置換する。
+ * - 英語文では「Keisei」など英語 TTS が誤読する固有名詞も、読み方が確定する
+ *   英単語の綴りへ置換する。
  * - 英語文に日本語が残っている場合は除去する。nameRoman が欠落した駅データ等では
  *   wrapPhoneme のローマ字フォールバックが効かず英語文に日本語が混ざることがあり、
  *   その場合エンジンが言語を誤判定して全文を日本語音声で合成してしまうため。
@@ -30,15 +33,17 @@ export const toSpeakableText = (
     language
   );
 
-  if (language === 'EN' && containsJapaneseCharacters(plain)) {
+  if (language === 'JA') {
+    return plain;
+  }
+
+  if (containsJapaneseCharacters(plain)) {
     console.warn(
       '[speakableText] English text contains Japanese characters, stripping:',
       plain
     );
-    return stripJapaneseCharacters(plain);
   }
-
-  return plain;
+  return fixEnglishReading(stripJapaneseCharacters(plain));
 };
 
 /**


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

英語アナウンスで「Keisei（京成）」が「かいせい」と読み上げられる誤読を、SSML を使わずに修正します。既存の「JR → J-R」置換（`fixJrReading`）と同じく、読み上げ直前のプレーンテキストに対して TTS エンジンが確実に読める表記へ置換する方式です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/englishReading.ts` を新設し、英語の読み上げテキスト専用の固有名詞読み替え表と `fixEnglishReading` を追加。現状のルールは `Keisei` → `Kay-say` の 1 件
  - 英語 TTS は "ei" を /aɪ/ と推定して「かいせい」と読むため、英語の辞書語 "Kay" + "say" で /keɪ.seɪ/（けいせい）を確定させる
  - 未知語の綴り（例: `Kaysei`）だとエンジンごとの G2P 推定に戻ってぶれるため、読み替え先は辞書語のハイフン連結に限定する方針をコメントに明記
  - ASCII の単語境界で大文字小文字を問わず一致させるため、`Keisei Main Line` / `Keisei-Ueno` / `Keisei Electric Railway` / `Keisei Bus` はすべて置換され、`Keiseibus` のような別語の一部は置換しない
- `src/utils/speakableText.ts` の `toSpeakableText` で、英語経路の最後に `fixEnglishReading` を通すよう変更。ネイティブ TTS（expo-speech）とリモート TTS（Google Cloud TTS）の両方がこの関数を経由するため、どちらの経路でも効く。日本語文は `<sub alias>` のカタカナ読みが使われるので対象外。表示用テキストには影響しない
- テスト: `src/utils/englishReading.test.ts` を新設、`src/utils/speakableText.test.ts` に英語文の置換と日本語文の非対象ケースを追加

### レビュー時の留意点

- `Kay-say` の実際の聞こえ方は実機では未確認です。iOS / Android / リモート音声のいずれかで不自然な場合は、`ENGLISH_READING_RULES` の読み替え先を差し替えるだけで調整できます
- 同じ理屈で「Keikyu」「Keio」「Keihan」なども誤読している可能性がありますが、実際に聞かずに変えると悪化しうるため、今回は京成のみに絞っています。必要なら同じ表に 1 行足すだけで追加できます

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果（Node 24.20.0 / npm 11.19.0）:

```text
npm run lint      -> Checked 721 files in 846ms. No fixes applied.
npm test -- src/utils/englishReading.test.ts src/utils/speakableText.test.ts src/utils/jrReading.test.ts src/hooks/tts
                  -> Test Suites: 7 passed, Tests: 99 passed
npm run typecheck -> エラーなし
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->
UI 変更なし: `src/utils/**` の読み上げテキスト生成ロジックのみの変更で、画面表示には変化がありません
<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 英語音声生成時の固有名詞の読み上げを改善しました。
  - 「Keisei」やハイフンで連結された駅名を、より自然な発音になるよう補正します。
  - 補正は音声生成用テキストにのみ適用され、表示テキストは変更されません。
  - 日本語テキストや対象外の表記は従来どおり保持されます。

- **テスト**
  - 複数箇所、大文字・小文字、部分一致、対象外テキストなどの読み補正を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->