### PR TITLE
速度フィルタの基準をEMA後ではなく生座標にして新幹線速度での現在地凍結を修正

### DIFF
--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -190,3 +190,134 @@ describe('setLocation', () => {
     });
   });
 });
+
+// 東北新幹線の一ノ関〜仙台に相当する南北方向の直線を走らせる。
+// 緯度1度 ≒ 111,320m として、速度から1サンプルあたりの緯度差を求める。
+const METERS_PER_DEG_LAT = 111_320;
+
+const runConstantSpeed = ({
+  speedKmh,
+  accuracy,
+  sampleIntervalMs,
+  samples,
+  startLat = 38.9,
+  startTimestamp = 1_000,
+}: {
+  speedKmh: number;
+  accuracy: number;
+  sampleIntervalMs: number;
+  samples: number;
+  startLat?: number;
+  startTimestamp?: number;
+}) => {
+  const degPerSample =
+    ((speedKmh / 3.6) * (sampleIntervalMs / 1000)) / METERS_PER_DEG_LAT;
+
+  let maxLagMeters = 0;
+  let lastLagMeters = 0;
+  for (let i = 0; i < samples; i++) {
+    const trueLat = startLat - degPerSample * i;
+    setLocation(
+      makeLocation(
+        trueLat,
+        140.9,
+        accuracy,
+        startTimestamp + sampleIntervalMs * i
+      )
+    );
+    const shownLat = store.get(locationAtom)?.coords.latitude ?? trueLat;
+    lastLagMeters = Math.abs(shownLat - trueLat) * METERS_PER_DEG_LAT;
+    maxLagMeters = Math.max(maxLagMeters, lastLagMeters);
+  }
+  return { maxLagMeters, lastLagMeters };
+};
+
+// 定速走行時にEMAが構造的に持つ追従遅れ ((1-α)/α)·v·dt。
+// 速度フィルタが正常に受理し続けている限り、ズレはこの値付近で頭打ちになる。
+// 逆にこれを大きく超える場合は棄却ループで位置が凍結していることを意味する。
+const expectedEmaLagMeters = (
+  speedKmh: number,
+  alpha: number,
+  sampleIntervalMs: number
+) => ((1 - alpha) / alpha) * (speedKmh / 3.6) * (sampleIntervalMs / 1000);
+
+describe('高速走行時の追従', () => {
+  beforeEach(() => {
+    resetLocationState();
+    setStationLineType(LineType.Normal);
+  });
+
+  // 回帰: 速度フィルタの基準にEMA後の座標を使うと、EMAの追従遅れが変位へ上乗せされ
+  // 算出速度が実速度の1/α倍に膨らむ。実効しきい値がα×360km/hまで下がり、
+  // 新幹線の320km/h走行が丸ごと棄却されて位置が数十km手前で凍結していた。
+  it.each([
+    // alphaはgetSmoothingAlphaの区分に対応する
+    { accuracy: 30, alpha: 0.8, label: '精度良好' },
+    { accuracy: 100, alpha: 0.6, label: '精度中' },
+    { accuracy: 300, alpha: 0.3, label: '精度不良' },
+  ])(
+    '320km/hで5分走り続けても位置が凍結しない（$label）',
+    ({ accuracy, alpha }) => {
+      const speedKmh = 320;
+      const sampleIntervalMs = 1000;
+      const { maxLagMeters, lastLagMeters } = runConstantSpeed({
+        speedKmh,
+        accuracy,
+        sampleIntervalMs,
+        samples: 300,
+      });
+
+      // 修正前はこの条件で98%以上の測位が棄却され、5分間で10km以上ズレていた。
+      // ズレがEMA固有の追従遅れの範囲に収まっていれば受理し続けられている。
+      const emaLag = expectedEmaLagMeters(speedKmh, alpha, sampleIntervalMs);
+      expect(maxLagMeters).toBeLessThan(emaLag * 1.1);
+      // 時間が経ってもズレが増えない（凍結して開き続けない）こと
+      expect(lastLagMeters).toBeLessThan(emaLag * 1.1);
+    }
+  );
+
+  it('130km/hの在来線速度でも追従する', () => {
+    const { maxLagMeters } = runConstantSpeed({
+      speedKmh: 130,
+      accuracy: 100,
+      sampleIntervalMs: 1000,
+      samples: 300,
+    });
+
+    // 到着判定圏(ARRIVED_MAX_THRESHOLD=200m)に十分収まること
+    expect(maxLagMeters).toBeLessThan(50);
+  });
+
+  // 回帰: 測位が長時間途切れたあとEMAで混ぜると新しい測位のα割しか反映されず、
+  // 残った遅れが次の変位へ乗って再棄却され、復帰できなくなっていた。
+  it('測位が30分途切れたあと最初の測位で現在地へ復帰する', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+
+    // 30分後、約160km南下した地点で測位が再開する
+    const resumedLat = 38.9 - 160_000 / METERS_PER_DEG_LAT;
+    setLocation(makeLocation(resumedLat, 140.9, 100, 1_000 + 30 * 60 * 1000));
+
+    // スムージングを挟まず生の座標へスナップすること
+    expect(store.get(locationAtom)?.coords.latitude).toBeCloseTo(resumedLat, 6);
+  });
+
+  it('連続棄却が上限に達したら基準を張り直して凍結から復帰する', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+
+    // 1秒間隔で物理的にありえない距離のジャンプを送り続ける
+    const jumpLat = 36.0;
+    for (let i = 1; i <= 5; i++) {
+      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 1000));
+    }
+
+    // 5回目(MAX_CONSECUTIVE_SPEED_REJECTIONS)で基準を張り直し、座標が反映される
+    expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
+  });
+
+  it('単発のジャンプは従来どおり棄却する', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+    setLocation(makeLocation(36.0, 140.9, 30, 2_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(38.9);
+  });
+});

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -314,6 +314,18 @@ describe('高速走行時の追従', () => {
     expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
   });
 
