### PR TITLE
VOICEVOXの話速の基準倍率をRemote Configのvoicevox_tts_speed_scale_iosで調整できるようにし既定を0.9にして早口を抑える

### DIFF
--- a/docs/spec/tts/on-device-tts-ios.md
+++ b/docs/spec/tts/on-device-tts-ios.md
@@ -47,8 +47,11 @@ Open JTalk がカタカナから読みとアクセントを推定するため、
 
 ### 速度
 
-アナウンス速度設定（`ttsSpeedPreferenceAtom`）を `VOICEVOX_SPEED_SCALES` で
-`AudioQuery.speedScale` へ写像する。倍率はリモート TTS の `REMOTE_TTS_SPEED_RATES` と同じ。
+アナウンス速度設定（`ttsSpeedPreferenceAtom`）を `VOICEVOX_SPEED_SCALES` で倍率
+（0.85 / 1.0 / 1.15。リモート TTS の `REMOTE_TTS_SPEED_RATES` と同じ）にし、Remote Config
+`voicevox_tts_speed_scale_ios` の基準倍率（既定 0.9）を掛けた値を `AudioQuery.speedScale`
+にする。No.7「アナウンス」は `speedScale` 1.0 でも Google Cloud TTS の 1.0 より速く聞こえる
+ため、基準倍率で揃える。声色を変えたときの再調整は KV の値だけで済み、再ビルドは要らない。
 ネイティブ側は `voicevox_synthesizer_tts` ではなく `create_audio_query` → `speedScale`
 書き換え → `synthesis` の 2 段で合成する。
 
@@ -233,6 +236,7 @@ Remote Config の値は変えなくてよい。
 | `voicevox_tts_enabled_ios` | boolean | `false` | VOICEVOX フォールバックの有効化 |
 | `voicevox_tts_manifest_url_ios` | string (https) | 未設定 | マニフェスト JSON の URL。未設定なら有効でも資産を取得できない |
 | `voicevox_tts_style_id_ios` | integer ≥ 0 | `30` | スタイル ID。配信した VVM に含まれる ID を指定する |
+| `voicevox_tts_speed_scale_ios` | number (0.5〜2.0) | `0.9` | 話速の基準倍率。速度設定の倍率に掛けて `speedScale` にする。範囲外はフォールバック |
 
 `remote_tts_enabled_ios` とは独立している。リモート合成を主経路のまま「フォールバック先だけ」を
 差し替える設計で、`voicevox_tts_enabled_ios` を `false` にすれば取得済みの資産があっても

