### PR TITLE
回転ラッパー外の開発者オーバレイでドラッグが軸ずれする問題を修正

### DIFF
--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -15,7 +15,11 @@ import {
 import { autoModeEnabledAtom } from '~/store/atoms/navigation';
 import { isLEDThemeAtom } from '~/store/atoms/theme';
 import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
-import DevOverlay, { getDevOverlayDragTranslation } from './DevOverlay';
+import DevOverlay, {
+  getDevOverlayClampedPosition,
+  getDevOverlayDragTranslation,
+  isDevOverlayRotatedToLandscape,
+} from './DevOverlay';
 
 jest.mock('jotai', () => {
   const actual = jest.requireActual('jotai');
@@ -300,6 +304,61 @@ describe('DevOverlay', () => {
         x: -10,
         y: -24,
       });
+    });
+
+    it('回転ラッパー配下では物理縦向きのときだけ座標変換が要る', () => {
+      expect(isDevOverlayRotatedToLandscape(false, 393, 852)).toBe(true);
+      expect(isDevOverlayRotatedToLandscape(false, 852, 393)).toBe(false);
+    });
+
+    it('ポートレートモードでは物理縦向きでも座標変換しない', () => {
+      expect(isDevOverlayRotatedToLandscape(true, 393, 852)).toBe(false);
+    });
+  });
+
+  describe('位置のクランプ', () => {
+    const size = { width: 160, height: 44 };
+
+    it('パネルが画面内に収まるようマージン込みで丸める', () => {
+      expect(
+        getDevOverlayClampedPosition(
+          -50,
+          -50,
+          size,
+          { width: 360, height: 780 },
+          12
+        )
+      ).toEqual({ x: 12, y: 12 });
+      expect(
+        getDevOverlayClampedPosition(
+          9999,
+          9999,
+          size,
+          { width: 360, height: 780 },
+          12
+        )
+      ).toEqual({ x: 188, y: 724 });
+    });
+
+    // ポートレートモードでは回転ラッパーの外に出るので、長辺=width に正規化した
+    // 寸法でクランプすると横は画面外まで許し、縦は画面の半分までしか動かせなくなる
+    it('縦画面の実寸と長辺正規化寸法とでクランプ範囲が変わる', () => {
+      const portrait = getDevOverlayClampedPosition(
+        9999,
+        9999,
+        size,
+        { width: 360, height: 780 },
+        12
+      );
+      const normalized = getDevOverlayClampedPosition(
+        9999,
+        9999,
+        size,
+        { width: 780, height: 360 },
+        12
+      );
+      expect(portrait).toEqual({ x: 188, y: 724 });
+      expect(normalized).toEqual({ x: 608, y: 304 });
     });
   });
 

--- a/src/components/DevOverlay.test.tsx
+++ b/src/components/DevOverlay.test.tsx
@@ -311,7 +311,7 @@ describe('DevOverlay', () => {
       expect(isDevOverlayRotatedToLandscape(false, 852, 393)).toBe(false);
     });
 
-    it('ポートレートモードでは物理縦向きでも座標変換しない', () => {
+    it('回転ラッパーの外なら物理縦向きでも座標変換しない', () => {
       expect(isDevOverlayRotatedToLandscape(true, 393, 852)).toBe(false);
     });
   });
@@ -340,8 +340,8 @@ describe('DevOverlay', () => {
       ).toEqual({ x: 188, y: 724 });
     });
 