+  // 回帰: 「基準が古い」判定が速度フィルタより先に return していると、
+  // 測位間隔が空いた直後の1点に限ってワープ対策が無効になる
+  it('30秒以上途切れたあとでも物理的にありえないジャンプは棄却する', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+
+    // 60秒後に約500km離れた地点（≒8300m/s）へ飛ぶ測位が届く
+    const warpLat = 38.9 - 500_000 / METERS_PER_DEG_LAT;
+    setLocation(makeLocation(warpLat, 140.9, 30, 1_000 + 60_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(38.9);
+  });
+
   it('単発のジャンプは従来どおり棄却する', () => {
     setLocation(makeLocation(38.9, 140.9, 30, 1_000));
     setLocation(makeLocation(36.0, 140.9, 30, 2_000));

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -301,6 +301,18 @@ describe('高速走行時の追従', () => {
     expect(store.get(locationAtom)?.coords.latitude).toBeCloseTo(resumedLat, 6);
   });
 
+  // 回帰: STALE_REFERENCE_MS は「これ以上古い」基準なので、境界値ちょうどでも
+  // スナップする（比較が > だと境界でEMAが掛かり生座標へ張り付かない）
+  it('途切れがSTALE_REFERENCE_MSちょうど(30秒)でも生座標へスナップする', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+
+    // ちょうど30秒後、速度としては妥当な範囲(約1.6km先 ≒ 53m/s)で測位が再開する
+    const resumedLat = 38.9 - 1_600 / METERS_PER_DEG_LAT;
+    setLocation(makeLocation(resumedLat, 140.9, 100, 1_000 + 30_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBeCloseTo(resumedLat, 9);
+  });
+
   it('連続棄却が上限に達したら基準を張り直して凍結から復帰する', () => {
     setLocation(makeLocation(38.9, 140.9, 30, 1_000));
 

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -17,8 +17,8 @@ const MAX_PLAUSIBLE_SPEED = 100;
 // 測位で基準を張り直す。
 const MAX_CONSECUTIVE_SPEED_REJECTIONS = 5;
 
-// 基準座標がこれ以上古い場合、EMAの基準としても速度判定の基準としても意味を
-// 持たないため、スムージングせず新しい測位へスナップして基準を張り直す。
+// 基準座標がこれ以上古い場合、EMAの基準としては意味を持たないため、速度フィルタを
+// 通過したうえでスムージングせず新しい測位へスナップし、基準を張り直す。
 // バックグラウンド測位の抑止(「常に許可」未設定)やトンネルで測位が数十分途切れた
 // あと、EMAで混ぜると新しい測位のα割しか反映されず、残った遅れがそのまま次の
 // 変位へ乗って再び速度超過になる、という復帰不能ループを防ぐ。
@@ -167,16 +167,13 @@ export const setLocation = (location: Location.LocationObject) => {
     return;
   }
 
-  // 基準が古すぎる場合は判定にもスムージングにも使えないため張り直す。
-  // 測位が長く途切れたあとにEMAで混ぜると新しい測位のα割しか反映されず、
-  // 残った遅れが次回の変位へ乗って再棄却…という復帰不能ループの原因になる。
-  if (location.timestamp - rawPrev.timestamp > STALE_REFERENCE_MS) {
-    resyncLocationReference(location, updatedHistory);
-    return;
-  }
-
   // 前回の座標が存在する場合、速度ベースの異常値フィルタを適用する。
   // 基準は「生の前回座標」であってEMA後の座標ではない（lastRawLocationAtom参照）。
+  //
+  // 測位が長く途切れたあとでも、このフィルタは先に必ず通す。意味を失うのはEMAの方
+  // (下のSTALE_REFERENCE_MS判定)だけで、変位÷経過時間という速度の妥当性検査は
+  // 経過時間が延びても成立するため。ここを飛ばすと、間隔が空いた直後の1点に限って
+  // ワープ対策が無効になる。
   const dt = (location.timestamp - rawPrev.timestamp) / 1000; // 秒
   if (dt > 0) {
     const dist = getDistance(
@@ -206,6 +203,15 @@ export const setLocation = (location: Location.LocationObject) => {
   }
 
   consecutiveSpeedRejections = 0;
+
+  // 速度としては妥当だが基準が古すぎる場合、EMAの基準としては使えないため
+  // スムージングせず生の座標へスナップして基準を張り直す。長く途切れたあとに
+  // EMAで混ぜると新しい測位のα割しか反映されず、残った遅れが次回の変位へ乗って
+  // 再棄却…という復帰不能ループの原因になる。
+  if (location.timestamp - rawPrev.timestamp > STALE_REFERENCE_MS) {
+    resyncLocationReference(location, updatedHistory);
+    return;
+  }
 
   // EMA(指数移動平均)で座標をスムージングする
   // 精度が良いほどαが大きくなり、新しい測位値をより信頼する

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -10,6 +10,20 @@ const MAX_ACCURACY_HISTORY = 12;
 
 // 物理的にありえない速度でのジャンプを棄却する閾値(m/s ≒ 360km/h)
 const MAX_PLAUSIBLE_SPEED = 100;
+
+// 速度フィルタが連続して棄却できる回数の上限。棄却しても基準座標は更新しないため、
+// 基準側が実際の現在地から乖離している場合は正常な測位が延々と弾かれ、位置が
+// 永久に凍結する。この回数に達したら「基準の方が誤っている」と判断し、届いた
+// 測位で基準を張り直す。
+const MAX_CONSECUTIVE_SPEED_REJECTIONS = 5;
+
+// 基準座標がこれ以上古い場合、EMAの基準としても速度判定の基準としても意味を
+// 持たないため、スムージングせず新しい測位へスナップして基準を張り直す。
+// バックグラウンド測位の抑止(「常に許可」未設定)やトンネルで測位が数十分途切れた
+// あと、EMAで混ぜると新しい測位のα割しか反映されず、残った遅れがそのまま次の
+// 変位へ乗って再び速度超過になる、という復帰不能ループを防ぐ。
+const STALE_REFERENCE_MS = 30_000;
+
 // GPS精度に応じたスムージング重みを返す（精度が良いほど新しい値を信頼する）
 const getSmoothingAlpha = (accuracy: number | null): number => {
   if (accuracy == null || accuracy <= 0) {
@@ -57,9 +71,19 @@ export const backgroundLocationTrackingAtom = atom(false);
 // 下流の処理が「現在位置を信用できない＝走行中」と扱えるようにする。
 export const locationAccuracyOutlierAtom = atom(false);
 
-// 速度フィルタ・EMAスムージングの基準として使う「最後にフィルタ処理を通過した位置」
+// EMAスムージングの基準として使う「最後にフィルタ処理を通過した位置」
 // 地下鉄モード中は更新しないため、モード復帰後にノイジーなprevで誤棄却されるのを防ぐ
 const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
+
+// 速度フィルタの基準として使う「最後に受理した“生の”座標」。
+// EMA後の座標を基準にすると、EMAの追従遅れ(定速時 ((1-α)/α)·v·dt)が変位へ上乗せ
+// され、算出速度が実速度の 1/α 倍に膨らむ。実効的なしきい値が α×360km/h まで下がり、
+// 精度が良くても288km/h、精度200m超では108km/hで棄却が始まるため、新幹線の320km/h
+// 走行が丸ごと弾かれて位置が凍結していた。速度判定は生座標同士で行う。
+const lastRawLocationAtom = atom<Location.LocationObject | null>(null);
+
+// 速度フィルタが連続で棄却した回数。MAX_CONSECUTIVE_SPEED_REJECTIONSの判定に使う。
+let consecutiveSpeedRejections = 0;
 
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
@@ -67,7 +91,9 @@ export const resetLocationState = () => {
   store.set(rawLocationAtom, null);
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
+  store.set(lastRawLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
+  consecutiveSpeedRejections = 0;
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -84,6 +110,21 @@ export const setRawLocation = (location: Location.LocationObject) => {
   store.set(rawLocationAtom, location);
 };
 
+// スムージングせず測位をそのまま反映し、EMA基準・速度フィルタ基準の双方を張り直す。
+// 基準が無い(初回起動・地下鉄からの復帰)、基準が古すぎる、基準が誤っていると判断した
+// 場合に使う。基準を両方とも生の測位へ揃えるのが要点で、片方だけ残すと次回の変位に
+// 古い遅れが乗って誤棄却の引き金になる。
+const resyncLocationReference = (
+  location: Location.LocationObject,
+  updatedHistory: number[]
+) => {
+  store.set(locationAtom, location);
+  store.set(lastFilteredLocationAtom, location);
+  store.set(lastRawLocationAtom, location);
+  store.set(accuracyHistoryAtom, updatedHistory);
+  consecutiveSpeedRejections = 0;
+};
+
 // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
 // 手動選択(StationSearchModal/useInitialNearbyStation/Privacy等)もここを通る。
 export const setLocation = (location: Location.LocationObject) => {
@@ -95,6 +136,7 @@ export const setLocation = (location: Location.LocationObject) => {
   store.set(locationAccuracyOutlierAtom, false);
 
   const filteredPrev = store.get(lastFilteredLocationAtom);
+  const rawPrev = store.get(lastRawLocationAtom);
   const currentHistory = store.get(accuracyHistoryAtom);
   const newAccuracy = location.coords.accuracy;
 
@@ -110,28 +152,37 @@ export const setLocation = (location: Location.LocationObject) => {
     currentLineType === LineType.Subway && !isAccuracyStable(updatedHistory);
 
   // スムージングスキップ時はフィルタ・スムージングを全てスキップする
-  // UIには生の座標を反映するが、フィルタ基準(lastFilteredLocationAtom)は更新しない
+  // UIには生の座標を反映するが、EMA基準(lastFilteredLocationAtom)も速度フィルタ基準
+  // (lastRawLocationAtom)も更新しない。地上復帰時は基準が古いためSTALE_REFERENCE_MSの
+  // 判定に掛かり、そこで張り直される
   if (skipSmoothing) {
     store.set(locationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
     return;
   }
 
-  // フィルタ基準となるprevが無い場合（初回起動時や地下鉄→地上の復帰直後）
-  if (filteredPrev == null) {
-    store.set(locationAtom, location);
-    store.set(lastFilteredLocationAtom, location);
-    store.set(accuracyHistoryAtom, updatedHistory);
+  // 基準が無い場合（初回起動時や地下鉄→地上の復帰直後）
+  if (filteredPrev == null || rawPrev == null) {
+    resyncLocationReference(location, updatedHistory);
     return;
   }
 
-  // 前回の座標が存在する場合、速度ベースの異常値フィルタを適用
-  const dt = (location.timestamp - filteredPrev.timestamp) / 1000; // 秒
+  // 基準が古すぎる場合は判定にもスムージングにも使えないため張り直す。
+  // 測位が長く途切れたあとにEMAで混ぜると新しい測位のα割しか反映されず、
+  // 残った遅れが次回の変位へ乗って再棄却…という復帰不能ループの原因になる。
+  if (location.timestamp - rawPrev.timestamp > STALE_REFERENCE_MS) {
+    resyncLocationReference(location, updatedHistory);
+    return;
+  }
+
+  // 前回の座標が存在する場合、速度ベースの異常値フィルタを適用する。
+  // 基準は「生の前回座標」であってEMA後の座標ではない（lastRawLocationAtom参照）。
+  const dt = (location.timestamp - rawPrev.timestamp) / 1000; // 秒
   if (dt > 0) {
     const dist = getDistance(
       {
-        latitude: filteredPrev.coords.latitude,
-        longitude: filteredPrev.coords.longitude,
+        latitude: rawPrev.coords.latitude,
+        longitude: rawPrev.coords.longitude,
       },
       {
         latitude: location.coords.latitude,
@@ -142,10 +193,19 @@ export const setLocation = (location: Location.LocationObject) => {
 
     // 物理的にありえない速度の場合は座標を棄却し、前回値を維持する
     if (speed > MAX_PLAUSIBLE_SPEED) {
+      consecutiveSpeedRejections += 1;
+      // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま
+      // 復帰できなくなるのを避けるため、上限に達したら基準を張り直す。
+      if (consecutiveSpeedRejections >= MAX_CONSECUTIVE_SPEED_REJECTIONS) {
+        resyncLocationReference(location, updatedHistory);
+        return;
+      }
       store.set(accuracyHistoryAtom, updatedHistory);
       return;
     }
   }
+
+  consecutiveSpeedRejections = 0;
 
   // EMA(指数移動平均)で座標をスムージングする
   // 精度が良いほどαが大きくなり、新しい測位値をより信頼する
@@ -168,5 +228,7 @@ export const setLocation = (location: Location.LocationObject) => {
 
   store.set(locationAtom, smoothedLocation);
   store.set(lastFilteredLocationAtom, smoothedLocation);
+  // 速度フィルタの基準はスムージング前の生座標を保持する
+  store.set(lastRawLocationAtom, location);
   store.set(accuracyHistoryAtom, updatedHistory);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -208,7 +208,7 @@ export const setLocation = (location: Location.LocationObject) => {
   // スムージングせず生の座標へスナップして基準を張り直す。長く途切れたあとに
   // EMAで混ぜると新しい測位のα割しか反映されず、残った遅れが次回の変位へ乗って
   // 再棄却…という復帰不能ループの原因になる。
-  if (location.timestamp - rawPrev.timestamp > STALE_REFERENCE_MS) {
+  if (location.timestamp - rawPrev.timestamp >= STALE_REFERENCE_MS) {
     resyncLocationReference(location, updatedHistory);
     return;
   }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

320km/h 運転の新幹線など高速走行中に現在地が手前で凍結し、駅名が更新されなくなる不具合を修正します。

ワープ対策の速度フィルタが、判定の基準に EMA スムージング**後**の座標を使っていたことが原因です。EMA は定速走行時に `((1-α)/α)·v·dt` だけ実位置より遅れるため、その遅れが変位へ上乗せされ、算出速度が実速度の `1/α` 倍に膨張していました。結果、`MAX_PLAUSIBLE_SPEED`（100m/s ≒ 360km/h）の実効しきい値が `α×360km/h` まで下がります。

| GPS精度 | α | 実効しきい値 |
| ---- | ---- | ---- |
| < 50m | 0.8 | 288 km/h |
| 50〜200m | 0.6 | 216 km/h |
| ≧ 200m | 0.3 | 108 km/h |

棄却時は基準座標を更新しないため、遅れを抱えたまま次の測位も棄却される自己強化ループに入り、位置が凍結したまま復帰できなくなっていました。修正前のロジックをそのまま数値シミュレーションすると、320km/h・精度100m・1Hz の条件で 99% の測位が棄却され、5 分間で最大 37km ズレます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

`src/store/atoms/location.ts`

- 速度フィルタの基準として `lastRawLocationAtom`（スムージング前の生座標）を新設し、ワープ判定を生座標同士で行うようにしました。EMA のスムージング基準は従来どおり `lastFilteredLocationAtom` のままです。
- 前回受理から 30 秒（`STALE_REFERENCE_MS`）以上空いた測位は、EMA を挟まず生座標へスナップして基準を張り直します。バックグラウンド測位の抑止（「常に許可」未設定）やトンネルで測位が長時間途切れたあと、EMA で混ぜると新しい測位の α 割しか反映されず、残った遅れが次の変位へ乗って再棄却される復帰不能ループを断ちます。
- **このスナップ判定は速度フィルタの後ろに置いています。** 長時間の途切れで意味を失うのは EMA だけで、「変位 ÷ 経過時間」という速度の妥当性検査は経過時間が延びても成立するためです。先に return すると、間隔が空いた直後の 1 点に限ってワープ対策が無効になります。
- 速度フィルタが 5 回（`MAX_CONSECUTIVE_SPEED_REJECTIONS`）連続で棄却した場合は「基準側が誤っている」と判断して張り直すガードを追加しました。想定外の凍結が起きても最大 5 サンプルで復帰します。
- 地下鉄モード中に両基準を更新しない挙動は従来どおりです。地上復帰時は上記 `STALE_REFERENCE_MS` の判定で張り直されます。

`src/store/atoms/location.test.ts`

- 「高速走行時の追従」を追加。320km/h × 5 分を精度 30 / 100 / 300m の 3 水準で流し、ズレが EMA 固有の追従遅れ `((1-α)/α)·v·dt` の 1.1 倍以内に収まること、かつ時間が経ってもズレが開き続けないことを検証します。
- 30 分の測位途切れからの復帰、`STALE_REFERENCE_MS` 境界値ちょうどでのスナップ、連続棄却からの復帰、30 秒以上途切れたあとのワープ棄却、単発ジャンプの棄却維持も追加しました。

### コミット

| コミット | 内容 |
| ---- | ---- |
| `848379c` | 速度フィルタの基準を EMA 後ではなく生座標にして新幹線速度での現在地凍結を修正 |
| `1280e5d` | 測位間隔が空いた直後にワープ対策の速度フィルタが無効化される問題を修正（スナップ判定を速度フィルタの後ろへ移動） |
| `f533a26` | 基準の陳腐化判定を境界値ちょうどでも成立するよう `>=` へ修正（CodeRabbit の指摘対応） |

### 影響範囲とリグレッションリスク

変更は `setLocation` の速度フィルタ判定とその基準の持ち方に限定され、EMA の重み（`getSmoothingAlpha`）・精度履歴・地下鉄スキップ判定・`MAX_PERMIT_ACCURACY` フィルタ（`handleTrackingLocation`）はいずれも未変更です。

**通常速度域への影響**（旧ロジックと新ロジックを同条件でシミュレーションした結果、600 サンプル）

| 速度 | 精度 | 旧 棄却数 | 新 棄却数 | 旧 最大ズレ | 新 最大ズレ |
| ---- | ---- | ---- | ---- | ---- | ---- |
| 0〜130 km/h | 30〜100m | 0 | 0 | 同一 | 同一 |
| 130 km/h | 300m | 563 | 0 | 3,963m | 84m |
| 160 km/h | 300m | 578 | 0 | 8,303m | 104m |

停車中〜130km/h・精度良好の領域は棄却が元々発生しないため、**出力座標は 1 サンプルも変わりません**。挙動が変わるのは、これまで誤って棄却されていた領域（精度不良かつ高速）だけです。在来線特急でも精度 300m 帯では旧ロジックが 4km 近くズレていました。

**ワープ耐性の変化**（棄却される最小のジャンプ距離）

| 測位間隔 | 速度 | 精度 | 旧 | 新 |
| ---- | ---- | ---- | ---- | ---- |
| 1s | 停車中 | 任意 | 100m | 100m |
| 1s | 80 km/h | 30m | 72m | 78m |
| 1s | 80 km/h | 300m | 26m | 78m |
| 10s | 停車中 | 任意 | 1,000m | 1,000m |
| 10s | 80 km/h | 30m | 722m | 778m |
| 10s | 80 km/h | 300m | 259m | 778m |

停車中は完全に不変、精度良好時もほぼ不変です。緩むのは「移動中かつ精度不良」の一点で、旧ロジックはここで測定誤差そのもの（精度 300m なら数百m のばらつきは正常範囲）をワープとして棄却していました。新しいしきい値は誤差のフロアより上、実際のワープ（km オーダー）より下に収まります。

その他:

- 単発ワープの棄却挙動は変わりません（回帰テストで固定）。
- 30 秒スナップは、更新間隔が常に 30 秒を超える環境では EMA が実質無効化されます（速度フィルタは効いたままです）。Android は `LOCATION_TIME_INTERVAL` が 10 秒、iOS は `distanceInterval` 基準で概ね 1Hz のため、通常運用では該当しません。

### 既知の残課題（本 PR のスコープ外）

- 精度 300m・320km/h では EMA 構造上の追従遅れが 207m 残り、`ARRIVED_MAX_THRESHOLD`（200m）をわずかに超えます。到着検知が約 2.3 秒遅れるだけで駅の取りこぼしは起きませんが、詰めるなら EMA のラグ補正か α のスケジューリングが別途必要です。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果（`f533a26` 時点）:

```text
npm run lint      → Checked 733 files. No fixes applied.
npm run typecheck → エラーなし
npm test          → 270 suites / 2938 tests すべてパス
```

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Closes #6883

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: 変更は `src/store/atoms/location.ts` の測位フィルタのみで、コンポーネント・レイアウト・表示文言はいずれも変更していません。表示駅名の正しさは 320km/h での継続測位の受理率で決まるため静止画では差分を示せず、代わりに `src/store/atoms/location.test.ts` の回帰テストで追従性を検証しています。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBzR1eC63sLk9XMDhs5m4P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 高速移動中の位置追従精度を改善しました。
  - 一時的な測位中断から復帰した際、適切な位置へ再同期するようになりました。
  - 長時間の測位中断後も、不自然な大きな位置ジャンプを抑制します。
  - 一時的な測位誤差や速度変動による位置の乱れを軽減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->