### PR TITLE
VOICEVOXフレームワークを取得時にad-hocで署名し直して署名識別子をCFBundleIdentifierに揃えTestFlightアップロードの検証失敗を修正

### DIFF
--- a/docs/spec/tts/on-device-tts-ios.md
+++ b/docs/spec/tts/on-device-tts-ios.md
@@ -87,14 +87,24 @@ VOICEVOX CORE の C API はスレッドセーフを保証していないため�
 （voicevox_core Issue #715）問題は現行の配布物では起きない。バージョンを上げるときは JSON の
 `url` と `sha256` を両方更新すること。
 
-`voicevox_onnxruntime` 1.23.2 の iOS スライスは `CFBundleIdentifier` が
-`jp.hiroshiba.voicevox.voicevox_onnxruntime` とアンダースコアを含んでおり、Apple の規則
-（英数字・ハイフン・ピリオドのみ）に反するため Xcode の archive 時検証で
-`had an invalid CFBundleIdentifier in its Info.plist` として失敗する。取得スクリプトは展開後に
-各スライスの `Info.plist` を走査してアンダースコアをハイフンへ置き換える（`voicevox_core` は
-元から `voicevox-core` なので対象外）。配布物は未署名で Xcode が埋め込み時に署名し直すため、
-この書き換えで署名は壊れない。取得を省略した場合も毎回走る冪等な処理なので、展開済みの
-ローカル環境でも `npm run ios:frameworks` を一度実行すれば反映される。
+`voicevox_onnxruntime` 1.23.2 の配布物はそのまま埋め込むと App Store 向けの検証に 2 段階で
+弾かれるため、取得スクリプトが展開後に次の 2 つを補正する。取得を省略した場合も毎回走る冪等な
+処理なので、展開済みのローカル環境でも `npm run ios:frameworks` を一度実行すれば反映される。
+
+1. **`CFBundleIdentifier` の正規化**: iOS スライスの識別子が
+   `jp.hiroshiba.voicevox.voicevox_onnxruntime` とアンダースコアを含んでおり、Apple の規則
+   （英数字・ハイフン・ピリオドのみ）に反するため Xcode の archive 時検証で
+   `had an invalid CFBundleIdentifier in its Info.plist` として失敗する。各スライスの
+   `Info.plist` を走査してアンダースコアをハイフンへ置き換える（`voicevox_core` は元から
+   `voicevox-core` なので対象外）。
+1. **ad-hoc での署名し直し**: `voicevox_onnxruntime` のバイナリには識別子
+   `libvoicevox_onnxruntime.1` の ad-hoc 署名が埋め込まれている。Xcode は埋め込み時に
+   `--preserve-metadata=identifier` で既存の識別子を引き継ぐため、App Store Connect への
+   アップロードが `Invalid Code Signature Identifier ... must match its Bundle Identifier` で
+   失敗する。`codesign --force --sign - --identifier <CFBundleIdentifier>` で各スライスの
+   framework を署名し直し、識別子をバンドル識別子に揃える（未署名の `voicevox_core` は Xcode が
+   `CFBundleIdentifier` から識別子を導出するので元々問題無いが、配布物の署名状態に依存しないよう
+   一律に署名し直す）。`codesign` は macOS にしか無いので、それ以外の環境では省略する。
 
 ### App Clip には含めない
 

--- a/scripts/fetch-voicevox-frameworks.mjs
+++ b/scripts/fetch-voicevox-frameworks.mjs
@@ -11,8 +11,9 @@
 //
 // Android ビルドや Jest には不要なので postinstall には繋いでいない。
 //
-// 環境変数 VOICEVOX_FRAMEWORKS_DIR で取得先ディレクトリ（定義 JSON の置き場所）を
-// 差し替えられる。テストが一時ディレクトリで実行するためのもので、通常は指定しない。
+// 環境変数（いずれもテスト用で、通常は指定しない）:
+//   - VOICEVOX_FRAMEWORKS_DIR: 取得先ディレクトリ（定義 JSON の置き場所）を差し替える
+//   - VOICEVOX_CODESIGN: 署名し直しに使う codesign コマンドを差し替える。空文字なら署名し直しを省略する
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -35,6 +36,15 @@ const frameworksDir = process.env.VOICEVOX_FRAMEWORKS_DIR
 const manifestPath = join(frameworksDir, 'voicevox-frameworks.json');
 
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+// 署名し直しに使う codesign。macOS 以外には無いので、そこでは省略する
+// （iOS ビルドは macOS でしか行わないため実害は無い）。
+const codesignCommand =
+  process.env.VOICEVOX_CODESIGN !== undefined
+    ? process.env.VOICEVOX_CODESIGN
+    : process.platform === 'darwin'
+      ? 'codesign'
+      : '';
 
 const sha256Hex = (buffer) => createHash('sha256').update(buffer).digest('hex');
 
