### PR TITLE
Kotlinデーモンのメタスペース上限を明示してAndroidリリースビルドのOutOfMemoryErrorを解消

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,16 +10,16 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
+# ヒープは据え置き。枯渇していたのは Metaspace だけなので、上限を上げるのはそちらに絞る。
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 
 # Kotlin コンパイルデーモンの JVM 引数。未指定だと org.gradle.jvmargs をそのまま
 # 継承するため、1 プロセスで node_modules 配下の全ネイティブモジュール +
 # :app + :wearable を続けてコンパイルすると Metaspace が枯渇し
 # `OutOfMemoryError: Metaspace` でリリースビルドが停止する
 # (CI 実測: ubuntu-22.04 の :wearable:compileDevReleaseKotlin で発生)。
-# Metaspace は上限を確保するだけで実使用分しかコミットされないため、
-# 上限は余裕を持たせておく方が安全。
-kotlin.daemon.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=2048m
+# 継承任せだと Gradle 側の変更に引きずられるので、値が同じでも明示しておく。
+kotlin.daemon.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,16 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
+
+# Kotlin コンパイルデーモンの JVM 引数。未指定だと org.gradle.jvmargs をそのまま
+# 継承するため、1 プロセスで node_modules 配下の全ネイティブモジュール +
+# :app + :wearable を続けてコンパイルすると Metaspace が枯渇し
+# `OutOfMemoryError: Metaspace` でリリースビルドが停止する
+# (CI 実測: ubuntu-22.04 の :wearable:compileDevReleaseKotlin で発生)。
+# Metaspace は上限を確保するだけで実使用分しかコミットされないため、
+# 上限は余裕を持たせておく方が安全。
+kotlin.daemon.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=2048m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -150,16 +150,31 @@ its `timeout-minutes: 45` budget and surfaced only as
 `The operation was canceled.` — read the log above the cancellation to see the
 real cause.
 
-`android/gradle.properties` therefore raises both limits and pins the Kotlin
-daemon explicitly rather than letting it inherit:
+`android/gradle.properties` therefore raises the Metaspace ceiling and pins the
+Kotlin daemon explicitly rather than letting it inherit:
 
-| Property | Value |
-| --- | --- |
-| `org.gradle.jvmargs` | `-Xmx4096m -XX:MaxMetaspaceSize=1024m` |
-| `kotlin.daemon.jvmargs` | `-Xmx3072m -XX:MaxMetaspaceSize=2048m` |
+| Property | Heap | Metaspace (before → after) |
+| --- | --- | --- |
+| `org.gradle.jvmargs` | `-Xmx2048m` | `512m` → `1024m` |
+| `kotlin.daemon.jvmargs` | `-Xmx2048m` | inherited `512m` → `1024m` |
 
-A JVM only reserves `-Xmx` and `-XX:MaxMetaspaceSize`; it commits what it
-actually uses. Generous ceilings therefore cost nothing on an idle build and
-still turn a runaway allocation into a clear error rather than an OOM-killed
-runner. Keep `kotlin.daemon.jvmargs` set whenever `org.gradle.jvmargs` changes,
+**Only the Metaspace ceiling changes.** Both heap ceilings stay at the `2048m`
+the build already ran with — it compiled every native module, `:app`, and R8
+without a heap OOM, so raising `-Xmx` would treat a symptom the build never had.
+
+Do not read a heap ceiling as free headroom. Metaspace is committed lazily, so
+its ceiling mostly just converts a runaway allocation into a clear error. A heap
+ceiling is different: the JVM defers full GCs and lets the heap grow toward
+`-Xmx`, so a larger value raises real resident memory. Two JVMs run
+concurrently here, and Gradle worker processes, R8, and Node sit alongside them,
+so budget the *sum* of the ceilings against the runner rather than each one on
+its own.
+
+This repository is public, so its jobs get the 4-vCPU / 16 GB standard runner
+(the 2-vCPU / 8 GB tier applies to private repositories). The ceilings above
+total 4 GB of heap and 2 GB of Metaspace, which fits either tier with room for
+the rest of the job. Re-check that sum before raising any of these values, and
+prefer a larger runner over ceilings the runner cannot back.
+
+Keep `kotlin.daemon.jvmargs` set whenever `org.gradle.jvmargs` changes,
 otherwise the daemon silently picks up the Gradle value again.

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -128,3 +128,38 @@ Both modules build with R8 enabled
 each upload step passes its own module's `mapping.txt`. Keep the `mappingFile`
 path aligned with the module of that step — a mismatched mapping silently
 corrupts crash deobfuscation for the affected bundle.
