### PR TITLE
voicevox_onnxruntimeのCFBundleIdentifierに含まれるアンダースコアを取得時にハイフンへ正規化してiOSのArchive検証失敗を修正

### DIFF
--- a/docs/spec/tts/on-device-tts-ios.md
+++ b/docs/spec/tts/on-device-tts-ios.md
@@ -87,6 +87,15 @@ VOICEVOX CORE の C API はスレッドセーフを保証していないため�
 （voicevox_core Issue #715）問題は現行の配布物では起きない。バージョンを上げるときは JSON の
 `url` と `sha256` を両方更新すること。
 
+`voicevox_onnxruntime` 1.23.2 の iOS スライスは `CFBundleIdentifier` が
+`jp.hiroshiba.voicevox.voicevox_onnxruntime` とアンダースコアを含んでおり、Apple の規則
+（英数字・ハイフン・ピリオドのみ）に反するため Xcode の archive 時検証で
+`had an invalid CFBundleIdentifier in its Info.plist` として失敗する。取得スクリプトは展開後に
+各スライスの `Info.plist` を走査してアンダースコアをハイフンへ置き換える（`voicevox_core` は
+元から `voicevox-core` なので対象外）。配布物は未署名で Xcode が埋め込み時に署名し直すため、
+この書き換えで署名は壊れない。取得を省略した場合も毎回走る冪等な処理なので、展開済みの
+ローカル環境でも `npm run ios:frameworks` を一度実行すれば反映される。
+
 ### App Clip には含めない
 
 App Clip（`ProdAppClip` / `CanaryAppClip`）は deployment target が 16.4 のため非圧縮

--- a/scripts/fetch-voicevox-frameworks.mjs
+++ b/scripts/fetch-voicevox-frameworks.mjs
@@ -3,19 +3,23 @@
 // ios/Frameworks/voicevox-frameworks.json に固定したバージョン・URL・SHA-256 の
 // とおりに zip を取得し、検証してから ios/Frameworks/<name>.xcframework へ展開する。
 // 展開物はリポジトリに含めない（数十 MB のバイナリで、GitHub Releases から
-// 再現可能に取得できるため）。既に同じバージョンが展開済みなら何もしない。
+// 再現可能に取得できるため）。既に同じバージョンが展開済みなら取得はしない。
 //
 // 実行タイミング:
 //   - ローカル: `npm run ios` の前段（package.json の ios スクリプト）
 //   - CI: .github/workflows/build_ios_*.yml の pod install 前
 //
 // Android ビルドや Jest には不要なので postinstall には繋いでいない。
+//
+// 環境変数 VOICEVOX_FRAMEWORKS_DIR で取得先ディレクトリ（定義 JSON の置き場所）を
+// 差し替えられる。テストが一時ディレクトリで実行するためのもので、通常は指定しない。
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -25,7 +29,9 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const frameworksDir = resolve(scriptDir, '..', 'ios', 'Frameworks');
+const frameworksDir = process.env.VOICEVOX_FRAMEWORKS_DIR
+  ? resolve(process.env.VOICEVOX_FRAMEWORKS_DIR)
+  : resolve(scriptDir, '..', 'ios', 'Frameworks');
 const manifestPath = join(frameworksDir, 'voicevox-frameworks.json');
 
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
@@ -40,6 +46,65 @@ const download = async (url) => {
   return Buffer.from(await response.arrayBuffer());
 };
 
