### PR TITLE
全ナンバリングアイコンでAndroidのグリフ上下ズレを補正

### DIFF
--- a/src/components/NumberingIconHalfSquare.tsx
+++ b/src/components/NumberingIconHalfSquare.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingGlyphLift } from '../utils/numberingGlyphLift';
 import NumberingIconReversedSquare from './NumberingIconReversedSquare';
 import Typography from './Typography';
 
@@ -17,6 +18,15 @@ type Props = {
   darkText: boolean;
   withOutline?: boolean;
 };
+
+const FONT = 'MyriadPro';
+const SYMBOL_SIZE = isTablet ? 22 * 1.5 : 22;
+const NUMBER_SIZE = isTablet ? 37 * 1.5 : 37;
+
+// Androidのグリフ上寄り補正。番号は白地の箱の中で単独に中央寄せされるため、
+// 記号と番号はそれぞれ1行として求める
+const SYMBOL_GLYPH_LIFT = numberingGlyphLift(SYMBOL_SIZE, FONT);
+const NUMBER_GLYPH_LIFT = numberingGlyphLift(NUMBER_SIZE, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -33,11 +43,13 @@ const styles = StyleSheet.create({
     borderColor: 'white',
   },
   lineSymbol: {
-    fontSize: isTablet ? 22 * 1.5 : 22,
-    lineHeight: isTablet ? 22 * 1.5 : 22,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: SYMBOL_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,
-    marginTop: 4,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 4 : 0,
   },
   stationNumberContainer: {
     backgroundColor: 'white',
@@ -49,8 +61,9 @@ const styles = StyleSheet.create({
   },
   stationNumber: {
     color: '#231f20',
-    fontSize: isTablet ? 37 * 1.5 : 37,
-    lineHeight: isTablet ? 37 * 1.5 : 37,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: NUMBER_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,
   },

--- a/src/components/NumberingIconHankyu.tsx
+++ b/src/components/NumberingIconHankyu.tsx
@@ -1,7 +1,8 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingStackedGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -9,6 +10,16 @@ type Props = {
   lineColor: string;
   withOutline?: boolean;
 };
+
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 21 * 1.5 : 21;
+const NUMBER_SIZE = isTablet ? 35 * 1.5 : 35;
+
+// Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -27,15 +38,18 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   lineSymbol: {
-    fontSize: isTablet ? 21 * 1.5 : 21,
-    lineHeight: isTablet ? 21 * 1.5 : 21,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: isTablet ? 4 : 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 4 : 2) : 0,
   },
   stationNumber: {
-    fontSize: isTablet ? 35 * 1.5 : 35,
-    lineHeight: isTablet ? 35 * 1.5 : 35,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconHanshin.tsx
+++ b/src/components/NumberingIconHanshin.tsx
@@ -1,7 +1,8 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingStackedGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -9,6 +10,16 @@ type Props = {
   lineColor: string;
   withOutline?: boolean;
 };
+
+const FONT = 'VerdanaBold';
+const SYMBOL_SIZE = isTablet ? 21 * 1.5 : 21;
+const NUMBER_SIZE = isTablet ? 35 * 1.5 : 35;
+
+// Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -27,15 +38,18 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   lineSymbol: {
-    fontSize: isTablet ? 21 * 1.5 : 21,
-    lineHeight: isTablet ? 21 * 1.5 : 21,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.VerdanaBold,
-    marginTop: isTablet ? 4 : 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 4 : 2) : 0,
   },
   stationNumber: {
-    fontSize: isTablet ? 35 * 1.5 : 35,
-    lineHeight: isTablet ? 35 * 1.5 : 35,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.VerdanaBold,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconKeikyu.tsx
+++ b/src/components/NumberingIconKeikyu.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { FONTS } from '~/constants';
 import isTablet from '~/utils/isTablet';
+import { numberingStackedGlyphLift } from '~/utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -9,6 +10,16 @@ type Props = {
   lineColor: string;
   withOutline?: boolean;
 };
+
+const FONT = 'FuturaLTPro';
+const SYMBOL_SIZE = isTablet ? 16 * 1.5 : 16;
+const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
+
+// Androidのグリフ上寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -28,15 +39,17 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: '#00386D',
-    fontSize: isTablet ? 16 * 1.5 : 16,
-    lineHeight: isTablet ? 16 * 1.5 : 16,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
   stationNumber: {
     color: '#00386D',
-    fontSize: isTablet ? 26 * 1.5 : 26,
-    lineHeight: isTablet ? 26 * 1.5 : 26,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },

--- a/src/components/NumberingIconKeikyu.tsx
+++ b/src/components/NumberingIconKeikyu.tsx
@@ -16,10 +16,26 @@ const SYMBOL_SIZE = isTablet ? 16 * 1.5 : 16;
 const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
 
 // Androidのグリフ上寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
-const GLYPH_LIFT = numberingStackedGlyphLift(
-  { fontSize: SYMBOL_SIZE, font: FONT },
-  { fontSize: NUMBER_SIZE, font: FONT }
-);
+const glyphLiftStyles = StyleSheet.create({
+  normal: {
+    transform: numberingStackedGlyphLift(
+      { fontSize: SYMBOL_SIZE, font: FONT },
+      { fontSize: NUMBER_SIZE, font: FONT }
+    ),
+  },
+  // longStationNumberAdditional は fontSize だけを縮め lineHeight は据え置くので、
+  // 行の高さは NUMBER_SIZE のまま
+  longNumber: {
+    transform: numberingStackedGlyphLift(
+      { fontSize: SYMBOL_SIZE, font: FONT },
+      {
+        fontSize: isTablet ? 20 * 1.5 : 20,
+        lineHeight: NUMBER_SIZE,
+        font: FONT,
+      }
+    ),
+  },
+});
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -41,7 +57,6 @@ const styles = StyleSheet.create({
     color: '#00386D',
     fontSize: SYMBOL_SIZE,
     lineHeight: SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -49,7 +64,6 @@ const styles = StyleSheet.create({
     color: '#00386D',
     fontSize: NUMBER_SIZE,
     lineHeight: NUMBER_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -67,17 +81,27 @@ const NumberingIconKeikyu: React.FC<Props> = ({
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
   const isIncludesSubNumber = stationNumber.includes('-');
+  // 記号と番号で同じ値を当てないと両者の間隔が変わるので、1つ選んで両方に渡す
+  const glyphLift = isIncludesSubNumber
+    ? glyphLiftStyles.longNumber
+    : glyphLiftStyles.normal;
   const stationNumberTextStyles = useMemo(() => {
     if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
+      return [
+        styles.stationNumber,
+        styles.longStationNumberAdditional,
+        glyphLift,
+      ];
     }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
+    return [styles.stationNumber, glyphLift];
+  }, [isIncludesSubNumber, glyphLift]);
 
   return (
     <View style={withOutline ? styles.optionalBorder : undefined}>
       <View style={[styles.root, { borderColor: lineColor }]}>
-        <Typography style={styles.lineSymbol}>{lineSymbol}</Typography>
+        <Typography style={[styles.lineSymbol, glyphLift]}>
+          {lineSymbol}
+        </Typography>
         <Typography style={stationNumberTextStyles}>{stationNumber}</Typography>
       </View>
     </View>

--- a/src/components/NumberingIconKeisei.tsx
+++ b/src/components/NumberingIconKeisei.tsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +18,18 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 22 * 1.5 : 22;
+const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
+
+// Androidのグリフ下寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -32,11 +48,13 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   lineSymbol: {
-    fontSize: isTablet ? 22 * 1.5 : 22,
-    lineHeight: isTablet ? 22 * 1.5 : 22,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: isTablet ? 4 : 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 4 : 2) : 0,
   },
   rootTiny: {
     width: 20,
@@ -51,13 +69,16 @@ const styles = StyleSheet.create({
   lineSymbolTiny: {
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   stationNumber: {
-    fontSize: isTablet ? 26 * 1.5 : 26,
-    lineHeight: isTablet ? 26 * 1.5 : 26,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconKeisei.tsx
+++ b/src/components/NumberingIconKeisei.tsx
@@ -25,10 +25,26 @@ const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
 
 // Androidのグリフ下寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
 // 縦に並ぶ2行には同じ値を使い回す
-const GLYPH_LIFT = numberingStackedGlyphLift(
-  { fontSize: SYMBOL_SIZE, font: FONT },
-  { fontSize: NUMBER_SIZE, font: FONT }
-);
+const glyphLiftStyles = StyleSheet.create({
+  normal: {
+    transform: numberingStackedGlyphLift(
+      { fontSize: SYMBOL_SIZE, font: FONT },
+      { fontSize: NUMBER_SIZE, font: FONT }
+    ),
+  },
+  // longStationNumberAdditional は fontSize だけを縮め lineHeight は据え置くので、
+  // 行の高さは NUMBER_SIZE のまま
+  longNumber: {
+    transform: numberingStackedGlyphLift(
+      { fontSize: SYMBOL_SIZE, font: FONT },
+      {
+        fontSize: isTablet ? 20 * 1.5 : 20,
+        lineHeight: NUMBER_SIZE,
+        font: FONT,
+      }
+    ),
+  },
+});
 const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 
 const styles = StyleSheet.create({
@@ -50,7 +66,6 @@ const styles = StyleSheet.create({
   lineSymbol: {
     fontSize: SYMBOL_SIZE,
     lineHeight: SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
@@ -78,7 +93,6 @@ const styles = StyleSheet.create({
   stationNumber: {
     fontSize: NUMBER_SIZE,
     lineHeight: NUMBER_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? -4 : -2,
@@ -98,12 +112,20 @@ const NumberingIconKeisei: React.FC<Props> = ({
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
   const isIncludesSubNumber = stationNumber.includes('-');
+  // 記号と番号で同じ値を当てないと両者の間隔が変わるので、1つ選んで両方に渡す
+  const glyphLift = isIncludesSubNumber
+    ? glyphLiftStyles.longNumber
+    : glyphLiftStyles.normal;
   const stationNumberTextStyles = useMemo(() => {
     if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
+      return [
+        styles.stationNumber,
+        styles.longStationNumberAdditional,
+        glyphLift,
+      ];
     }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
+    return [styles.stationNumber, glyphLift];
+  }, [isIncludesSubNumber, glyphLift]);
 
   if (size === NUMBERING_ICON_SIZE.SMALL) {
     return (
@@ -118,7 +140,9 @@ const NumberingIconKeisei: React.FC<Props> = ({
   return (
     <View style={withOutline ? styles.optionalBorder : undefined}>
       <View style={[styles.root, { borderColor: lineColor }]}>
-        <Typography style={[styles.lineSymbol, { color: lineColor }]}>
+        <Typography
+          style={[styles.lineSymbol, glyphLift, { color: lineColor }]}
+        >
           {lineSymbol}
         </Typography>
         <Typography style={[stationNumberTextStyles, { color: lineColor }]}>

--- a/src/components/NumberingIconKintetsu.tsx
+++ b/src/components/NumberingIconKintetsu.tsx
@@ -1,11 +1,12 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +15,14 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+// Androidのグリフ下寄り補正。LARGE は lineHeight を指定しておらず
+// CustomLineHeightSpan を通らないため、iOS と同じ描画になり補正しない
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(
+  isTablet ? 25 * 1.5 : 25,
+  'FrutigerNeueLTProBold'
+);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, 'FrutigerNeueLTProBold');
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -65,15 +74,19 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.FrutigerNeueLTProBold,
     fontSize: isTablet ? 25 * 1.5 : 25,
     lineHeight: isTablet ? 25 * 1.5 : 25,
-    marginTop: isTablet ? 8 : 4,
+    transform: MEDIUM_GLYPH_LIFT,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 8 : 4) : 0,
   },
   lineSymbolTiny: {
     color: 'white',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   stationNumber: {
     color: 'white',

--- a/src/components/NumberingIconNTL.tsx
+++ b/src/components/NumberingIconNTL.tsx
@@ -2,12 +2,25 @@ import type React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingStackedGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
   stationNumber: string;
   withOutline?: boolean;
 };
+
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 18 * 1.5 : 18;
+const NUMBER_SIZE = isTablet ? 28 * 1.5 : 28;
+
+// Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる。
+// inner は上詰めで中央寄せしていないため marginTop は位置指定そのものと解釈し、
+// プラットフォーム分岐は入れずフォント由来のズレだけを打ち消す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -34,15 +47,17 @@ const styles = StyleSheet.create({
     borderRadius: isTablet ? 6 : 4,
   },
   lineSymbol: {
-    lineHeight: isTablet ? 18 * 1.5 : 18,
-    fontSize: isTablet ? 18 * 1.5 : 18,
+    lineHeight: SYMBOL_SIZE,
+    fontSize: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: 4,
   },
   stationNumber: {
-    lineHeight: isTablet ? 28 * 1.5 : 28,
-    fontSize: isTablet ? 28 * 1.5 : 28,
+    lineHeight: NUMBER_SIZE,
+    fontSize: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     marginTop: -4,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,

--- a/src/components/NumberingIconNankai.tsx
+++ b/src/components/NumberingIconNankai.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import Svg, { Ellipse } from 'react-native-svg';
 import {
   FONTS,
@@ -7,6 +7,10 @@ import {
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 const ICON_SIZE = isTablet ? 72 * 1.5 : 72;
@@ -20,6 +24,17 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const SYMBOL_SIZE = isTablet ? 18 * 1.5 : 18;
+const NUMBER_SIZE = isTablet ? 32 * 1.5 : 32;
+
+// Androidのグリフ上寄り補正。記号と番号でフォントが違うので両方のメトリクスから求める。
+// 記号と番号で異なる値を使うと両者の間隔まで変わるため同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: 'FuturaLTPro' },
+  { fontSize: NUMBER_SIZE, font: 'MyriadPro' }
+);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, 'FuturaLTPro');
 
 const styles = StyleSheet.create({
   root: {
@@ -42,11 +57,13 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: 'white',
-    fontSize: isTablet ? 18 * 1.5 : 18,
-    lineHeight: isTablet ? 18 * 1.5 : 18,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: isTablet ? 8 : 4,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 8 : 4) : 0,
   },
   rootTiny: {
     width: 20,
@@ -62,14 +79,17 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   stationNumber: {
     color: 'white',
-    fontSize: isTablet ? 32 * 1.5 : 32,
-    lineHeight: isTablet ? 32 * 1.5 : 32,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     marginTop: isTablet ? -4 * 1.2 : -4,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,

--- a/src/components/NumberingIconOdakyu.tsx
+++ b/src/components/NumberingIconOdakyu.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingStackedGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -10,6 +11,16 @@ type Props = {
   withOutline?: boolean;
   shouldGrayscale?: boolean;
 };
+
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 22 * 1.5 : 22;
+const NUMBER_SIZE = isTablet ? 32 * 1.5 : 32;
+
+// Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -29,17 +40,20 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: '#221714',
-    fontSize: isTablet ? 22 * 1.5 : 22,
-    lineHeight: isTablet ? 22 * 1.5 : 22,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: Platform.select({ android: -2, ios: 8 }),
+    // Androidの下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.select({ android: 0, ios: 8 }),
     letterSpacing: -1,
   },
   stationNumber: {
     color: '#221714',
-    fontSize: isTablet ? 32 * 1.5 : 32,
-    lineHeight: isTablet ? 32 * 1.5 : 32,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconReversedRound.tsx
+++ b/src/components/NumberingIconReversedRound.tsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +18,21 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const FONT = 'FuturaLTPro';
+const SYMBOL_SIZE = isTablet ? 24 * 1.5 : 24;
+const LONG_SYMBOL_SIZE = isTablet ? 20 * 1.5 : 20;
+const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
+
+// Androidのグリフ上寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 : 14, FONT);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
+const TINY_LONG_GLYPH_LIFT = numberingGlyphLift(5, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -33,15 +52,17 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: 'white',
-    fontSize: isTablet ? 24 * 1.5 : 24,
-    lineHeight: isTablet ? 24 * 1.5 : 24,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
   lineSymbolLong: {
     color: 'white',
-    fontSize: isTablet ? 20 * 1.5 : 20,
-    lineHeight: isTablet ? 20 * 1.5 : 20,
+    fontSize: LONG_SYMBOL_SIZE,
+    lineHeight: LONG_SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -69,30 +90,37 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolTinyLong: {
     color: 'white',
     fontSize: 5,
     lineHeight: 5,
+    transform: TINY_LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolMedium: {
     color: 'white',
     fontSize: isTablet ? 24 : 14,
     lineHeight: isTablet ? 24 : 14,
+    transform: MEDIUM_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   stationNumber: {
     color: 'white',
-    fontSize: isTablet ? 26 * 1.5 : 26,
-    lineHeight: isTablet ? 26 * 1.5 : 26,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconReversedRound.tsx
+++ b/src/components/NumberingIconReversedRound.tsx
@@ -24,12 +24,33 @@ const SYMBOL_SIZE = isTablet ? 24 * 1.5 : 24;
 const LONG_SYMBOL_SIZE = isTablet ? 20 * 1.5 : 20;
 const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
 
+const SYMBOL_LINE = { fontSize: SYMBOL_SIZE, font: FONT } as const;
+const LONG_SYMBOL_LINE = { fontSize: LONG_SYMBOL_SIZE, font: FONT } as const;
+const NUMBER_LINE = { fontSize: NUMBER_SIZE, font: FONT } as const;
+// longStationNumberAdditional は fontSize だけを縮め lineHeight は据え置くので、
+// 行の高さは NUMBER_SIZE のまま
+const LONG_NUMBER_LINE = {
+  fontSize: isTablet ? 20 * 1.5 : 20,
+  lineHeight: NUMBER_SIZE,
+  font: FONT,
+} as const;
+
 // Androidのグリフ上寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
-// 縦に並ぶ2行には同じ値を使い回す
-const GLYPH_LIFT = numberingStackedGlyphLift(
-  { fontSize: SYMBOL_SIZE, font: FONT },
-  { fontSize: NUMBER_SIZE, font: FONT }
-);
+// 縦に並ぶ2行には同じ値を使い回す。記号・番号のどちらにも縮小版があり、実際に使う
+// 組み合わせでズレ量が変わるので4通り用意する
+const glyphLiftStyles = StyleSheet.create({
+  normal: { transform: numberingStackedGlyphLift(SYMBOL_LINE, NUMBER_LINE) },
+  longSymbol: {
+    transform: numberingStackedGlyphLift(LONG_SYMBOL_LINE, NUMBER_LINE),
+  },
+  longNumber: {
+    transform: numberingStackedGlyphLift(SYMBOL_LINE, LONG_NUMBER_LINE),
+  },
+  longBoth: {
+    transform: numberingStackedGlyphLift(LONG_SYMBOL_LINE, LONG_NUMBER_LINE),
+  },
+});
+
 const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 : 14, FONT);
 const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 const TINY_LONG_GLYPH_LIFT = numberingGlyphLift(5, FONT);
@@ -54,7 +75,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: SYMBOL_SIZE,
     lineHeight: SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -62,7 +82,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: LONG_SYMBOL_SIZE,
     lineHeight: LONG_SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -120,7 +139,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: NUMBER_SIZE,
     lineHeight: NUMBER_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
     marginTop: isTablet ? -4 : -2,
@@ -140,12 +158,28 @@ const NumberingIconReversedRound: React.FC<Props> = ({
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
   const isIncludesSubNumber = stationNumber.includes('-');
+  const isLongSymbol = lineSymbol.length === 2;
+  // 記号と番号で同じ値を当てないと両者の間隔が変わるので、1つ選んで両方に渡す
+  const glyphLift = useMemo(() => {
+    if (isLongSymbol) {
+      return isIncludesSubNumber
+        ? glyphLiftStyles.longBoth
+        : glyphLiftStyles.longSymbol;
+    }
+    return isIncludesSubNumber
+      ? glyphLiftStyles.longNumber
+      : glyphLiftStyles.normal;
+  }, [isLongSymbol, isIncludesSubNumber]);
   const stationNumberTextStyles = useMemo(() => {
     if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
+      return [
+        styles.stationNumber,
+        styles.longStationNumberAdditional,
+        glyphLift,
+      ];
     }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
+    return [styles.stationNumber, glyphLift];
+  }, [isIncludesSubNumber, glyphLift]);
 
   if (size === NUMBERING_ICON_SIZE.SMALL) {
     return (
@@ -175,9 +209,10 @@ const NumberingIconReversedRound: React.FC<Props> = ({
     <View style={withOutline ? styles.optionalBorder : undefined}>
       <View style={[styles.root, { backgroundColor: lineColor }]}>
         <Typography
-          style={
-            lineSymbol.length === 2 ? styles.lineSymbolLong : styles.lineSymbol
-          }
+          style={[
+            isLongSymbol ? styles.lineSymbolLong : styles.lineSymbol,
+            glyphLift,
+          ]}
         >
           {lineSymbol}
         </Typography>

--- a/src/components/NumberingIconReversedSquare.tsx
+++ b/src/components/NumberingIconReversedSquare.tsx
@@ -1,11 +1,15 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -15,6 +19,20 @@ type Props = {
   darkText?: boolean;
   withOutline?: boolean;
 };
+
+const FONT = 'MyriadPro';
+const SYMBOL_SIZE = isTablet ? 22 * 1.5 : 22;
+const NUMBER_SIZE = isTablet ? 37 * 1.5 : 35;
+const MEDIUM_SIZE = isTablet ? 18 * 1.5 : 18;
+
+// Androidのグリフ上寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(MEDIUM_SIZE, FONT);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -53,29 +71,36 @@ const styles = StyleSheet.create({
     borderColor: 'white',
   },
   lineSymbol: {
-    fontSize: isTablet ? 22 * 1.5 : 22,
-    lineHeight: isTablet ? 22 * 1.5 : 22,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,
-    marginTop: 4,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 4 : 0,
   },
   lineSymbolMedium: {
-    fontSize: isTablet ? 18 * 1.5 : 18,
-    lineHeight: isTablet ? 18 * 1.5 : 18,
+    fontSize: MEDIUM_SIZE,
+    lineHeight: MEDIUM_SIZE,
+    transform: MEDIUM_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   lineSymbolTiny: {
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   stationNumber: {
-    fontSize: isTablet ? 37 * 1.5 : 35,
-    lineHeight: isTablet ? 37 * 1.5 : 35,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     marginTop: isTablet ? -4 * 1.2 : -4,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,

--- a/src/components/NumberingIconReversedSquareWest.tsx
+++ b/src/components/NumberingIconReversedSquareWest.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { FONTS } from '../constants';
 import isTablet from '../utils/isTablet';
-import { numberingGlyphLift } from '../utils/numberingGlyphLift';
+import { numberingStackedGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -13,8 +13,14 @@ type Props = {
   withOutline?: boolean;
 };
 
+const FONT = 'FrutigerNeueLTProBold';
+const TEXT_SIZE = isTablet ? 30 * 1.5 : 30;
+
 // Androidのグリフ下寄り補正。記号と番号で同じ値を使わないと両者の間隔が変わる
-const GLYPH_LIFT = numberingGlyphLift(isTablet ? 30 * 1.5 : 30);
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: TEXT_SIZE, font: FONT },
+  { fontSize: TEXT_SIZE, font: FONT }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {

--- a/src/components/NumberingIconRound.tsx
+++ b/src/components/NumberingIconRound.tsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +18,22 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const FONT = 'FuturaLTPro';
+const SYMBOL_SIZE = isTablet ? 24 * 1.5 : 24;
+const LONG_SYMBOL_SIZE = isTablet ? 20 * 1.5 : 20;
+const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
+
+// Androidのグリフ上寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 : 14, FONT);
+const MEDIUM_LONG_GLYPH_LIFT = numberingGlyphLift(isTablet ? 16 : 11, FONT);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
+const TINY_LONG_GLYPH_LIFT = numberingGlyphLift(5, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -33,15 +53,17 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: '#221714',
-    fontSize: isTablet ? 24 * 1.5 : 24,
-    lineHeight: isTablet ? 24 * 1.5 : 24,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
   lineSymbolLong: {
     color: '#221714',
-    fontSize: isTablet ? 20 * 1.5 : 20,
-    lineHeight: isTablet ? 20 * 1.5 : 20,
+    fontSize: LONG_SYMBOL_SIZE,
+    lineHeight: LONG_SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -69,39 +91,48 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolTinyLong: {
     color: '#221714',
     fontSize: 5,
     lineHeight: 5,
+    transform: TINY_LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolMedium: {
     color: '#221714',
     fontSize: isTablet ? 24 : 14,
     lineHeight: isTablet ? 24 : 14,
+    transform: MEDIUM_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   lineSymbolMediumLong: {
     color: '#221714',
     fontSize: isTablet ? 16 : 11,
     lineHeight: isTablet ? 16 : 11,
+    transform: MEDIUM_LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
     alignSelf: 'center',
   },
   stationNumber: {
     color: '#221714',
-    fontSize: isTablet ? 26 * 1.5 : 26,
-    lineHeight: isTablet ? 26 * 1.5 : 26,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
     marginTop: isTablet ? -4 : -2,

--- a/src/components/NumberingIconRound.tsx
+++ b/src/components/NumberingIconRound.tsx
@@ -24,12 +24,33 @@ const SYMBOL_SIZE = isTablet ? 24 * 1.5 : 24;
 const LONG_SYMBOL_SIZE = isTablet ? 20 * 1.5 : 20;
 const NUMBER_SIZE = isTablet ? 26 * 1.5 : 26;
 
+const SYMBOL_LINE = { fontSize: SYMBOL_SIZE, font: FONT } as const;
+const LONG_SYMBOL_LINE = { fontSize: LONG_SYMBOL_SIZE, font: FONT } as const;
+const NUMBER_LINE = { fontSize: NUMBER_SIZE, font: FONT } as const;
+// longStationNumberAdditional は fontSize だけを縮め lineHeight は据え置くので、
+// 行の高さは NUMBER_SIZE のまま
+const LONG_NUMBER_LINE = {
+  fontSize: isTablet ? 20 * 1.5 : 20,
+  lineHeight: NUMBER_SIZE,
+  font: FONT,
+} as const;
+
 // Androidのグリフ上寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
-// 縦に並ぶ2行には同じ値を使い回す
-const GLYPH_LIFT = numberingStackedGlyphLift(
-  { fontSize: SYMBOL_SIZE, font: FONT },
-  { fontSize: NUMBER_SIZE, font: FONT }
-);
+// 縦に並ぶ2行には同じ値を使い回す。記号・番号のどちらにも縮小版があり、実際に使う
+// 組み合わせでズレ量が変わるので4通り用意する
+const glyphLiftStyles = StyleSheet.create({
+  normal: { transform: numberingStackedGlyphLift(SYMBOL_LINE, NUMBER_LINE) },
+  longSymbol: {
+    transform: numberingStackedGlyphLift(LONG_SYMBOL_LINE, NUMBER_LINE),
+  },
+  longNumber: {
+    transform: numberingStackedGlyphLift(SYMBOL_LINE, LONG_NUMBER_LINE),
+  },
+  longBoth: {
+    transform: numberingStackedGlyphLift(LONG_SYMBOL_LINE, LONG_NUMBER_LINE),
+  },
+});
+
 const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 : 14, FONT);
 const MEDIUM_LONG_GLYPH_LIFT = numberingGlyphLift(isTablet ? 16 : 11, FONT);
 const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
@@ -55,7 +76,6 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: SYMBOL_SIZE,
     lineHeight: SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -63,7 +83,6 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: LONG_SYMBOL_SIZE,
     lineHeight: LONG_SYMBOL_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -132,7 +151,6 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: NUMBER_SIZE,
     lineHeight: NUMBER_SIZE,
-    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
     marginTop: isTablet ? -4 : -2,
@@ -152,12 +170,28 @@ const NumberingIconRound: React.FC<Props> = ({
   const [lineSymbol, ...stationNumberRest] = stationNumberRaw.split('-');
   const stationNumber = stationNumberRest.join('-');
   const isIncludesSubNumber = stationNumber.includes('-');
+  const isLongSymbol = lineSymbol.length === 2;
+  // 記号と番号で同じ値を当てないと両者の間隔が変わるので、1つ選んで両方に渡す
+  const glyphLift = useMemo(() => {
+    if (isLongSymbol) {
+      return isIncludesSubNumber
+        ? glyphLiftStyles.longBoth
+        : glyphLiftStyles.longSymbol;
+    }
+    return isIncludesSubNumber
+      ? glyphLiftStyles.longNumber
+      : glyphLiftStyles.normal;
+  }, [isLongSymbol, isIncludesSubNumber]);
   const stationNumberTextStyles = useMemo(() => {
     if (isIncludesSubNumber) {
-      return [styles.stationNumber, styles.longStationNumberAdditional];
+      return [
+        styles.stationNumber,
+        styles.longStationNumberAdditional,
+        glyphLift,
+      ];
     }
-    return styles.stationNumber;
-  }, [isIncludesSubNumber]);
+    return [styles.stationNumber, glyphLift];
+  }, [isIncludesSubNumber, glyphLift]);
 
   if (size === NUMBERING_ICON_SIZE.SMALL) {
     return (
@@ -195,9 +229,10 @@ const NumberingIconRound: React.FC<Props> = ({
     <View style={withOutline ? styles.optionalBorder : undefined}>
       <View style={[styles.root, { borderColor: lineColor }]}>
         <Typography
-          style={
-            lineSymbol.length === 2 ? styles.lineSymbolLong : styles.lineSymbol
-          }
+          style={[
+            isLongSymbol ? styles.lineSymbolLong : styles.lineSymbol,
+            glyphLift,
+          ]}
         >
           {lineSymbol}
         </Typography>

--- a/src/components/NumberingIconRoundHorizontal.tsx
+++ b/src/components/NumberingIconRoundHorizontal.tsx
@@ -1,11 +1,12 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import { numberingGlyphLift } from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +15,16 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const FONT = 'FuturaLTPro';
+
+// Androidのグリフ上寄り補正。いずれも1行なのでサイズごとに求める
+const GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 * 1.5 : 24, FONT);
+const LONG_GLYPH_LIFT = numberingGlyphLift(isTablet ? 16 * 1.5 : 16, FONT);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 : 14, FONT);
+const MEDIUM_LONG_GLYPH_LIFT = numberingGlyphLift(isTablet ? 16 : 11, FONT);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
+const TINY_LONG_GLYPH_LIFT = numberingGlyphLift(5, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -35,6 +46,7 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: isTablet ? 24 * 1.5 : 24,
     lineHeight: isTablet ? 24 * 1.5 : 24,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -42,6 +54,7 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: isTablet ? 16 * 1.5 : 16,
     lineHeight: isTablet ? 16 * 1.5 : 16,
+    transform: LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
@@ -69,33 +82,41 @@ const styles = StyleSheet.create({
     color: '#221714',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolTinyLong: {
     color: '#221714',
     fontSize: 5,
     lineHeight: 5,
+    transform: TINY_LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 1,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 1 : 0,
   },
   lineSymbolMedium: {
     color: '#221714',
     fontSize: isTablet ? 24 : 14,
     lineHeight: isTablet ? 24 : 14,
+    transform: MEDIUM_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   lineSymbolMediumLong: {
     color: '#221714',
     fontSize: isTablet ? 16 : 11,
     lineHeight: isTablet ? 16 : 11,
+    transform: MEDIUM_LONG_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
     alignSelf: 'center',
   },
 });

--- a/src/components/NumberingIconSanyo.tsx
+++ b/src/components/NumberingIconSanyo.tsx
@@ -1,11 +1,15 @@
 import type React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import {
   FONTS,
   NUMBERING_ICON_SIZE,
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -14,6 +18,20 @@ type Props = {
   size?: NumberingIconSize;
   withOutline?: boolean;
 };
+
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 20 * 1.5 : 20;
+const NUMBER_SIZE = isTablet ? 35 * 1.5 : 35;
+const SMALL_SYMBOL_SIZE = isTablet ? 18 * 1.5 : 18;
+
+// Androidのグリフ下寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
+);
+const SMALL_GLYPH_LIFT = numberingGlyphLift(SMALL_SYMBOL_SIZE, FONT);
+const TINY_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -41,11 +59,13 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: 'white',
-    fontSize: isTablet ? 20 * 1.5 : 20,
-    lineHeight: isTablet ? 20 * 1.5 : 20,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: isTablet ? 4 * 1.2 : 4,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 4 * 1.2 : 4) : 0,
   },
   rootTiny: {
     width: 20,
@@ -83,22 +103,27 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 10,
     lineHeight: 10,
+    transform: TINY_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: 2,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? 2 : 0,
   },
   lineSymbolSmall: {
     color: 'white',
-    fontSize: isTablet ? 18 * 1.5 : 18,
-    lineHeight: isTablet ? 18 * 1.5 : 18,
+    fontSize: SMALL_SYMBOL_SIZE,
+    lineHeight: SMALL_SYMBOL_SIZE,
+    transform: SMALL_GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
-    marginTop: isTablet ? 6 : 4,
+    // Androidの上下ズレは GLYPH_LIFT が打ち消すので、視覚補正の marginTop は iOS のみ
+    marginTop: Platform.OS === 'ios' ? (isTablet ? 6 : 4) : 0,
   },
   stationNumber: {
     color: 'white',
-    fontSize: isTablet ? 35 * 1.5 : 35,
-    lineHeight: isTablet ? 35 * 1.5 : 35,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     marginTop: isTablet ? -2 * 1.2 : -2,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,

--- a/src/components/NumberingIconSquare.tsx
+++ b/src/components/NumberingIconSquare.tsx
@@ -6,7 +6,10 @@ import {
   type NumberingIconSize,
 } from '../constants';
 import isTablet from '../utils/isTablet';
-import { numberingGlyphLift } from '../utils/numberingGlyphLift';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from '../utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -21,15 +24,39 @@ type Props = {
 
 const TLC_SCALE = 0.7;
 
+const FONT = 'FrutigerNeueLTProBold';
+const SYMBOL_SIZE = isTablet ? 24 * 1.5 : 24;
+const NUMBER_SIZE = isTablet ? 32 * 1.5 : 32;
+const TLC_SYMBOL_SIZE = isTablet
+  ? Math.round(24 * 1.5 * TLC_SCALE)
+  : Math.round(24 * TLC_SCALE);
+const TLC_NUMBER_SIZE = isTablet
+  ? Math.round(32 * 1.5 * TLC_SCALE)
+  : Math.round(32 * TLC_SCALE);
+const TLC_COMPACT_SYMBOL_SIZE = isTablet ? 12 : 8;
+const TLC_COMPACT_NUMBER_SIZE = isTablet ? 15 : 10;
+
 // Androidのグリフ下寄り補正。記号と番号で異なる値を使うと両者の間隔まで変わるため、
-// アイコンごとに基準の行高から1つだけ求めて使い回す
-const GLYPH_LIFT = numberingGlyphLift(isTablet ? 24 * 1.5 : 24);
-const TLC_GLYPH_LIFT = numberingGlyphLift(
-  isTablet ? Math.round(24 * 1.5 * TLC_SCALE) : Math.round(24 * TLC_SCALE)
+// 縦に並ぶ2行には同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: FONT },
+  { fontSize: NUMBER_SIZE, font: FONT }
 );
-const TLC_COMPACT_GLYPH_LIFT = numberingGlyphLift(isTablet ? 12 : 8);
-const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 32 : 20);
-const SMALL_GLYPH_LIFT = numberingGlyphLift(10);
+const TLC_LABEL_LIFT = numberingGlyphLift(TLC_SYMBOL_SIZE, FONT);
+const TLC_ICON_LIFT = numberingStackedGlyphLift(
+  { fontSize: TLC_SYMBOL_SIZE, font: FONT },
+  { fontSize: TLC_NUMBER_SIZE, font: FONT }
+);
+const TLC_COMPACT_LABEL_LIFT = numberingGlyphLift(
+  TLC_COMPACT_SYMBOL_SIZE,
+  FONT
+);
+const TLC_COMPACT_ICON_LIFT = numberingStackedGlyphLift(
+  { fontSize: TLC_COMPACT_SYMBOL_SIZE, font: FONT },
+  { fontSize: TLC_COMPACT_NUMBER_SIZE, font: FONT }
+);
+const MEDIUM_GLYPH_LIFT = numberingGlyphLift(isTablet ? 32 : 20, FONT);
+const SMALL_GLYPH_LIFT = numberingGlyphLift(10, FONT);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -76,10 +103,8 @@ const styles = StyleSheet.create({
       : Math.round(24 * TLC_SCALE),
     fontFamily: FONTS.FrutigerNeueLTProBold,
     includeFontPadding: false,
-    lineHeight: isTablet
-      ? Math.round(24 * 1.5 * TLC_SCALE)
-      : Math.round(24 * TLC_SCALE),
-    transform: TLC_GLYPH_LIFT,
+    lineHeight: TLC_SYMBOL_SIZE,
+    transform: TLC_LABEL_LIFT,
   },
   tlcIconRoot: {
     width: isTablet
@@ -100,10 +125,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   tlcLineSymbol: {
-    lineHeight: isTablet
-      ? Math.round(24 * 1.5 * TLC_SCALE)
-      : Math.round(24 * TLC_SCALE),
-    transform: TLC_GLYPH_LIFT,
+    lineHeight: TLC_SYMBOL_SIZE,
+    transform: TLC_ICON_LIFT,
     fontSize: isTablet
       ? Math.round(24 * 1.5 * TLC_SCALE)
       : Math.round(24 * TLC_SCALE),
@@ -113,10 +136,8 @@ const styles = StyleSheet.create({
     color: '#231e1f',
   },
   tlcStationNumber: {
-    lineHeight: isTablet
-      ? Math.round(32 * 1.5 * TLC_SCALE)
-      : Math.round(32 * TLC_SCALE),
-    transform: TLC_GLYPH_LIFT,
+    lineHeight: TLC_NUMBER_SIZE,
+    transform: TLC_ICON_LIFT,
     fontSize: isTablet
       ? Math.round(32 * 1.5 * TLC_SCALE)
       : Math.round(32 * TLC_SCALE),
@@ -135,7 +156,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: isTablet ? 2 : 1,
   },
   tlcTextCompact: {
-    transform: TLC_COMPACT_GLYPH_LIFT,
+    transform: TLC_COMPACT_LABEL_LIFT,
     color: 'white',
     textAlign: 'center',
     fontSize: isTablet ? 12 : 8,
@@ -154,8 +175,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   tlcLineSymbolCompact: {
-    lineHeight: isTablet ? 12 : 8,
-    transform: TLC_COMPACT_GLYPH_LIFT,
+    lineHeight: TLC_COMPACT_SYMBOL_SIZE,
+    transform: TLC_COMPACT_ICON_LIFT,
     fontSize: isTablet ? 12 : 8,
     textAlign: 'center',
     fontFamily: FONTS.FrutigerNeueLTProBold,
@@ -163,8 +184,8 @@ const styles = StyleSheet.create({
     color: '#231e1f',
   },
   tlcStationNumberCompact: {
-    lineHeight: isTablet ? 15 : 10,
-    transform: TLC_COMPACT_GLYPH_LIFT,
+    lineHeight: TLC_COMPACT_NUMBER_SIZE,
+    transform: TLC_COMPACT_ICON_LIFT,
     fontSize: isTablet ? 15 : 10,
     marginTop: isTablet ? -2 : -1,
     textAlign: 'center',

--- a/src/components/NumberingIconTWR.tsx
+++ b/src/components/NumberingIconTWR.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { FONTS } from '~/constants';
 import isTablet from '~/utils/isTablet';
+import { numberingStackedGlyphLift } from '~/utils/numberingGlyphLift';
 import Typography from './Typography';
 
 type Props = {
@@ -9,6 +10,16 @@ type Props = {
   lineColor: string;
   withOutline?: boolean;
 };
+
+const SYMBOL_SIZE = isTablet ? 22 * 1.5 : 22;
+const NUMBER_SIZE = isTablet ? 35 * 1.5 : 35;
+
+// Androidのグリフ上寄り補正。記号と番号でフォントが違うので両方のメトリクスから求める。
+// 記号と番号で異なる値を使うと両者の間隔まで変わるため同じ値を使い回す
+const GLYPH_LIFT = numberingStackedGlyphLift(
+  { fontSize: SYMBOL_SIZE, font: 'FuturaLTPro' },
+  { fontSize: NUMBER_SIZE, font: 'MyriadPro' }
+);
 
 const styles = StyleSheet.create({
   optionalBorder: {
@@ -37,15 +48,17 @@ const styles = StyleSheet.create({
   },
   lineSymbol: {
     color: 'white',
-    fontSize: isTablet ? 22 * 1.5 : 22,
-    lineHeight: isTablet ? 22 * 1.5 : 22,
+    fontSize: SYMBOL_SIZE,
+    lineHeight: SYMBOL_SIZE,
+    transform: GLYPH_LIFT,
     textAlign: 'center',
     fontFamily: FONTS.FuturaLTPro,
   },
   stationNumber: {
     color: 'white',
-    fontSize: isTablet ? 35 * 1.5 : 35,
-    lineHeight: isTablet ? 35 * 1.5 : 35,
+    fontSize: NUMBER_SIZE,
+    lineHeight: NUMBER_SIZE,
+    transform: GLYPH_LIFT,
     marginTop: isTablet ? -4 * 1.2 : -4,
     textAlign: 'center',
     fontFamily: FONTS.MyriadPro,

--- a/src/components/numberingIconGlyphLift.test.tsx
+++ b/src/components/numberingIconGlyphLift.test.tsx
@@ -1,0 +1,96 @@
+import { render } from '@testing-library/react-native';
+import { Platform, StyleSheet, Text, type TextStyle } from 'react-native';
+import { MARK_SHAPE, NUMBERING_ICON_SIZE } from '~/constants';
+
+jest.mock('~/utils/isTablet', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+jest.mock('react-native-svg', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: unknown) => <View {...(props as object)} />,
+    Ellipse: (props: unknown) => <View {...(props as object)} />,
+    Polygon: (props: unknown) => <View {...(props as object)} />,
+    Svg: (props: unknown) => <View {...(props as object)} />,
+  };
+});
+
+// 補正は StyleSheet.create の評価時に決まるため、アイコンを読み込む前に
+// Android へ切り替えておく必要がある(iOSで補正が入らないことは
+// numberingGlyphLift のユニットテストで担保している)
+Object.defineProperty(Platform, 'OS', { value: 'android' });
+const NumberingIcon = require('./NumberingIcon').default;
+
+/**
+ * Android でグリフの上下ズレを打ち消す対象。`lineHeight` を指定したテキストは
+ * RN Android の CustomLineHeightSpan を通るため、フォントごとの補正が必要になる。
+ *
+ * ここに無いシェイプ(REVERSED_SQUARE_HORIZONTAL / REVERSED_ROUND_HORIZONTAL /
+ * NEW_SHUTTLE / KEIHAN / KEIO / SMR / NISHITETSU / IZUHAKONE /
+ * MONOCHROME_ROUND)は、実機計測でズレが 1dp 未満だったか、`lineHeight` を
+ * 指定しておらず CustomLineHeightSpan を通らないため対象外。
+ */
+const CORRECTED = [
+  { shape: MARK_SHAPE.SQUARE, stationNumber: 'JY-01' },
+  { shape: MARK_SHAPE.REVERSED_SQUARE_WEST, stationNumber: 'A-01' },
+  { shape: MARK_SHAPE.KEISEI, stationNumber: 'KS-01' },
+  { shape: MARK_SHAPE.SANYO, stationNumber: 'SY-01' },
+  { shape: MARK_SHAPE.HANKYU, stationNumber: 'HK-01' },
+  { shape: MARK_SHAPE.NTL, stationNumber: 'NT-01' },
+  { shape: MARK_SHAPE.ODAKYU, stationNumber: 'OH-01' },
+  { shape: MARK_SHAPE.ROUND, stationNumber: 'M-01' },
+  { shape: MARK_SHAPE.ROUND_HORIZONTAL, stationNumber: 'M-01' },
+  { shape: MARK_SHAPE.REVERSED_ROUND, stationNumber: 'N-01' },
+  { shape: MARK_SHAPE.KEIKYU, stationNumber: 'KK-01' },
+  { shape: MARK_SHAPE.REVERSED_SQUARE, stationNumber: 'A-01' },
+  { shape: MARK_SHAPE.HALF_SQUARE, stationNumber: 'A-01' },
+  { shape: MARK_SHAPE.NANKAI, stationNumber: 'NK-01' },
+  { shape: MARK_SHAPE.TWR, stationNumber: 'R-01' },
+  { shape: MARK_SHAPE.HANSHIN, stationNumber: 'HS-01' },
+];
+
+/** lineHeight を指定しているテキストだけが補正の対象になる */
+const linedTextStyles = (shape: string, stationNumber: string) =>
+  render(
+    <NumberingIcon
+      lineColor="#0072bc"
+      shape={shape}
+      size={NUMBERING_ICON_SIZE.LARGE}
+      stationNumber={stationNumber}
+    />
+  )
+    .UNSAFE_getAllByType(Text)
+    .map((node) => (StyleSheet.flatten(node.props.style) ?? {}) as TextStyle)
+    .filter((style) => typeof style.lineHeight === 'number');
+
+describe('ナンバリングアイコンのグリフ位置補正', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(CORRECTED)('$shape', ({ shape, stationNumber }) => {
+    it('lineHeightを指定した全てのテキストに補正が入る', () => {
+      const styles = linedTextStyles(shape, stationNumber);
+      expect(styles.length).toBeGreaterThan(0);
+      for (const style of styles) {
+        expect(style.transform).toEqual([{ translateY: expect.any(Number) }]);
+      }
+    });
+
+    it('記号と番号で同じ補正量を使い両者の間隔を変えない', () => {
+      // HALF_SQUARE は番号が独立した白地の箱に入るため行ごとに値が異なる
+      if (shape === MARK_SHAPE.HALF_SQUARE) {
+        return;
+      }
+      const lifts = linedTextStyles(shape, stationNumber).map(
+        (style) => (style.transform as { translateY: number }[])[0]
+      );
+      for (const lift of lifts) {
+        expect(lift).toEqual(lifts[0]);
+      }
+    });
+  });
+});

--- a/src/components/numberingIconGlyphLift.test.tsx
+++ b/src/components/numberingIconGlyphLift.test.tsx
@@ -41,6 +41,12 @@ const CORRECTED = [
   { shape: MARK_SHAPE.HANKYU, stationNumber: 'HK-01' },
   { shape: MARK_SHAPE.NTL, stationNumber: 'NT-01' },
   { shape: MARK_SHAPE.ODAKYU, stationNumber: 'OH-01' },
+  // 近鉄は LARGE が lineHeight を指定していないため MEDIUM で見る
+  {
+    shape: MARK_SHAPE.KINTETSU,
+    stationNumber: 'A-01',
+    size: NUMBERING_ICON_SIZE.MEDIUM,
+  },
   { shape: MARK_SHAPE.ROUND, stationNumber: 'M-01' },
   { shape: MARK_SHAPE.ROUND_HORIZONTAL, stationNumber: 'M-01' },
   { shape: MARK_SHAPE.REVERSED_ROUND, stationNumber: 'N-01' },
@@ -52,13 +58,38 @@ const CORRECTED = [
   { shape: MARK_SHAPE.HANSHIN, stationNumber: 'HS-01' },
 ];
 
+/**
+ * 記号や番号を縮める派生スタイルを持つシェイプ。`longStationNumberAdditional` は
+ * fontSize だけを縮めて lineHeight は据え置くため、通常サイズと同じ補正量では合わない。
+ */
+const SIZE_VARIANTS = [
+  { shape: MARK_SHAPE.ROUND, normal: 'M-01', variant: 'M-01-1' },
+  { shape: MARK_SHAPE.REVERSED_ROUND, normal: 'N-01', variant: 'N-01-1' },
+  { shape: MARK_SHAPE.KEISEI, normal: 'KS-01', variant: 'KS-01-1' },
+  { shape: MARK_SHAPE.KEIKYU, normal: 'KK-01', variant: 'KK-01-1' },
+];
+
+/**
+ * 2文字の記号は縮小版のスタイルに切り替わる。こちらは lineHeight も一緒に縮むため
+ * 補正量の差は 0.2dp 未満にしかならず、物理ピクセルへ丸めると通常サイズと一致しうる。
+ * そのため補正量が変わることまでは要求せず、2行で同じ値を使うことだけを見る。
+ */
+const LONG_SYMBOL_VARIANTS = [
+  { shape: MARK_SHAPE.ROUND, variant: 'MB-01' },
+  { shape: MARK_SHAPE.REVERSED_ROUND, variant: 'NB-01' },
+];
+
 /** lineHeight を指定しているテキストだけが補正の対象になる */
-const linedTextStyles = (shape: string, stationNumber: string) =>
+const linedTextStyles = (
+  shape: string,
+  stationNumber: string,
+  size: string = NUMBERING_ICON_SIZE.LARGE
+) =>
   render(
     <NumberingIcon
       lineColor="#0072bc"
       shape={shape}
-      size={NUMBERING_ICON_SIZE.LARGE}
+      size={size}
       stationNumber={stationNumber}
     />
   )
@@ -66,14 +97,17 @@ const linedTextStyles = (shape: string, stationNumber: string) =>
     .map((node) => (StyleSheet.flatten(node.props.style) ?? {}) as TextStyle)
     .filter((style) => typeof style.lineHeight === 'number');
 
+const liftsOf = (styles: TextStyle[]) =>
+  styles.map((style) => (style.transform as { translateY: number }[])[0]);
+
 describe('ナンバリングアイコンのグリフ位置補正', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe.each(CORRECTED)('$shape', ({ shape, stationNumber }) => {
+  describe.each(CORRECTED)('$shape', ({ shape, stationNumber, size }) => {
     it('lineHeightを指定した全てのテキストに補正が入る', () => {
-      const styles = linedTextStyles(shape, stationNumber);
+      const styles = linedTextStyles(shape, stationNumber, size);
       expect(styles.length).toBeGreaterThan(0);
       for (const style of styles) {
         expect(style.transform).toEqual([{ translateY: expect.any(Number) }]);
@@ -85,12 +119,44 @@ describe('ナンバリングアイコンのグリフ位置補正', () => {
       if (shape === MARK_SHAPE.HALF_SQUARE) {
         return;
       }
-      const lifts = linedTextStyles(shape, stationNumber).map(
-        (style) => (style.transform as { translateY: number }[])[0]
-      );
+      const lifts = liftsOf(linedTextStyles(shape, stationNumber, size));
       for (const lift of lifts) {
         expect(lift).toEqual(lifts[0]);
       }
     });
   });
+
+  describe.each(SIZE_VARIANTS)(
+    '$shape ($variant)',
+    ({ shape, normal, variant }) => {
+      it('縮小版のスタイルでも記号と番号で同じ補正量を使う', () => {
+        const lifts = liftsOf(linedTextStyles(shape, variant));
+        expect(lifts.length).toBeGreaterThan(0);
+        for (const lift of lifts) {
+          expect(lift).toEqual(lifts[0]);
+        }
+      });
+
+      // longStationNumberAdditional は fontSize だけを縮めて lineHeight を据え置くので、
+      // 通常サイズと同じ補正量では ink 全体が 1dp ほどズレる
+      it('実際に使う文字サイズの組み合わせから補正量を出している', () => {
+        const [normalLift] = liftsOf(linedTextStyles(shape, normal));
+        const [variantLift] = liftsOf(linedTextStyles(shape, variant));
+        expect(variantLift).not.toEqual(normalLift);
+      });
+    }
+  );
+
+  describe.each(LONG_SYMBOL_VARIANTS)(
+    '$shape ($variant)',
+    ({ shape, variant }) => {
+      it('縮小版の記号でも記号と番号で同じ補正量を使う', () => {
+        const lifts = liftsOf(linedTextStyles(shape, variant));
+        expect(lifts.length).toBeGreaterThan(0);
+        for (const lift of lifts) {
+          expect(lift).toEqual(lifts[0]);
+        }
+      });
+    }
+  );
 });

--- a/src/utils/numberingGlyphLift.test.ts
+++ b/src/utils/numberingGlyphLift.test.ts
@@ -1,5 +1,8 @@
-import { Platform } from 'react-native';
-import { numberingGlyphLift } from './numberingGlyphLift';
+import { PixelRatio, Platform } from 'react-native';
+import {
+  numberingGlyphLift,
+  numberingStackedGlyphLift,
+} from './numberingGlyphLift';
 
 describe('numberingGlyphLift', () => {
   const originalOS = Platform.OS;
@@ -12,34 +15,115 @@ describe('numberingGlyphLift', () => {
   const setOS = (os: typeof Platform.OS) =>
     Object.defineProperty(Platform, 'OS', { value: os });
 
-  it('iOSでは補正しない', () => {
+  const translateY = (transform: { translateY: number }[]) =>
+    transform[0].translateY;
+
+  it('iOSではどのフォントでも補正しない', () => {
     setOS('ios');
-    expect(numberingGlyphLift(24)).toEqual([]);
+    expect(numberingGlyphLift(24, 'FrutigerNeueLTProBold')).toEqual([]);
+    expect(numberingGlyphLift(24, 'FuturaLTPro')).toEqual([]);
+    expect(numberingGlyphLift(24, 'MyriadPro')).toEqual([]);
+    expect(numberingGlyphLift(24, 'VerdanaBold')).toEqual([]);
+    expect(
+      numberingStackedGlyphLift(
+        { fontSize: 24, font: 'FrutigerNeueLTProBold' },
+        { fontSize: 32, font: 'FrutigerNeueLTProBold' }
+      )
+    ).toEqual([]);
   });
 
-  // FrutigerNeueLTPro-Bold のメトリクスから導かれる比率は約 0.084em
-  it('Androidでは行の高さに比例して上方向へ補正する', () => {
+  // FrutigerNeueLTPro-Bold は ink が行ボックスの下寄りに描かれるため上へ持ち上げる
+  it('下寄りに描画されるフォントは上方向(負)へ補正する', () => {
     setOS('android');
-    expect(numberingGlyphLift(8)).toEqual([{ translateY: -1 }]);
-    expect(numberingGlyphLift(24)).toEqual([{ translateY: -2 }]);
-    expect(numberingGlyphLift(36)).toEqual([{ translateY: -3 }]);
+    for (const fontSize of [8, 10, 12, 20, 24, 30, 32, 45, 48]) {
+      expect(
+        translateY(numberingGlyphLift(fontSize, 'FrutigerNeueLTProBold'))
+      ).toBeLessThan(0);
+      expect(
+        translateY(numberingGlyphLift(fontSize, 'VerdanaBold'))
+      ).toBeLessThan(0);
+    }
   });
 
-  it('補正量は行の高さに対して単調増加する', () => {
+  // myriadpro-bold / FuturaLTPro-Bold は逆に上寄りなので押し下げる
+  it('上寄りに描画されるフォントは下方向(正)へ補正する', () => {
     setOS('android');
-    const lifts = [8, 12, 20, 24, 32, 48].map(
-      (lh) => -numberingGlyphLift(lh)[0].translateY
+    for (const fontSize of [10, 16, 22, 24, 35]) {
+      expect(
+        translateY(numberingGlyphLift(fontSize, 'MyriadPro'))
+      ).toBeGreaterThan(0);
+      expect(
+        translateY(numberingGlyphLift(fontSize, 'FuturaLTPro'))
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('補正量は文字サイズに対して単調に増える', () => {
+    setOS('android');
+    const lifts = [8, 12, 20, 24, 32, 48].map((fontSize) =>
+      Math.abs(
+        translateY(numberingGlyphLift(fontSize, 'FrutigerNeueLTProBold'))
+      )
     );
     for (let i = 1; i < lifts.length; i++) {
       expect(lifts[i]).toBeGreaterThanOrEqual(lifts[i - 1]);
     }
   });
 
-  it('補正量は常に上方向(負)になる', () => {
+  it('文字がぼやけないよう物理ピクセル境界に丸める', () => {
     setOS('android');
-    for (const lineHeight of [8, 10, 12, 17, 20, 24, 30, 32, 45, 48]) {
-      const [{ translateY }] = numberingGlyphLift(lineHeight);
-      expect(translateY).toBeLessThan(0);
-    }
+    const lift = translateY(numberingGlyphLift(24, 'FrutigerNeueLTProBold'));
+    expect(PixelRatio.roundToNearestPixel(lift)).toBe(lift);
+  });
+});
+
+describe('numberingStackedGlyphLift', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS });
+    jest.clearAllMocks();
+  });
+
+  const setOS = (os: typeof Platform.OS) =>
+    Object.defineProperty(Platform, 'OS', { value: os });
+
+  const translateY = (transform: { translateY: number }[]) =>
+    transform[0].translateY;
+
+  it('番号が大きいほど ink 全体は下に伸びるので補正は下方向へ寄る', () => {
+    setOS('android');
+    const symbol = { fontSize: 22, font: 'FrutigerNeueLTProBold' } as const;
+    const small = numberingStackedGlyphLift(symbol, {
+      fontSize: 26,
+      font: 'FrutigerNeueLTProBold',
+    });
+    const large = numberingStackedGlyphLift(symbol, {
+      fontSize: 40,
+      font: 'FrutigerNeueLTProBold',
+    });
+    expect(translateY(large)).toBeGreaterThan(translateY(small));
+  });
+
+  it('記号と番号が同じ行なら単独行の補正と一致する', () => {
+    setOS('android');
+    const line = { fontSize: 30, font: 'FrutigerNeueLTProBold' } as const;
+    expect(numberingStackedGlyphLift(line, line)).toEqual(
+      numberingGlyphLift(line.fontSize, line.font)
+    );
+  });
+
+  it('記号と番号でフォントが違っても両方のメトリクスから求める', () => {
+    setOS('android');
+    const symbol = { fontSize: 22, font: 'FuturaLTPro' } as const;
+    const sameFont = numberingStackedGlyphLift(symbol, {
+      fontSize: 35,
+      font: 'FuturaLTPro',
+    });
+    const mixedFont = numberingStackedGlyphLift(symbol, {
+      fontSize: 35,
+      font: 'MyriadPro',
+    });
+    expect(translateY(mixedFont)).not.toBe(translateY(sameFont));
   });
 });

--- a/src/utils/numberingGlyphLift.ts
+++ b/src/utils/numberingGlyphLift.ts
@@ -1,45 +1,102 @@
-import { Platform } from 'react-native';
+import { PixelRatio, Platform } from 'react-native';
 
 /**
- * FrutigerNeueLTPro-Bold の縦メトリクス(unitsPerEm=1000 に対する比率)。
- * android/app/src/main/assets/fonts/FrutigerNeueLTPro-Bold.ttf の hhea / OS/2 の値。
+ * ナンバリングアイコンで使う同梱フォントの縦メトリクス
+ * (unitsPerEm に対する比率)。
+ *
+ * `ascent` / `descent` は hhea、`capHeight` は OS/2 の sCapHeight
+ * (Verdana は OS/2 v1 で sCapHeight を持たないため `H` のアウトラインの yMax)。
  */
-const FONT_ASCENT = 1.13;
-const FONT_DESCENT = 0.264;
-const FONT_CAP_HEIGHT = 0.698;
+const FONT_METRICS = {
+  // android/app/src/main/assets/fonts/FrutigerNeueLTPro-Bold.ttf
+  FrutigerNeueLTProBold: { ascent: 1.13, descent: 0.264, capHeight: 0.698 },
+  // android/app/src/main/assets/fonts/FuturaLTPro-Bold.ttf
+  FuturaLTPro: { ascent: 0.825, descent: 0.175, capHeight: 0.754 },
+  // android/app/src/main/assets/fonts/myriadpro-bold.ttf
+  MyriadPro: { ascent: 0.75, descent: 0.25, capHeight: 0.674 },
+  // android/app/src/main/assets/fonts/verdana-bold.ttf
+  VerdanaBold: { ascent: 1.005, descent: 0.21, capHeight: 0.727 },
+} as const;
+
+export type NumberingGlyphFont = keyof typeof FONT_METRICS;
+
+/** ナンバリングの1行分。`lineHeight === fontSize` であることが前提 */
+export type NumberingGlyphLine = {
+  fontSize: number;
+  font: NumberingGlyphFont;
+};
 
 /**
- * Android でナンバリングのグリフが行ボックス内で下寄りになる分の比率。
+ * 行ボックスの上端からベースラインまでの距離(fontSize に対する比率)。
  *
  * RN Android の CustomLineHeightSpan は lineHeight とフォントの ascent+descent の差
- * (leading) を上下へ等分するため、行ボックスの中心はフォントの ascent/descent ボックスの
- * 中心に一致する。ナンバリングの記号と番号は大文字と数字だけでディセンダを持たないので、
- * ベースラインより下の descent がそのまま余白として残り、グリフが下寄りに見える。
- * ズレ量は (ascent - descent) - capHeight で、その半分を引き上げると上下が揃う。
- * 式から lineHeight が消えることからも分かるとおり、補正量は文字サイズに比例する。
+ * (leading) を上下へ等分するため、ベースラインは行ボックスの中心から
+ * (ascent - descent) / 2 だけ下に来る。lineHeight === fontSize なので上端からは
+ * 0.5 + (ascent - descent) / 2 の位置になる。
  *
- * 端末やOSではなくフォントに依存する値である点に注意:
- * フォントは APK 同梱で `Typography` も allowFontScaling={false} のため、端末や
- * フォントサイズ設定では変わらない。一方 myriadpro-bold は -0.087em、FuturaLTPro-Bold は
- * -0.052em と符号が逆になるので、別フォントのアイコンにそのまま流用してはいけない。
- * React Native 0.86.2 の CustomLineHeightSpan を前提にしているので、RN のメジャー
- * アップグレード時は実機で見た目を確認すること。
+ * 端末やOSではなくフォントに依存する値である点に注意: フォントは APK 同梱で
+ * `Typography` も allowFontScaling={false} のため、端末やフォントサイズ設定では
+ * 変わらない。React Native 0.86.2 の CustomLineHeightSpan を前提にしているので、
+ * RN のメジャーアップグレード時は実機で見た目を確認すること。
  */
-const GLYPH_LIFT_RATIO = (FONT_ASCENT - FONT_DESCENT - FONT_CAP_HEIGHT) / 2;
+const baselineRatio = (font: NumberingGlyphFont) => {
+  const { ascent, descent } = FONT_METRICS[font];
+  return 0.5 + (ascent - descent) / 2;
+};
+
+/** 行ボックスの上端から、大文字・数字の上端(= ベースライン - capHeight)までの距離 */
+const inkTopOffset = ({ fontSize, font }: NumberingGlyphLine) =>
+  fontSize * (baselineRatio(font) - FONT_METRICS[font].capHeight);
 
 /**
- * Android のグリフ下寄り分を打ち消す transform を返す(iOS は行ボックス内で中央に
- * 描かれるため補正しない)。
- *
- * marginTop の負値では兄弟要素ごと動いてアイコン全体が縮むため、レイアウトに影響しない
- * transform で文字だけを持ち上げる。
- *
- * 記号と番号で異なる値を渡すと両者の間隔まで変わってしまうので、1つのアイコンでは
- * 必ず同じ戻り値を使い回すこと。
- *
- * @param baseLineHeight 基準にする行の高さ(本リポジトリでは lineHeight === fontSize)
+ * 行ボックスの下端から ink の下端までの距離。
+ * ナンバリングの記号と番号は大文字と数字だけでディセンダを持たないので、
+ * ink の下端はベースラインそのものになる。
  */
-export const numberingGlyphLift = (baseLineHeight: number) =>
+const inkBottomOffset = ({ fontSize, font }: NumberingGlyphLine) =>
+  fontSize * (1 - baselineRatio(font));
+
+/**
+ * translateY はレイアウトに影響しないぶん端数がそのまま描画位置になるので、
+ * 文字がぼやけないよう物理ピクセル境界に丸める。
+ */
+const toTransform = (lift: number) =>
   Platform.OS === 'android'
-    ? [{ translateY: -Math.round(baseLineHeight * GLYPH_LIFT_RATIO) }]
+    ? [{ translateY: PixelRatio.roundToNearestPixel(-lift) }]
     : [];
+
+/**
+ * 1行だけのテキストで、グリフを行ボックスの上下中央に揃える transform を返す
+ * (iOS は lineHeight が font.lineHeight より小さいと RN が補正を当てないため、
+ * この補正は Android のみ)。
+ *
+ * marginTop の負値では兄弟要素ごと動いてアイコン全体が縮むため、レイアウトに
+ * 影響しない transform で文字だけを動かす。
+ *
+ * ズレの向きはフォント依存で、FrutigerNeueLTPro-Bold は下寄り、
+ * myriadpro-bold と FuturaLTPro-Bold は上寄りと符号まで変わる。
+ */
+export const numberingGlyphLift = (
+  fontSize: number,
+  font: NumberingGlyphFont
+) => {
+  const line = { fontSize, font };
+  return toTransform((inkTopOffset(line) - inkBottomOffset(line)) / 2);
+};
+
+/**
+ * 記号と番号が縦に並ぶアイコンで、2行の ink 全体をアイコンの上下中央へ揃える
+ * transform を返す。
+ *
+ * 記号と番号で異なる値を当てると両者の間隔まで変わってしまうので、戻り値は
+ * 必ず両方の Text で同じものを使い回すこと。行ごとに最適な量が違っても、
+ * 揃えたいのは ink 全体の位置なので 1 つの値で足りる。
+ *
+ * 上下の余白は「上の行の ink 上端までの余白」と「下の行の ink 下端からの余白」で
+ * 決まり、その差の半分が中心のズレになる。記号側の marginTop はレイアウト箱ごと
+ * 下げてしまうため、Android では当てないこと(iOS 側の視覚補正として残す)。
+ */
+export const numberingStackedGlyphLift = (
+  symbol: NumberingGlyphLine,
+  stationNumber: NumberingGlyphLine
+) => toTransform((inkTopOffset(symbol) - inkBottomOffset(stationNumber)) / 2);

--- a/src/utils/numberingGlyphLift.ts
+++ b/src/utils/numberingGlyphLift.ts
@@ -20,41 +20,49 @@ const FONT_METRICS = {
 
 export type NumberingGlyphFont = keyof typeof FONT_METRICS;
 
-/** ナンバリングの1行分。`lineHeight === fontSize` であることが前提 */
+/** ナンバリングの1行分 */
 export type NumberingGlyphLine = {
   fontSize: number;
+  /**
+   * 省略時は `fontSize` と同値。`longStationNumberAdditional` のように
+   * `fontSize` だけを上書きするスタイルでは、実際に効く `lineHeight` を明示する。
+   */
+  lineHeight?: number;
   font: NumberingGlyphFont;
 };
 
 /**
- * 行ボックスの上端からベースラインまでの距離(fontSize に対する比率)。
+ * 行ボックスの上端からベースラインまでの距離。
  *
  * RN Android の CustomLineHeightSpan は lineHeight とフォントの ascent+descent の差
  * (leading) を上下へ等分するため、ベースラインは行ボックスの中心から
- * (ascent - descent) / 2 だけ下に来る。lineHeight === fontSize なので上端からは
- * 0.5 + (ascent - descent) / 2 の位置になる。
+ * fontSize × (ascent - descent) / 2 だけ下に来る。
  *
  * 端末やOSではなくフォントに依存する値である点に注意: フォントは APK 同梱で
  * `Typography` も allowFontScaling={false} のため、端末やフォントサイズ設定では
  * 変わらない。React Native 0.86.2 の CustomLineHeightSpan を前提にしているので、
  * RN のメジャーアップグレード時は実機で見た目を確認すること。
  */
-const baselineRatio = (font: NumberingGlyphFont) => {
+const baselineOffset = ({
+  fontSize,
+  lineHeight = fontSize,
+  font,
+}: NumberingGlyphLine) => {
   const { ascent, descent } = FONT_METRICS[font];
-  return 0.5 + (ascent - descent) / 2;
+  return lineHeight / 2 + (fontSize * (ascent - descent)) / 2;
 };
 
 /** 行ボックスの上端から、大文字・数字の上端(= ベースライン - capHeight)までの距離 */
-const inkTopOffset = ({ fontSize, font }: NumberingGlyphLine) =>
-  fontSize * (baselineRatio(font) - FONT_METRICS[font].capHeight);
+const inkTopOffset = (line: NumberingGlyphLine) =>
+  baselineOffset(line) - line.fontSize * FONT_METRICS[line.font].capHeight;
 
 /**
  * 行ボックスの下端から ink の下端までの距離。
  * ナンバリングの記号と番号は大文字と数字だけでディセンダを持たないので、
  * ink の下端はベースラインそのものになる。
  */
-const inkBottomOffset = ({ fontSize, font }: NumberingGlyphLine) =>
-  fontSize * (1 - baselineRatio(font));
+const inkBottomOffset = (line: NumberingGlyphLine) =>
+  (line.lineHeight ?? line.fontSize) - baselineOffset(line);
 
 /**
  * translateY はレイアウトに影響しないぶん端数がそのまま描画位置になるので、


### PR DESCRIPTION
## 概要

PR #6814 で JR 東日本・JR 西日本のナンバリングに入れた Android のグリフ位置補正を、全ナンバリングコンポーネントへ横展開します。京成・山陽をはじめ、同じ症状が残っていた 15 コンポーネントを実機計測で 0±1px まで揃えました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### 原因: #6814 の式は1行のアイコンにしか当てはまらない

#6814 の補正量は `((ascent - descent) - capHeight) / 2 × fontSize` でしたが、これは**テキストが1行のアイコン**の式です。記号と番号が縦に並ぶアイコンでは、2行まとめた ink の中心のズレは

```text
(記号の行の上端から ink 上端までの余白 - 番号の行の下端から ink 下端までの余白) / 2
```

になります。番号の方が文字サイズが大きいため、1行分の式をそのまま当てても合いません。実機計測はこの式と全アイコンで ±1px 以内で一致しました。

もう一点、`lineSymbol` の**正の `marginTop` は iOS 向けの視覚補正**で、中央寄せの列では ink 中心を `marginTop / 2` だけ動かします（負の `marginTop` は行間だけを詰め、中心は動かしません）。#6814 が JR 東西でこれを `Platform.OS === 'ios'` に限定していたのはこのためで、京成・山陽など他社線ではここが未対応のまま残っていました。

### `numberingGlyphLift` の一般化

- 同梱フォント4種（FrutigerNeueLTPro-Bold / FuturaLTPro-Bold / myriadpro-bold / verdana-bold）の縦メトリクスを持たせ、フォント別に補正量を出すようにしました。ズレの向きはフォント依存で、Frutiger と Verdana は下寄り、Futura と Myriad は**上寄り**と符号まで変わります。
- 縦2行用に `numberingStackedGlyphLift(記号, 番号)` を追加。記号と番号でフォントが異なる南海・TWR も1つの値で扱えます。戻り値を両方の Text で共有するので、2行の間隔は変わりません。
- 行の高さと文字サイズを分けて受け取れるようにしました。`longStationNumberAdditional` のように `fontSize` だけを上書きして `lineHeight` を据え置くスタイルがあるためです（下記）。
- 丸めを `Math.round`（dp 単位）から `PixelRatio.roundToNearestPixel` に変更し、物理ピクセル境界へ合わせました。3x 端末では最大 1.5px あった丸め誤差が 0.5px 未満になり、文字が半ピクセルに乗ってぼやけることもありません。

### 縮小版のスタイルに合わせた補正（CodeRabbit の指摘対応）

東京メトロ系・京成・京急はサブ番号付きの駅番号で `longStationNumberAdditional` に切り替わりますが、このスタイルは `fontSize` だけを 20 に縮めて `lineHeight` は元のままです。通常サイズの補正量を当てると ink 全体が 1dp ほどズレるため、実際に使う文字サイズの組み合わせごとに補正量を持ち、選んだ1つを記号と番号の両方へ渡すようにしました（ROUND / REVERSED_ROUND は記号2文字の縮小版もあるので4通り、KEISEI / KEIKYU は2通り）。

### 補正を適用したコンポーネント

京成・山陽・阪急・小田急・近鉄(MEDIUM/SMALL)・NTL・JR東(SQUARE)・JR西・東京メトロ系(ROUND / ROUND_HORIZONTAL / REVERSED_ROUND)・京急・都営系(REVERSED_SQUARE)・HALF_SQUARE・南海・TWR・阪神 の 17 ファイル。あわせて記号側の正の `marginTop` を `Platform.OS === 'ios'` で分岐しました。

### 対象外にしたもの

| コンポーネント | 理由 |
| ---- | ---- |
| REVERSED_SQUARE_HORIZONTAL / REVERSED_ROUND_HORIZONTAL / ニューシャトル | 実機計測でズレが 0〜0.5px。既存の `marginTop` がフォント由来のズレをちょうど打ち消していたため触っていません |
| 近鉄 LARGE / 伊豆箱根 / 西鉄 / モノクロ丸 | `lineHeight` を指定しておらず `CustomLineHeightSpan` を通らないため、Android 固有のズレが発生しません |
| 京阪 | 絶対配置で下端基準に置いており、中央寄せの前提が成り立ちません |
| 京王 / SMR | Roboto は補正量が 0.4px 未満で、丸めると 0 になります |

### 実機計測（Galaxy SCG13 / density 3、+ が下寄り）

| アイコン | フォント | 修正前 | 修正後 |
| ---- | ---- | ---- | ---- |
| 京成 | Frutiger | +8.5px | +0.5px |
| 山陽 | Frutiger | +9.5px | -1.0px |
| 阪急 | Frutiger | +7.0px | +0.5px |
| 小田急 | Frutiger | +8.5px | +0.0px |
| 近鉄 MEDIUM | Frutiger | +12.0px | +0.5px |
| 東京メトロ (ROUND) | Futura | -4.0px | +0.0px |
| 都営 (REVERSED_SQUARE) | Myriad | -4.8px | +0.0px |
| 京急 | Futura | -4.3px | +0.5px |
| 南海 | Futura+Myriad | -3.5px | -0.5px |
| りんかい線 (TWR) | Futura+Myriad | -10.0px | +0.0px |
| 阪神 | Verdana | +5.0px | +1.0px |
| JR東 (SQUARE) | Frutiger | -0.5px | +0.5px |
| JR西 | Frutiger | -1.0px | +0.0px |

サブ番号付き（縮小版のスタイル）も実機で計測し、ROUND / REVERSED_ROUND は +0.0px、KEISEI / KEIKYU は +0.5px と通常サイズと同じ位置に揃うことを確認しています。

検証は、全アイコンを1行1個で並べた一時画面を実機に出し、アイコンの上下中央（マゼンタ線）と外形（シアン線）を基準にスクリーンショットからピクセル単位で ink の位置を測る方法で行いました。この一時画面は PR には含めていません。

### 回帰リスクと緩和

- **iOS には影響しません。** 補正は `Platform.OS === 'android'` のときだけ transform を返し、iOS では空配列のままです。`marginTop` も iOS 側の値は変えていません。
- **レイアウトは変わりません。** 補正は `transform: translateY` なので兄弟要素を動かしません。`marginTop` の分岐は Android のみで、かつ2行の間隔（負の `marginTop`）には触れていません。
- **NTL に約 9.5px の下寄りが残ります。** `inner` が中央寄せしておらずテキストが上詰めのままはみ出す**レイアウト側**の問題で、iOS でも同じ配置です。今回は Android 固有のフォント由来分だけを直しました。直すなら `inner` に `justifyContent: 'center'` を入れる話になり iOS の見た目も変わるため、別PRに分けるのが安全だと判断しています。
- **RN のバージョンに依存します。** React Native 0.86.2 の `CustomLineHeightSpan` の実装が前提です。メジャーアップグレード時に実機確認が必要な旨はヘルパーのコメントに残しています。
- 横展開漏れが再発しないよう、`lineHeight` を指定した全テキストに補正が入っていること・記号と番号が同じ補正量を使っていることを検証する回帰テストを追加しました。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 264 suites / 2853 tests。追加したテストは以下のとおりです。

- `numberingGlyphLift`: フォントごとに補正の向きが変わること、文字サイズに比例すること、物理ピクセル境界に丸まること
- `numberingStackedGlyphLift`: 番号が大きいほど補正が下方向へ寄ること、記号と番号が同じ行なら単独行の補正と一致すること、フォントが違っても両方のメトリクスを使うこと
- `numberingIconGlyphLift.test.tsx`: 対象17ケースについて `lineHeight` を指定した全テキストに補正が入ること、記号と番号で同じ補正量を使い間隔を変えないこと、サブ番号ありの縮小版では実際の文字サイズの組み合わせから補正量を出していること（対象外にしたシェイプとその理由もこのファイルに記載）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### Galaxy SCG13（実機キャプチャに基準線を合成）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_numbering-glyph-alignment-rollout-14f8e44ba7c0/83a0a0de910a-numbering_before_after.png" width="360" alt="修正前後の比較。マゼンタ線がアイコンの上下中央、シアン線が外形の上下端。" />

修正前後の比較。マゼンタ線がアイコンの上下中央、シアン線が外形の上下端。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcNhShP3R1kZg8MNrvu7kR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Androidで、各路線のナンバリングアイコンに含まれる記号・駅番号の上下位置を調整し、表示の整合性を改善しました。
  - 通常サイズ・小サイズ・長い駅番号など、文字サイズや組み合わせに応じた補正に対応しました。
  - さまざまなアイコン形式で、記号と駅番号がより自然に揃って表示されます。
  - iOSでは従来の表示調整を維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->