### PR TITLE
外観設定の「自動」ラベルから自明なカッコ書きを削除

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -51,7 +51,7 @@
   "subwayAlertText": "Operation is not guaranteed because it is difficult for radio waves to enter the subway line. Please be careful.",
   "selectThemeTitle": "Themes",
   "colorSchemeSettings": "Appearance",
-  "colorSchemeAuto": "Auto (follow system)",
+  "colorSchemeAuto": "Auto",
   "colorSchemeLight": "Light",
   "colorSchemeDark": "Dark",
   "colorSchemeDescription": "Changes the colors of screens such as settings and line selection. \"Auto\" follows your device's dark mode setting. The screen shown while riding keeps the colors of the selected theme, except for Portrait Mode, which follows this setting. While the LED theme is selected, its own colors are used regardless of this setting, except for the Portrait Mode display.",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -51,7 +51,7 @@
   "subwayAlertText": "地下鉄線内は電波が入りづらいため、動作保証外となります。ご注意ください。",
   "selectThemeTitle": "テーマ設定",
   "colorSchemeSettings": "外観",
-  "colorSchemeAuto": "自動（端末の設定に合わせる）",
+  "colorSchemeAuto": "自動",
   "colorSchemeLight": "ライト",
   "colorSchemeDark": "ダーク",
   "colorSchemeDescription": "設定や路線選択などの操作画面の配色を変更します。「自動」では端末のダークモード設定に合わせて自動的に切り替わります。走行中の画面はテーマ設定の配色のままですが、ポートレートモードの表示だけはこの設定に追従します。電光掲示板風テーマを選んでいる間は、ポートレートモードの表示を除き、この設定にかかわらず電光掲示板風テーマの配色が使われます。",


### PR DESCRIPTION
## 概要

外観設定の配色プリセット「自動」のラベルから、カッコ書き `（端末の設定に合わせる）` を削除しました。同じ画面の説明文で「「自動」では端末のダークモード設定に合わせて自動的に切り替わります」と述べており、ラベル側の補足は自明で重複しているためです。

削除に伴い、日本語では 2 行に折り返していたラベルが 1 行に収まり、行の高さが他のプリセット（ライト / ダーク）と揃います。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `assets/translations/ja.json`: `colorSchemeAuto` を `自動（端末の設定に合わせる）` → `自動`
- `assets/translations/en.json`: `colorSchemeAuto` を `Auto (follow system)` → `Auto`

参照箇所は `src/screens/ColorSchemeSettings.tsx` の `settingItems` のみで、テストは翻訳キー名で要素を引いているため影響はありません。説明文 `colorSchemeDescription` は変更していないので、挙動の説明が失われることもありません。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

実行結果:

- `npm run lint`: Checked 740 files, No fixes applied
- `npm test`: 274 suites / 2987 tests passed
- `npm run typecheck`: エラーなし

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy S23 (SCG13) 実機キャプチャ

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_appearance-auto-label-b98317c05/22b8005e2c4d-appearance-auto-before.png" width="320" alt="変更前: 自動（端末の設定に合わせる）が2行に折り返している" />

変更前: 「自動（端末の設定に合わせる）」が 2 行に折り返している

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_appearance-auto-label-b98317c05/fd9e818a91a0-appearance-auto-after.png" width="320" alt="変更後: 自動" />

変更後: 「自動」の 1 行になり、ライト / ダークと行の高さが揃う

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FY1tjbcqJXsfDK6w9hJBD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **表示変更**
  - カラースキーム設定の「自動」表示を、英語・日本語で簡潔な表記に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->