### PR TITLE
リモートTTSへは「Keisei」の読み替えを適用せず原文のまま送るよう端末内蔵TTS限定に変更

### DIFF
--- a/src/hooks/tts/useNativeSpeechEngine.ts
+++ b/src/hooks/tts/useNativeSpeechEngine.ts
@@ -159,14 +159,14 @@ export const useNativeSpeechEngine = (): SpeechEngine => {
         const plainJa =
           request.speakJa && canSpeakJa
             ? truncateToSpeechLimit(
-                toSpeakableText(request.ssmlJa, 'JA'),
+                toSpeakableText(request.ssmlJa, 'JA', 'native'),
                 limit
               )
             : '';
         const plainEn =
           request.speakEn && canSpeakEn
             ? truncateToSpeechLimit(
-                toSpeakableText(request.ssmlEn, 'EN'),
+                toSpeakableText(request.ssmlEn, 'EN', 'native'),
                 limit
               )
             : '';

--- a/src/hooks/tts/useRemoteSpeechEngine.ts
+++ b/src/hooks/tts/useRemoteSpeechEngine.ts
@@ -176,13 +176,13 @@ export const useRemoteSpeechEngine = (): SpeechEngine => {
           // 合成は文字数課金のため、無効な言語のテキストは送らない
           const textJa = request.speakJa
             ? truncateToByteLimit(
-                toSpeakableText(request.ssmlJa, 'JA'),
+                toSpeakableText(request.ssmlJa, 'JA', 'remote'),
                 REMOTE_TTS_MAX_INPUT_BYTES
               )
             : '';
           const textEn = request.speakEn
             ? truncateToByteLimit(
-                toSpeakableText(request.ssmlEn, 'EN'),
+                toSpeakableText(request.ssmlEn, 'EN', 'remote'),
                 REMOTE_TTS_MAX_INPUT_BYTES
               )
             : '';

--- a/src/utils/speakableText.test.ts
+++ b/src/utils/speakableText.test.ts
@@ -11,14 +11,18 @@ describe('toSpeakableText', () => {
 
   it('SSML タグを除去し、sub は読み仮名を採用する', () => {
     expect(
-      toSpeakableText('次は<sub alias="オオサキ">大崎</sub>です', 'JA')
+      toSpeakableText(
+        '次は<sub alias="オオサキ">大崎</sub>です',
+        'JA',
+        'native'
+      )
     ).toBe('次はオオサキです');
   });
 
   it('日本語の break は読点へ置き換える', () => {
-    expect(toSpeakableText('次は<break time="250ms"/>大崎です', 'JA')).toBe(
-      '次は、大崎です'
-    );
+    expect(
+      toSpeakableText('次は<break time="250ms"/>大崎です', 'JA', 'native')
+    ).toBe('次は、大崎です');
   });
 
   it('英語の break は半角スペースへ置き換える', () => {
@@ -26,29 +30,53 @@ describe('toSpeakableText', () => {
     expect(
       toSpeakableText(
         'The next station is Osaki,<break time="200ms"/> J Y 24.',
-        'EN'
+        'EN',
+        'native'
       )
     ).toBe('The next station is Osaki, J Y 24.');
   });
 
   it('「JR」を言語ごとの読み方が確定する表記へ置換する', () => {
-    expect(toSpeakableText('<sub alias="JRセン">JR線</sub>', 'JA')).toBe(
-      'ジェーアールセン'
+    expect(
+      toSpeakableText('<sub alias="JRセン">JR線</sub>', 'JA', 'native')
+    ).toBe('ジェーアールセン');
+    expect(toSpeakableText('the JR Kobe Line', 'EN', 'native')).toBe(
+      'the J-R Kobe Line'
     );
-    expect(toSpeakableText('the JR Kobe Line', 'EN')).toBe('the J-R Kobe Line');
   });
 
-  it('英語文の「Keisei」を英語 TTS が「けいせい」と読む表記へ置換する', () => {
+  it('端末内蔵 TTS 向けの英語文では「Keisei」を「けいせい」と読む表記へ置換する', () => {
     expect(
       toSpeakableText(
         'The next station is Keisei-Ueno,<break time="200ms"/> KS 1.',
-        'EN'
+        'EN',
+        'native'
       )
     ).toBe('The next station is Kay-say-Ueno, KS 1.');
     // 日本語文はカタカナ読み (sub alias) がそのまま使われるので対象外
     expect(
-      toSpeakableText('<sub alias="ケイセイウエノ">京成上野</sub>', 'JA')
+      toSpeakableText(
+        '<sub alias="ケイセイウエノ">京成上野</sub>',
+        'JA',
+        'native'
+      )
     ).toBe('ケイセイウエノ');
+  });
+
+  it('リモート TTS 向けの英語文では「Keisei」を置換せず原文のまま送る', () => {
+    // 同じ置換を TrainLCD/functions の normalizeRomanText が合成前に行うため、
+    // アプリ側では手を入れずサーバーの正規化とキャッシュキーを単一の入力に揃える
+    expect(
+      toSpeakableText(
+        'The next station is Keisei-Ueno,<break time="200ms"/> KS 1.',
+        'EN',
+        'remote'
+      )
+    ).toBe('The next station is Keisei-Ueno, KS 1.');
+    // JR の置換はサーバー側が J-R を素通しする前提なので、リモートでも適用する
+    expect(toSpeakableText('the JR Kobe Line', 'EN', 'remote')).toBe(
+      'the J-R Kobe Line'
+    );
   });
 
   it('英語文に混入した日本語を除去する', () => {
@@ -56,7 +84,7 @@ describe('toSpeakableText', () => {
     // 全文を日本語音声で読んでしまうため最終防衛線として除去する
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-    expect(toSpeakableText('Arriving at あかさか K 7.', 'EN')).toBe(
+    expect(toSpeakableText('Arriving at あかさか K 7.', 'EN', 'native')).toBe(
       'Arriving at K 7.'
     );
     expect(warnSpy).toHaveBeenCalledWith(
@@ -66,7 +94,7 @@ describe('toSpeakableText', () => {
   });
 
   it('日本語文の日本語は当然除去しない', () => {
-    expect(toSpeakableText('つぎはあかさかです', 'JA')).toBe(
+    expect(toSpeakableText('つぎはあかさかです', 'JA', 'native')).toBe(
       'つぎはあかさかです'
     );
   });

--- a/src/utils/speakableText.ts
+++ b/src/utils/speakableText.ts
@@ -16,15 +16,22 @@ import getStringBytes from './stringBytes';
  *   含まれるため半角スペースへ置き換える。
  * - 「JR」は TTS エンジンが "Jr."（ジュニア）と誤読するため、読み方が確定する
  *   表記へ置換する。
- * - 英語文では「Keisei」など英語 TTS が誤読する固有名詞も、読み方が確定する
- *   英単語の綴りへ置換する。
+ * - 端末内蔵 TTS 向け (`engine: 'native'`) の英語文では、「Keisei」など英語 TTS が
+ *   誤読する固有名詞も読み方が確定する英単語の綴りへ置換する。リモート TTS
+ *   (`engine: 'remote'`) では同じ置換を TrainLCD/functions の `normalizeRomanText`
+ *   が合成前に行うため、アプリ側では適用せず原文の表記のまま送る。二重に置換
+ *   しても結果は変わらないが、サーバー側の正規化とキャッシュキーを単一の入力に
+ *   揃えるため、置換の責務をサーバーに寄せる。
  * - 英語文に日本語が残っている場合は除去する。nameRoman が欠落した駅データ等では
  *   wrapPhoneme のローマ字フォールバックが効かず英語文に日本語が混ざることがあり、
  *   その場合エンジンが言語を誤判定して全文を日本語音声で合成してしまうため。
  */
+export type SpeechEngineKind = 'native' | 'remote';
+
 export const toSpeakableText = (
   ssml: string,
-  language: 'JA' | 'EN'
+  language: 'JA' | 'EN',
+  engine: SpeechEngineKind
 ): string => {
   const plain = fixJrReading(
     ssmlToPlainText(ssml, {
@@ -43,7 +50,8 @@ export const toSpeakableText = (
       plain
     );
   }
-  return fixEnglishReading(stripJapaneseCharacters(plain));
+  const english = stripJapaneseCharacters(plain);
+  return engine === 'native' ? fixEnglishReading(english) : english;
 };
 
 /**


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6869 で入れた「Keisei → Kay-say」の読み替えを、端末内蔵 TTS（expo-speech）の経路に限定します。リモート TTS（Google Cloud TTS）の経路では同じ置換を TrainLCD/functions 側（TrainLCD/functions#25）の `normalizeRomanText` が合成前に行うため、アプリからは原文の「Keisei」のまま送り、サーバー側の正規化とキャッシュキーを単一の入力に揃えます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/speakableText.ts`: `toSpeakableText` に第 3 引数 `engine: 'native' | 'remote'` を追加。英語文の固有名詞読み替え（`fixEnglishReading`）は `native` のときだけ適用し、`remote` では日本語文字の除去までで止めて原文の表記のまま返す
  - 「JR → J-R」の置換は従来どおり両経路で適用します（サーバー側は `J-R` を素通しする前提で実装済みのため）
- `src/hooks/tts/useNativeSpeechEngine.ts`: `toSpeakableText(..., 'native')` を渡す
- `src/hooks/tts/useRemoteSpeechEngine.ts`: `toSpeakableText(..., 'remote')` を渡す
- `src/utils/speakableText.test.ts`: 既存ケースに `engine` を明示し、リモート向けでは「Keisei」が置換されないこと・JR は置換されることのテストを追加

### 補足

- Android はリモート TTS を基本使わないため、端末内蔵 TTS 向けの置換はこれまでどおり残しています
- Functions 側の PR（TrainLCD/functions#25）がデプロイされるまでの間、リモート TTS では「Keisei」が「かいせい」と読まれる状態に戻ります。両 PR を近い時期にマージ・デプロイする想定です

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果（Node 24.20.0 / npm 11.19.0）:

```text
npm run lint      -> Checked 721 files. No fixes applied.
npm test -- src/utils/speakableText.test.ts src/utils/englishReading.test.ts src/hooks/tts src/hooks/useTTS.test.ts
                  -> Test Suites: 7 passed, Tests: 120 passed
npm run typecheck -> エラーなし
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- Refs #6869
- Refs TrainLCD/functions#25

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->
UI 変更なし: `src/utils/**` と `src/hooks/tts/**` の読み上げテキスト生成ロジックのみの変更で、画面表示には変化がありません
<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 音声エンジンに応じて、読み上げテキストを適切に変換するよう改善しました。
  - 端末内蔵の音声では、英語の固有名詞を発音しやすい表記に補正します。
  - リモート音声では、英語の固有名詞を原文のまま維持し、意図しない読み替えを防ぎます。
  - 日本語の除去、SSML、読み上げ範囲など、既存の読み上げ動作は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->