--- a/src/constants/voicevox.ts
+++ b/src/constants/voicevox.ts
@@ -12,9 +12,20 @@ import {
 // (https://voiceseven.com/#j0200)。ライセンス画面のクレジットと対応させること。
 export const VOICEVOX_DEFAULT_STYLE_ID = 30;
 
+// 話速の基準倍率の既定値。No.7「アナウンス」は speedScale 1.0 でも Google Cloud TTS の
+// 1.0 より速く聞こえるため、リモート TTS と同じ倍率 (VOICEVOX_SPEED_SCALES) に
+// この基準倍率を掛けて揃える。Remote Config (voicevox_tts_speed_scale_ios) で上書きできる。
+export const VOICEVOX_DEFAULT_SPEED_SCALE = 0.9;
+
+// Remote Config で受理する基準倍率の範囲。ネイティブ側 (VoicevoxTTSModule.applySpeedScale)
+// が AudioQuery.speedScale を 0.5〜2.0 に丸めるので、その範囲に収まる値だけ受け付ける。
+export const VOICEVOX_SPEED_SCALE_MIN = 0.5;
+export const VOICEVOX_SPEED_SCALE_MAX = 2.0;
+
 // アナウンス速度設定を VOICEVOX の AudioQuery.speedScale へ写像する。
 // リモート TTS の speakingRate (REMOTE_TTS_SPEED_RATES) と同じ倍率にして、
-// フォールバック時も設定どおりの速さで読ませる。
+// フォールバック時も設定どおりの速さで読ませる。実際の speedScale はこれに
+// 基準倍率 (getVoicevoxTTSSpeedScale) を掛けた値。
 export const VOICEVOX_SPEED_SCALES: Record<TTSSpeedPreference, number> = {
   [TTS_SPEED_PREFERENCE.SLOW]: 0.85,
   [TTS_SPEED_PREFERENCE.NORMAL]: 1.0,

--- a/src/hooks/tts/useVoicevoxSpeechEngine.test.ts
+++ b/src/hooks/tts/useVoicevoxSpeechEngine.test.ts
@@ -25,10 +25,13 @@ jest.mock('~/utils/native/ios/voicevoxTtsModule', () => ({
 
 let mockEnabled = true;
 let mockStyleId = 30;
+// 既定は 1 にして、速度設定の倍率がそのまま speedScale になる前提で検証する
+let mockSpeedScale = 1;
 const mockRemoteConfigListeners = new Set<() => void>();
 jest.mock('~/lib/remoteConfig', () => ({
   isVoicevoxTTSEnabled: () => mockEnabled,
   getVoicevoxTTSStyleId: () => mockStyleId,
+  getVoicevoxTTSSpeedScale: () => mockSpeedScale,
   subscribeRemoteConfig: (listener: () => void) => {
     mockRemoteConfigListeners.add(listener);
     return () => {
@@ -129,6 +132,7 @@ describe('useVoicevoxSpeechEngine', () => {
     mockModuleAvailable = true;
     mockEnabled = true;
     mockStyleId = 30;
+    mockSpeedScale = 1;
     mockInstalled = installedAssets;
     mockRemoteConfigListeners.clear();
     mockSetup.mockResolvedValue({ coreVersion: '0.17.0', styleIds: [29, 30] });
@@ -155,6 +159,19 @@ describe('useVoicevoxSpeechEngine', () => {
       }
     });
     expect(mockEnsureAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it('Remote Config の基準倍率を速度設定の倍率に掛けて 3 桁に丸めた speedScale で合成する', async () => {
+    mockSpeedScale = 0.9;
+    const { result } = renderEngine('FAST');
+
+    result.current.speak(defaultRequest, callbacks());
+    await flushAsync();
+
+    // 1.15 × 0.9 = 1.0349999… をそのまま渡さず 1.035 にする
+    expect(mockSynthesize).toHaveBeenCalledWith(
+      expect.objectContaining({ speedScale: 1.035 })
+    );
   });
 
   it('日本語を VOICEVOX で合成して再生し、英語は委譲する', async () => {

--- a/src/hooks/tts/useVoicevoxSpeechEngine.ts
+++ b/src/hooks/tts/useVoicevoxSpeechEngine.ts
@@ -6,6 +6,7 @@ import {
   VOICEVOX_SPEED_SCALES,
 } from '~/constants/voicevox';
 import {
+  getVoicevoxTTSSpeedScale,
   getVoicevoxTTSStyleId,
   isVoicevoxTTSEnabled,
   subscribeRemoteConfig,
@@ -184,7 +185,14 @@ export const useVoicevoxSpeechEngine = (
           await module.synthesize({
             text,
             styleId: getVoicevoxTTSStyleId(),
-            speedScale: VOICEVOX_SPEED_SCALES[speedRef.current],
+            // 速度設定の倍率 × Remote Config の基準倍率。浮動小数の端数 (1.15 × 0.9 =
+            // 1.0349999…) がそのまま AudioQuery に載らないよう 3 桁に丸める
+            speedScale:
+              Math.round(
+                VOICEVOX_SPEED_SCALES[speedRef.current] *
+                  getVoicevoxTTSSpeedScale() *
+                  1000
+              ) / 1000,
             outputPath: fileUriToPath(file.uri),
           });
         } catch (e) {

--- a/src/lib/remoteConfig.test.ts
+++ b/src/lib/remoteConfig.test.ts
@@ -5,6 +5,7 @@ import {
   getEtaFallbackMaxDurationMin,
   getMaxPermitAccuracy,
   getVoicevoxTTSManifestUrl,
+  getVoicevoxTTSSpeedScale,
   getVoicevoxTTSStyleId,
   isAIAgentFeatureEnabled,
   isEtaAssistEnabled,
@@ -518,6 +519,34 @@ describe('VOICEVOX フォールバック（voicevox_tts_*_ios）', () => {
     await setupRemoteConfig();
     expect(getVoicevoxTTSStyleId()).toBe(0);
   });
+
+  it('話速の基準倍率は未配信なら 0.9 で、配信値を受理する', async () => {
+    expect(getVoicevoxTTSSpeedScale()).toBe(0.9);
+    mockRemoteConfig({
+      max_permit_accuracy: 1500,
+      voicevox_tts_speed_scale_ios: 0.8,
+    });
+    await setupRemoteConfig();
+    expect(getVoicevoxTTSSpeedScale()).toBe(0.8);
+  });
+
+  it.each([
+    ['範囲外(小)', 0.4],
+    ['範囲外(大)', 2.5],
+    ['0', 0],
+    ['負値', -1],
+    ['文字列', '0.9'],
+  ])(
+    '話速の基準倍率が %s のときはフォールバックする',
+    async (_label, value) => {
+      mockRemoteConfig({
+        max_permit_accuracy: 1500,
+        voicevox_tts_speed_scale_ios: value as number,
+      });
+      await setupRemoteConfig();
+      expect(getVoicevoxTTSSpeedScale()).toBe(0.9);
+    }
+  );
 });
 
 describe('isAIAgentFeatureEnabled（サーバー側キルスイッチ）', () => {

--- a/src/lib/remoteConfig.ts
+++ b/src/lib/remoteConfig.ts
@@ -1,6 +1,11 @@
 import { Platform } from 'react-native';
 import { MAX_PERMIT_ACCURACY } from '~/constants/location';
-import { VOICEVOX_DEFAULT_STYLE_ID } from '~/constants/voicevox';
+import {
+  VOICEVOX_DEFAULT_SPEED_SCALE,
+  VOICEVOX_DEFAULT_STYLE_ID,
+  VOICEVOX_SPEED_SCALE_MAX,
+  VOICEVOX_SPEED_SCALE_MIN,
+} from '~/constants/voicevox';
 import { workerUrl } from './workerApi';
 
 // Cloudflare Worker(/config/remote) 配信の設定キー。Worker 側のレスポンスキーと一致させる。
@@ -45,6 +50,10 @@ export const REMOTE_CONFIG_KEYS = {
   // VOICEVOX のスタイル ID (話者と声色)。配信した音声モデルに含まれる ID を指定する。
   // 未配信時は VOICEVOX_DEFAULT_STYLE_ID (No.7 アナウンス)。
   VOICEVOX_TTS_STYLE_ID_IOS: 'voicevox_tts_style_id_ios',
+  // VOICEVOX の話速の基準倍率。アナウンス速度設定の倍率 (VOICEVOX_SPEED_SCALES) に掛けて
+  // AudioQuery.speedScale にする。声色ごとの素の話速の違いを再ビルドなしに吸収するためのもので、
+  // 未配信時は VOICEVOX_DEFAULT_SPEED_SCALE。
+  VOICEVOX_TTS_SPEED_SCALE_IOS: 'voicevox_tts_speed_scale_ios',
   // AIエージェント(行き先相談)機能の有効/無効。障害・コスト超過時にサーバー側から
   // エントリポイントごと機能を止められるようにするキルスイッチ。
   AI_AGENT_ENABLED: 'ai_agent_enabled',
@@ -65,6 +74,7 @@ type RemoteConfigResponse = {
   voicevox_tts_enabled_ios?: boolean;
   voicevox_tts_manifest_url_ios?: string;
   voicevox_tts_style_id_ios?: number;
+  voicevox_tts_speed_scale_ios?: number;
   ai_agent_enabled?: boolean;
 };
 
@@ -120,6 +130,20 @@ const parseHttpsUrl = (value: unknown): string | null => {
   return trimmed;
 };
 
+// 話速の基準倍率はネイティブ側が丸める範囲 (0.5〜2.0) に収まる有限の数値のみ受理する。
+// 範囲外は「設定ミス」とみなしてフォールバックへ倒し、極端な速さで読ませない。
+const parseSpeedScale = (value: unknown): number | null => {
+  const parsed = parsePositiveFiniteNumber(value);
+  if (
+    parsed == null ||
+    parsed < VOICEVOX_SPEED_SCALE_MIN ||
+    parsed > VOICEVOX_SPEED_SCALE_MAX
+  ) {
+    return null;
+  }
+  return parsed;
+};
+
 // スタイル ID は 0 以上の整数のみ受理する(0 は四国めたん あまあま)。
 const parseNonNegativeInteger = (value: unknown): number | null => {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
@@ -144,6 +168,7 @@ let cachedAIAgentEnabled: boolean | null = null;
 let cachedVoicevoxTTSEnabledIOS: boolean | null = null;
 let cachedVoicevoxTTSManifestUrlIOS: string | null = null;
 let cachedVoicevoxTTSStyleIdIOS: number | null = null;
+let cachedVoicevoxTTSSpeedScaleIOS: number | null = null;
 
 // setupRemoteConfig は起動時に非同期で完了するため、初回レンダー後にキャッシュが
 // 更新されても React は再レンダーしない。UI(FxTTS・設定画面)が useSyncExternalStore
@@ -179,6 +204,7 @@ export const resetRemoteConfigCache = (): void => {
   cachedVoicevoxTTSEnabledIOS = null;
   cachedVoicevoxTTSManifestUrlIOS = null;
   cachedVoicevoxTTSStyleIdIOS = null;
+  cachedVoicevoxTTSSpeedScaleIOS = null;
   notifyRemoteConfigListeners();
 };
 
@@ -241,6 +267,10 @@ export const setupRemoteConfig = async (): Promise<void> => {
   const styleId = parseNonNegativeInteger(data.voicevox_tts_style_id_ios);
   if (styleId != null) {
     cachedVoicevoxTTSStyleIdIOS = styleId;
+  }
+  const speedScale = parseSpeedScale(data.voicevox_tts_speed_scale_ios);
+  if (speedScale != null) {
+    cachedVoicevoxTTSSpeedScaleIOS = speedScale;
   }
   notifyRemoteConfigListeners();
 };
@@ -375,3 +405,10 @@ export const getVoicevoxTTSManifestUrl = (): string | null =>
  */
 export const getVoicevoxTTSStyleId = (): number =>
   cachedVoicevoxTTSStyleIdIOS ?? VOICEVOX_DEFAULT_STYLE_ID;
+
+/**
+ * VOICEVOX の話速の基準倍率。アナウンス速度設定の倍率に掛けて AudioQuery.speedScale にする。
+ * 未配信・不正値(0.5〜2.0 の範囲外)ならフォールバック(VOICEVOX_DEFAULT_SPEED_SCALE)。
+ */
+export const getVoicevoxTTSSpeedScale = (): number =>
+  cachedVoicevoxTTSSpeedScaleIOS ?? VOICEVOX_DEFAULT_SPEED_SCALE;


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

Canary の実機確認で VOICEVOX（No.7「アナウンス」）の読み上げが「速い」設定で若干早口に聞こえたため、VOICEVOX 側だけ話速の基準倍率を掛けられるようにする。倍率は Remote Config（Workers KV の `config:remote`）で調整でき、耳で追い込む際に再ビルドが要らない。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/lib/remoteConfig.ts`: キー `voicevox_tts_speed_scale_ios`（number）を追加。0.5〜2.0 の有限数のみ受理し、範囲外・型違いはフォールバック（`VOICEVOX_DEFAULT_SPEED_SCALE` = 0.9）へ倒す。取得関数 `getVoicevoxTTSSpeedScale()` を追加
- `src/constants/voicevox.ts`: 既定の基準倍率 0.9 と受理範囲（ネイティブ側 `applySpeedScale` の丸め範囲と同じ 0.5〜2.0）を定義
- `src/hooks/tts/useVoicevoxSpeechEngine.ts`: `speedScale` を「速度設定の倍率（0.85 / 1.0 / 1.15）× 基準倍率」にし、浮動小数の端数が AudioQuery に載らないよう 3 桁に丸める。既定では ゆっくり 0.765 / 標準 0.9 / 速い 1.035 になる
- テスト: Remote Config の受理・範囲外フォールバック（`it.each`）、エンジン側の掛け算と丸め（1.15 × 0.9 → 1.035）を追加。既存のエンジンテストはモックの基準倍率を 1 にして従来の期待値を維持
- `docs/spec/tts/on-device-tts-ios.md`: 速度の節と Remote Config の表にキーを追記

リモート TTS・端末内蔵 TTS の速度は変えていない。ネイティブモジュール（Swift）は変更なし。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npx jest src/lib/remoteConfig.test.ts src/hooks/tts/useVoicevoxSpeechEngine.test.ts src/hooks/useTTS.test.ts`（110 件 pass）で対象スコープを確認。実機での聞こえ方は Canary で確認する。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

- 前段: #6882（VOICEVOX フォールバック本体）

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

UI 変更なし: 合成時の話速パラメータと Remote Config の読み取りのみで、画面表示には変化がありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhiZDbeC767daH6qcLpArb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * VOICEVOXの読み上げ速度に基準倍率を適用し、より適切な速度で再生できるようになりました。
  * 読み上げ速度の基準倍率をリモート設定で調整できるようになりました。
  * 無効な設定値には既定値を適用します。

* **ドキュメント**
  * iOS向けオンデバイス音声合成の速度設定仕様を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->