### PR TITLE
エージェント向け手順書に分岐の前提検証・指摘の解釈確認・承認範囲の遵守を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 - **Favor minimal, auditable diffs:** prefer additive edits, keep formatting deterministic, and annotate non-obvious changes with concise comments.
 - **Document reproducibility:** record every manual command you execute and note any local assumptions about environment variables or credentials.
 - **Validate assumptions proactively:** confirm tool versions, workflow expectations, and environment needs instead of relying on cached knowledge.
+- **Verify what a branch actually claims, not just its shape:** before changing or removing a conditional — a platform branch, a feature gate, a piece of guidance copy — confirm that the thing it points at really exists on each side. When a platform-paired construct loses one side, re-validate the side you keep: the remaining branch was written under an assumption that may no longer hold, and nothing else will catch it. Copy that names a device setting, a screen, or a menu path is a factual claim about that platform and must be checked the same way as code.
 - **Clarify uncertainty:** request guidance or leave TODO notes rather than guessing at intent.
 - **Prioritize quality and performance over speed:** prefer well-structured, performant implementations over quick solutions. Take extra time to consider edge cases, optimize hot paths, and ensure code correctness rather than rushing to deliver.
 
@@ -17,7 +18,7 @@ This handbook defines how automation agents collaborate safely and effectively o
 1. **Intake:** read the full issue, PR discussion, or prompt; restate deliverables and constraints before coding.
 2. **Reconnaissance:** map relevant files with `rg`, `ls`, or `find`; review interfaces and existing patterns to plan compatible changes.
 3. **Plan:** outline discrete steps, keep the plan updated as you progress, and expose blockers early.
-4. **Implement:** use `apply_patch` for targeted edits, commit in small logical units, and avoid regenerating large files unless required.
+4. **Implement:** use `apply_patch` for targeted edits, commit in small logical units, and avoid regenerating large files unless required. Stay inside what was actually approved: an approval covers the change that was described, not the wording, naming, structure, or history around it. Adjacent cleanups that look obviously right are still a separate proposal — raise them and wait, rather than folding them into the approved edit.
 5. **Validate:** run only the necessary commands (`npm run lint`, `npm test`, `npm run typecheck`, etc.) and capture summarized output.
 6. **Document & Handoff:** update READMEs or docs when behavior changes, summarize modifications, list executed commands, and attach artifacts (logs, screenshots) before opening PRs.
 
@@ -196,5 +197,6 @@ Command mapping — the skills under `.claude/skills/` follow this table:
 ## Communication & Incident Reporting
 
 - Surface blockers or ambiguities in the task thread; do not proceed on assumptions.
+- When a review comment or correction can be read more than one way, ask which reading is meant before implementing one. Terse feedback usually points at a defect the author already understands, so a plausible-sounding reinterpretation is likely to fix the wrong thing while looking responsive. Quote the reading you would act on and confirm it.
 - When discovering regressions or flaky tests, open an issue with reproduction steps and assign the relevant code owner.
 - After incidents or hot fixes, append learnings to `docs/changelog.md` and notify maintainers for follow-up.


### PR DESCRIPTION
## 概要

エージェントの作業手順書（`AGENTS.md` / `CLAUDE.md`）に、実作業で表面化した 3 つの失敗を再発させないための規則を追加します。

きっかけは #6922 で、そこでは以下が起きました。

1. `TTSSettings` のプラットフォーム分岐を変更する際、案内文が指す設定が Android に実在するか確かめないまま表示条件だけを変えた。元の欠陥（#6688 で iOS 側を削除した際、残した Android 側の妥当性が検証されなかった）と同じ失敗を繰り返した
2. レビュー指摘が二通りに読める状態で、確認せず自分の解釈で実装した
3. 承認された変更の範囲を超えて、文面の書き換えと過去版への差し戻しまで踏み込んだ

いずれも既存節に属する内容のため、新節は設けず該当箇所へ追記しています。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

`AGENTS.md`（`CLAUDE.md` は同ファイルへのシンボリックリンク）へ 3 項目を追記しました。

| 追記先 | 内容 |
| --- | --- |
| Operating Principles for Automation Agents | **Verify what a branch actually claims, not just its shape** — 条件分岐やゲート、案内文を変更・削除する前に、それが指す対象が各プラットフォームに実在するか確かめる。プラットフォーム対で書かれた構造から片方が失われたときは、残す側も検証し直す。端末の設定名・画面・メニュー階層に言及する文言はそのプラットフォームに対する事実主張なので、コードと同じ基準で確認する |
| Standard Workflow → 4. Implement | 承認された範囲の中に留まる。承認は説明された変更を対象とし、その周辺の文言・命名・構造・履歴までは含まない。明らかに正しく見える周辺の整理も別提案として起票し、承認された編集に混ぜない |
| Communication & Incident Reporting | レビュー指摘や訂正が二通り以上に読めるときは、どちらの意味かを確認してから実装する。短い指摘は書き手が既に把握している欠陥を指していることが多く、もっともらしい読み替えは「反応はしているが直す対象が違う」結果になりやすい。自分が実行しようとしている解釈を引用して確認する |

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: `AGENTS.md` のみの変更で、アプリのコードには一切触れていません。`markdownlint-cli2` の指摘は既存行と同種（MD013）のみで、本ファイルは同ルールの対象範囲（`docs/` / README / `.claude/skills/**/SKILL.md`）に含まれません。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6922

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: `AGENTS.md` のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5LbSodnxw9n4yid8s43L


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - 条件分岐やプラットフォーム固有の案内を変更・削除する際、参照先と関連する前提を確認する手順を追加しました。
  - 承認範囲を超える周辺的な整理は、別提案として扱う方針を明記しました。
  - 曖昧なレビュー指摘や修正依頼について、対応前に意図を確認する手順を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->