-    // ポートレートモードでは回転ラッパーの外に出るので、長辺=width に正規化した
-    // 寸法でクランプすると横は画面外まで許し、縦は画面の半分までしか動かせなくなる
+    // 回転ラッパーの外に描画される場合、長辺=width に正規化した寸法でクランプすると
+    // 横は画面外まで許し、縦は画面の半分までしか動かせなくなる
     it('縦画面の実寸と長辺正規化寸法とでクランプ範囲が変わる', () => {
       const portrait = getDevOverlayClampedPosition(
         9999,

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -56,6 +56,34 @@ const AURORA_COLORS = [
   'rgba(217, 70, 239, 0.2)',
 ] as const;
 
+// パネルを画面内に収める。screen は「実際に描画されている座標系」の寸法で、
+// 回転ラッパー配下なら長辺=width の正規化寸法、ポートレートモードなら画面の実寸。
+export const getDevOverlayClampedPosition = (
+  rightOffset: number,
+  y: number,
+  size: { width: number; height: number },
+  screen: { width: number; height: number },
+  margin: number
+) => ({
+  x: Math.min(
+    Math.max(rightOffset, margin),
+    Math.max(margin, screen.width - size.width - margin)
+  ),
+  y: Math.min(
+    Math.max(y, margin),
+    Math.max(margin, screen.height - size.height - margin)
+  ),
+});
+
+// ドラッグ量の座標変換が要るのは Main の 90deg 回転ラッパーの内側にいるときだけ。
+// ポートレートモードのレイアウトは回転ラッパーの外に描画されるため、端末が
+// 物理的に縦向きでも変換してはいけない(縦ドラッグで横に動く等の逆転になる)。
+export const isDevOverlayRotatedToLandscape = (
+  portrait: boolean,
+  physicalWidth: number,
+  physicalHeight: number
+) => !portrait && physicalHeight > physicalWidth;
+
 export const getDevOverlayDragTranslation = (
   dx: number,
   dy: number,
@@ -327,7 +355,14 @@ const MetricCard: React.FC<MetricCardProps> = ({
   </View>
 );
 
-const DevOverlay: React.FC = () => {
+type Props = {
+  // ポートレートモードのレイアウト配下など、Main の 90deg 回転ラッパーの外に
+  // 置かれる場合に true。パネルが実際に描画される座標系が画面の実寸そのものに
+  // なるため、位置のクランプとドラッグ量の変換をそちらに合わせる。
+  portrait?: boolean;
+};
+
+const DevOverlay: React.FC<Props> = ({ portrait = false }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedHeight, setExpandedHeight] = useState(0);
   // アンカーの経過秒表示用の現在時刻。レンダー中に Date.now() を直接呼ぶと純粋性違反に
@@ -503,9 +538,18 @@ const DevOverlay: React.FC = () => {
 
   const dim = useLandscapeWindowDimensions();
   const physicalDim = useWindowDimensions();
+  // パネルの寸法は従来どおり長辺=width の正規化寸法から決める。一方で位置の
+  // クランプとドラッグ量の変換は「実際に描画されている座標系」で行う必要があり、
+  // 回転ラッパーの外に出るポートレートモードでは画面の実寸が正しい基準になる。
+  const screenWidth = portrait ? physicalDim.width : dim.width;
+  const screenHeight = portrait ? physicalDim.height : dim.height;
   const [basePosition, setBasePosition] = useState({ x: 0, y: 0 });
   const isLandscape = dim.width > dim.height;
-  const isRotatedToLandscape = physicalDim.height > physicalDim.width;
+  const isRotatedToLandscape = isDevOverlayRotatedToLandscape(
+    portrait,
+    physicalDim.width,
+    physicalDim.height
+  );
   const panelWidth = isLandscape
     ? Math.min(Math.max(dim.width * 0.29, 360), 520)
     : Math.min(Math.max(dim.width * 0.34, 280), 430);
@@ -616,17 +660,15 @@ const DevOverlay: React.FC = () => {
   }, [isExpanded, animatedProgress]);
 
   const clampPosition = useMemo(
-    () => (rightOffset: number, y: number, width: number, height: number) => {
-      const margin = isLandscape ? 8 : 12;
-      const maxRight = Math.max(margin, dim.width - width - margin);
-      const maxY = Math.max(margin, dim.height - height - margin);
-
-      return {
-        x: Math.min(Math.max(rightOffset, margin), maxRight),
-        y: Math.min(Math.max(y, margin), maxY),
-      };
-    },
-    [dim.height, dim.width, isLandscape]
+    () => (rightOffset: number, y: number, width: number, height: number) =>
+      getDevOverlayClampedPosition(
+        rightOffset,
+        y,
+        { width, height },
+        { width: screenWidth, height: screenHeight },
+        isLandscape ? 8 : 12
+      ),
+    [screenWidth, screenHeight, isLandscape]
   );
 
   useEffect(() => {

--- a/src/components/DevOverlay.tsx
+++ b/src/components/DevOverlay.tsx
@@ -57,7 +57,7 @@ const AURORA_COLORS = [
 ] as const;
 
 // パネルを画面内に収める。screen は「実際に描画されている座標系」の寸法で、
-// 回転ラッパー配下なら長辺=width の正規化寸法、ポートレートモードなら画面の実寸。
+// 回転ラッパー配下なら長辺=width の正規化寸法、ラッパーの外なら画面の実寸。
 export const getDevOverlayClampedPosition = (
   rightOffset: number,
   y: number,
@@ -76,13 +76,13 @@ export const getDevOverlayClampedPosition = (
 });
 
 // ドラッグ量の座標変換が要るのは Main の 90deg 回転ラッパーの内側にいるときだけ。
-// ポートレートモードのレイアウトは回転ラッパーの外に描画されるため、端末が
-// 物理的に縦向きでも変換してはいけない(縦ドラッグで横に動く等の逆転になる)。
+// ラッパーの外に描画されている場合は、端末が物理的に縦向きでも変換してはいけない
+// (縦ドラッグで横に動く等の逆転になる)。
 export const isDevOverlayRotatedToLandscape = (
-  portrait: boolean,
+  unrotated: boolean,
   physicalWidth: number,
   physicalHeight: number
-) => !portrait && physicalHeight > physicalWidth;
+) => !unrotated && physicalHeight > physicalWidth;
 
 export const getDevOverlayDragTranslation = (
   dx: number,
@@ -356,13 +356,13 @@ const MetricCard: React.FC<MetricCardProps> = ({
 );
 
 type Props = {
-  // ポートレートモードのレイアウト配下など、Main の 90deg 回転ラッパーの外に
-  // 置かれる場合に true。パネルが実際に描画される座標系が画面の実寸そのものに
-  // なるため、位置のクランプとドラッグ量の変換をそちらに合わせる。
-  portrait?: boolean;
+  // Main の 90deg 回転ラッパーの外に置かれる場合に true(ポートレートモードの
+  // レイアウト配下と低消費電力テーマ)。パネルが実際に描画される座標系が画面の
+  // 実寸そのものになるため、位置のクランプとドラッグ量の変換をそちらに合わせる。
+  unrotated?: boolean;
 };
 
-const DevOverlay: React.FC<Props> = ({ portrait = false }) => {
+const DevOverlay: React.FC<Props> = ({ unrotated = false }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedHeight, setExpandedHeight] = useState(0);
   // アンカーの経過秒表示用の現在時刻。レンダー中に Date.now() を直接呼ぶと純粋性違反に
@@ -540,13 +540,13 @@ const DevOverlay: React.FC<Props> = ({ portrait = false }) => {
   const physicalDim = useWindowDimensions();
   // パネルの寸法は従来どおり長辺=width の正規化寸法から決める。一方で位置の
   // クランプとドラッグ量の変換は「実際に描画されている座標系」で行う必要があり、
-  // 回転ラッパーの外に出るポートレートモードでは画面の実寸が正しい基準になる。
-  const screenWidth = portrait ? physicalDim.width : dim.width;
-  const screenHeight = portrait ? physicalDim.height : dim.height;
+  // 回転ラッパーの外に出る場合は画面の実寸が正しい基準になる。
+  const screenWidth = unrotated ? physicalDim.width : dim.width;
+  const screenHeight = unrotated ? physicalDim.height : dim.height;
   const [basePosition, setBasePosition] = useState({ x: 0, y: 0 });
   const isLandscape = dim.width > dim.height;
   const isRotatedToLandscape = isDevOverlayRotatedToLandscape(
-    portrait,
+    unrotated,
     physicalDim.width,
     physicalDim.height
   );

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -821,7 +821,8 @@ const MainScreen: React.FC = () => {
           onPress={updateBottomState}
           onTransferPress={handleTransferPress}
         />
-        {isDevApp && devOverlayEnabled && <DevOverlay />}
+        {/* 回転ラッパーの外＝縦向きのまま描画されるので portrait を渡す */}
+        {isDevApp && devOverlayEnabled && <DevOverlay portrait />}
         {selectBoundModal}
       </>
     );

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -821,8 +821,8 @@ const MainScreen: React.FC = () => {
           onPress={updateBottomState}
           onTransferPress={handleTransferPress}
         />
-        {/* 回転ラッパーの外＝縦向きのまま描画されるので portrait を渡す */}
-        {isDevApp && devOverlayEnabled && <DevOverlay portrait />}
+        {/* 回転ラッパーの外＝画面の向きのまま描画されるので unrotated を渡す */}
+        {isDevApp && devOverlayEnabled && <DevOverlay unrotated />}
         {selectBoundModal}
       </>
     );
@@ -860,7 +860,8 @@ const MainScreen: React.FC = () => {
           <LineBoard hasTerminus={hasTerminus} />
         </View>
 
-        {isDevApp && devOverlayEnabled && <DevOverlay />}
+        {/* 回転ラッパーの外に置いているので unrotated を渡す */}
+        {isDevApp && devOverlayEnabled && <DevOverlay unrotated />}
         {/* 回転しているビューの外に置いて正立させる(案A) */}
         <PortraitModePrompt />
       </>


### PR DESCRIPTION
## 概要

Main の 90deg 回転ラッパーの**外**に描画される開発者オーバレイで、ドラッグ&ドロップが正しく動かない問題を修正します。縦にドラッグすると横へ動くなど軸が入れ替わり、画面内に収めるクランプ範囲も画面の縦横が逆のまま計算されていました。該当するのはポートレートモード（設定 → 外観）の走行画面と、低消費電力テーマの走行画面です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

`DevOverlay` は「Main の 90deg 回転ラッパーの内側に描画される」ことを前提に書かれていました。

- 寸法は `useLandscapeWindowDimensions()`（長辺を `width` に正規化した値）で決める
- ドラッグ量は `isRotatedToLandscape = 端末が物理的に縦向きか` だけで判定し、真なら `(dx, dy) → (-dy, -dx)` にローカル座標へ変換する

ところが `src/screens/Main.tsx` の 3 つの分岐のうち 2 つでは、`DevOverlay` が回転ラッパーの**外**に置かれています。

| 分岐 | `DevOverlay` の位置 |
| ---- | ---- |
| ポートレートモード（`PortraitMain`） | ラッパーの外 |
| 低消費電力テーマ | ラッパーの外 |
| 既定（テーマ別レイアウト） | ラッパーの中 |

端末が物理的に縦向きだと `isRotatedToLandscape` が真になるため、回転していないのに座標変換が入っていました。クランプも長辺／短辺が入れ替わった値を基準にしており、横は画面外まで許し、縦は画面のおよそ半分までしか動かせない状態でした。

- `DevOverlay` に `unrotated` prop を追加し、回転ラッパーの外に置いている 2 箇所へ渡す
- 位置のクランプとドラッグ量の座標変換を「実際に描画されている座標系」の寸法で行う（回転ラッパー配下は従来どおりの正規化寸法、ラッパーの外は画面の実寸）
- 回転判定を `isDevOverlayRotatedToLandscape()`、クランプを `getDevOverlayClampedPosition()` として切り出し、単体テストを追加

パネルの寸法計算（`panelWidth` など）は従来どおりに据え置いています。`dim` 自体を実寸へ差し替えると `isLandscape` が偽になり、これまで一度も到達していなかった縦画面レイアウト分岐が有効化されて、タイトルの3行折り返し・メトリクスカードの1列化・チャートのはみ出しといった見た目の退行が出るためです（この未使用レイアウトの扱いは本 PR のスコープ外）。

### 回帰リスクと緩和

- `unrotated` の既定値は `false` で、回転ラッパー配下の呼び出しは挙動が変わりません（`screenWidth` / `screenHeight` は従来の `dim.width` / `dim.height` と同値、`isRotatedToLandscape` の式も同値）。
- 端末が物理的に横向きのときは `physicalDim` と長辺正規化寸法が一致するため、`unrotated` を渡した 2 箇所も横向き時の挙動は変わりません。
- 実機で、ポートレートモード ON / OFF の両方でドラッグが指に追従することを確認しています（下記）。
- `clampPosition` の `useMemo` 依存はプリミティブのまま（オブジェクトを渡すと毎レンダー同一性が変わり、位置リセットの `useEffect` が回り続けるため）。

## テスト

実機（Galaxy SCG13 / Android 16、ローカル debug ビルド）で確認しました。

**ポートレートモード ON・端末縦持ち（修正対象）**

- 折りたたみ状態: `(816, 90)` から `(350, 1300)` へドラッグ → 着地 `(351, 1301)`
- 展開状態: 下方向へ 400px ドラッグ → 398px 移動
- 画面下端までドラッグ → パネル上端 1570px で停止（画面高 2340px と実寸から算出した上限に一致）。画面外に出ない

**ポートレートモード OFF・端末縦持ち（90deg 回転ラッパー配下 / 回帰確認）**

- 上方向へ 400px ドラッグ → 狙いとの差 10px。従来どおり追従

低消費電力テーマの分岐はレビュー指摘を受けて後から追加したため、実機での再確認は行っていません（ポートレートモードで検証済みのコードパスに、同じ呼び出し側フラグを渡すだけの変更です）。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（274 suites / 2991 tests）
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

未添付: 検証時の実機キャプチャには走行中の現在地（駅名・次駅・測位精度）が写っており、public リポジトリの資材ブランチへ恒久公開すると撮影者の位置情報が残るため見送りました。マスキング済みの画像が必要であれば差し替えます。なお本 PR は開発者向けオーバレイの操作性修正で、エンドユーザー向け画面の見た目は変わりません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NixmQgk4mJmzqZ1Prra399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ポートレート表示時の開発者オーバーレイが、回転状態に応じて正しく配置されるようになりました。
  - オーバーレイのドラッグ位置が、画面サイズや余白に基づいて適切に制限されるようになりました。
  - 回転表示時の座標変換を見直し、オーバーレイの位置が安定するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->