@@ -105,6 +115,38 @@ const normalizeBundleIdentifiers = (xcframeworkDir) => {
   return rewritten;
 };
 
+// 各スライスの framework を ad-hoc で署名し直し、署名の識別子を CFBundleIdentifier に揃える。
+// voicevox_onnxruntime 1.23.2 のバイナリには識別子 `libvoicevox_onnxruntime.1` の ad-hoc 署名が
+// 埋め込まれており、Xcode は埋め込み時に `--preserve-metadata=identifier` で既存の識別子を
+// 引き継ぐため、App Store Connect のアップロード検証が
+// "Invalid Code Signature Identifier ... must match its Bundle Identifier" で失敗する。
+// 未署名の voicevox_core は Xcode が CFBundleIdentifier から識別子を導出するので問題無いが、
+// 配布物の署名状態に依存しないよう全スライスを一律に署名し直す（冪等）。
+const resignFrameworks = (xcframeworkDir) => {
+  const resigned = [];
+  for (const plistPath of listFrameworkInfoPlists(xcframeworkDir)) {
+    const frameworkDir = dirname(plistPath);
+    // macOS スライス (Versions/A/Resources/Info.plist) は iOS アプリに埋め込まれないので対象外
+    if (!frameworkDir.endsWith('.framework')) {
+      continue;
+    }
+    const match = readFileSync(plistPath, 'utf8').match(
+      /<key>CFBundleIdentifier<\/key>\s*<string>([^<]*)<\/string>/
+    );
+    if (!match) {
+      continue;
+    }
+    const identifier = match[1];
+    execFileSync(
+      codesignCommand,
+      ['--force', '--sign', '-', '--identifier', identifier, frameworkDir],
+      { stdio: 'inherit' }
+    );
+    resigned.push({ frameworkDir, identifier });
+  }
+  return resigned;
+};
+
 for (const framework of manifest.frameworks) {
   const { name, version, url, sha256 } = framework;
   const destination = join(frameworksDir, `${name}.xcframework`);
@@ -161,5 +203,17 @@ for (const framework of manifest.frameworks) {
     console.log(
       `[voicevox] normalized CFBundleIdentifier ${from} -> ${to} (${plistPath})`
     );
+  }
+
+  if (codesignCommand === '') {
+    console.log(
+      `[voicevox] skipped re-signing ${name} (codesign is unavailable on this platform)`
+    );
+  } else {
+    for (const { frameworkDir, identifier } of resignFrameworks(destination)) {
+      console.log(
+        `[voicevox] re-signed ${frameworkDir} with identifier ${identifier}`
+      );
+    }
   }
 }

--- a/scripts/fetch-voicevox-frameworks.test.js
+++ b/scripts/fetch-voicevox-frameworks.test.js
@@ -57,11 +57,29 @@ const setupFrameworksDir = ({ name, version, identifiers }) => {
   return { dir, xcframework, slicePlists };
 };
 
-const runScript = (frameworksDir) =>
+// VOICEVOX_CODESIGN を空にして署名し直しを省略する（テスト用の framework にはバイナリが無く、
+// macOS 上で本物の codesign を呼ぶと失敗する）。署名し直しの検証は fakeCodesign で行う
+const runScript = (frameworksDir, { codesign = '' } = {}) =>
   execFileSync(process.execPath, [scriptPath], {
     encoding: 'utf8',
-    env: { ...process.env, VOICEVOX_FRAMEWORKS_DIR: frameworksDir },
+    env: {
+      ...process.env,
+      VOICEVOX_FRAMEWORKS_DIR: frameworksDir,
+      VOICEVOX_CODESIGN: codesign,
+    },
   });
+
+// 受け取った引数を 1 呼び出し 1 行で記録するだけの偽 codesign
+const fakeCodesign = (dir) => {
+  const logPath = path.join(dir, 'codesign.log');
+  const scriptPath = path.join(dir, 'codesign');
+  fs.writeFileSync(
+    scriptPath,
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${logPath}"\n`,
+    { mode: 0o755 }
+  );
+  return { scriptPath, logPath };
+};
 
 const readIdentifier = (plistPath) =>
   fs
