### PR TITLE
英語TTSで「Seibu」が「さいぶ」と読まれる誤読を端末内蔵TTS向けの読み替え表に追加して修正

### DIFF
--- a/src/utils/englishReading.test.ts
+++ b/src/utils/englishReading.test.ts
@@ -25,8 +25,19 @@ describe('fixEnglishReading', () => {
     );
   });
 
+  it('「Seibu」を英語 TTS が「せいぶ」と読む表記へ置換する', () => {
+    expect(fixEnglishReading('Change here for the Seibu Ikebukuro Line.')).toBe(
+      'Change here for the Say-boo Ikebukuro Line.'
+    );
+    expect(fixEnglishReading('The next station is Seibu-Shinjuku.')).toBe(
+      'The next station is Say-boo-Shinjuku.'
+    );
+  });
+
   it('別語の一部は置換しない', () => {
     expect(fixEnglishReading('Keiseibus')).toBe('Keiseibus');
+    // 西武園 (Seibuen) は 1 語なので語単位の一致では対象外
+    expect(fixEnglishReading('Seibuen')).toBe('Seibuen');
   });
 
   it('対象を含まないテキストはそのまま返す', () => {

--- a/src/utils/englishReading.ts
+++ b/src/utils/englishReading.ts
@@ -17,6 +17,9 @@ const ENGLISH_READING_RULES: readonly EnglishReadingRule[] = [
   // 「Keisei (京成)」は英語 TTS が "ei" を /aɪ/ と推定して「かいせい」と読む
   // ため、英単語 "Kay" + "say" で /keɪ.seɪ/ (けいせい) を確定させる。
   { pattern: /\bKeisei\b/gi, reading: 'Kay-say' },
+  // 「Seibu (西武)」も同じく "ei" を /aɪ/ と推定して「さいぶ」と読むため、
+  // "Say" + "boo" で /seɪ.buː/ (せいぶ) を確定させる。
+  { pattern: /\bSeibu\b/gi, reading: 'Say-boo' },
 ];
 
 /**


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

英語アナウンスで「Seibu（西武）」が「さいぶ」と読み上げられる誤読を、#6869 で入れた「Keisei → Kay-say」と同じ方式で修正します。端末内蔵 TTS 向けの読み替え表に `Seibu → Say-boo` を追加します。リモート TTS 向けの同じ置換は TrainLCD/functions#27 で行います。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/utils/englishReading.ts`: `ENGLISH_READING_RULES` に `/\bSeibu\b/gi → 'Say-boo'` を追加
  - 英語 TTS は "ei" を /aɪ/ と推定して「さいぶ」と読むため、英語の辞書語 "Say" + "boo" で /seɪ.buː/（せいぶ）を確定させます
  - 単語境界で一致させるため、`Seibu Ikebukuro Line` / `Seibu-Shinjuku` は置換され、1 語の `Seibuen`（西武園）は対象外です
- `src/utils/englishReading.test.ts`: 上記のケースを追加
- #6872 の分担どおり、この置換は端末内蔵 TTS（`engine: 'native'`）の経路だけに適用されます。リモート TTS へは原文の「Seibu」のまま送ります

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

ローカル実行結果（Node 24.20.0 / npm 11.19.0）:

```text
npm run lint      -> Checked 721 files. No fixes applied.
npm test -- src/utils/englishReading.test.ts src/utils/speakableText.test.ts src/hooks/tts
                  -> Test Suites: 6 passed, Tests: 92 passed
npm run typecheck -> エラーなし
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- Refs #6869
- Refs TrainLCD/functions#27

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->
UI 変更なし: `src/utils/**` の読み上げテキスト生成ロジックのみの変更で、画面表示には変化がありません
<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS1LSBnYTMfm7CyrzqKxuW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 英語音声読み上げで、「Seibu」を「Say-boo」と発音しやすくなるよう改善しました。
  * 「Seibuen」など、対象外の単語には意図せず適用されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->