### PR TITLE
位置テレメトリにアプリバージョン・プラットフォーム・チャネルを付与してTHQ側でビルド間比較できるようにする

### DIFF
--- a/src/hooks/useTelemetrySender.enabled.test.tsx
+++ b/src/hooks/useTelemetrySender.enabled.test.tsx
@@ -379,6 +379,9 @@ describe('useTelemetrySender', () => {
         const input = body.variables.input;
         expect(input.sessionId).toBe('test-session-id');
         expect(input.device).toBe('MockDevice');
+        expect(input.appVersion).toBe('1.0.0(42)');
+        expect(input.platform).toBe('ios');
+        expect(input.channel).toBe('production');
         // useAtomValueのモックが全atomに同じtruthyな値を返すためarrivedになる
         expect(input.state).toBe('arrived');
         expect(input.lineId).toBe(11302);

--- a/src/hooks/useTelemetrySender.ts
+++ b/src/hooks/useTelemetrySender.ts
@@ -43,10 +43,19 @@ const BATTERY_STATE_MAP: Record<Battery.BatteryState, TelemetryBatteryState> = {
   [Battery.BatteryState.NOT_CHARGING]: 'unknown',
 };
 
+// テレメトリ基盤のGraphQL enum Platform
+const TelemetryPlatform = z.enum(['ios', 'android', 'macos', 'unknown']);
+type TelemetryPlatform = z.infer<typeof TelemetryPlatform>;
+
 // テレメトリ基盤のGraphQL LocationEventInputに対応
 const LocationEventInput = z.object({
   sessionId: z.string().min(1),
   device: z.string(),
+  // THQ側でlocation_logs自体にビルド情報を持たせ、log_events等とのjoin無しで
+  // ビルド間比較・集計ができるようにするため送る(THQ#30)
+  appVersion: z.string().min(1),
+  platform: TelemetryPlatform,
+  channel: z.enum(['production', 'canary']),
   state: MovingState,
   stationId: z.number().nullable().optional(),
   lineId: z.number(),
@@ -89,10 +98,6 @@ const SendLocationResponse = z
   .refine((res) => res.data != null || (res.errors?.length ?? 0) > 0, {
     message: 'Either data.sendLocation or non-empty errors is required',
   });
-
-// テレメトリ基盤のGraphQL enum Platform
-const TelemetryPlatform = z.enum(['ios', 'android', 'macos', 'unknown']);
-type TelemetryPlatform = z.infer<typeof TelemetryPlatform>;
 
 // テレメトリ基盤がセッション単位でイベントを紐付けるためのID。
 // フックは複数コンポーネントから使われるため、インスタンス毎ではなく
@@ -422,6 +427,9 @@ export const useTelemetrySender = (
     const payload = LocationEventInput.safeParse({
       sessionId: getOrCreateSessionId(),
       device: Device.modelName ?? 'unknown',
+      appVersion: `${Application.nativeApplicationVersion}(${Application.nativeBuildVersion})`,
+      platform: getTelemetryPlatform(),
+      channel: isDevApp ? 'canary' : 'production',
       state,
       lineId: line.id,
       stationId: station?.id ?? null,


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

THQ#30（テスト乗車を自動回帰チェックにする）の MobileApp 側対応です。`sendLocation` のペイロードに `appVersion` / `platform` / `channel` を付与し、THQ が `location_logs` 自体にビルド情報を持てるようにします。これにより THQ 側の凍結検出クエリが `log_events` との join なしにビルド間比較・集計できます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/hooks/useTelemetrySender.ts`: `LocationEventInput` に `appVersion` / `platform` / `channel` を追加し、`sendTelemetry` の payload に `sendLog` / `sendInteractionEvent` と同じ式で 3 つを付与。`TelemetryPlatform` の宣言を `LocationEventInput` より前に移動（TDZ 回避）
- `src/hooks/useTelemetrySender.enabled.test.tsx`: `sendLocation` の入力に 3 フィールドが載ることのアサーションを追加

**デプロイ順序**: THQ 側の対応 PR（TrainLCD/THQ の `claude/thq-ticket-30-jx257w`）を先にデプロイしてください。旧 THQ サーバーは未知の入力フィールドとして `sendLocation` を拒否します。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint`（733 ファイル、指摘なし）、`npm test -- src/hooks/useTelemetrySender`（4 suites / 25 tests 成功）、`npm run typecheck`（エラーなし）を実行しました。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs TrainLCD/THQ#30

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `src/hooks/**` のテレメトリ送信ペイロードのみの変更で、画面表示に変化はありません

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QH9qF8Fg8z2AZbg8HQHk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH9qF8Fg8z2AZbg8HQHk2T)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 位置情報イベントの送信内容に、アプリバージョン、実行プラットフォーム、環境チャネルが含まれるようになりました。
  * これらの情報が期待どおり送信されることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->