### PR TITLE
VOICEVOX資産のstaging配信先の手順を設計書に追記

### DIFF
--- a/docs/spec/tts/on-device-tts-ios.md
+++ b/docs/spec/tts/on-device-tts-ios.md
@@ -229,6 +229,35 @@ Remote Config の値は変えなくてよい。
 資産を差し替えるときは新しい `version`（別ディレクトリ）で同じ手順を繰り返す。
 アプリは `version` の変化で全ファイルを取り直し、旧ディレクトリを消す。
 
+### staging 配信先
+
+マニフェストは `voicevox/manifest.json` の固定パスに置くので、本番バケットの資産を差し替えると
+公開した瞬間に全端末へ効く。canary で先に確かめられるよう、配信先ごと分けてある。
+
+| 環境 | R2 バケット | ホスト | 参照する `CONFIG_KV` |
+| --- | --- | --- | --- |
+| 本番 | `trainlcd-assets` | `assets.trainlcd.app` | production（`trainlcd-worker`） |
+| staging | `trainlcd-assets-dev` | `assets-stg.trainlcd.app` | dev（`trainlcd-worker-dev`。canary アプリはこちらを向く） |
+
+バケットが `-dev`、ホストが `-stg` で揃っていないのは、既存の命名の混在
+（`trainlcd-uploads-dev` ↔ `uploads-dev.trainlcd.app` / `stationapi-stg` ↔ `gql-stg.trainlcd.app`）に
+合わせた結果で、ここだけ直しても全体は揃わないため意図的にこの組み合わせにしている。
+
+`scripts/publish-voicevox-assets.mjs` は配信先を環境変数で切り替えられるので、staging でも同じ
+スクリプトを使う。バケット作成と独自ドメインの紐付けも、存在しなければ作る形で同じ実行に含まれる。
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=… CLOUDFLARE_ZONE_ID=… CLOUDFLARE_API_TOKEN=…
+export VOICEVOX_R2_BUCKET=trainlcd-assets-dev
+export VOICEVOX_ASSETS_HOST=assets-stg.trainlcd.app
+node scripts/publish-voicevox-assets.mjs "$WORK/2026-09-10" 2026-09-10
+# → dev の Remote Config: voicevox_tts_manifest_url_ios = https://assets-stg.trainlcd.app/voicevox/manifest.json
+```
+
+Remote Config は dev 側の `voicevox_tts_manifest_url_ios` だけを staging の URL に向け、production 側は
+`assets.trainlcd.app` のまま据え置く。canary で確認できたら、同じ資産セット（同じ `version`）を
+本番バケットへも公開する。
+
 ## Remote Config
 
 | キー | 型 | フォールバック | 役割 |


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

#6931 のうち、**ドキュメントの追記のみ**を行う。VOICEVOX 資産の staging 配信先（R2 バケット `trainlcd-assets-dev` / ホスト `assets-stg.trainlcd.app`）への公開手順を、オンデバイス TTS 設計書に追加した。

Cloudflare 側の実作業（バケット作成・独自ドメインの紐付け・staging への公開）と dev `CONFIG_KV` への `voicevox_tts_manifest_url_ios` 追加は**このPRには含まれない**。詳細は下の「残作業」を参照。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `docs/spec/tts/on-device-tts-ios.md` に「staging 配信先」節を追加
  - 本番 / staging のバケット・ホスト・参照する `CONFIG_KV` の対応表
  - バケットが `-dev`、ホストが `-stg` と揃っていない理由（既存の命名の混在に合わせた意図的な選択であること）
  - `VOICEVOX_R2_BUCKET` / `VOICEVOX_ASSETS_HOST` を渡して `scripts/publish-voicevox-assets.mjs` を実行する手順。バケット作成とドメイン紐付けも同じ実行に含まれる
  - dev 側の `voicevox_tts_manifest_url_ios` だけを staging に向け、production は据え置くという運用

アプリ側のコード変更は無い（#6931 の想定どおり）。

### 残作業（このPRの範囲外）

1. R2 バケット `trainlcd-assets-dev` の作成と `assets-stg.trainlcd.app` の紐付け
2. staging バケットへの資産公開
3. dev `CONFIG_KV` の `config:remote` に `voicevox_tts_manifest_url_ios = https://assets-stg.trainlcd.app/voicevox/manifest.json` を追加（functions リポジトリ側）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: `docs/**` のみの変更でアプリのコードに変更が無いため。`markdownlint-cli2` は追加箇所について MD013（line-length）以外の指摘なしを確認した（MD013 はこのファイルの既存行にも出ており、リポジトリで運用していない）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

Refs #6931

Issue の 4 項目のうちドキュメント（項目 4）だけを満たすため、`Closes` ではなく `Refs` にしている。

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI 変更なし: `docs/**` のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tVYs6Yu7jchkzxe6hAG2t
