### PR TITLE
GPXをAndroidのテストプロバイダへ流して実機の測位パイプラインを検証するスクリプトとスキルを追加

### DIFF
--- a/.claude/skills/replay-gpx/SKILL.md
+++ b/.claude/skills/replay-gpx/SKILL.md
@@ -65,11 +65,11 @@ npm run gpx:replay -- --gpx ios/SampleTohokuShinkansen.gpx --serial <serial>
 
 | オプション | 説明 |
 | ---- | ---- |
-| `--gpx <path>` | 再生する GPX (必須) |
+| `--gpx <path>` | 再生する GPX (必須)。`<wpt>` と `<trkpt>` のどちらでも読む |
 | `--serial <serial>` | adb シリアル。接続が 1 台だけなら省略可 |
 | `--speed <n>` | 再生倍率。既定 1 |
 | `--accuracy <m>` | 水平精度 (m)。既定 8。カンマ区切りで区間ごとに巡回 |
-| `--start <sec>` | GPX 先頭からのスキップ秒数 |
+| `--start <sec>` | GPX 先頭からのスキップ秒数。`--loop` 時は初回の再生にだけ効く |
 | `--provider <names>` | テストプロバイダ名。既定 `gps,network,fused` |
 | `--loop` | 終端で先頭に戻る |
 | `--keep` | 終了時にテストプロバイダを残す |
@@ -86,7 +86,8 @@ screenshot udid=<serial> scale=0.35
 ### 5. 後始末
 
 `Ctrl+C` (または `SIGTERM`) でテストプロバイダと `mock_location` の appop を元に戻す。