+
+## Build memory
+
+A release build compiles Kotlin for every native module under `node_modules`
+plus `:app` and `:wearable` in a single Gradle invocation. All of those
+compilations share one Kotlin compile daemon, so its Metaspace grows across the
+whole run.
+
+The Kotlin daemon inherits `org.gradle.jvmargs` when `kotlin.daemon.jvmargs` is
+not set. With the previous `-XX:MaxMetaspaceSize=512m` the daemon ran out of
+Metaspace part-way through the build:
+
+```text
+Exception in thread "RMI TCP Connection(idle)" java.lang.OutOfMemoryError: Metaspace
+> Task :wearable:compileDevReleaseKotlin FAILED
+```
+
+The daemon then kept thrashing instead of exiting, so the job burned the rest of
+its `timeout-minutes: 45` budget and surfaced only as
+`The operation was canceled.` — read the log above the cancellation to see the
+real cause.
+
+`android/gradle.properties` therefore raises both limits and pins the Kotlin
+daemon explicitly rather than letting it inherit:
+
+| Property | Value |
+| --- | --- |
+| `org.gradle.jvmargs` | `-Xmx4096m -XX:MaxMetaspaceSize=1024m` |
+| `kotlin.daemon.jvmargs` | `-Xmx3072m -XX:MaxMetaspaceSize=2048m` |
+
+A JVM only reserves `-Xmx` and `-XX:MaxMetaspaceSize`; it commits what it
+actually uses. Generous ceilings therefore cost nothing on an idle build and
+still turn a runaway allocation into a clear error rather than an OOM-killed
+runner. Keep `kotlin.daemon.jvmargs` set whenever `org.gradle.jvmargs` changes,
+otherwise the daemon silently picks up the Gradle value again.

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -172,9 +172,14 @@ its own.
 
 This repository is public, so its jobs get the 4-vCPU / 16 GB standard runner
 (the 2-vCPU / 8 GB tier applies to private repositories). The ceilings above
-total 4 GB of heap and 2 GB of Metaspace, which fits either tier with room for
-the rest of the job. Re-check that sum before raising any of these values, and
-prefer a larger runner over ceilings the runner cannot back.
+total 4 GB of heap and 2 GB of Metaspace — but a ceiling is not a memory
+budget. Gradle worker processes, R8, Node, and each JVM's own native memory
+(thread stacks, code cache, direct buffers) all sit on top of those numbers,
+and none of that has been measured here. So do not read the difference between
+the ceilings and the runner's RAM as available headroom, least of all on the
+8 GB tier. Before raising any of these values, measure peak RSS across the
+whole build on the runner you actually target, and prefer a larger runner over
+ceilings the runner cannot back.
 
 Keep `kotlin.daemon.jvmargs` set whenever `org.gradle.jvmargs` changes,
 otherwise the daemon silently picks up the Gradle value again.


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Android の Canary デプロイが `java.lang.OutOfMemoryError: Metaspace` で停止していた問題を修正する。