+// xcframework 配下の各スライス (<slice>/<name>.framework/Info.plist) を列挙する。
+// macOS スライスは Versions/ 配下にシンボリックリンクを張っているので辿らない
+// （iOS アプリには埋め込まれず、リンク先の実体は Versions/A 側で列挙される）。
+const listFrameworkInfoPlists = (dir, found = []) => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      listFrameworkInfoPlists(path, found);
+    } else if (
+      entry.name === 'Info.plist' &&
+      /\.framework$|[\\/]Resources$/.test(dirname(path))
+    ) {
+      found.push(path);
+    }
+  }
+  return found;
+};
+
+// CFBundleIdentifier に使える文字は英数字・ハイフン・ピリオドだけで、アンダースコアは不可。
+// voicevox_onnxruntime 1.23.2 の iOS スライスは `jp.hiroshiba.voicevox.voicevox_onnxruntime`
+// を名乗っており、Xcode の archive 時検証 (-validate-for-store) が
+// "had an invalid CFBundleIdentifier in its Info.plist" で失敗する。展開後にアンダースコアを
+// ハイフンへ置き換える。配布物は未署名 (_CodeSignature 無し) で、Xcode が埋め込み時に
+// 署名し直すため Info.plist の書き換えは署名を壊さない。
+// 既に展開済みの環境にも効くよう、取得を省略した場合にも毎回呼ぶ（冪等）。
+const normalizeBundleIdentifiers = (xcframeworkDir) => {
+  const rewritten = [];
+  for (const plistPath of listFrameworkInfoPlists(xcframeworkDir)) {
+    const source = readFileSync(plistPath, 'utf8');
+    // 配布物の Info.plist は XML 形式。バイナリ plist だと下の置換が効かないので明示的に止める
+    if (source.startsWith('bplist')) {
+      throw new Error(
+        `[voicevox] ${plistPath} is a binary plist; convert it to XML before normalizing CFBundleIdentifier`
+      );
+    }
+    const pattern =
+      /(<key>CFBundleIdentifier<\/key>\s*<string>)([^<]*)(<\/string>)/;
+    const match = source.match(pattern);
+    if (!match) {
+      continue;
+    }
+    const identifier = match[2];
+    if (!identifier.includes('_')) {
+      continue;
+    }
+    const normalized = identifier.replaceAll('_', '-');
+    writeFileSync(
+      plistPath,
+      source.replace(pattern, `$1${normalized}$3`),
+      'utf8'
+    );
+    rewritten.push({ plistPath, from: identifier, to: normalized });
+  }
+  return rewritten;
+};
+
 for (const framework of manifest.frameworks) {
   const { name, version, url, sha256 } = framework;
   const destination = join(frameworksDir, `${name}.xcframework`);
@@ -48,45 +113,53 @@ for (const framework of manifest.frameworks) {
 
   // マーカーだけでなく xcframework の実体 (Info.plist) も確認する。中身が消えた
   // 不完全な展開物にマーカーだけ残っていると、ここで飛ばした後の Xcode ビルドが失敗する
-  if (
+  const installed =
     existsSync(versionMarker) &&
     existsSync(join(destination, 'Info.plist')) &&
-    readFileSync(versionMarker, 'utf8').trim() === version
-  ) {
+    readFileSync(versionMarker, 'utf8').trim() === version;
+
+  if (installed) {
     console.log(`[voicevox] ${name} ${version} is already installed`);
-    continue;
-  }
-
-  console.log(`[voicevox] downloading ${name} ${version}`);
-  const zip = await download(url);
-  const actual = sha256Hex(zip);
-  if (actual !== sha256) {
-    throw new Error(
-      `[voicevox] SHA-256 mismatch for ${name}: expected ${sha256}, got ${actual}`
-    );
-  }
-
-  const tempDir = mkdtempSync(join(tmpdir(), 'voicevox-'));
-  try {
-    const zipPath = join(tempDir, `${name}.zip`);
-    writeFileSync(zipPath, zip);
-    // zip のトップレベルが <name>.xcframework/ なので、展開先の親へそのまま展開する
-    rmSync(destination, { recursive: true, force: true });
-    execFileSync(
-      'unzip',
-      ['-q', '-o', zipPath, `${name}.xcframework/*`, '-d', frameworksDir],
-      {
-        stdio: 'inherit',
-      }
-    );
-    if (!existsSync(join(destination, 'Info.plist'))) {
+  } else {
+    console.log(`[voicevox] downloading ${name} ${version}`);
+    const zip = await download(url);
+    const actual = sha256Hex(zip);
+    if (actual !== sha256) {
       throw new Error(
-        `[voicevox] ${name}.xcframework was not found in the archive`
+        `[voicevox] SHA-256 mismatch for ${name}: expected ${sha256}, got ${actual}`
       );
     }
-    writeFileSync(versionMarker, `${version}\n`);
-    console.log(`[voicevox] installed ${name} ${version} -> ${destination}`);
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'voicevox-'));
+    try {
+      const zipPath = join(tempDir, `${name}.zip`);
+      writeFileSync(zipPath, zip);
+      // zip のトップレベルが <name>.xcframework/ なので、展開先の親へそのまま展開する
+      rmSync(destination, { recursive: true, force: true });
+      execFileSync(
+        'unzip',
+        ['-q', '-o', zipPath, `${name}.xcframework/*`, '-d', frameworksDir],
+        {
+          stdio: 'inherit',
+        }
+      );
+      if (!existsSync(join(destination, 'Info.plist'))) {
+        throw new Error(
+          `[voicevox] ${name}.xcframework was not found in the archive`
+        );
+      }
+      writeFileSync(versionMarker, `${version}\n`);
+      console.log(`[voicevox] installed ${name} ${version} -> ${destination}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  for (const { plistPath, from, to } of normalizeBundleIdentifiers(
+    destination
+  )) {
+    console.log(
+      `[voicevox] normalized CFBundleIdentifier ${from} -> ${to} (${plistPath})`
+    );
   }
 }

--- a/scripts/fetch-voicevox-frameworks.test.js
+++ b/scripts/fetch-voicevox-frameworks.test.js
@@ -1,0 +1,145 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const scriptPath = path.resolve(__dirname, 'fetch-voicevox-frameworks.mjs');
+
+const infoPlist = (identifier) => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>CFBundleExecutable</key>
+\t<string>voicevox_onnxruntime</string>
+\t<key>CFBundleIdentifier</key>
+\t<string>${identifier}</string>
+\t<key>CFBundleName</key>
+\t<string>voicevox_onnxruntime</string>
+\t<key>CFBundlePackageType</key>
+\t<string>FMWK</string>
+</dict>
+</plist>
+`;
+
+// 展開済み扱いになる xcframework を組み立てる。取得を省略する経路
+// (.trainlcd-version と xcframework 直下の Info.plist が揃っている) を通すことで
+// ネットワークに触れずに正規化処理だけを検証できる
+const setupFrameworksDir = ({ name, version, identifiers }) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'voicevox-frameworks-'));
+  fs.writeFileSync(
+    path.join(dir, 'voicevox-frameworks.json'),
+    JSON.stringify({
+      frameworks: [
+        {
+          name,
+          version,
+          url: 'https://example.invalid/never-downloaded.zip',
+          sha256: '0'.repeat(64),
+        },
+      ],
+    })
+  );
+  const xcframework = path.join(dir, `${name}.xcframework`);
+  fs.mkdirSync(xcframework, { recursive: true });
+  fs.writeFileSync(path.join(xcframework, '.trainlcd-version'), `${version}\n`);
+  fs.writeFileSync(
+    path.join(xcframework, 'Info.plist'),
+    '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict><key>CFBundlePackageType</key><string>XFWK</string></dict></plist>\n'
+  );
+  const slicePlists = {};
+  for (const [slice, identifier] of Object.entries(identifiers)) {
+    const frameworkDir = path.join(xcframework, slice, `${name}.framework`);
+    fs.mkdirSync(frameworkDir, { recursive: true });
+    const plistPath = path.join(frameworkDir, 'Info.plist');
+    fs.writeFileSync(plistPath, infoPlist(identifier));
+    slicePlists[slice] = plistPath;
+  }
+  return { dir, xcframework, slicePlists };
+};
+
+const runScript = (frameworksDir) =>
+  execFileSync(process.execPath, [scriptPath], {
+    encoding: 'utf8',
+    env: { ...process.env, VOICEVOX_FRAMEWORKS_DIR: frameworksDir },
+  });
+
+const readIdentifier = (plistPath) =>
+  fs
+    .readFileSync(plistPath, 'utf8')
+    .match(/<key>CFBundleIdentifier<\/key>\s*<string>([^<]*)<\/string>/)[1];
+
+describe('fetch-voicevox-frameworks', () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('CFBundleIdentifier のアンダースコアを全スライスでハイフンに置き換える', () => {
+    const { dir, slicePlists } = setupFrameworksDir({
+      name: 'voicevox_onnxruntime',
+      version: '1.23.2',
+      identifiers: {
+        'ios-arm64': 'jp.hiroshiba.voicevox.voicevox_onnxruntime',
+        'ios-arm64_x86_64-simulator':
+          'jp.hiroshiba.voicevox.voicevox_onnxruntime',
+      },
+    });
+    tempDirs.push(dir);
+
+    const stdout = runScript(dir);
+
+    expect(stdout).toContain(
+      'voicevox_onnxruntime 1.23.2 is already installed'
+    );
+    expect(stdout).toContain(
+      'normalized CFBundleIdentifier jp.hiroshiba.voicevox.voicevox_onnxruntime -> jp.hiroshiba.voicevox.voicevox-onnxruntime'
+    );
+    for (const plistPath of Object.values(slicePlists)) {
+      expect(readIdentifier(plistPath)).toBe(
+        'jp.hiroshiba.voicevox.voicevox-onnxruntime'
+      );
+      // 識別子以外（実行ファイル名やバンドル名）は書き換えない
+      expect(fs.readFileSync(plistPath, 'utf8')).toBe(
+        infoPlist('jp.hiroshiba.voicevox.voicevox-onnxruntime')
+      );
+    }
+  });
+
+  it('既に有効な CFBundleIdentifier はそのままにし、再実行しても変化しない', () => {
+    const { dir, slicePlists } = setupFrameworksDir({
+      name: 'voicevox_core',
+      version: '0.17.0',
+      identifiers: {
+        'ios-arm64': 'jp.hiroshiba.voicevox.voicevox-core',
+      },
+    });
+    tempDirs.push(dir);
+    const plistPath = slicePlists['ios-arm64'];
+    const before = fs.statSync(plistPath).mtimeMs;
+
+    const first = runScript(dir);
+    const second = runScript(dir);
+
+    expect(first).not.toContain('normalized CFBundleIdentifier');
+    expect(second).not.toContain('normalized CFBundleIdentifier');
+    expect(readIdentifier(plistPath)).toBe(
+      'jp.hiroshiba.voicevox.voicevox-core'
+    );
+    expect(fs.statSync(plistPath).mtimeMs).toBe(before);
+  });
+
+  it('バイナリ plist は黙って素通しせずエラーにする', () => {
+    const { dir, slicePlists } = setupFrameworksDir({
+      name: 'voicevox_onnxruntime',
+      version: '1.23.2',
+      identifiers: { 'ios-arm64': 'placeholder' },
+    });
+    tempDirs.push(dir);
+    fs.writeFileSync(slicePlists['ios-arm64'], 'bplist00');
+
+    expect(() => runScript(dir)).toThrow(/is a binary plist/);
+  });
+});


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Canary iOS ビルド（run 34221136300）が `Archive canary` の store 向け検証で失敗した原因への対処。

```text
error: Framework .../CanaryTrainLCD.app/Frameworks/voicevox_onnxruntime.framework had an invalid CFBundleIdentifier in its Info.plist: jp.hiroshiba.voicevox.voicevox_onnxruntime
```

`voicevox_onnxruntime` 1.23.2 の iOS スライスは `CFBundleIdentifier` にアンダースコアを含んでおり、Apple の規則（英数字・ハイフン・ピリオドのみ）に反するため Xcode の `-validate-for-store` が Archive を失敗させる。`voicevox_core` は元から `jp.hiroshiba.voicevox.voicevox-core` なので対象外。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `scripts/fetch-voicevox-frameworks.mjs`: 展開後に xcframework 配下の各スライスの `Info.plist` を走査し、`CFBundleIdentifier` のアンダースコアをハイフンへ置き換える処理を追加
  - 取得を省略した場合（展開済み）にも毎回走る冪等な処理なので、既にフレームワークを展開済みのローカル環境でも `npm run ios:frameworks` を一度実行すれば反映される
  - 配布物は未署名（`_CodeSignature` 無し）で Xcode が埋め込み時に署名し直すため、`Info.plist` の書き換えで署名は壊れない
  - バイナリ plist は置換が効かないため、黙って素通しせずエラーで止める
  - テスト用に `VOICEVOX_FRAMEWORKS_DIR` で取得先ディレクトリを差し替えられるようにした
- `scripts/fetch-voicevox-frameworks.test.js`: 正規化（全スライス・他キー不変）、既に有効な識別子は変更しない冪等性、バイナリ plist の拒否を検証（Jest が `scripts/*.test.js` を拾う）
- `docs/spec/tts/on-device-tts-ios.md`: この正規化の背景と挙動を追記

ローカルで実フレームワークに対して実行し、`ios-arm64` / `ios-arm64_x86_64-simulator` の 2 スライスが `jp.hiroshiba.voicevox.voicevox-onnxruntime` に書き換わり、再実行では何も変えないことを確認済み。Xcode の検証は macOS が無いためこの環境では再現できず、Canary ビルドで確認する。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

`src/` に変更が無いためチェックは外しているが、`npm run lint`（Biome, src）、`npx biome check` の対象 2 ファイル、`npx jest scripts`（8 件 pass）は実行済み。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- 失敗した Canary iOS ビルド: https://github.com/TrainLCD/MobileApp/actions/runs/34221136300
- 前回の修正 PR: #6887

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

UI 変更なし: iOS ビルド用の取得スクリプトとドキュメントの変更のみで、画面表示には変化がありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - iOS向けVOICEVOX Framework取得時、各スライスの識別子を正しい形式に自動調整するようになりました。
  - 既存の展開済みFrameworkにも調整を適用します。
  - Frameworkの取得先を環境変数で変更できるようになりました。

- **バグ修正**
  - バイナリ形式の設定ファイルを検出した場合、適切にエラーを通知します。

- **テスト**
  - 識別子の調整、再実行時の安定性、エラー処理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->