-`kill -9` すると後始末が走らないので、その場合は手動で戻す。
+1 回目のシグナルは停止を要求するだけで、進行中の投入が終わってから後始末が 1 回だけ走る。
+**2 回目を送るか `kill -9` すると後始末を待たずに落ちる**ので、その場合は下を手動で実行する。
 
 ```bash
 adb -s <serial> shell cmd location providers remove-test-provider gps
@@ -112,6 +113,8 @@ adb -s <serial> shell appops set 2000 android:mock_location default
 - **`CURRENT SPEED` は常に 0km/h になる。** `cmd location providers` に速度を渡す
   引数が無く、`coords.speed` が埋まらないため。アプリ内の速度フィルタは座標差分から
   算出するので影響しないが、DEV OVERLAY の速度表示は当てにならない。
+- **中断は 1 回で待つ。** 2 回目の `Ctrl+C` は後始末を飛ばすため、テストプロバイダと
+  `mock_location` の appop が端末に残る。私物端末では特に、1 回で待って後始末を通す。
 - **ユーザーの私物端末では MMKV を書き換えない。** テーマやウォークスルーの状態を
   変更する検証は避ける。
 

--- a/.claude/skills/replay-gpx/SKILL.md
+++ b/.claude/skills/replay-gpx/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: replay-gpx
+description: Replay a GPX track as mock locations on a connected Android device or emulator, so the app's real positioning pipeline (speed filter, EMA smoothing, accuracy filter) runs end to end. Use when the user asks to feed a GPX to a device, simulate riding a line, verify arrival/passing detection, or reproduce a positioning bug on Android.
+---
+
+# replay-gpx
+
+`ios/*.gpx` を Android の**テストプロバイダ**経由で流し込み、実機・エミュレータの
+測位パイプラインを実際に通す。オートモード (`useSimulationMode`) と違い
+`locationAtom` へ直書きしないので、`src/store/atoms/location.ts` の速度フィルタ・
+EMA スムージング・精度フィルタがすべて効いた状態を観測できる。
+
+Argent の MCP ツールには位置情報を注入するものが無いため、投入は `adb` で行い、
+画面の確認だけ Argent (`screenshot` / `describe`) を使う。
+
+## 前提
+
+- Android 実機またはエミュレータが `adb devices` に出ていること。iOS は対象外
+  (Linux ホストでは iOS シミュレータを起動できない)。
+- dev ビルド (`me.tinykitten.trainlcd.dev`) がインストール済みで、位置情報権限が
+  許可済みであること。
+- 端末の Android バージョンが 11 以降 (`cmd location providers` サブコマンドが必要)。
+
+## 手順
+
+### 1. 走らせる GPX を用意する
+
+同梱のサンプルをそのまま使う場合はこの節を飛ばす。
+
+| ファイル | 内容 |
+| ---- | ---- |
+| `ios/SampleJY.gpx` | 山手線。実走行ログ |
+| `ios/SampleTohokuShinkansen.gpx` | 東北新幹線 盛岡→仙台。最高 320km/h |
+
+新しい経路は `npm run gpx:generate` で作る。詳細は `docs/location-simulation.md`。
+
+```bash
+npm run gpx:generate -- --line 1004 --list
+npm run gpx:generate -- --line 1004 --from 100418 --to 100411 --max-speed 320 \
+  --skip 100417,100416,100415,100413,100412 --out ios/SampleTohokuShinkansen.gpx
+```
+
+### 2. アプリを対象の路線に入れる
+
+ディープリンクの `sids` 形式で経路を直接開く。**`auto=1` は付けない** —
+オートモードは測位パイプラインを飛ばすため、この検証の目的を無効化する。
+
+`sids` は駅 ID をカンマ区切りで並べた順序が進行方向、`skips` はその配列に対する
+0 起点の通過駅インデックス。
+
+```bash
+adb -s <serial> shell "am start -a android.intent.action.VIEW -d \
+  'trainlcd-canary://?sids=100418,100417,100416,100415,100414,100413,100412,100411&skips=1,2,3,5,6'"
+```
+
+上の例は盛岡→仙台で、一ノ関だけ停車・残り 5 駅は通過になる。
+
+### 3. GPX を流す
+
+```bash
+npm run gpx:replay -- --gpx ios/SampleTohokuShinkansen.gpx --serial <serial>
+```
+
+長時間になるのでバックグラウンドで走らせ、進捗はログで見る。
+
+| オプション | 説明 |
+| ---- | ---- |
+| `--gpx <path>` | 再生する GPX (必須) |
+| `--serial <serial>` | adb シリアル。接続が 1 台だけなら省略可 |
+| `--speed <n>` | 再生倍率。既定 1 |
+| `--accuracy <m>` | 水平精度 (m)。既定 8。カンマ区切りで区間ごとに巡回 |
+| `--start <sec>` | GPX 先頭からのスキップ秒数 |
+| `--provider <names>` | テストプロバイダ名。既定 `gps,network,fused` |
+| `--loop` | 終端で先頭に戻る |
+| `--keep` | 終了時にテストプロバイダを残す |
+
+### 4. 画面を確認する
+
+Argent で撮る。DEV OVERLAY の `LOCATION ACCURACY` が `--accuracy` の値になっていれば
+モックが届いている。
+
+```text
+screenshot udid=<serial> scale=0.35
+```
+
+### 5. 後始末
+
+`Ctrl+C` (または `SIGTERM`) でテストプロバイダと `mock_location` の appop を元に戻す。
+`kill -9` すると後始末が走らないので、その場合は手動で戻す。
+
+```bash
+adb -s <serial> shell cmd location providers remove-test-provider gps
+adb -s <serial> shell cmd location providers remove-test-provider network
+adb -s <serial> shell cmd location providers remove-test-provider fused
+adb -s <serial> shell appops set 2000 android:mock_location default
+```
+
+## 落とし穴
+
+- **`--speed` は 1 のままにする。** `MAX_PLAUSIBLE_SPEED` は 100m/s (360km/h) なので、
+  320km/h の GPX を 2 倍速以上で流すと速度フィルタが全点を棄却して現在地が凍る。
+  倍速で流したいときは `--max-speed` を下げた GPX を作り直す。
+- **`gps` だけでは足りない。** Play 開発者サービスの Fused は独自に融合するため、
+  既定どおり `gps,network,fused` の 3 つへ同じ座標を流す。`fused` 単独だと
+  実測位が優先されてモックが無視される。
+- **テストプロバイダは走行中に OS 側から外れることがある。** Samsung の
+  「擬似ロケーション」通知の OFF や location サービス再起動で消える。スクリプトは
+  失敗を検知して自動で再登録し、ログに `再登録n回` として出す。
+- **`--time` は渡さない。** ホストと端末の時計がずれていると Samsung の
+  `PositionManager` が `ignore mock location for time validation` で捨て、
+  `handleTrackingLocation` の重複破棄にも引っかかる。
+- **`CURRENT SPEED` は常に 0km/h になる。** `cmd location providers` に速度を渡す
+  引数が無く、`coords.speed` が埋まらないため。アプリ内の速度フィルタは座標差分から
+  算出するので影響しないが、DEV OVERLAY の速度表示は当てにならない。
+- **ユーザーの私物端末では MMKV を書き換えない。** テーマやウォークスルーの状態を
+  変更する検証は避ける。
+
+## 再現できないこと
+
+| 条件 | この手順 |
+| ---- | ---- |
+| 精度を落とした測位 (α=0.6 / 0.3) | ✅ `--accuracy 100,300` などで指定できる |
+| トンネルでの測位途絶 | ❌ 途絶を表現できない |
+| 車体による GPS 減衰 | ❌ |
+| `coords.speed` を使う表示の検証 | ❌ 常に 0 |

--- a/docs/location-simulation.md
+++ b/docs/location-simulation.md
@@ -70,7 +70,7 @@ npm run gpx:generate -- \
 経路上の 8 駅すべてに `ARRIVED_MAX_THRESHOLD` (200m) 以内まで接近するので、
 各駅の到着判定・通過判定をそのまま観測できる。
 
-## シミュレータで再生する
+## iOS シミュレータで再生する
 
 1. Xcode でワークスペースを開く。
 1. メニューの Debug > Simulate Location > Add GPX File to Workspace… で GPX を選ぶ。
@@ -78,15 +78,45 @@ npm run gpx:generate -- \
 
 Xcode は `<time>` の間隔どおりに測位を配信するので、GPX 側で速度を制御できる。
 
+## Android 実機・エミュレータで再生する
+
+`scripts/replay-location-gpx.mjs` が GPX を Android のテストプロバイダへ流し込む。
+`adb shell cmd location providers` を使うので、実機でも仮の現在地アプリを別途
+入れる必要はない。手順の全体は `.claude/skills/replay-gpx/SKILL.md` にある。
+
+```bash
+npm run gpx:replay -- --gpx ios/SampleTohokuShinkansen.gpx --serial <serial>
+```
+
+主なオプションは次のとおり。`--help` で全件を表示できる。
+
+| オプション | 説明 |
+| ---- | ---- |
+| `--gpx` | 再生する GPX (必須) |
+| `--serial` | adb シリアル。接続が 1 台だけなら省略可 |
+| `--speed` | 再生倍率。既定 `1` |
+| `--accuracy` | 水平精度 (m)。既定 `8`。カンマ区切りで区間ごとに巡回 |
+| `--start` | GPX 先頭からのスキップ秒数 |
+| `--provider` | テストプロバイダ名。既定 `gps,network,fused` |
+
+Xcode と違い精度を指定できるので、`--accuracy 100,300` のように渡せば
+`getSmoothingAlpha` の低精度分岐も実機で観測できる。一方で `coords.speed` を
+渡す手段が無いため、DEV OVERLAY の `CURRENT SPEED` は常に 0km/h を表示する。
+
+`MAX_PLAUSIBLE_SPEED` は 100m/s (360km/h) なので、320km/h の GPX を `--speed 2`
+以上で流すと速度フィルタが全点を棄却して現在地が凍る。倍速で見たいときは
+`--max-speed` を下げた GPX を作り直す。
+
 ## 検証できること・できないこと
 
-| 条件 | GPX | 実乗車 |
-| ---- | ---- | ---- |
-| 320km/h・精度良好 (α=0.8、実効しきい値 288km/h) | ✅ | ✅ |
-| 精度 100m / 300m (α=0.6 / 0.3) | ❌ シミュレータは常に良好な精度を返す | ✅ |
-| トンネルでの測位途絶からの復帰 | ❌ | ✅ |
-| 車体による GPS 減衰 | ❌ | ✅ |
+| 条件 | GPX (iOS シミュレータ) | GPX (Android) | 実乗車 |
+| ---- | ---- | ---- | ---- |
+| 320km/h・精度良好 (α=0.8、実効しきい値 288km/h) | ✅ | ✅ | ✅ |
+| 精度 100m / 300m (α=0.6 / 0.3) | ❌ 常に良好な精度を返す | ✅ `--accuracy` で指定 | ✅ |
+| トンネルでの測位途絶からの復帰 | ❌ | ❌ | ✅ |
+| 車体による GPS 減衰 | ❌ | ❌ | ✅ |
+| `coords.speed` を使う表示 | ✅ | ❌ 常に 0 | ✅ |
 
-精度を落とした状態や測位途絶の挙動は GPX では再現できない。
+測位途絶や車体による減衰は GPX では再現できない。
 これらは `src/store/atoms/location.test.ts` のユニットテストで代替するか、
 dev ビルドの `DevOverlay` (精度履歴・生座標を表示) を出したまま実際に乗車して確認する。

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "watch:test": "cross-env TZ=UTC jest --watch",
     "gql:codegen": "graphql-codegen --config utils/codegen.ts",
     "gpx:generate": "node --no-warnings=MODULE_TYPELESS_PACKAGE_JSON scripts/generate-location-gpx.mjs",
+    "gpx:replay": "node --no-warnings=MODULE_TYPELESS_PACKAGE_JSON scripts/replay-location-gpx.mjs",
     "version:bump": "node scripts/bump-version.js",
     "postinstall": "patch-package"
   },

--- a/scripts/replay-location-gpx.mjs
+++ b/scripts/replay-location-gpx.mjs
@@ -16,33 +16,58 @@ const opt = (name, fallback) => {
 };
 const flag = (name) => argv.includes(`--${name}`);
 
-if (flag('help') || !opt('gpx')) {
-  console.log(`使い方: npm run gpx:replay -- --gpx <file> [options]
+const USAGE = `使い方: npm run gpx:replay -- --gpx <file> [options]
 
-  --gpx <path>        再生する GPX (必須)
+  --gpx <path>        再生する GPX (必須)。<wpt> と <trkpt> のどちらでも読む
   --serial <serial>   adb のデバイスシリアル (省略時は接続中の 1 台)
   --provider <names>  テストプロバイダ名 (カンマ区切り)。既定 gps,network,fused
                       Play 開発者サービスの Fused は gps/network を見るため
                       既定では 3 つすべてに同じ座標を流す
   --speed <n>         再生倍率。既定 1 (GPX の <time> どおり)
   --accuracy <m>      水平精度 (m)。既定 8。カンマ区切りで区間ごとに巡回
-  --start <sec>       GPX 先頭からのスキップ秒数
+  --start <sec>       GPX 先頭からのスキップ秒数。--loop 時は初回のみ適用
   --loop              終端に達したら先頭から繰り返す
-  --keep              終了時にテストプロバイダを削除しない`);
+  --keep              終了時にテストプロバイダを削除しない`;
+
+if (flag('help') || !opt('gpx')) {
+  console.log(USAGE);
   process.exit(opt('gpx') ? 0 : 1);
 }
 
+const fail = (message) => {
+  console.error(message);
+  console.error(`\n${USAGE}`);
+  process.exit(1);
+};
+
+// --- 引数の検証 -----------------------------------------------------------
+// 不正値のまま走ると、非有限の待ち時間で無限に止まったり、undefined を adb へ
+// 渡したり、1 点も投入しないまま正常終了したりする。再生を始める前に弾く。
 const serial = opt('serial');
 const providers = String(opt('provider', 'gps,network,fused'))
   .split(',')
   .map((v) => v.trim())
   .filter(Boolean);
+if (providers.length === 0) {
+  fail('--provider にはプロバイダ名を 1 つ以上指定してください。');
+}
+
 const speed = Number(opt('speed', '1'));
+if (!Number.isFinite(speed) || speed <= 0) {
+  fail(`--speed は正の有限数で指定してください: ${opt('speed')}`);
+}
+
 const accuracies = String(opt('accuracy', '8'))
   .split(',')
-  .map((v) => Number(v.trim()))
-  .filter((v) => Number.isFinite(v) && v > 0);
+  .map((v) => Number(v.trim()));
+if (accuracies.some((v) => !Number.isFinite(v) || v <= 0)) {
+  fail(`--accuracy は正の有限数をカンマ区切りで指定してください: ${opt('accuracy')}`);
+}
+
 const startSec = Number(opt('start', '0'));
+if (!Number.isFinite(startSec) || startSec < 0) {
+  fail(`--start は 0 以上の有限数で指定してください: ${opt('start')}`);
+}
 
 const adbArgs = (...rest) => (serial ? ['-s', serial, ...rest] : rest);
 const adb = async (...rest) => {
@@ -53,26 +78,59 @@ const adb = async (...rest) => {
 };
 
 // --- GPX 読み込み ---------------------------------------------------------
-const xml = readFileSync(opt('gpx'), 'utf8');
+// <wpt> と <trkpt> の両方を読む。属性の並び順には依存しない。
+const gpxPath = opt('gpx');
+const xml = readFileSync(gpxPath, 'utf8');
+const nodeRe = /<(wpt|trkpt)\b([^>]*?)(?:\/>|>([\s\S]*?)<\/\1\s*>)/g;
+const attr = (attrs, name) => {
+  const m = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`).exec(attrs);
+  if (!m) return null;
+  return m[2] ?? m[3];
+};
+
 const points = [];
-const wptRe =
-  /<wpt[^>]*\blat="([-\d.]+)"[^>]*\blon="([-\d.]+)"[^>]*>([\s\S]*?)<\/wpt>/g;
-for (let m; (m = wptRe.exec(xml)); ) {
-  const timeMatch = /<time>([^<]+)<\/time>/.exec(m[3]);
-  points.push({
-    lat: Number(m[1]),
-    lon: Number(m[2]),
-    t: timeMatch ? Date.parse(timeMatch[1]) : null,
-  });
+for (let m; (m = nodeRe.exec(xml)); ) {
+  const [, tag, attrs, inner = ''] = m;
+  const lat = Number(attr(attrs, 'lat'));
+  const lon = Number(attr(attrs, 'lon'));
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    fail(`<${tag}> の lat/lon を数値として読めません: ${attrs.trim()}`);
+  }
+  const timeMatch = /<time>([^<]*)<\/time>/.exec(inner);
+  points.push({ lat, lon, rawTime: timeMatch ? timeMatch[1].trim() : null });
 }
 if (points.length === 0) {
-  console.error('GPX に <wpt> が見つかりません');
-  process.exit(1);
+  fail(`${gpxPath} に <wpt> / <trkpt> が見つかりません。`);
 }
-// <time> が無い GPX は 1Hz とみなす
-const base = points[0].t ?? 0;
-for (const [i, p] of points.entries()) {
-  p.offset = p.t === null ? i * 1000 : p.t - base;
+
+// 再生時刻の組み立て。<time> の有無が混在した GPX は、先頭に <time> が無いだけで
+// 後続の offset が Unix epoch ミリ秒になり、事実上停止したように見える。
+// 混在と解釈不能な日時はここで弾き、全点無しのときだけ 1Hz とみなす。
+const timed = points.filter((p) => p.rawTime !== null);
+if (timed.length !== 0 && timed.length !== points.length) {
+  fail(
+    `${gpxPath} は <time> のある点と無い点が混在しています (${timed.length}/${points.length})。`
+  );
+}
+if (timed.length === 0) {
+  points.forEach((p, i) => {
+    p.offset = i * 1000;
+  });
+} else {
+  const base = Date.parse(points[0].rawTime);
+  if (!Number.isFinite(base)) {
+    fail(`<time> を日時として読めません: ${points[0].rawTime}`);
+  }
+  for (const [i, p] of points.entries()) {
+    const t = Date.parse(p.rawTime);
+    if (!Number.isFinite(t)) {
+      fail(`<time> を日時として読めません: ${p.rawTime}`);
+    }
+    p.offset = t - base;
+    if (i > 0 && p.offset < points[i - 1].offset) {
+      fail(`<time> が逆行しています: ${points[i - 1].rawTime} -> ${p.rawTime}`);
+    }
+  }
 }
 
 // --- テストプロバイダの準備 ----------------------------------------------
@@ -85,7 +143,9 @@ async function setup() {
     .filter((l) => /\tdevice$/.test(l));
   if (devices.length === 0) throw new Error('adb に接続中のデバイスがありません');
   if (!serial && devices.length > 1)
-    throw new Error(`デバイスが複数あります。--serial を指定してください:\n${devices.join('\n')}`);
+    throw new Error(
+      `デバイスが複数あります。--serial を指定してください:\n${devices.join('\n')}`
+    );
 
   await registerProviders();
   console.log(`テストプロバイダ ${providers.join(', ')} を有効化しました`);
@@ -109,37 +169,58 @@ async function teardown() {
     await loc('set-test-provider-enabled', provider, 'false').catch(() => {});
     await loc('remove-test-provider', provider).catch(() => {});
   }
-  await adb('shell', 'appops', 'set', '2000', 'android:mock_location', 'default').catch(
-    () => {}
-  );
+  await adb(
+    'shell',
+    'appops',
+    'set',
+    '2000',
+    'android:mock_location',
+    'default'
+  ).catch(() => {});
   console.log(`\nテストプロバイダ ${providers.join(', ')} を削除しました`);
 }
 
-// --- 再生 -----------------------------------------------------------------
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// --- 中断の扱い -----------------------------------------------------------
+// シグナルでは停止を要求するだけにする。ハンドラから直接 teardown() を呼ぶと、
+// 進行中の push() が失敗して registerProviders() を走らせた場合に、削除の後で
+// プロバイダと appop が再設定されて端末に残る。
+let stopping = false;
+const sleepers = new Set();
 
-async function play() {
-  const first = points.findIndex((p) => p.offset >= startSec * 1000);
-  const from = first === -1 ? 0 : first;
-  const originOffset = points[from].offset;
-  const wallStart = Date.now();
+const sleep = (ms) =>
+  new Promise((resolve) => {
+    if (stopping) {
+      resolve();
+      return;
+    }
+    const entry = {};
+    entry.resolve = resolve;
+    entry.timer = setTimeout(() => {
+      sleepers.delete(entry);
+      resolve();
+    }, ms);
+    sleepers.add(entry);
+  });
 
-  for (let i = from; i < points.length; i++) {
-    const p = points[i];
-    const due = wallStart + (p.offset - originOffset) / speed;
-    const wait = due - Date.now();
-    if (wait > 0) await sleep(wait);
-
-    const acc = accuracies[i % accuracies.length];
-    await push(p, acc);
-
-    const elapsed = ((p.offset - originOffset) / 1000).toFixed(0);
-    process.stdout.write(
-      `\r[${i + 1}/${points.length}] +${elapsed}s  ${p.lat.toFixed(5)}, ${p.lon.toFixed(5)}  acc=${acc}m  再登録${reregistrations}回   `
-    );
+const wakeAllSleepers = () => {
+  for (const entry of sleepers) {
+    clearTimeout(entry.timer);
+    entry.resolve();
   }
+  sleepers.clear();
+};
+
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    // 2 回目は後始末を待たずに落とす。テストプロバイダが残るので、その場合は
+    // 手動で remove-test-provider と appops set ... default を実行する。
+    if (stopping) process.exit(130);
+    stopping = true;
+    wakeAllSleepers();
+  });
 }
 
+// --- 投入 -----------------------------------------------------------------
 // テストプロバイダは走行中に OS 側から外されることがある
 // (Samsung の擬似ロケーション通知の OFF、省電力による location サービス再起動など)。
 // 外れたら黙って再登録してから同じ点を打ち直す。
@@ -166,31 +247,53 @@ async function push(point, acc, retry = true) {
       throw new Error(results.join('\n'));
     }
   } catch (e) {
-    if (!retry) throw e;
+    // 中断中は再登録しない。teardown() と競合して削除後に再設定されてしまう。
+    if (!retry || stopping) throw e;
     reregistrations += 1;
     await registerProviders();
     await push(point, acc, false);
   }
 }
 
-let stopping = false;
-for (const sig of ['SIGINT', 'SIGTERM']) {
-  process.on(sig, async () => {
-    if (stopping) process.exit(1);
-    stopping = true;
-    await teardown();
-    process.exit(0);
-  });
+// --- 再生 -----------------------------------------------------------------
+async function play(skipSec) {
+  const first = points.findIndex((p) => p.offset >= skipSec * 1000);
+  const from = first === -1 ? 0 : first;
+  const originOffset = points[from].offset;
+  const wallStart = Date.now();
+
+  for (let i = from; i < points.length; i++) {
+    if (stopping) return;
+
+    const p = points[i];
+    const due = wallStart + (p.offset - originOffset) / speed;
+    const wait = due - Date.now();
+    if (wait > 0) await sleep(wait);
+    if (stopping) return;
+
+    const acc = accuracies[i % accuracies.length];
+    await push(p, acc);
+
+    const elapsed = ((p.offset - originOffset) / 1000).toFixed(0);
+    process.stdout.write(
+      `\r[${i + 1}/${points.length}] +${elapsed}s  ${p.lat.toFixed(5)}, ${p.lon.toFixed(5)}  acc=${acc}m  再登録${reregistrations}回   `
+    );
+  }
 }
 
+let exitCode = 0;
 try {
   await setup();
+  // --start は初回の再生だけに効かせる。2 周目以降も先頭を飛ばすと、
+  // 「終端に達したら先頭から繰り返す」という --loop の説明と食い違う。
+  let isFirstLap = true;
   do {
-    await play();
+    await play(isFirstLap ? startSec : 0);
+    isFirstLap = false;
   } while (flag('loop') && !stopping);
-  await teardown();
 } catch (e) {
   console.error(`\n${e.message}`);
-  await teardown();
-  process.exit(1);
+  exitCode = 1;
 }
+await teardown();
+process.exit(exitCode);

--- a/scripts/replay-location-gpx.mjs
+++ b/scripts/replay-location-gpx.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// GPX を Android のテストプロバイダ経由で流し込む。
+// 実機・エミュレータのどちらでも動く (adb shell cmd location providers)。
+// 使い方:
+//   npm run gpx:replay -- --gpx ios/SampleTohokuShinkansen.gpx [options]
+import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const argv = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? fallback : argv[i + 1];
+};
+const flag = (name) => argv.includes(`--${name}`);
+
+if (flag('help') || !opt('gpx')) {
+  console.log(`使い方: npm run gpx:replay -- --gpx <file> [options]
+
+  --gpx <path>        再生する GPX (必須)
+  --serial <serial>   adb のデバイスシリアル (省略時は接続中の 1 台)
+  --provider <names>  テストプロバイダ名 (カンマ区切り)。既定 gps,network,fused
+                      Play 開発者サービスの Fused は gps/network を見るため
+                      既定では 3 つすべてに同じ座標を流す
+  --speed <n>         再生倍率。既定 1 (GPX の <time> どおり)
+  --accuracy <m>      水平精度 (m)。既定 8。カンマ区切りで区間ごとに巡回
+  --start <sec>       GPX 先頭からのスキップ秒数
+  --loop              終端に達したら先頭から繰り返す
+  --keep              終了時にテストプロバイダを削除しない`);
+  process.exit(opt('gpx') ? 0 : 1);
+}
+
+const serial = opt('serial');
+const providers = String(opt('provider', 'gps,network,fused'))
+  .split(',')
+  .map((v) => v.trim())
+  .filter(Boolean);
+const speed = Number(opt('speed', '1'));
+const accuracies = String(opt('accuracy', '8'))
+  .split(',')
+  .map((v) => Number(v.trim()))
+  .filter((v) => Number.isFinite(v) && v > 0);
+const startSec = Number(opt('start', '0'));
+
+const adbArgs = (...rest) => (serial ? ['-s', serial, ...rest] : rest);
+const adb = async (...rest) => {
+  const { stdout, stderr } = await execFileAsync('adb', adbArgs(...rest), {
+    maxBuffer: 1 << 22,
+  });
+  return `${stdout}${stderr}`.trim();
+};
+
+// --- GPX 読み込み ---------------------------------------------------------
+const xml = readFileSync(opt('gpx'), 'utf8');
+const points = [];
+const wptRe =
+  /<wpt[^>]*\blat="([-\d.]+)"[^>]*\blon="([-\d.]+)"[^>]*>([\s\S]*?)<\/wpt>/g;
+for (let m; (m = wptRe.exec(xml)); ) {
+  const timeMatch = /<time>([^<]+)<\/time>/.exec(m[3]);
+  points.push({
+    lat: Number(m[1]),
+    lon: Number(m[2]),
+    t: timeMatch ? Date.parse(timeMatch[1]) : null,
+  });
+}
+if (points.length === 0) {
+  console.error('GPX に <wpt> が見つかりません');
+  process.exit(1);
+}
+// <time> が無い GPX は 1Hz とみなす
+const base = points[0].t ?? 0;
+for (const [i, p] of points.entries()) {
+  p.offset = p.t === null ? i * 1000 : p.t - base;
+}
+
+// --- テストプロバイダの準備 ----------------------------------------------
+const loc = (...rest) => adb('shell', 'cmd', 'location', 'providers', ...rest);
+
+async function setup() {
+  const devices = (await adb('devices'))
+    .split('\n')
+    .slice(1)
+    .filter((l) => /\tdevice$/.test(l));
+  if (devices.length === 0) throw new Error('adb に接続中のデバイスがありません');
+  if (!serial && devices.length > 1)
+    throw new Error(`デバイスが複数あります。--serial を指定してください:\n${devices.join('\n')}`);
+
+  await registerProviders();
+  console.log(`テストプロバイダ ${providers.join(', ')} を有効化しました`);
+}
+
+async function registerProviders() {
+  // uid 2000 (adb shell) に MOCK_LOCATION を許可しないと add-test-provider が
+  // SecurityException になる。
+  await adb('shell', 'appops', 'set', '2000', 'android:mock_location', 'allow');
+
+  for (const provider of providers) {
+    await loc('remove-test-provider', provider).catch(() => {});
+    await loc('add-test-provider', provider);
+    await loc('set-test-provider-enabled', provider, 'true');
+  }
+}
+
+async function teardown() {
+  if (flag('keep')) return;
+  for (const provider of providers) {
+    await loc('set-test-provider-enabled', provider, 'false').catch(() => {});
+    await loc('remove-test-provider', provider).catch(() => {});
+  }
+  await adb('shell', 'appops', 'set', '2000', 'android:mock_location', 'default').catch(
+    () => {}
+  );
+  console.log(`\nテストプロバイダ ${providers.join(', ')} を削除しました`);
+}
+
+// --- 再生 -----------------------------------------------------------------
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function play() {
+  const first = points.findIndex((p) => p.offset >= startSec * 1000);
+  const from = first === -1 ? 0 : first;
+  const originOffset = points[from].offset;
+  const wallStart = Date.now();
+
+  for (let i = from; i < points.length; i++) {
+    const p = points[i];
+    const due = wallStart + (p.offset - originOffset) / speed;
+    const wait = due - Date.now();
+    if (wait > 0) await sleep(wait);
+
+    const acc = accuracies[i % accuracies.length];
+    await push(p, acc);
+
+    const elapsed = ((p.offset - originOffset) / 1000).toFixed(0);
+    process.stdout.write(
+      `\r[${i + 1}/${points.length}] +${elapsed}s  ${p.lat.toFixed(5)}, ${p.lon.toFixed(5)}  acc=${acc}m  再登録${reregistrations}回   `
+    );
+  }
+}
+
+// テストプロバイダは走行中に OS 側から外されることがある
+// (Samsung の擬似ロケーション通知の OFF、省電力による location サービス再起動など)。
+// 外れたら黙って再登録してから同じ点を打ち直す。
+let reregistrations = 0;
+async function push(point, acc, retry = true) {
+  // --time は渡さない。ホストと端末の時計がずれていると Samsung の
+  // PositionManager が "ignore mock location for time validation" で捨てるうえ、
+  // handleTrackingLocation の重複破棄 (lastProcessedTimestampMs) にも引っかかる。
+  // 省略すればフレームワークが端末時計で打刻する。
+  const args = (provider) => [
+    'set-test-provider-location',
+    provider,
+    '--location',
+    `${point.lat.toFixed(7)},${point.lon.toFixed(7)}`,
+    '--accuracy',
+    String(acc),
+  ];
+  try {
+    const results = await Promise.all(
+      providers.map((provider) => loc(...args(provider)))
+    );
+    // cmd location は失敗しても終了コード 0 を返し、本文に例外を吐く。
+    if (results.some((out) => out.includes('Exception occurred'))) {
+      throw new Error(results.join('\n'));
+    }
+  } catch (e) {
+    if (!retry) throw e;
+    reregistrations += 1;
+    await registerProviders();
+    await push(point, acc, false);
+  }
+}
+
+let stopping = false;
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, async () => {
+    if (stopping) process.exit(1);
+    stopping = true;
+    await teardown();
+    process.exit(0);
+  });
+}
+
+try {
+  await setup();
+  do {
+    await play();
+  } while (flag('loop') && !stopping);
+  await teardown();
+} catch (e) {
+  console.error(`\n${e.message}`);
+  await teardown();
+  process.exit(1);
+}

--- a/scripts/replay-location-gpx.mjs
+++ b/scripts/replay-location-gpx.mjs
@@ -133,6 +133,15 @@ if (timed.length === 0) {
   }
 }
 
+// --start が GPX の長さを超えていたら、黙って先頭へ戻さずエラーにする。
+// 戻すと「指定位置から再生した」と誤認したまま全区間が流れる。
+const totalMs = points[points.length - 1].offset;
+if (startSec * 1000 > totalMs) {
+  fail(
+    `--start が GPX の長さ (${(totalMs / 1000).toFixed(0)}秒) を超えています: ${startSec}`
+  );
+}
+
 // --- テストプロバイダの準備 ----------------------------------------------
 const loc = (...rest) => adb('shell', 'cmd', 'location', 'providers', ...rest);
 
@@ -257,8 +266,9 @@ async function push(point, acc, retry = true) {
 
 // --- 再生 -----------------------------------------------------------------
 async function play(skipSec) {
-  const first = points.findIndex((p) => p.offset >= skipSec * 1000);
-  const from = first === -1 ? 0 : first;
+  // startSec は上で GPX の長さ以下だと検証済みで、offset は 0 始まりの非減少列
+  // なので、この findIndex は必ず一致する。
+  const from = points.findIndex((p) => p.offset >= skipSec * 1000);
   const originOffset = points[from].offset;
   const wallStart = Date.now();
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

GPX を Android のテストプロバイダへ流し込み、実機・エミュレータの測位パイプラインを実際に通すためのスクリプトとスキルを追加します。

これまで GPX の再生手段は Xcode の Simulate Location だけで、Linux ホストからは iOS シミュレータを起動できないため実質使えませんでした。`adb shell cmd location providers` を使えば実機でも仮の現在地アプリを別途入れずに投入できるので、その経路を整備しました。オートモード (`useSimulationMode`) と違い `locationAtom` へ直書きしないので、`src/store/atoms/location.ts` の速度フィルタ・EMA スムージング・精度フィルタがすべて効いた状態を観測できます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `scripts/replay-location-gpx.mjs` を追加。GPX の `<wpt>` を `<time>` の間隔どおりに `adb shell cmd location providers set-test-provider-location` へ流す。
- `package.json` に `gpx:replay` スクリプトを追加。
- `.claude/skills/replay-gpx/SKILL.md` を追加。GPX の用意からディープリンクでの経路投入、再生、後始末までの手順と落とし穴をまとめた。
- `docs/location-simulation.md` に Android 節を追加し、再現できること・できないことの表を iOS / Android / 実乗車の 3 列に広げた。

アプリ本体 (`src/**` / `android/**` / `ios/**` / `assets/**`) には一切変更がありません。

### 実機で確認した内容

Galaxy SCG13 (Android 16, dev ビルド) で `ios/SampleTohokuShinkansen.gpx` を等速再生しました。

- アプリを冷起動すると現在駅が盛岡になり、東北新幹線・秋田新幹線・田沢湖線・山田線が並んだ。
- DEV OVERLAY の `LOCATION ACCURACY` が `--accuracy` で指定した 8m を表示した。
- 新花巻までの残距離が開始時 33,013m から +84 秒で 14,791m まで減った。

### 実装上の判断

検証中に見つかった挙動を踏まえて、次の 4 点をスクリプトとスキルに反映しています。

- **投入先は `gps` / `network` / `fused` の 3 つ**。Play 開発者サービスの Fused は独自に融合するため、`fused` 単独ではモックが無視されて実測位が優先されました。
- **速度フィルタとの関係を明記**。`MAX_PLAUSIBLE_SPEED` は 100m/s (360km/h) なので、320km/h の GPX を倍速で流すと全点が棄却されて現在地が凍ります。15 倍速で再現しました。
- **テストプロバイダが走行中に OS 側から外れる**ため、検知して自動で再登録し、ログに再登録回数を出します。
- **`--time` は渡さない**。ホストと端末の時計がずれていると Samsung の `PositionManager` が `ignore mock location for time validation` で捨てるうえ、`handleTrackingLocation` の重複破棄にも引っかかります。

### レビュー指摘の反映

CodeRabbit の指摘 5 件をすべて修正しました。

- **引数を再生前に検証する**。`--speed 0` は非有限の待ち時間、`--accuracy foo` は `undefined` の adb 引数、空の `--provider` は 1 点も投入しない正常終了になっていた。不正値は使い方を表示して終了コード 1 で止まる。
- **`<trkpt>` と属性の並び順に対応する**。`lat` が `lon` より前にある `<wpt>` だけを読んでいたため、外部ツールが吐くトラック形式の GPX を拒否していた。自己終了タグも読む。
- **`<time>` の欠損と混在を弾く**。先頭に `<time>` が無く後続にある GPX は、後続点のオフセットが Unix epoch ミリ秒になり事実上停止していた。混在・解釈不能・逆行を検出して中断する。
- **中断時の後始末の競合を解消する**。シグナルハンドラから直接後始末を呼んでいたため、進行中の投入が失敗して再登録に入ると、削除の後でテストプロバイダと `mock_location` の appop が端末に残りうる状態だった。シグナルは停止要求だけにして、再生が畳まれてから後始末を 1 回だけ実行する。私物端末に権限が残る事故を防ぐため優先して直した。
- **`--loop` の 2 周目は先頭から再生する**。`--start` を毎周適用していたため、説明と挙動が食い違っていた。
- **GPX の長さを超える `--start` をエラーにする**。`findIndex` が `-1` を返して先頭へ戻るため、指定位置から再生したつもりで全区間が流れていた。

Galaxy SCG13 で再確認しました。正常終了と `SIGTERM` 中断をそれぞれ 3 回ずつ試し、いずれもテストプロバイダが 0 件になり `mock_location` の appop が `default` へ戻ります。境界値の `--start` (GPX 末尾ちょうど) も末尾 1 点を再生して正常終了します。

### 既知の制約

`cmd location providers` に速度を渡す引数が無く `coords.speed` が埋まらないため、DEV OVERLAY の `CURRENT SPEED` は常に 0km/h を表示します。アプリ内の速度フィルタは座標差分から算出するので影響しません。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

チェック欄は OFF ですが、`npm run lint` と `npm run typecheck` は実行して通っています。`npm test` は `src/**` に変更が無く、追加したのが `scripts/**` の開発者向け CLI とドキュメントのみのため省略しました。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: 変更は `scripts/**`・`docs/**`・`.claude/**`・`package.json` のみで、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfFqbxEsz7sm3zdCqmmP5B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GPXファイルを使用して、Android実機・エミュレータ上で位置情報を再生できるようになりました。
  - 再生速度、開始位置、精度、対象デバイスの指定に対応しました。
  - `<wpt>` と `<trkpt>` の読み込みに対応しました。
  - ループ再生では、開始位置が初回のみ適用されます。
  - `gpx:replay` コマンドから簡単に実行できます。
  - 開始位置が再生範囲外の場合にエラーを表示します。

- **ドキュメント**
  - iOS・Androidの位置情報シミュレーション手順と検証項目を整理しました。
  - Androidでの精度指定や速度に関する制限事項を追記しました。
  - 停止操作後の終了処理と、強制終了時の復旧方法を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

