### PR TITLE
警告パネルの既読状態を種別ごとに保持してオートモード通知の再表示を防止

### DIFF
--- a/src/hooks/useWarningInfo.test.tsx
+++ b/src/hooks/useWarningInfo.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useAtomValue } from 'jotai';
+import { STORAGE_KEYS } from '~/constants';
+import { useWarningInfo } from '~/hooks/useWarningInfo';
+import { storage } from '~/lib/storage';
+
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}));
+
+jest.mock('~/store/atoms/station', () => ({
+  __esModule: true,
+  default: { toString: () => 'stationState' },
+  selectedBoundAtom: { toString: () => 'selectedBoundAtom' },
+}));
+
+jest.mock('~/store/atoms/navigation', () => ({
+  __esModule: true,
+  default: { toString: () => 'navigationState' },
+  autoModeEnabledAtom: { toString: () => 'autoModeEnabledAtom' },
+  leftStationsAtom: { toString: () => 'leftStationsAtom' },
+}));
+
+jest.mock('~/store/atoms/tuning', () => ({
+  __esModule: true,
+  default: { toString: () => 'tuningState' },
+}));
+
+jest.mock('~/translation', () => ({
+  __esModule: true,
+  isJapanese: true,
+  translate: (key: string) => key,
+}));
+
+jest.mock('react-native-app-clip', () => ({
+  isClip: () => false,
+}));
+
+jest.mock('expo-location', () => ({
+  ...jest.requireActual('expo-location'),
+  useForegroundPermissions: () => [{ granted: false }],
+}));
+
+const mockUseConnectivity = jest.fn(() => true);
+const mockUseBadAccuracy = jest.fn(() => false);
+const mockUseLocationPermissionsGranted = jest.fn(() => true);
+
+jest.mock('~/hooks/useConnectivity', () => ({
+  useConnectivity: () => mockUseConnectivity(),
+}));
+
+jest.mock('~/hooks/useBadAccuracy', () => ({
+  useBadAccuracy: () => mockUseBadAccuracy(),
+}));
+
+jest.mock('~/hooks/useLocationPermissionsGranted', () => ({
+  useLocationPermissionsGranted: () => mockUseLocationPermissionsGranted(),
+}));
+
+jest.mock('~/hooks/useWrongDirectionDetector', () => ({
+  useWrongDirectionDetector: () => ({
+    isWrongDirection: false,
+    isLoopLineWrongDirection: false,
+  }),
+}));
+
+const mockedUseAtomValue = useAtomValue as jest.Mock;
+
+type AtomValues = {
+  autoModeEnabled: boolean;
+  selectedBound: unknown;
+  untouchableModeEnabled: boolean;
+};
+
+const setAtomValues = ({
+  autoModeEnabled,
+  selectedBound,
+  untouchableModeEnabled,
+}: AtomValues) => {
+  mockedUseAtomValue.mockImplementation((atom: unknown) => {
+    switch (String(atom)) {
+      case 'autoModeEnabledAtom':
+        return autoModeEnabled;
+      case 'selectedBoundAtom':
+        return selectedBound;
+      case 'leftStationsAtom':
+        return [];
+      case 'tuningState':
+        return { untouchableModeEnabled };
+      default:
+        return undefined;
+    }
+  });
+};
+
+describe('useWarningInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // 長押し案内は表示済み扱いにして、オートモード通知の挙動だけを見る
+    storage.set(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED, 'true');
+    mockUseConnectivity.mockReturnValue(true);
+    mockUseBadAccuracy.mockReturnValue(false);
+    mockUseLocationPermissionsGranted.mockReturnValue(true);
+    setAtomValues({
+      autoModeEnabled: true,
+      selectedBound: { id: 1 },
+      untouchableModeEnabled: false,
+    });
+  });
+
+  it('オートモード中は通知パネルを表示する', () => {
+    const { result } = renderHook(() => useWarningInfo());
+    expect(result.current.warningInfo?.text).toBe('autoModeInProgress');
+  });
+
+  it('タップで閉じたオートモード通知は再表示されない', () => {
+    const { result } = renderHook(() => useWarningInfo());
+
+    act(() => {
+      result.current.clearWarningInfo();
+    });
+
+    expect(result.current.warningInfo).toBeNull();
+  });
+
+  it('閉じたオートモード通知はオフライン検知を挟んでも復活しない', () => {
+    const { result, rerender } = renderHook(() => useWarningInfo());
+
+    act(() => {
+      result.current.clearWarningInfo();
+    });
+    expect(result.current.warningInfo).toBeNull();
+
+    // 通信が切れると、オートモード通知ではなくオフライン警告だけが出る
+    mockUseConnectivity.mockReturnValue(false);
+    rerender({});
+    expect(result.current.warningInfo?.text).toBe('offlineWarningText');
+
+    // 通信が復帰してもオートモード通知は閉じたまま
+    mockUseConnectivity.mockReturnValue(true);
+    rerender({});
+    expect(result.current.warningInfo).toBeNull();
+  });
+
+  it('オフライン警告を閉じても、再度オフラインになれば改めて表示される', () => {
+    setAtomValues({
+      autoModeEnabled: false,
+      selectedBound: { id: 1 },
+      untouchableModeEnabled: false,
+    });
+    mockUseConnectivity.mockReturnValue(false);
+    const { result, rerender } = renderHook(() => useWarningInfo());
+    expect(result.current.warningInfo?.text).toBe('offlineWarningText');
+
+    act(() => {
+      result.current.clearWarningInfo();
+    });
+    expect(result.current.warningInfo).toBeNull();
+
+    mockUseConnectivity.mockReturnValue(true);
+    rerender({});
+    mockUseConnectivity.mockReturnValue(false);
+    rerender({});
+    expect(result.current.warningInfo?.text).toBe('offlineWarningText');
+  });
+
+  it('オートモードを切り直すとオートモード通知が改めて表示される', () => {
+    const { result, rerender } = renderHook(() => useWarningInfo());
+
+    act(() => {
+      result.current.clearWarningInfo();
+    });
+    expect(result.current.warningInfo).toBeNull();
+
+    setAtomValues({
+      autoModeEnabled: false,
+      selectedBound: { id: 1 },
+      untouchableModeEnabled: false,
+    });
+    rerender({});
+
+    setAtomValues({
+      autoModeEnabled: true,
+      selectedBound: { id: 1 },
+      untouchableModeEnabled: false,
+    });
+    rerender({});
+
+    expect(result.current.warningInfo?.text).toBe('autoModeInProgress');
+  });
+
+  it('オートモード通知を閉じても、条件が成立した別の警告は表示される', () => {
+    const { result, rerender } = renderHook(() => useWarningInfo());
+
+    act(() => {
+      result.current.clearWarningInfo();
+    });
+
+    mockUseBadAccuracy.mockReturnValue(true);
+    rerender({});
+
+    expect(result.current.warningInfo?.text).toBe('badAccuracy');
+    expect(result.current.warningInfo?.level).toBe('URGENT');
+  });
+});

