### PR TITLE
VOICEVOXモジュールで曖昧になるVoicevoxResultCode型の参照をInt32に置き換えてiOSビルドを修正

### DIFF
--- a/ios/Modules/VoicevoxTTS/VoicevoxTTSModule.swift
+++ b/ios/Modules/VoicevoxTTS/VoicevoxTTSModule.swift
@@ -76,7 +76,9 @@ final class VoicevoxTTSModule: NSObject {
 
   private enum VoicevoxError: Error, CustomStringConvertible {
     case invalidArgument(String)
-    case core(String, VoicevoxResultCode)
+    // C API の戻り値型。ヘッダーが `enum VoicevoxResultCode` と `typedef int32_t VoicevoxResultCode`
+    // の両方を定義するため Swift では型名 `VoicevoxResultCode` の参照が曖昧になる。typedef の実体である Int32 で扱う
+    case core(String, Int32)
     case notInitialized
     case io(String)
 
@@ -104,12 +106,17 @@ final class VoicevoxTTSModule: NSObject {
     }
   }
 
-  // C API の戻り値 VoicevoxResultCode は Swift では Int32 の typealias として
-  // 取り込まれ、VOICEVOX_RESULT_OK などの定数は rawValue を持つ列挙として取り込まれる
-  // (cbindgen 生成ヘッダーの `enum X {…}; typedef int32_t X;` パターン)。
-  private static let resultOK = VoicevoxResultCode(VOICEVOX_RESULT_OK.rawValue)
+  // cbindgen 生成ヘッダーは `enum X {…}; typedef int32_t X;` の形で、Swift には列挙と
+  // Int32 の typealias が同名で取り込まれる。型名 `VoicevoxResultCode` /
+  // `VoicevoxAccelerationMode` を Swift 側で書くと "ambiguous for type lookup" になるため、
+  // typedef の実体 Int32 で扱い、定数はヘッダーの値をそのまま書く (フレームワークの版は
+  // ios/Frameworks/voicevox-frameworks.json で固定している)。
+  // voicevox_core.h: VOICEVOX_RESULT_OK = 0
+  private static let resultOK: Int32 = 0
+  // voicevox_core.h: VOICEVOX_ACCELERATION_MODE_CPU = 1
+  private static let accelerationModeCPU: Int32 = 1
 
-  private func check(_ result: VoicevoxResultCode, _ operation: String) throws {
+  private func check(_ result: Int32, _ operation: String) throws {
     if result != Self.resultOK {
       throw VoicevoxError.core(operation, result)
     }
@@ -150,8 +157,7 @@ final class VoicevoxTTSModule: NSObject {
     self.openJtalk = openJtalk
 
     var options = voicevox_make_default_initialize_options()
-    options.acceleration_mode = VoicevoxAccelerationMode(
-      VOICEVOX_ACCELERATION_MODE_CPU.rawValue)
+    options.acceleration_mode = Self.accelerationModeCPU
     options.cpu_num_threads = config.cpuNumThreads
 
     var synthesizer: OpaquePointer?


### PR DESCRIPTION
## 概要

Canary の iOS ビルド（[Build iOS Canary run 34218232751](https://github.com/TrainLCD/MobileApp/actions/runs/34218232751/job/102034977638)）が `Archive canary` で失敗した問題を修正する。

```text
ios/Modules/VoicevoxTTS/VoicevoxTTSModule.swift:79:23: error: 'VoicevoxResultCode' is ambiguous for type lookup in this context
  voicevox_core.h:152:6: note: found this candidate   (enum VoicevoxResultCode)
  voicevox_core.h:283:17: note: found this candidate  (typedef int32_t VoicevoxResultCode;)
```

VOICEVOX CORE 0.17.0 の cbindgen 生成ヘッダーは `enum VoicevoxResultCode {…}; typedef int32_t VoicevoxResultCode;` の形で、Swift には列挙と `Int32` の typealias が同名で取り込まれる。そのため Swift 側で型名 `VoicevoxResultCode`（および同じ形の `VoicevoxAccelerationMode`）を書くと型解決が曖昧になり、モジュール生成の段階で失敗していた。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `VoicevoxError.core` の関連値と `check(_:_:)` の引数型を `VoicevoxResultCode` から typedef の実体である `Int32` に変更（C API の戻り値・`voicevox_error_result_to_message` の引数はいずれも typedef 側の `Int32` なので、そのまま渡せる）。
- `VOICEVOX_RESULT_OK` / `VOICEVOX_ACCELERATION_MODE_CPU` は列挙定数の `.rawValue` 経由をやめ、ヘッダーの値（`0` / `1`）を `Int32` の定数として直接持つ。フレームワークの版は `ios/Frameworks/voicevox-frameworks.json` で固定しているため値は安定している。
- `VoicevoxInitializeOptions.acceleration_mode` への代入も同じ定数に変更。

変更は `ios/Modules/VoicevoxTTS/VoicevoxTTSModule.swift` の 1 ファイルのみ。JS 側・App Clip・Android には影響しない。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

Swift の変更のみで JS 側の差分は無い（lint は実行、Jest / tsc の対象外）。この環境には Swift コンパイラが無いため、修正後の Swift ファイルで使っている全 C API の型を `voicevox_core.h`（ios-arm64 スライス）のプロトタイプと突き合わせて静的に確認した。

- 戻り値・引数の `VoicevoxResultCode` は `typedef int32_t` → Swift `Int32`
- `VoicevoxStyleId` は `typedef uint32_t` → `UInt32`、`cpu_num_threads` は `uint16_t` → `UInt16`
- `uintptr_t *output_wav_length` → `UnsafeMutablePointer<UInt>`、`uint8_t **output_wav` → `UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>`

最終確認は Canary の iOS ビルドワークフローで行う。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `ios/Modules/VoicevoxTTS/VoicevoxTTSModule.swift` の型参照の修正のみで、画面表示には変化がありません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * iOS版で、音声合成のエラー処理およびアクセラレーション設定に関する型の曖昧さを解消しました。
  * CPUアクセラレーション設定と成功判定が、環境によらず正しく扱われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->