### PR TITLE
測位が速度を持たない場合にDEV OVERLAYの速度を変位から算出して表示

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -657,4 +657,94 @@ describe('DevOverlay', () => {
       );
     });
   });
+
+  // Androidのテストプロバイダ経由の測位(GPX再生)はcoords.speedを運んでこず、
+  // 欠測がnullではなく0として届く。実測が取れない間だけ変位から算出した値へ落とす。
+  describe('実測速度が得られない場合のフォールバック', () => {
+    const movingSample = (latitude: number, timestamp: number) => ({
+      coords: { latitude, longitude: 139, speed: 0, accuracy: 8 },
+      timestamp,
+    });
+
+    // DevOverlayはReact.memoでpropsを持たないため、rerender()では再描画されない。
+    // 常駐の1秒ティック(nowTick)を進めて、モックし直したatom値を読ませる。
+    const advanceOneTick = () => {
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    };
+
+    it('coords.speedが0のまま動いている場合は変位から算出した速度を表示する', () => {
+      jest.useFakeTimers();
+      try {
+        setupAtomValues({ rawLocation: movingSample(35, 1000) });
+        const { getByTestId } = render(<DevOverlay />);
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '0km/h'
+        );
+
+        // 緯度0.0009度 ≒ 100m を1秒。100m/s = 360km/h
+        setupAtomValues({ rawLocation: movingSample(35.0009, 2000) });
+        advanceOneTick();
+
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '360km/h'
+        );
+        expect(getByTestId('dev-overlay-speed-meta')).toHaveTextContent(
+          '変位から算出'
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('実測速度を一度でも観測したら以降は実測値を使い続ける', () => {
+      jest.useFakeTimers();
+      try {
+        setupAtomValues({
+          rawLocation: {
+            coords: { latitude: 35, longitude: 139, speed: 10, accuracy: 8 },
+            timestamp: 1000,
+          },
+        });
+        const { getByTestId, queryByTestId } = render(<DevOverlay />);
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '36km/h'
+        );
+
+        // 停車して速度が0になっても、変位由来の値では上書きしない
+        setupAtomValues({
+          rawLocation: {
+            coords: {
+              latitude: 35.0009,
+              longitude: 139,
+              speed: 0,
+              accuracy: 8,
+            },
+            timestamp: 2000,
+          },
+        });
+        advanceOneTick();
+
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '0km/h'
+        );
+        expect(queryByTestId('dev-overlay-speed-meta')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('実測が無く算出もできない間は出所ラベルを出さない', () => {
+      setupAtomValues({
+        rawLocation: {
+          coords: { latitude: 35, longitude: 139, speed: 0, accuracy: 8 },
+          timestamp: 1000,
+        },
+      });
+      const { getByTestId, queryByTestId } = render(<DevOverlay />);
+      expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent('0km/h');
+      expect(queryByTestId('dev-overlay-speed-meta')).toBeNull();
+    });
+  });
 });

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -735,6 +735,54 @@ describe('DevOverlay', () => {
       }
     });
 
+    it('オートモードの切り替えで測位ソースが変わったら判定と基準をやり直す', () => {
+      jest.useFakeTimers();
+      try {
+        // オートモード中はシミュレーションが必ず速度を持つため実測扱いになる
+        setupAtomValues({
+          location: {
+            coords: { latitude: 35, longitude: 139, speed: 25, accuracy: 0 },
+            timestamp: 1000,
+          },
+          autoModeEnabled: true,
+        });
+        const { getByTestId, queryByTestId } = render(<DevOverlay />);
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '90km/h'
+        );
+
+        // オートモードを抜けるとrawLocationAtomへ参照が移る。シミュレーション由来の
+        // 実測フラグを持ち越すと、速度を運んでこない測位でも0km/hに固定されてしまう。
+        // ソースが変わった直後は基準も無いため、変位からの算出値も出さない
+        setupAtomValues({
+          rawLocation: movingSample(35.05, 2000),
+          autoModeEnabled: false,
+        });
+        advanceOneTick();
+
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '0km/h'
+        );
+        expect(queryByTestId('dev-overlay-speed-meta')).toBeNull();
+
+        // 同じソースで2点そろってから算出値へ落ちる
+        setupAtomValues({
+          rawLocation: movingSample(35.0509, 3000),
+          autoModeEnabled: false,
+        });
+        advanceOneTick();
+
+        expect(getByTestId('dev-overlay-speed-value')).toHaveTextContent(
+          '360km/h'
+        );
+        expect(getByTestId('dev-overlay-speed-meta')).toHaveTextContent(
+          '変位から算出'
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('実測が無く算出もできない間は出所ラベルを出さない', () => {
       setupAtomValues({
         rawLocation: {

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -1,5 +1,6 @@
 import * as Application from 'expo-application';
 import { LinearGradient } from 'expo-linear-gradient';
+import type * as Location from 'expo-location';
 import { useAtomValue } from 'jotai';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -28,6 +29,10 @@ import {
   rawLocationAtom,
 } from '~/store/atoms/location';
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
+import {
+  getDisplacementSpeed,
+  hasMeasuredSpeed,
+} from '~/utils/displacementSpeed';
 import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
 import AccuracyHistoryChart from './AccuracyHistoryChart';
 import Typography from './Typography';
@@ -345,6 +350,39 @@ const DevOverlay: React.FC = () => {
   const location = autoModeEnabled ? simulatedLocation : rawLocation;
   const speed = location?.coords?.speed;
   const accuracy = location?.coords?.accuracy;
+
+  // Androidのテストプロバイダ経由の測位はcoords.speedを運んでこない。
+  // cmd location providersに速度を渡す引数が無く、expo-locationがLocation#getSpeed()を
+  // 素通しするため、欠測はnullではなく0として届く（=値だけでは停車と区別できない）。
+  // そこで「正の速度を一度でも観測したか」で実測の有無を判定し、観測できたなら以降は
+  // 0（停車）も含めて実測を使い続ける。観測できない間だけ変位からの算出値へ落とす。
+  const [hasEverMeasuredSpeed, setHasEverMeasuredSpeed] = useState(false);
+  const [displacementSpeed, setDisplacementSpeed] = useState<number | null>(
+    null
+  );
+  const prevSpeedSampleRef = useRef<Location.LocationObject | null>(null);
+
+  useEffect(() => {
+    if (!location) {
+      // 測位が途切れたら基準も判定もやり直す。復帰後の1点目を古い基準と突き合わせると、
+      // 途切れていた時間ぶんならした速度が出てしまう。
+      prevSpeedSampleRef.current = null;
+      setDisplacementSpeed(null);
+      setHasEverMeasuredSpeed(false);
+      return;
+    }
+
+    if (hasMeasuredSpeed(location.coords.speed)) {
+      setHasEverMeasuredSpeed(true);
+    }
+
+    const derived = getDisplacementSpeed(prevSpeedSampleRef.current, location);
+    prevSpeedSampleRef.current = location;
+    // 算出不能（同一タイムスタンプの再配信など）のときは前回値を残す
+    if (derived != null) {
+      setDisplacementSpeed(derived);
+    }
+  }, [location]);
   const distanceToNextStation = useDistanceToNextStation();
   const nextStation = useNextStation(false);
   const isTelemetryEnabled = useTelemetryEnabled();
@@ -358,7 +396,9 @@ const DevOverlay: React.FC = () => {
   const etaPhase = useMemo(() => getEtaPhaseNow(nowTick), [nowTick]);
   const etaAnchor = useAtomValue(etaAnchorAtom);
 
-  const coordsSpeed = ((speed ?? 0) < 0 ? 0 : speed) ?? 0;
+  const effectiveSpeed = hasEverMeasuredSpeed
+    ? Math.max(0, speed ?? 0)
+    : (displacementSpeed ?? 0);
   const accuracyMeters =
     accuracy != null ? Math.max(0, Math.floor(accuracy)) : null;
   // 最大許容精度のフィルタに関係なく生の精度を判定し、許容値を超えたら赤字で警告する。
@@ -373,13 +413,14 @@ const DevOverlay: React.FC = () => {
     accuracy <= maxPermitAccuracy;
 
   const speedKMH = useMemo(
-    () =>
-      (
-        (speed && Math.round((coordsSpeed * 3600) / 1000)) ??
-        0
-      ).toLocaleString(),
-    [coordsSpeed, speed]
+    () => Math.round((effectiveSpeed * 3600) / 1000).toLocaleString(),
+    [effectiveSpeed]
   );
+  // 算出値は停車中の測位ゆらぎでも値が立つため、実測と読み違えないよう出所を添える
+  const speedMeta =
+    !hasEverMeasuredSpeed && displacementSpeed != null
+      ? '変位から算出'
+      : undefined;
 
   // 最新の測位精度を ref で保持し、setInterval から常に最新値を参照できるようにする
   const latestAccuracyRef = useRef<number | null | undefined>(accuracy);
@@ -815,6 +856,8 @@ const DevOverlay: React.FC = () => {
                     label="CURRENT SPEED"
                     value={speedKMH}
                     suffix="km/h"
+                    meta={speedMeta}
+                    metaTestID="dev-overlay-speed-meta"
                     style={[{ width: leftMetricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-speed-value"
                     labelStyle={metricLabelStyle}
@@ -900,6 +943,8 @@ const DevOverlay: React.FC = () => {
                     label="CURRENT SPEED"
                     value={speedKMH}
                     suffix="km/h"
+                    meta={speedMeta}
+                    metaTestID="dev-overlay-speed-meta"
                     style={[{ width: metricWidth }, metricCardStyle]}
                     valueTestID="dev-overlay-speed-value"
                     labelStyle={metricLabelStyle}

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -361,10 +361,28 @@ const DevOverlay: React.FC = () => {
     null
   );
   const prevSpeedSampleRef = useRef<Location.LocationObject | null>(null);
+  // 直近に読んでいた測位ソース。オートモードの切り替えで参照元がlocationAtomと
+  // rawLocationAtomの間を移るため、ソースをまたいだサンプルで速度を出さないよう見張る。
+  const prevSpeedSourceRef = useRef<'simulated' | 'raw' | null>(null);
 
   useEffect(() => {
+    // 測位ソースが変わったら基準も判定もやり直す。オートモードのシミュレーションと
+    // GPSの継続測位ではタイムスタンプの系列も速度の有無も異なり、両者をまたいで
+    // 変位を取ると無意味な速度になる。実測の有無もソースごとに判断し直す
+    // （シミュレーションは常に速度を持つため、そのフラグをGPS側へ持ち越すと
+    // 速度を運んでこない測位でも実測扱いのまま0km/hに固定されてしまう）。
+    const speedSource = autoModeEnabled ? 'simulated' : 'raw';
+    const isSourceChanged = prevSpeedSourceRef.current !== speedSource;
+    prevSpeedSourceRef.current = speedSource;
+
+    if (isSourceChanged) {
+      prevSpeedSampleRef.current = null;
+      setDisplacementSpeed(null);
+      setHasEverMeasuredSpeed(false);
+    }
+
     if (!location) {
-      // 測位が途切れたら基準も判定もやり直す。復帰後の1点目を古い基準と突き合わせると、
+      // 測位が途切れたときも同様。復帰後の1点目を古い基準と突き合わせると、
       // 途切れていた時間ぶんならした速度が出てしまう。
       prevSpeedSampleRef.current = null;
       setDisplacementSpeed(null);
@@ -382,7 +400,7 @@ const DevOverlay: React.FC = () => {
     if (derived != null) {
       setDisplacementSpeed(derived);
     }
-  }, [location]);
+  }, [location, autoModeEnabled]);
   const distanceToNextStation = useDistanceToNextStation();
   const nextStation = useNextStation(false);
   const isTelemetryEnabled = useTelemetryEnabled();

--- a/src/utils/displacementSpeed.test.ts
+++ b/src/utils/displacementSpeed.test.ts
@@ -1,0 +1,78 @@
+import type * as Location from 'expo-location';
+import { getDisplacementSpeed, hasMeasuredSpeed } from './displacementSpeed';
+
+const sample = (
+  latitude: number,
+  longitude: number,
+  timestamp: number
+): Pick<Location.LocationObject, 'coords' | 'timestamp'> =>
+  ({
+    coords: { latitude, longitude },
+    timestamp,
+  }) as Pick<Location.LocationObject, 'coords' | 'timestamp'>;
+
+describe('getDisplacementSpeed', () => {
+  it('基準が無い場合はnullを返す', () => {
+    expect(getDisplacementSpeed(null, sample(35, 139, 1000))).toBeNull();
+    expect(getDisplacementSpeed(undefined, sample(35, 139, 1000))).toBeNull();
+  });
+
+  it('現在値が無い場合はnullを返す', () => {
+    expect(getDisplacementSpeed(sample(35, 139, 1000), null)).toBeNull();
+  });
+
+  it('経過時間が0以下の場合はnullを返す', () => {
+    // 同一タイムスタンプの再配信。0除算でInfinityを出さないこと
+    expect(
+      getDisplacementSpeed(sample(35, 139, 1000), sample(35.001, 139, 1000))
+    ).toBeNull();
+    expect(
+      getDisplacementSpeed(sample(35, 139, 2000), sample(35.001, 139, 1000))
+    ).toBeNull();
+  });
+
+  it('タイムスタンプが欠けている場合はnullを返す', () => {
+    const broken = {
+      coords: { latitude: 35, longitude: 139 },
+    } as Pick<Location.LocationObject, 'coords' | 'timestamp'>;
+    expect(getDisplacementSpeed(broken, sample(35.001, 139, 1000))).toBeNull();
+  });
+
+  it('変位と経過時間から速度(m/s)を返す', () => {
+    // 緯度1度は約111.32km。0.0009度 ≒ 100m を1秒で進む
+    const speed = getDisplacementSpeed(
+      sample(35, 139, 1000),
+      sample(35.0009, 139, 2000)
+    );
+    expect(speed).not.toBeNull();
+    expect(speed as number).toBeCloseTo(100, 0);
+  });
+
+  it('停止している場合は0を返す', () => {
+    expect(
+      getDisplacementSpeed(sample(35, 139, 1000), sample(35, 139, 2000))
+    ).toBe(0);
+  });
+
+  it('複数秒空いた場合はその間の平均速度になる', () => {
+    const speed = getDisplacementSpeed(
+      sample(35, 139, 1000),
+      sample(35.0009, 139, 3000)
+    );
+    expect(speed as number).toBeCloseTo(50, 0);
+  });
+});
+
+describe('hasMeasuredSpeed', () => {
+  it.each([null, undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    '%p は実測とみなさない',
+    (value) => {
+      expect(hasMeasuredSpeed(value)).toBe(false);
+    }
+  );
+
+  it('正の有限値は実測とみなす', () => {
+    expect(hasMeasuredSpeed(0.1)).toBe(true);
+    expect(hasMeasuredSpeed(88.9)).toBe(true);
+  });
+});

--- a/src/utils/displacementSpeed.ts
+++ b/src/utils/displacementSpeed.ts
@@ -1,0 +1,52 @@
+import type * as Location from 'expo-location';
+import getDistance from 'geolib/es/getDistance';
+
+type SpeedSample = Pick<Location.LocationObject, 'coords' | 'timestamp'>;
+
+// 測位が速度を運んでこない環境向けに、直近 2 点の変位から速度(m/s)を求める。
+//
+// Android のテストプロバイダ(`adb shell cmd location providers`)には速度を渡す
+// 引数が無い。`set-test-provider-location` が受けるのは --location / --accuracy /
+// --time だけで、`add-test-provider --supportsSpeed` はプロバイダの能力を宣言する
+// だけの値である。さらに expo-location は `Location#getSpeed()` を素通しするため
+// (LocationResults.kt)、速度が無い測位は null ではなく 0 として届く。
+// 結果として GPX 再生中は DEV OVERLAY の速度が 0km/h に張り付く。
+//
+// 実測の速度が取れているならそちらが常に優先で、この算出値は実測が出てこない間の
+// 代替にすぎない。呼び出し側(DevOverlay)が実測の有無を判定して使い分ける。
+export const getDisplacementSpeed = (
+  prev: SpeedSample | null | undefined,
+  current: SpeedSample | null | undefined
+): number | null => {
+  if (!prev || !current) {
+    return null;
+  }
+
+  // 同一タイムスタンプの再配信では変位も経過時間も意味を持たない。
+  // 0 除算で Infinity を出すより、算出不能として前回値を残させる。
+  const dt = (current.timestamp - prev.timestamp) / 1000;
+  if (!Number.isFinite(dt) || dt <= 0) {
+    return null;
+  }
+
+  const dist = getDistance(
+    { latitude: prev.coords.latitude, longitude: prev.coords.longitude },
+    {
+      latitude: current.coords.latitude,
+      longitude: current.coords.longitude,
+    }
+  );
+  if (!Number.isFinite(dist)) {
+    return null;
+  }
+
+  return dist / dt;
+};
+
+// 測位が「実際に速度を持っている」と言えるかを判定する。
+// Android は速度が未設定でも 0 を返すため、0 と欠測を値だけでは区別できない。
+// 正の値を一度でも観測できたかどうかで判断し、観測できた以降は 0(停車)も
+// 実測として扱う ―― 判定を呼び出し側で保持させるための述語。
+export const hasMeasuredSpeed = (
+  speed: number | null | undefined
+): speed is number => speed != null && Number.isFinite(speed) && speed > 0;


### PR DESCRIPTION
## 概要

DEV OVERLAY の `CURRENT SPEED` が、測位が速度を運んでこない環境で 0km/h に張り付く問題を解消する。実測の速度が取れているならこれまで通り実測を表示し、取れない間だけ直近 2 点の変位から算出した値へ落とす。

`scripts/replay-location-gpx.mjs` による GPX 再生（Android のテストプロバイダ経由）で速度がまったく読めず、測位パイプラインの検証時に走行速度を確認できなかったのが発端。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

### `src/utils/displacementSpeed.ts`（新規）

- `getDisplacementSpeed(prev, current)`: 直近 2 点の変位 ÷ 経過時間で速度(m/s)を返す純関数。`dt <= 0`（同一タイムスタンプの再配信）や `timestamp` 欠落では `null` を返し、0 除算で `Infinity` を出さない。
- `hasMeasuredSpeed(speed)`: 測位が実際に速度を持っているかの述語。

### `src/components/DevOverlay.tsx`

- 表示中の測位（通常時 `rawLocationAtom` / オートモード時 `locationAtom`）の変化を effect で拾い、変位由来の速度を保持する。
- 実測が取れていれば実測、取れない間だけ算出値を表示する。算出値を出しているときだけ `変位から算出` を値の下に添える。
- 測位が途切れて `location` が null になったら、基準も判定もリセットする。復帰後の 1 点目を古い基準と突き合わせると、途切れていた時間ぶんならした速度が出てしまうため。

### 「実測が取れている」の判定について

当初は `coords.speed == null` で判定する想定だったが、**Android では null にならない**。`expo-location` の `LocationResults.kt:155` が `location.speed.toDouble()` を無条件で通しており、Android の `Location#getSpeed()` は未設定時に `0.0f` を返す。つまり欠測と「本当に停車中の 0km/h」が値だけでは区別できない。

そこで「正の速度を一度でも観測したか」というスティッキーなフラグで判定している。

- 実機の GPS: 走り出した最初の 1 点でフラグが立ち、以降は停車中の 0km/h も含めて実測を使い続ける。算出値へは戻らない。
- テストプロバイダ（GPX 再生）: フラグは立たないので常に算出値。

なお `adb shell cmd location providers` 側での対処は不可能であることを Android 16 実機で確認済み。`set-test-provider-location` が受けるのは `--location` / `--accuracy` / `--time` のみで、`add-test-provider --supportsSpeed` はプロバイダの能力を宣言するだけの値。

## 回帰リスクと緩和

| リスク | 評価 |
| ---- | ---- |
| 実機の速度表示が算出値に置き換わる | 実測が取れた時点でフラグが立ち、以降は実測固定。置き換わらない |
| 起動直後に停車したままだと算出値（GPS ゆらぎ由来の数 km/h）が出る | 最初に動き出すまでの一時的なもの。`変位から算出` ラベルで実測と区別できる |
| 本番ビルドへの影響 | `DevOverlay` は `isDevApp` 時しか描画されないため無し |
| 測位パイプラインへの影響 | 無し。`src/store/atoms/location.ts` は変更しておらず、表示側のみで完結 |

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

```text
npm run lint       → Checked 736 files in 4s. No fixes applied.
npm run typecheck  → エラーなし
npm test           → 272 suites / 2963 tests すべて成功
```

追加したテスト:

- `src/utils/displacementSpeed.test.ts`（新規・14 件）: 基準欠落 / 経過時間 0 以下 / タイムスタンプ欠落 / 通常の算出 / 停止時 / 複数秒空いた場合、および `hasMeasuredSpeed` の境界値。
- `src/components/DevOverlay.test.tsx`（3 件追加）: `coords.speed` が 0 のまま動いている場合に算出値とラベルを出すこと、実測を一度観測したら以降は実測を使い続けること、算出できない間はラベルを出さないこと。

既存の速度関連テストは無改変で通っている。

なお `DevOverlay` は `React.memo` で props を持たないため `rerender()` では再描画されない。追加テストは常駐の 1 秒ティックを `advanceTimersByTime` で進めて再描画させている（理由はテスト内にコメントで記載）。

## 関連Issue

なし

## スクリーンショット（任意）

画像なし: 実機確認の途中で対象端末から dev ビルド（`me.tinykitten.trainlcd.dev`）が消えており、DEV OVERLAY を表示できなかったため。変更は DEV OVERLAY 内の `CURRENT SPEED` の値と、その下に出る出所ラベル（`変位から算出`）のみで、レイアウトの変更は無い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8ryXhufaztuu6ds9SXGK9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 実測速度が取得できない場合でも、位置情報の移動距離から速度を算出して表示できるようになりました。
  * 実測速度を取得した後は、停止時の速度「0」も正しく反映します。
  * 算出した速度には、その旨を示す表示を追加しました。
  * 測位ソースの切り替え時に判定や基準をリセットし、異なるソースのデータが速度計算に混在しないよう改善しました。
  * 同一ソースの測位サンプルが揃うまで、算出速度を表示しないようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->