[該当ジョブ](https://github.com/TrainLCD/MobileApp/actions/runs/34063787204/job/101572289364) のログ末尾は `The operation was canceled.` だが、これは `timeout-minutes: 45` に到達した結果であって原因ではない。実際の失敗はその 27 分前に起きている。

```text
##[error]Exception in thread "RMI TCP Connection(idle)" java.lang.OutOfMemoryError: Metaspace
> Task :wearable:compileDevReleaseKotlin FAILED
```

`RMI TCP Connection` は Kotlin コンパイルデーモン側のスレッドなので、Metaspace を使い切ったのは Gradle 本体ではなく **Kotlin デーモン**。`kotlin.daemon.jvmargs` が未設定だと Kotlin デーモンは `org.gradle.jvmargs` をそのまま継承するため、`-XX:MaxMetaspaceSize=512m` が適用されていた。

リリースビルドは `node_modules` 配下の全ネイティブモジュール（reanimated / screens / svg / sentry など）→ `:app` → `:wearable` を **1 つのデーモンで連続コンパイル**するため、モジュールごとのコンパイラプラグイン用クラスローダが積み上がり、最後の `:wearable` で 512m を超えていた。OOM 後もデーモンが終了せずスラッシングし続けたことが、タイムアウトまで走り切って本当の原因が末尾に残らなかった理由でもある。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `android/gradle.properties`: `kotlin.daemon.jvmargs` を新設し、Kotlin デーモンの JVM 引数を `org.gradle.jvmargs` からの暗黙の継承ではなく明示指定に変更
- `android/gradle.properties`: Gradle・Kotlin デーモン双方の Metaspace 上限を `512m` → `1024m` に引き上げ（**ヒープ上限は据え置き**）
- `docs/android-build-workflows.md`: 「Build memory」節を追加し、失敗ログの読み方（キャンセルではなく Metaspace 枯渇である点）、JVM 上限はジョブ全体のメモリ収支ではない点、`org.gradle.jvmargs` を変更したら `kotlin.daemon.jvmargs` も必ず追従させる必要がある点を記載

| プロパティ | ヒープ | Metaspace（変更前 → 変更後） |
| --- | --- | --- |
| `org.gradle.jvmargs` | `-Xmx2048m`（据え置き） | `512m` → `1024m` |
| `kotlin.daemon.jvmargs` | `-Xmx2048m`（従来の継承値と同じ） | 継承 `512m` → `1024m` |

**変わるのは Metaspace 上限だけ。** 今回の失敗はヒープ OOM を一度も伴っておらず、全ネイティブモジュール・`:app`・R8 の minify まで `-Xmx2048m` で通っていたため、ヒープ上限の引き上げはビルドが持っていない症状への対処になる。

なお `-Xmx` と `-XX:MaxMetaspaceSize` の合計はジョブ全体の RSS ではない。Gradle worker、R8、Node、各 JVM 自身の native memory がその上に乗るため、上限とランナー搭載メモリの差を「余裕」と読んではいけない。ドキュメントにもその旨と、今後この値を動かすならピーク RSS の計測が先である旨を明記した。

### リグレッションリスクと緩和策

| リスク | 評価 / 緩和策 |
| --- | --- |
| ランナーのメモリ超過 | 判断の根拠は上限の合計ではなく**差分**。ヒープ上限は失敗したビルドと同一値で、増えたのは遅延コミットされる Metaspace 上限 1 GB 分のみ。したがってピーク RSS が増える余地は、Kotlin デーモンが実際に追加で使う Metaspace 分に限られる（絶対量は未計測） |
| ローカル開発マシンへの影響 | 同じ Metaspace 枯渇はローカルのリリースビルドでも起こりうるため、`gradle.properties` に入れるのが正しい置き場所。上限引き上げのみでビルド成果物には影響しない |
| アプリ挙動への影響 | ビルド時の JVM 設定のみの変更で、`src/**` およびアプリのソースコードは一切変更していない |
| 効果が不十分な可能性 | Android SDK がない環境のため実ビルドでの再現・検証はできていない（下記参照）。仮に 1024m でも不足する場合は、上限をさらに上げるのではなく `:app` と `:wearable` を別ステップの Gradle 実行に分けてデーモンをリセットする方向で対応する |

なお `timeout-minutes: 45` は変更していない。R8 の minify だけで約 4 分かかっており余裕は大きくないので、ビルド時間が伸びてきた段階で別途引き上げを検討したい。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint` — Checked 722 files, no fixes applied
- `npm test` — 264 suites / 2854 tests すべて pass
- `npm run typecheck` — エラーなし
- `npx markdownlint-cli2 docs/android-build-workflows.md` — 0 issues
- `java -Xmx2048m -XX:MaxMetaspaceSize=1024m -version` — フラグが受理されることを確認

**未検証の点**: 作業環境に Android SDK がないため、実際の Gradle リリースビルドでの再現・修正確認、およびビルド中のピーク RSS の計測はできていない。効果の最終確認は Canary ワークフローの再実行が必要。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `android/gradle.properties` のビルド時 JVM 設定と `docs/**` のみの変更で、`src/components/**` / `src/screens/**` / `assets/**` / `src/translation.ts` には触れておらず、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112b6Wdr9wTXGp4UbzjZ2FT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Android ビルドの Gradle および Kotlin コンパイル処理のメモリ上限を見直し、使用量を抑えやすくしました。
  - Kotlin コンパイル処理のメモリ設定を明示的に指定するよう変更しました。

- **ドキュメント**
  - Android ビルドのメモリ設定、容量見積もり、同時実行プロセスの影響に関する説明を更新しました。
  - GitHub Actions ランナーのメモリ構成と、設定変更時に必要な項目を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->