@@ -129,6 +147,47 @@ describe('fetch-voicevox-frameworks', () => {
       'jp.hiroshiba.voicevox.voicevox-core'
     );
     expect(fs.statSync(plistPath).mtimeMs).toBe(before);
+  });
+
+  it('各スライスの framework を CFBundleIdentifier を識別子にして ad-hoc で署名し直す', () => {
+    const { dir, xcframework } = setupFrameworksDir({
+      name: 'voicevox_onnxruntime',
+      version: '1.23.2',
+      identifiers: {
+        'ios-arm64': 'jp.hiroshiba.voicevox.voicevox_onnxruntime',
+        'ios-arm64_x86_64-simulator':
+          'jp.hiroshiba.voicevox.voicevox_onnxruntime',
+      },
+    });
+    tempDirs.push(dir);
+    const codesign = fakeCodesign(dir);
+
+    const stdout = runScript(dir, { codesign: codesign.scriptPath });
+
+    const calls = fs.readFileSync(codesign.logPath, 'utf8').trim().split('\n');
+    expect(calls.sort()).toEqual(
+      [
+        `--force --sign - --identifier jp.hiroshiba.voicevox.voicevox-onnxruntime ${path.join(xcframework, 'ios-arm64', 'voicevox_onnxruntime.framework')}`,
+        `--force --sign - --identifier jp.hiroshiba.voicevox.voicevox-onnxruntime ${path.join(xcframework, 'ios-arm64_x86_64-simulator', 'voicevox_onnxruntime.framework')}`,
+      ].sort()
+    );
+    expect(stdout).toContain(
+      'with identifier jp.hiroshiba.voicevox.voicevox-onnxruntime'
+    );
+    expect(stdout).not.toContain('skipped re-signing');
+  });
+
+  it('codesign が無い環境では署名し直しを省略して続行する', () => {
+    const { dir } = setupFrameworksDir({
+      name: 'voicevox_core',
+      version: '0.17.0',
+      identifiers: { 'ios-arm64': 'jp.hiroshiba.voicevox.voicevox-core' },
+    });
+    tempDirs.push(dir);
+
+    const stdout = runScript(dir, { codesign: '' });
+
+    expect(stdout).toContain('skipped re-signing voicevox_core');
   });
 
   it('バイナリ plist は黙って素通しせずエラーにする', () => {


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Canary iOS ビルド（run 34225304358）で `Archive canary` は初めて成功したものの、続く `Upload to TestFlight` が App Store Connect の検証で失敗した原因への対処。

```text
Invalid Code Signature Identifier. The identifier "libvoicevox_onnxruntime.1" in your code signature for "voicevox_onnxruntime" must match its Bundle Identifier "jp.hiroshiba.voicevox.voicevox-onnxruntime"
```

`voicevox_onnxruntime` 1.23.2 の iOS 用バイナリには識別子 `libvoicevox_onnxruntime.1` の ad-hoc 署名が埋め込まれている（Mach-O の `LC_CODE_SIGNATURE` を解析して確認。`voicevox_core` の実機用バイナリは未署名）。Xcode は埋め込み時に `--preserve-metadata=identifier` で既存の識別子を引き継ぐため、バンドル識別子と一致せず弾かれる。#6890 の `CFBundleIdentifier` 正規化より前から存在していた問題で、Archive 検証を通過して初めて表面化した。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `scripts/fetch-voicevox-frameworks.mjs`: `CFBundleIdentifier` の正規化に続けて、各スライスの framework を `codesign --force --sign - --identifier <CFBundleIdentifier>` で ad-hoc 署名し直す処理を追加
  - 未署名の `voicevox_core` は Xcode が `CFBundleIdentifier` から識別子を導出するので元々問題無いが、配布物の署名状態に依存しないよう全スライスを一律に署名し直す（冪等。取得を省略した場合も毎回走る）
  - `codesign` は macOS にしか無いため、それ以外の環境では省略してログに出す（iOS ビルドは macOS でしか行わないので実害なし）
  - テスト用に `VOICEVOX_CODESIGN` で codesign コマンドを差し替え（空文字で省略）できるようにした
- `scripts/fetch-voicevox-frameworks.test.js`: 引数を記録するだけの偽 codesign を使い、両スライスに対して期待どおりの引数で呼ばれることと、codesign 無しでは省略して続行することを検証（既存テストも署名し直しを省略するよう更新）
- `docs/spec/tts/on-device-tts-ios.md`: 「配布物は未署名」という誤った記述を改め、2 段階の補正（識別子の正規化・署名し直し）として整理

Xcode / codesign 自体は macOS が無いためこの環境では再現できず、Canary ビルドで確認する。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

`src/` に変更が無いためチェックは外しているが、`npm run lint`（Biome, src）、`npx biome check` の対象 2 ファイル、`npx jest scripts`（10 件 pass）は実行済み。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- 失敗した Canary iOS ビルド: https://github.com/TrainLCD/MobileApp/actions/runs/34225304358
- 前段の修正 PR: #6887, #6890

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

UI 変更なし: iOS ビルド用の取得スクリプトとドキュメントの変更のみで、画面表示には変化がありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - iOS向けフレームワークの署名識別子をBundle Identifierに一致させ、App Store Connectへのアップロード時に発生するコード署名エラーを解消しました。
  - 取得済みのフレームワークにも署名補正を適用します。

- **ドキュメント**
  - フレームワーク取得手順を更新し、macOS以外では署名処理を省略する条件を明記しました。
  - 取得コマンドによる反映方法を引き続き案内しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->