--- a/src/hooks/useWarningInfo.test.tsx
+++ b/src/hooks/useWarningInfo.test.tsx
@@ -37,9 +37,11 @@ jest.mock('react-native-app-clip', () => ({
   isClip: () => false,
 }));
 
+const mockUseForegroundPermissions = jest.fn(() => ({ granted: false }));
+
 jest.mock('expo-location', () => ({
   ...jest.requireActual('expo-location'),
-  useForegroundPermissions: () => [{ granted: false }],
+  useForegroundPermissions: () => [mockUseForegroundPermissions()],
 }));
 
 const mockUseConnectivity = jest.fn(() => true);
@@ -102,6 +104,7 @@ describe('useWarningInfo', () => {
     mockUseConnectivity.mockReturnValue(true);
     mockUseBadAccuracy.mockReturnValue(false);
     mockUseLocationPermissionsGranted.mockReturnValue(true);
+    mockUseForegroundPermissions.mockReturnValue({ granted: false });
     setAtomValues({
       autoModeEnabled: true,
       selectedBound: { id: 1 },
@@ -188,6 +191,47 @@ describe('useWarningInfo', () => {
     rerender({});
 
     expect(result.current.warningInfo?.text).toBe('autoModeInProgress');
+  });
+
+  describe('長押し案内が未読の場合', () => {
+    beforeEach(() => {
+      storage.remove(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED);
+    });
+
+    it('長押し案内を閉じたときだけ既読状態が永続化される', () => {
+      const { result } = renderHook(() => useWarningInfo());
+      expect(result.current.warningInfo?.text).toBe('longPressNotice');
+
+      act(() => {
+        result.current.clearWarningInfo();
+      });
+
+      expect(storage.getString(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED)).toBe(
+        'true'
+      );
+      // 長押し案内を閉じると、次点のオートモード通知へ切り替わる
+      expect(result.current.warningInfo?.text).toBe('autoModeInProgress');
+    });
+
+    it('権限警告を閉じても長押し案内は既読にならない', () => {
+      // 位置情報の常時許可が無い状態にして、長押し案内より上位の警告を出す
+      mockUseForegroundPermissions.mockReturnValue({ granted: true });
+      mockUseLocationPermissionsGranted.mockReturnValue(false);
+
+      const { result } = renderHook(() => useWarningInfo());
+      expect(result.current.warningInfo?.text).toBe(
+        'alwaysPermissionNotGrantedPanelText'
+      );
+
+      act(() => {
+        result.current.clearWarningInfo();
+      });
+
+      expect(
+        storage.getString(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED)
+      ).toBeUndefined();
+      expect(result.current.warningInfo?.text).toBe('longPressNotice');
+    });
   });
 
   it('オートモード通知を閉じても、条件が成立した別の警告は表示される', () => {

--- a/src/hooks/useWarningInfo.ts
+++ b/src/hooks/useWarningInfo.ts
@@ -91,8 +91,10 @@ export const useWarningInfo = () => {
     [leftStations]
   );
 
-  // 現在成立している警告を優先度順に並べる。表示するのはこの中で
-  // まだ閉じられていない先頭の1件。
+  // 現在成立している警告を表示優先度順(=登録順)に並べる。表示するのはこの中で
+  // まだ閉じられていない先頭の1件。順序は従来の if チェーンと同一で、
+  // level とは独立している(例: オートモード通知(INFO)は逆走警告(URGENT)より前)。
+  // 逆走・低精度はオートモード中は成立しないため、この順序で問題にならない。
   const candidates = useMemo<readonly WarningCandidate[]>(() => {
     const list: WarningCandidate[] = [];
 
@@ -233,16 +235,26 @@ export const useWarningInfo = () => {
     [currentWarning]
   );
 
+  // 副作用は閉じた種別に対応するものだけに限定する。どの警告を閉じても
+  // 長押し案内を既読にしていると、一度も表示しないまま永続的に既読化してしまう。
   const clearWarningInfo = useCallback(() => {
     const dismissedKind = currentWarning?.kind;
-    if (dismissedKind) {
-      setDismissedKinds((prev) =>
-        prev.includes(dismissedKind) ? prev : [...prev, dismissedKind]
-      );
+    if (!dismissedKind) {
+      return;
     }
-    setScreenshotTaken(false);
 
-    if (!longPressNoticeDismissed) {
+    setDismissedKinds((prev) =>
+      prev.includes(dismissedKind) ? prev : [...prev, dismissedKind]
+    );
+
+    if (dismissedKind === WARNING_KIND.SHARE_NOTICE) {
+      setScreenshotTaken(false);
+    }
+
+    if (
+      dismissedKind === WARNING_KIND.LONG_PRESS_NOTICE &&
+      !longPressNoticeDismissed
+    ) {
       setLongPressNoticeDismissed(true);
       storage.set(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED, 'true');
     }

--- a/src/hooks/useWarningInfo.ts
+++ b/src/hooks/useWarningInfo.ts
@@ -23,8 +23,38 @@ const WARNING_PANEL_LEVEL = {
   INFO: 'INFO',
 } as const;
 
+// タップして閉じた警告を種別ごとに記録するためのキー。
+// 単一の真偽値で「閉じた」を管理していると、別の警告を出すためのリセットが
+// 閉じたはずの警告まで復活させてしまう(例: 一時的なオフライン検知のたびに
+// オートモード中の常設通知が再表示される)ため、種別単位で保持する。
+const WARNING_KIND = {
+  ALWAYS_PERMISSION_NOT_GRANTED: 'ALWAYS_PERMISSION_NOT_GRANTED',
+  LONG_PRESS_NOTICE: 'LONG_PRESS_NOTICE',
+  AUTO_MODE: 'AUTO_MODE',
+  OFFLINE: 'OFFLINE',
+  WRONG_DIRECTION: 'WRONG_DIRECTION',
+  WRONG_DIRECTION_LOOP_LINE: 'WRONG_DIRECTION_LOOP_LINE',
+  BAD_ACCURACY: 'BAD_ACCURACY',
+  PARTIALLY_PASS: 'PARTIALLY_PASS',
+  SHARE_NOTICE: 'SHARE_NOTICE',
+  UNTOUCHABLE_MODE: 'UNTOUCHABLE_MODE',
+} as const;
+
+type WarningKind = (typeof WARNING_KIND)[keyof typeof WARNING_KIND];
+type WarningLevel =
+  (typeof WARNING_PANEL_LEVEL)[keyof typeof WARNING_PANEL_LEVEL];
+
+type WarningCandidate = {
+  kind: WarningKind;
+  level: WarningLevel;
+  // 表示対象に選ばれた1件だけ翻訳を引くための遅延評価
+  getText: () => string;
+};
+
 export const useWarningInfo = () => {
-  const [warningDismissed, setWarningDismissed] = useState(false);
+  const [dismissedKinds, setDismissedKinds] = useState<readonly WarningKind[]>(
+    []
+  );
   const [longPressNoticeDismissed, setLongPressNoticeDismissed] = useState(
     () => storage.getString(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED) === 'true'
   );
@@ -61,102 +91,104 @@ export const useWarningInfo = () => {
     [leftStations]
   );
 
-  useEffect(() => {
-    if (autoModeEnabled) {
-      setWarningDismissed(false);
-    }
-  }, [autoModeEnabled]);
-
-  useEffect(() => {
-    if (!isInternetAvailable) {
-      setWarningDismissed(false);
-    }
-  }, [isInternetAvailable]);
-
-  const warningInfo = useMemo(() => {
-    if (warningDismissed) {
-      return null;
-    }
+  // 現在成立している警告を優先度順に並べる。表示するのはこの中で
+  // まだ閉じられていない先頭の1件。
+  const candidates = useMemo<readonly WarningCandidate[]>(() => {
+    const list: WarningCandidate[] = [];
 
     // NOTE: フォアグラウンドも許可しない設定の場合はそもそもオートモード前提で使われていると思うので警告は不要
-    if (fgPermStatus?.granted) {
-      if (
-        !bgPermGranted &&
-        !isAlwaysPermissionNotGrantedDismissed &&
-        !!selectedBound &&
-        !isClip()
-      ) {
-        return {
-          level: WARNING_PANEL_LEVEL.WARNING,
-          text: translate('alwaysPermissionNotGrantedPanelText'),
-        };
-      }
+    if (
+      fgPermStatus?.granted &&
+      !bgPermGranted &&
+      !isAlwaysPermissionNotGrantedDismissed &&
+      !!selectedBound &&
+      !isClip()
+    ) {
+      list.push({
+        kind: WARNING_KIND.ALWAYS_PERMISSION_NOT_GRANTED,
+        level: WARNING_PANEL_LEVEL.WARNING,
+        getText: () => translate('alwaysPermissionNotGrantedPanelText'),
+      });
     }
 
     if (!longPressNoticeDismissed && selectedBound) {
-      return {
+      list.push({
+        kind: WARNING_KIND.LONG_PRESS_NOTICE,
         level: WARNING_PANEL_LEVEL.INFO,
-        text: translate('longPressNotice'),
-      };
+        getText: () => translate('longPressNotice'),
+      });
     }
 
     if (autoModeEnabled) {
-      return {
+      list.push({
+        kind: WARNING_KIND.AUTO_MODE,
         level: WARNING_PANEL_LEVEL.INFO,
-        text: translate('autoModeInProgress'),
-      };
+        getText: () => translate('autoModeInProgress'),
+      });
     }
 
     if (!isInternetAvailable && selectedBound) {
-      return {
+      list.push({
+        kind: WARNING_KIND.OFFLINE,
         level: WARNING_PANEL_LEVEL.WARNING,
-        text: translate('offlineWarningText'),
-      };
+        getText: () => translate('offlineWarningText'),
+      });
     }
 
     if (isWrongDirection) {
-      return {
+      list.push({
+        kind: WARNING_KIND.WRONG_DIRECTION,
         level: WARNING_PANEL_LEVEL.URGENT,
-        text: translate('wrongDirectionWarning'),
-      };
+        getText: () => translate('wrongDirectionWarning'),
+      });
     }
+
     if (isLoopLineWrongDirection) {
-      return {
+      list.push({
+        kind: WARNING_KIND.WRONG_DIRECTION_LOOP_LINE,
         level: WARNING_PANEL_LEVEL.WARNING,
-        text: translate('wrongDirectionLoopLineWarning'),
-      };
+        getText: () => translate('wrongDirectionLoopLineWarning'),
+      });
     }
+
     if (badAccuracy) {
-      return {
+      list.push({
+        kind: WARNING_KIND.BAD_ACCURACY,
         level: WARNING_PANEL_LEVEL.URGENT,
-        text: translate('badAccuracy'),
-      };
+        getText: () => translate('badAccuracy'),
+      });
     }
+
     if (passStations.length > 0 && selectedBound) {
-      return {
+      list.push({
+        kind: WARNING_KIND.PARTIALLY_PASS,
         level: WARNING_PANEL_LEVEL.INFO,
-        text: translate('partiallyPassPanelNotice', {
-          stations: isJapanese
-            ? passStations.map((s) => s.name).join('、')
-            : ` ${passStations.map((s) => s.nameRoman).join(', ')}`,
-        }),
-      };
+        getText: () =>
+          translate('partiallyPassPanelNotice', {
+            stations: isJapanese
+              ? passStations.map((s) => s.name).join('、')
+              : ` ${passStations.map((s) => s.nameRoman).join(', ')}`,
+          }),
+      });
     }
 
     if (screenshotTaken) {
-      return {
+      list.push({
+        kind: WARNING_KIND.SHARE_NOTICE,
         level: WARNING_PANEL_LEVEL.INFO,
-        text: translate('shareNotice'),
-      };
+        getText: () => translate('shareNotice'),
+      });
     }
 
     if (untouchableModeEnabled) {
-      return {
+      list.push({
+        kind: WARNING_KIND.UNTOUCHABLE_MODE,
         level: WARNING_PANEL_LEVEL.INFO,
-        text: translate('untouchableModeEnabledNotice'),
-      };
+        getText: () => translate('untouchableModeEnabledNotice'),
+      });
     }
-    return null;
+
+    return list;
   }, [
     autoModeEnabled,
     badAccuracy,
@@ -169,20 +201,52 @@ export const useWarningInfo = () => {
     longPressNoticeDismissed,
     screenshotTaken,
     selectedBound,
-    warningDismissed,
     untouchableModeEnabled,
     passStations,
   ]);
 
+  // 条件が解消された警告は「閉じた」記録を捨て、再発時に改めて表示できるようにする。
+  // オートモードのように条件が継続する通知は記録が残り続けるため、一度閉じたら
+  // オートモードを切り替え直すまで再表示されない。
+  useEffect(() => {
+    setDismissedKinds((prev) => {
+      const next = prev.filter((kind) =>
+        candidates.some((candidate) => candidate.kind === kind)
+      );
+      return next.length === prev.length ? prev : next;
+    });
+  }, [candidates]);
+
+  const currentWarning = useMemo(
+    () =>
+      candidates.find(
+        (candidate) => !dismissedKinds.includes(candidate.kind)
+      ) ?? null,
+    [candidates, dismissedKinds]
+  );
+
+  const warningInfo = useMemo(
+    () =>
+      currentWarning
+        ? { level: currentWarning.level, text: currentWarning.getText() }
+        : null,
+    [currentWarning]
+  );
+
   const clearWarningInfo = useCallback(() => {
-    setWarningDismissed(true);
+    const dismissedKind = currentWarning?.kind;
+    if (dismissedKind) {
+      setDismissedKinds((prev) =>
+        prev.includes(dismissedKind) ? prev : [...prev, dismissedKind]
+      );
+    }
     setScreenshotTaken(false);
 
     if (!longPressNoticeDismissed) {
       setLongPressNoticeDismissed(true);
       storage.set(STORAGE_KEYS.LONG_PRESS_NOTICE_DISMISSED, 'true');
     }
-  }, [longPressNoticeDismissed]);
+  }, [currentWarning, longPressNoticeDismissed]);
 
   return { warningInfo, clearWarningInfo };
 };


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

オートモード中に表示される「オートモードで動作中です。…」の通知パネルが、タップして閉じても数十秒おきに何度も再表示される不具合を修正します。

原因は `useWarningInfo` が「閉じた」状態を単一の真偽値 `warningDismissed` で持っていたことです。この真偽値には別種の警告を出すためのリセットがぶら下がっており、通信断を検知するたびに `setWarningDismissed(false)` が走っていました。

```ts
useEffect(() => {
  if (!isInternetAvailable) {
    setWarningDismissed(false);
  }
}, [isInternetAvailable]);
```

一方で警告の優先度は `長押し案内 > オートモード通知 > オフライン警告 > …` の順です。そのため **オフライン警告を出すためのリセットが、それより上位のオートモード通知まで復活させていました**。乗車中はトンネルやハンドオーバーで `isConnected` が数十秒間隔で false へ落ちるため、閉じたはずのオートモード通知が繰り返し出てくることになります。報告された症状でオフライン警告ではなくオートモード通知が出ていた点が、この取り違えの裏付けです。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- 既読状態を単一の真偽値から **種別ごとの記録**（`WARNING_KIND`）へ変更。
- 成立中の警告を表示優先度順（＝登録順。従来の `if` チェーンと同一で `level` とは独立）の候補リストとして組み立て、**まだ閉じられていない先頭の1件**を表示する方式に変更。翻訳の取得は表示対象に選ばれた1件だけ遅延評価する。
- 条件が解消された警告のみ既読記録を破棄し、再発時に改めて表示できるようにした。オートモードのように条件が継続する通知は記録が残るため、**一度タップしたらオートモードを切り替え直すまで再表示されない**。
- リセット用の 2 つの `useEffect`（`autoModeEnabled` / `isInternetAvailable`）を廃止。オートモードを ON し直したときに通知が再表示される従来の意図は、上記の「条件が解消されたら記録を破棄する」規則がそのまま引き継ぐ。
- **`clearWarningInfo` の副作用を閉じた種別に限定**（`27ecfc4`、CodeRabbit の指摘対応）。`screenshotTaken` のリセットは `SHARE_NOTICE`、長押し案内の既読永続化は `LONG_PRESS_NOTICE` を閉じたときだけ実行する。従来はどの警告を閉じても長押し案内が既読化され、一度も表示されないまま永続的に消えることがあった。
- 副次的な改善として、オートモード通知を閉じた後にオフラインになれば今度はオフライン警告が表示される（従来は上位のオートモード通知に隠れて出なかった）。逆走・低精度などの URGENT 警告も、別の通知を閉じた巻き添えで握り潰されなくなる。
- 回帰テスト `src/hooks/useWarningInfo.test.tsx` を新規追加（8 件）。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

追加した 8 件のうち以下の 3 件は、**修正前の実装では失敗する**ことを確認済みです（該当箇所を修正前のコードへ差し戻して実行して確認）。

| テスト | 検出する不具合 |
| --- | --- |
| 閉じたオートモード通知はオフライン検知を挟んでも復活しない | 本 PR が対象とする再表示バグ（報告症状そのもの） |
| オートモード通知を閉じても、条件が成立した別の警告は表示される | 既読化が全種別に波及して他の警告が出なくなる問題 |
| 権限警告を閉じても長押し案内は既読にならない | 長押し案内が未表示のまま永続的に既読化される問題 |

`npm test` の結果: 271 suites / 2946 tests すべて成功。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Closes #6907

報告内容の詳細は非公開の管理チケット側にあるため公開できませんが、対応関係は次のとおりです。報告された症状「オートモード中に通知が数十秒に1回出てくる」に対し、原因（上記の既読状態リセット）を特定して修正し、その症状を再現する回帰テストを追加しています。仕様上は一度タップしたら再表示されないため、この症状はバグとして扱っています。

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

未添付: 変更は警告パネルの表示タイミング（既読状態の管理）のみで、パネル自体のレイアウト・文言・配色は一切変更していません。差分は「閉じた通知が時間経過後に再び出るかどうか」という時間軸上の挙動なので、静止画では示せません。挙動の確認は `src/hooks/useWarningInfo.test.tsx` の回帰テストで担保しています。手元で確認する場合は「オートモード ON → 通知をタップして閉じる → 機内モードを数回 ON/OFF」で再現できます。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFUBY2SJssJpQaFQVkixk7
