### PR TITLE
地下鉄でスムージングを飛ばす経路にも速度フィルタを通して無関係な駅へのワープを抑止

### DIFF
--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -478,31 +478,35 @@ describe('高速走行時の追従', () => {
   it('連続棄却が上限に達したら基準を張り直して凍結から復帰する', () => {
     setLocation(makeLocation(38.9, 140.9, 30, 1_000));
 
-    // Androidの配信間隔(10秒)で物理的にありえない距離のジャンプを送り続ける
+    // 1秒間隔で物理的にありえない距離のジャンプを送り続ける
     const jumpLat = 36.0;
     for (let i = 1; i <= 5; i++) {
-      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 10_000));
+      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 1000));
     }
 
-    // 回数(5回)と経過時間(20秒)の双方を満たした時点で基準を張り直す
+    // 5回目(MAX_CONSECUTIVE_SPEED_REJECTIONS)で基準を張り直し、座標が反映される
     expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
   });
 
-  // 回帰: 張り直しの条件が回数だけだと、ワープ対策の粘り強さが配信間隔に反比例する。
-  // iOSは概ね1Hz配信なので5回=5秒で基準を明け渡し、10秒間隔のAndroidより
-  // 桁違いにワープしやすくなっていた。
-  it('基準を張り直すまでの粘り強さが配信間隔に依存しない', () => {
+  // 回帰: 本線経路の張り直しに経過時間の条件を足すと、凍結時間が配信の速い端末ほど
+  // 延びて #6898(新幹線速度での現在地凍結の解消)を打ち消す。1Hz配信でも凍結が
+  // MAX_CONSECUTIVE_SPEED_REJECTIONSぶん(=5サンプル)で終わることを固定する。
+  it('1Hz配信でも凍結が5サンプルを超えて続かない', () => {
     setLocation(makeLocation(38.9, 140.9, 30, 1_000));
 
+    // 誤った基準から見て棄却され続ける座標が1秒間隔(iOS相当)で届き続ける
     const jumpLat = 36.0;
-    // iOS相当の1秒間隔。最初の棄却はt=2000なので、20秒経過するのはt=22000。
-    for (let i = 1; i <= 20; i++) {
+    let frozenSamples = 0;
+    for (let i = 1; i <= 10; i++) {
       setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 1_000));
+      if (store.get(locationAtom)?.coords.latitude !== jumpLat) {
+        frozenSamples += 1;
+      }
     }
-    expect(store.get(locationAtom)?.coords.latitude).toBe(38.9);
 
-    setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + 21 * 1_000));
-    expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
+    // 5サンプル目で張り直されるので、凍結したままなのは4サンプル(=4秒)まで。
+    // 320km/h(≒89m/s)なら凍結中の走行距離は約355mで、到着判定圏を大きくは超えない。
+    expect(frozenSamples).toBe(4);
   });
 
   // 回帰: 「基準が古い」判定が速度フィルタより先に return していると、

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -176,6 +176,117 @@ describe('setLocation', () => {
       expect(result?.coords.longitude).toBe(139.0);
     });
 
+    // 回帰: スムージングをスキップする経路がワープ対策の速度フィルタごと素通しに
+    // なっていたため、GPSが届かずWi-Fi/基地局測位へ落ちる地下鉄で、もっともらしい
+    // 精度のまま届く遠方の座標がそのまま反映され無関係な駅へ飛んでいた。
+    it('スムージングをスキップしてもありえない速度のワープは棄却する', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+
+      // 1秒後に約1km離れた別の駅付近の座標が届く(≒1000m/s)
+      const warpLat = 35.0 + 1_000 / METERS_PER_DEG_LAT;
+      setLocation(makeLocation(warpLat, 139.0, 500, 2_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
+    it('妥当な速度の移動はスムージングせず生の座標のまま反映する', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 1秒で約20m(=72km/h)進む
+      const movedLat = 35.0 + 20 / METERS_PER_DEG_LAT;
+      setLocation(makeLocation(movedLat, 139.0, 500, 2_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(movedLat);
+    });
+
+    // 測位が途切れた区間を跨いでも判定対象は平均速度なので、地下鉄の営業最高速度
+    // (おおむね110km/h以下)を超えない限り受理する
+    it('測位が途切れたあとの妥当な平均速度の移動は受理する', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 60秒で1.5km(=90km/h)先の次駅付近へ進む
+      const movedLat = 35.0 + 1_500 / METERS_PER_DEG_LAT;
+      setLocation(makeLocation(movedLat, 139.0, 500, 61_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(movedLat);
+    });
+
+    // 隣駅程度の距離(500m〜1km)のワープは、既定の閾値(360km/h)だと数秒で通ってしまう。
+    // 地下鉄ではその距離こそが典型的な誤測位なので路線種別に見合う閾値まで絞っている。
+    it('隣駅程度の距離のワープも数秒では受理しない', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 1秒間隔で500m先の駅付近の座標が届き続ける(既定の閾値なら5秒目で受理される)
+      const warpLat = 35.0 + 500 / METERS_PER_DEG_LAT;
+      for (let i = 1; i <= 10; i++) {
+        setLocation(makeLocation(warpLat, 139.0, 500, 1_000 + i * 1_000));
+      }
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
+    // 回帰: 基準の張り直しが回数だけの条件だと、配信の速いiOS(概ね1Hz)では
+    // 5秒でワープを受け入れてしまい、10秒間隔のAndroidとの差が「iPhoneだけ
+    // ワープしがち」として表面化する。
+    it('高頻度配信では棄却が数秒続いた程度で基準を明け渡さない', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 1秒間隔で同じ誤測位が届き続ける(MAX_CONSECUTIVE_SPEED_REJECTIONSは超える)。
+      // 基準が古くなるほど見かけの速度は下がるため、棄却され続ける距離を選ぶ。
+      const warpLat = 35.0 + 3_000 / METERS_PER_DEG_LAT;
+      for (let i = 1; i <= 10; i++) {
+        setLocation(makeLocation(warpLat, 139.0, 500, 1_000 + i * 1_000));
+      }
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
+    it('棄却が規定時間続いたら基準を張り直して凍結から復帰する', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 最初の棄却(t=2000)からMIN_SPEED_REJECTION_STREAK_MS(20秒)経過するまで送り続ける
+      const warpLat = 35.0 + 3_000 / METERS_PER_DEG_LAT;
+      for (let i = 1; i <= 21; i++) {
+        setLocation(makeLocation(warpLat, 139.0, 500, 1_000 + i * 1_000));
+      }
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(warpLat);
+    });
+
+    // 地上→地下鉄の切り替わり直後は、スキップ経路の基準がまだ一度も更新されていない。
+    // 本線経路の受理時に基準を揃えておかないと、この1点目だけ無防備になる。
+    it('地上から地下鉄へ切り替わった直後の1点にもワープ対策が効く', () => {
+      setStationLineType(LineType.Normal);
+      setLocation(makeLocation(35.0, 139.0, 30, 1_000));
+
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      const warpLat = 35.0 + 1_000 / METERS_PER_DEG_LAT;
+      setLocation(makeLocation(warpLat, 139.0, 500, 2_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
     it('平均精度がちょうど200mの境界値の場合はスムージングをスキップする', () => {
       setStationLineType(LineType.Subway);
       // 平均がちょうど200m（mean >= BAD_ACCURACY_THRESHOLD で不安定扱い）
@@ -367,13 +478,30 @@ describe('高速走行時の追従', () => {
   it('連続棄却が上限に達したら基準を張り直して凍結から復帰する', () => {
     setLocation(makeLocation(38.9, 140.9, 30, 1_000));
 
-    // 1秒間隔で物理的にありえない距離のジャンプを送り続ける
+    // Androidの配信間隔(10秒)で物理的にありえない距離のジャンプを送り続ける
     const jumpLat = 36.0;
     for (let i = 1; i <= 5; i++) {
-      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 1000));
+      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 10_000));
     }
 
-    // 5回目(MAX_CONSECUTIVE_SPEED_REJECTIONS)で基準を張り直し、座標が反映される
+    // 回数(5回)と経過時間(20秒)の双方を満たした時点で基準を張り直す
+    expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
+  });
+
+  // 回帰: 張り直しの条件が回数だけだと、ワープ対策の粘り強さが配信間隔に反比例する。
+  // iOSは概ね1Hz配信なので5回=5秒で基準を明け渡し、10秒間隔のAndroidより
+  // 桁違いにワープしやすくなっていた。
+  it('基準を張り直すまでの粘り強さが配信間隔に依存しない', () => {
+    setLocation(makeLocation(38.9, 140.9, 30, 1_000));
+
+    const jumpLat = 36.0;
+    // iOS相当の1秒間隔。最初の棄却はt=2000なので、20秒経過するのはt=22000。
+    for (let i = 1; i <= 20; i++) {
+      setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + i * 1_000));
+    }
+    expect(store.get(locationAtom)?.coords.latitude).toBe(38.9);
+
+    setLocation(makeLocation(jumpLat, 140.9, 30, 1_000 + 21 * 1_000));
     expect(store.get(locationAtom)?.coords.latitude).toBe(jumpLat);
   });
 

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -222,8 +222,9 @@ describe('setLocation', () => {
     });
 
     // 隣駅程度の距離(500m〜1km)のワープは、既定の閾値(360km/h)だと数秒で通ってしまう。
-    // 地下鉄ではその距離こそが典型的な誤測位なので路線種別に見合う閾値まで絞っている。
-    it('隣駅程度の距離のワープも数秒では受理しない', () => {
+    // 地下鉄ではその距離こそが典型的な誤測位なので、この経路だけ閾値を絞っている。
+    // 棄却を保てる時間は「距離÷閾値」なので、500mなら10秒。
+    it('隣駅程度の距離のワープは既定の閾値より長く棄却し続ける', () => {
       setStationLineType(LineType.Subway);
       store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
 
@@ -231,11 +232,28 @@ describe('setLocation', () => {
 
       // 1秒間隔で500m先の駅付近の座標が届き続ける(既定の閾値なら5秒目で受理される)
       const warpLat = 35.0 + 500 / METERS_PER_DEG_LAT;
-      for (let i = 1; i <= 10; i++) {
+      for (let i = 1; i <= 9; i++) {
         setLocation(makeLocation(warpLat, 139.0, 500, 1_000 + i * 1_000));
       }
 
       expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
+    // 回帰: この経路のlineTypeは「最後に到着した駅」のもので、地下鉄から直通先へ
+    // 抜けた区間もSubway扱いのままここを通る(useRefreshStationはisArrivedのときしか
+    // stationを進めない)。閾値を地下鉄の営業最高速度(110km/h)基準で置くと、
+    // 直通先の在来線速度域(最速は京成成田スカイアクセス線の160km/h)を誤棄却する。
+    it('地下鉄直通先の在来線速度(160km/h)でも誤棄却しない', () => {
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+
+      setLocation(makeLocation(35.0, 139.0, 500, 1_000));
+
+      // 60秒で約2.67km(=160km/h)進む
+      const movedLat = 35.0 + ((160 / 3.6) * 60) / METERS_PER_DEG_LAT;
+      setLocation(makeLocation(movedLat, 139.0, 500, 61_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(movedLat);
     });
 
     // 回帰: 基準の張り直しが回数だけの条件だと、配信の速いiOS(概ね1Hz)では

--- a/src/store/atoms/location.test.ts
+++ b/src/store/atoms/location.test.ts
@@ -290,6 +290,31 @@ describe('setLocation', () => {
       expect(store.get(locationAtom)?.coords.latitude).toBe(warpLat);
     });
 
+    // 回帰: 棄却回数と開始時刻を両経路で共有していると、地下鉄経路が抑え込んでいた
+    // ワープが、精度が安定して本線経路へ切り替わった最初の1点で受理される。
+    // 本線経路は経過時間の条件を課さないため、持ち越された回数だけで上限に達してしまう。
+    it('地下鉄経路の棄却回数が本線経路へ引き継がれない', () => {
+      // 地上で基準を作る(本線経路の基準と、スキップ経路の基準の両方が張られる)
+      setStationLineType(LineType.Normal);
+      setLocation(makeLocation(35.0, 139.0, 30, 1_000));
+
+      // 地下鉄・精度不安定へ移り、1秒間隔で3km先へのワープが届き続ける
+      setStationLineType(LineType.Subway);
+      store.set(accuracyHistoryAtom, [10, 300, 20, 400]);
+      const warpLat = 35.0 + 3_000 / METERS_PER_DEG_LAT;
+      for (let i = 1; i <= 4; i++) {
+        setLocation(makeLocation(warpLat, 139.0, 500, 1_000 + i * 1_000));
+      }
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+
+      // 精度が安定して本線経路へ切り替わる。同じワープ座標が届いても、
+      // 本線経路の棄却回数は1回目なので棄却され続けること
+      store.set(accuracyHistoryAtom, [30, 35, 28, 32]);
+      setLocation(makeLocation(warpLat, 139.0, 30, 6_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(35.0);
+    });
+
     // 地上→地下鉄の切り替わり直後は、スキップ経路の基準がまだ一度も更新されていない。
     // 本線経路の受理時に基準を揃えておかないと、この1点目だけ無防備になる。
     it('地上から地下鉄へ切り替わった直後の1点にもワープ対策が効く', () => {

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -11,11 +11,29 @@ const MAX_ACCURACY_HISTORY = 12;
 // 物理的にありえない速度でのジャンプを棄却する閾値(m/s ≒ 360km/h)
 const MAX_PLAUSIBLE_SPEED = 100;
 
+// スムージングスキップ経路(地下鉄かつ精度が不安定)で使う閾値(m/s ≒ 120km/h)。
+// 判定対象は2点間の平均速度なので、営業最高速度(地下鉄はおおむね110km/h以下)を
+// 上回ることは測位が途切れた区間を跨いでもあり得ない。新幹線を通せるよう緩めてある
+// 既定値(360km/h)をこの経路にも当てると、隣駅程度の距離(500m〜1km)のワープが
+// 数秒で通ってしまう——GPSが届かずWi-Fi/基地局測位へ落ちる区間ではその距離こそが
+// 典型的な誤りなので、路線種別から言える範囲まで絞る。
+const MAX_PLAUSIBLE_SUBWAY_SPEED = 33;
+
 // 速度フィルタが連続して棄却できる回数の上限。棄却しても基準座標は更新しないため、
 // 基準側が実際の現在地から乖離している場合は正常な測位が延々と弾かれ、位置が
-// 永久に凍結する。この回数に達したら「基準の方が誤っている」と判断し、届いた
-// 測位で基準を張り直す。
+// 永久に凍結する。この回数に達し、かつMIN_SPEED_REJECTION_STREAK_MSぶんの時間が
+// 経っていれば「基準の方が誤っている」と判断し、届いた測位で基準を張り直す。
 const MAX_CONSECUTIVE_SPEED_REJECTIONS = 5;
+
+// 連続棄却で基準を張り直すまでに最低限必要な経過時間(ms)。
+// 回数だけを条件にすると、ワープ対策の粘り強さが測位の配信間隔に依存してしまう。
+// iOSはtimeIntervalが効かずdistanceInterval基準で概ね1Hz配信されるため5回=約5秒で
+// 基準を明け渡すのに対し、Androidは10秒間隔なので約50秒粘る。同じ「配信間隔で
+// 保護の強さが変わる」問題はEMAのα側では正規化済み(LEGACY_ALPHA_INTERVAL_SEC)で、
+// ここも回数と経過時間の両方を満たしたときだけ張り直すことで間隔に依存させない。
+// 誤測位が数秒だけ固まって届くケース(地下鉄のWi-Fi/基地局測位)で基準を奪われない
+// 程度に長く、基準側が本当に誤っていたときの凍結が長引かない程度に短い値を採る。
+const MIN_SPEED_REJECTION_STREAK_MS = 20_000;
 
 // 基準座標がこれ以上古い場合、EMAの基準としては意味を持たないため、速度フィルタを
 // 通過したうえでスムージングせず新しい測位へスナップし、基準を張り直す。
@@ -114,8 +132,21 @@ const lastFilteredLocationAtom = atom<Location.LocationObject | null>(null);
 // 走行が丸ごと弾かれて位置が凍結していた。速度判定は生座標同士で行う。
 const lastRawLocationAtom = atom<Location.LocationObject | null>(null);
 
+// スムージングスキップ経路(地下鉄)専用の速度フィルタ基準。
+// この経路はEMAを通さず生の座標をそのままUIへ反映するが、ワープ対策の速度フィルタまで
+// 一緒に外すと、GPSが届かずWi-Fi/基地局測位へ落ちる地下鉄区間——もっともワープしやすい
+// 場所——が無防備になる。EMA用の基準(lastFilteredLocationAtom / lastRawLocationAtom)は
+// 地上復帰時にSTALE_REFERENCE_MSで張り直させるため据え置く必要があるので、
+// 速度判定にだけ使う基準を別に持つ。
+const lastSkipSmoothingLocationAtom = atom<Location.LocationObject | null>(
+  null
+);
+
 // 速度フィルタが連続で棄却した回数。MAX_CONSECUTIVE_SPEED_REJECTIONSの判定に使う。
 let consecutiveSpeedRejections = 0;
+// 現在の連続棄却が始まった測位のタイムスタンプ(ms)。
+// MIN_SPEED_REJECTION_STREAK_MSの判定に使う。
+let speedRejectionStreakStartedAtMs = 0;
 
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
@@ -124,8 +155,10 @@ export const resetLocationState = () => {
   store.set(accuracyHistoryAtom, []);
   store.set(lastFilteredLocationAtom, null);
   store.set(lastRawLocationAtom, null);
+  store.set(lastSkipSmoothingLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
   consecutiveSpeedRejections = 0;
+  speedRejectionStreakStartedAtMs = 0;
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -142,6 +175,50 @@ export const setRawLocation = (location: Location.LocationObject) => {
   store.set(rawLocationAtom, location);
 };
 
+// 2点間の見かけの速度が物理的にありえない水準かを判定する。
+// 経過時間が延びても「変位÷経過時間」の妥当性検査は成立するため、測位が長く途切れた
+// 直後の1点にも適用できる。
+const isImplausibleJump = (
+  prev: Location.LocationObject,
+  next: Location.LocationObject,
+  maxSpeed: number
+): boolean => {
+  const dtSec = (next.timestamp - prev.timestamp) / 1000;
+  if (!(dtSec > 0)) {
+    return false;
+  }
+  const dist = getDistance(
+    { latitude: prev.coords.latitude, longitude: prev.coords.longitude },
+    { latitude: next.coords.latitude, longitude: next.coords.longitude }
+  );
+  return dist / dtSec > maxSpeed;
+};
+
+const resetSpeedRejectionStreak = () => {
+  consecutiveSpeedRejections = 0;
+  speedRejectionStreakStartedAtMs = 0;
+};
+
+// 速度フィルタによる棄却を記録し、基準を張り直すべきか(=基準側が誤っていると
+// 判断すべきか)を返す。棄却が規定回数かつ規定時間続いたときにだけ真を返す。
+const registerSpeedRejection = (timestampMs: number): boolean => {
+  // 連続棄却の開始時、および時計の巻き戻りで経過時間が測れなくなった場合は数え直す
+  if (
+    consecutiveSpeedRejections === 0 ||
+    timestampMs < speedRejectionStreakStartedAtMs
+  ) {
+    consecutiveSpeedRejections = 0;
+    speedRejectionStreakStartedAtMs = timestampMs;
+  }
+  consecutiveSpeedRejections += 1;
+
+  return (
+    consecutiveSpeedRejections >= MAX_CONSECUTIVE_SPEED_REJECTIONS &&
+    timestampMs - speedRejectionStreakStartedAtMs >=
+      MIN_SPEED_REJECTION_STREAK_MS
+  );
+};
+
 // スムージングせず測位をそのまま反映し、EMA基準・速度フィルタ基準の双方を張り直す。
 // 基準が無い(初回起動・地下鉄からの復帰)、基準が古すぎる、基準が誤っていると判断した
 // 場合に使う。基準を両方とも生の測位へ揃えるのが要点で、片方だけ残すと次回の変位に
@@ -153,8 +230,9 @@ const resyncLocationReference = (
   store.set(locationAtom, location);
   store.set(lastFilteredLocationAtom, location);
   store.set(lastRawLocationAtom, location);
+  store.set(lastSkipSmoothingLocationAtom, location);
   store.set(accuracyHistoryAtom, updatedHistory);
-  consecutiveSpeedRejections = 0;
+  resetSpeedRejectionStreak();
 };
 
 // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
@@ -183,12 +261,31 @@ export const setLocation = (location: Location.LocationObject) => {
   const skipSmoothing =
     currentLineType === LineType.Subway && !isAccuracyStable(updatedHistory);
 
-  // スムージングスキップ時はフィルタ・スムージングを全てスキップする
-  // UIには生の座標を反映するが、EMA基準(lastFilteredLocationAtom)も速度フィルタ基準
-  // (lastRawLocationAtom)も更新しない。地上復帰時は基準が古いためSTALE_REFERENCE_MSの
-  // 判定に掛かり、そこで張り直される
+  // スムージングスキップ時はEMAを掛けず生の座標をUIへ反映するが、ワープ対策の
+  // 速度フィルタだけは通す。地下鉄ではGPSが届かずWi-Fi/基地局測位へ落ちるため、
+  // もっともらしい精度のまま数百m〜数km離れた別の駅付近の座標が届くことがあり、
+  // ここを素通しにすると届いた瞬間に無関係な駅へ飛ぶ。iOSはtimeIntervalが効かず
+  // 配信が速いぶん、この素通しがそのままワープの多さとして表面化する。
+  //
+  // EMA基準(lastFilteredLocationAtom)と速度フィルタ基準(lastRawLocationAtom)は
+  // 従来どおり更新しない。地上復帰時に基準が古いままSTALE_REFERENCE_MSの判定へ
+  // 掛かって張り直される流れを保つため。速度判定にはこの経路専用の基準を使う。
   if (skipSmoothing) {
+    const skipPrev = store.get(lastSkipSmoothingLocationAtom);
+    if (
+      skipPrev != null &&
+      isImplausibleJump(skipPrev, location, MAX_PLAUSIBLE_SUBWAY_SPEED) &&
+      // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま復帰
+      // できなくなるのを避けるため、上限に達したら棄却せず基準を張り直す。
+      !registerSpeedRejection(location.timestamp)
+    ) {
+      store.set(accuracyHistoryAtom, updatedHistory);
+      return;
+    }
+
+    resetSpeedRejectionStreak();
     store.set(locationAtom, location);
+    store.set(lastSkipSmoothingLocationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
     return;
   }
@@ -206,35 +303,19 @@ export const setLocation = (location: Location.LocationObject) => {
   // (下のSTALE_REFERENCE_MS判定)だけで、変位÷経過時間という速度の妥当性検査は
   // 経過時間が延びても成立するため。ここを飛ばすと、間隔が空いた直後の1点に限って
   // ワープ対策が無効になる。
-  const dt = (location.timestamp - rawPrev.timestamp) / 1000; // 秒
-  if (dt > 0) {
-    const dist = getDistance(
-      {
-        latitude: rawPrev.coords.latitude,
-        longitude: rawPrev.coords.longitude,
-      },
-      {
-        latitude: location.coords.latitude,
-        longitude: location.coords.longitude,
-      }
-    );
-    const speed = dist / dt;
-
-    // 物理的にありえない速度の場合は座標を棄却し、前回値を維持する
-    if (speed > MAX_PLAUSIBLE_SPEED) {
-      consecutiveSpeedRejections += 1;
-      // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま
-      // 復帰できなくなるのを避けるため、上限に達したら基準を張り直す。
-      if (consecutiveSpeedRejections >= MAX_CONSECUTIVE_SPEED_REJECTIONS) {
-        resyncLocationReference(location, updatedHistory);
-        return;
-      }
-      store.set(accuracyHistoryAtom, updatedHistory);
+  // 物理的にありえない速度の場合は座標を棄却し、前回値を維持する
+  if (isImplausibleJump(rawPrev, location, MAX_PLAUSIBLE_SPEED)) {
+    // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま
+    // 復帰できなくなるのを避けるため、上限に達したら基準を張り直す。
+    if (registerSpeedRejection(location.timestamp)) {
+      resyncLocationReference(location, updatedHistory);
       return;
     }
+    store.set(accuracyHistoryAtom, updatedHistory);
+    return;
   }
 
-  consecutiveSpeedRejections = 0;
+  resetSpeedRejectionStreak();
 
   // 速度としては妥当だが基準が古すぎる場合、EMAの基準としては使えないため
   // スムージングせず生の座標へスナップして基準を張り直す。長く途切れたあとに
@@ -272,5 +353,8 @@ export const setLocation = (location: Location.LocationObject) => {
   store.set(lastFilteredLocationAtom, smoothedLocation);
   // 速度フィルタの基準はスムージング前の生座標を保持する
   store.set(lastRawLocationAtom, location);
+  // 地上→地下鉄の切り替わり直後の1点にもワープ対策が効くよう、スキップ経路の
+  // 基準もここで揃えておく
+  store.set(lastSkipSmoothingLocationAtom, location);
   store.set(accuracyHistoryAtom, updatedHistory);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -152,11 +152,25 @@ const lastSkipSmoothingLocationAtom = atom<Location.LocationObject | null>(
   null
 );
 
-// 速度フィルタが連続で棄却した回数。MAX_CONSECUTIVE_SPEED_REJECTIONSの判定に使う。
-let consecutiveSpeedRejections = 0;
-// 現在の連続棄却が始まった測位のタイムスタンプ(ms)。
-// MIN_SPEED_REJECTION_STREAK_MSの判定に使う。
-let speedRejectionStreakStartedAtMs = 0;
+// 速度フィルタの連続棄却の記録。countはMAX_CONSECUTIVE_SPEED_REJECTIONSの、
+// startedAtMsはMIN_SPEED_REJECTION_STREAK_MSの判定に使う。
+type SpeedRejectionStreak = {
+  count: number;
+  startedAtMs: number;
+};
+
+// 棄却の記録は「どの基準に対して連続で棄却したか」を表すので、基準ごとに独立させる。
+// 共有すると、地下鉄経路が20秒条件で抑え込んでいる最中に精度が安定して本線経路へ
+// 切り替わったとき、持ち越された回数だけで本線経路(経過時間の条件なし)の上限に達し、
+// 抑え込んでいたワープがその1点目で受理されてしまう。
+const mainSpeedRejectionStreak: SpeedRejectionStreak = {
+  count: 0,
+  startedAtMs: 0,
+};
+const skipSpeedRejectionStreak: SpeedRejectionStreak = {
+  count: 0,
+  startedAtMs: 0,
+};
 
 // テスト用: モジュール内部の状態をリセットする
 export const resetLocationState = () => {
@@ -167,8 +181,8 @@ export const resetLocationState = () => {
   store.set(lastRawLocationAtom, null);
   store.set(lastSkipSmoothingLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
-  consecutiveSpeedRejections = 0;
-  speedRejectionStreakStartedAtMs = 0;
+  resetSpeedRejectionStreak(mainSpeedRejectionStreak);
+  resetSpeedRejectionStreak(skipSpeedRejectionStreak);
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -204,31 +218,29 @@ const isImplausibleJump = (
   return dist / dtSec > maxSpeed;
 };
 
-const resetSpeedRejectionStreak = () => {
-  consecutiveSpeedRejections = 0;
-  speedRejectionStreakStartedAtMs = 0;
+const resetSpeedRejectionStreak = (streak: SpeedRejectionStreak) => {
+  streak.count = 0;
+  streak.startedAtMs = 0;
 };
 
 // 速度フィルタによる棄却を記録し、基準を張り直すべきか(=基準側が誤っていると
 // 判断すべきか)を返す。棄却が規定回数に達し、かつ経過時間の下限(minStreakMs、
 // 本線経路は0)を満たしたときにだけ真を返す。
 const registerSpeedRejection = (
+  streak: SpeedRejectionStreak,
   timestampMs: number,
   minStreakMs: number
 ): boolean => {
   // 連続棄却の開始時、および時計の巻き戻りで経過時間が測れなくなった場合は数え直す
-  if (
-    consecutiveSpeedRejections === 0 ||
-    timestampMs < speedRejectionStreakStartedAtMs
-  ) {
-    consecutiveSpeedRejections = 0;
-    speedRejectionStreakStartedAtMs = timestampMs;
+  if (streak.count === 0 || timestampMs < streak.startedAtMs) {
+    streak.count = 0;
+    streak.startedAtMs = timestampMs;
   }
-  consecutiveSpeedRejections += 1;
+  streak.count += 1;
 
   return (
-    consecutiveSpeedRejections >= MAX_CONSECUTIVE_SPEED_REJECTIONS &&
-    timestampMs - speedRejectionStreakStartedAtMs >= minStreakMs
+    streak.count >= MAX_CONSECUTIVE_SPEED_REJECTIONS &&
+    timestampMs - streak.startedAtMs >= minStreakMs
   );
 };
 
@@ -245,7 +257,8 @@ const resyncLocationReference = (
   store.set(lastRawLocationAtom, location);
   store.set(lastSkipSmoothingLocationAtom, location);
   store.set(accuracyHistoryAtom, updatedHistory);
-  resetSpeedRejectionStreak();
+  resetSpeedRejectionStreak(mainSpeedRejectionStreak);
+  resetSpeedRejectionStreak(skipSpeedRejectionStreak);
 };
 
 // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
@@ -294,13 +307,18 @@ export const setLocation = (location: Location.LocationObject) => {
       ) &&
       // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま復帰
       // できなくなるのを避けるため、上限に達したら棄却せず基準を張り直す。
-      !registerSpeedRejection(location.timestamp, MIN_SPEED_REJECTION_STREAK_MS)
+      !registerSpeedRejection(
+        skipSpeedRejectionStreak,
+        location.timestamp,
+        MIN_SPEED_REJECTION_STREAK_MS
+      )
     ) {
       store.set(accuracyHistoryAtom, updatedHistory);
       return;
     }
 
-    resetSpeedRejectionStreak();
+    // 更新するのはスキップ経路の基準だけなので、本線経路の記録はそのまま残す
+    resetSpeedRejectionStreak(skipSpeedRejectionStreak);
     store.set(locationAtom, location);
     store.set(lastSkipSmoothingLocationAtom, location);
     store.set(accuracyHistoryAtom, updatedHistory);
@@ -325,7 +343,9 @@ export const setLocation = (location: Location.LocationObject) => {
     // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま
     // 復帰できなくなるのを避けるため、上限に達したら即座に基準を張り直す
     // (#6898: 新幹線速度での現在地凍結の解消。経過時間の条件は課さない)。
-    if (registerSpeedRejection(location.timestamp, 0)) {
+    if (
+      registerSpeedRejection(mainSpeedRejectionStreak, location.timestamp, 0)
+    ) {
       resyncLocationReference(location, updatedHistory);
       return;
     }
@@ -333,7 +353,7 @@ export const setLocation = (location: Location.LocationObject) => {
     return;
   }
 
-  resetSpeedRejectionStreak();
+  resetSpeedRejectionStreak(mainSpeedRejectionStreak);
 
   // 速度としては妥当だが基準が古すぎる場合、EMAの基準としては使えないため
   // スムージングせず生の座標へスナップして基準を張り直す。長く途切れたあとに
@@ -374,5 +394,6 @@ export const setLocation = (location: Location.LocationObject) => {
   // 地上→地下鉄の切り替わり直後の1点にもワープ対策が効くよう、スキップ経路の
   // 基準もここで揃えておく
   store.set(lastSkipSmoothingLocationAtom, location);
+  resetSpeedRejectionStreak(skipSpeedRejectionStreak);
   store.set(accuracyHistoryAtom, updatedHistory);
 };

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -11,13 +11,19 @@ const MAX_ACCURACY_HISTORY = 12;
 // 物理的にありえない速度でのジャンプを棄却する閾値(m/s ≒ 360km/h)
 const MAX_PLAUSIBLE_SPEED = 100;
 
-// スムージングスキップ経路(地下鉄かつ精度が不安定)で使う閾値(m/s ≒ 120km/h)。
-// 判定対象は2点間の平均速度なので、営業最高速度(地下鉄はおおむね110km/h以下)を
-// 上回ることは測位が途切れた区間を跨いでもあり得ない。新幹線を通せるよう緩めてある
-// 既定値(360km/h)をこの経路にも当てると、隣駅程度の距離(500m〜1km)のワープが
-// 数秒で通ってしまう——GPSが届かずWi-Fi/基地局測位へ落ちる区間ではその距離こそが
-// 典型的な誤りなので、路線種別から言える範囲まで絞る。
-const MAX_PLAUSIBLE_SUBWAY_SPEED = 33;
+// スムージングスキップ経路(地下鉄かつ精度が不安定)で使う閾値(m/s ≒ 180km/h)。
+// 新幹線を通すために緩めてある既定値(360km/h)をこの経路にも当てると、隣駅程度の
+// 距離(500m〜1km)のワープが数秒で通ってしまう。GPSが届かずWi-Fi/基地局測位へ落ちる
+// 区間ではその距離こそが典型的な誤りなので、棄却を保てる時間(距離÷この閾値)を
+// 稼ぐために絞る。
+//
+// 値の根拠は「地下鉄の営業最高速度」ではなく「在来線の営業最高速度」に採る。
+// 判定に使うlineTypeはstationState.station、すなわち最後に“到着した”駅のもので、
+// 次駅へ到着するまで更新されない(useRefreshStation)。地下鉄から直通先へ抜けた
+// 区間はまだSubway扱いのままこの経路を通るため、直通先の速度域を外すと正常な
+// 走行を誤棄却する。在来線最速は京成成田スカイアクセス線の160km/hなので、
+// それを上回る180km/hを採る。新幹線はlineTypeがBulletTrainでこの経路に入らない。
+const MAX_PLAUSIBLE_SKIP_SMOOTHING_SPEED = 50;
 
 // 速度フィルタが連続して棄却できる回数の上限。棄却しても基準座標は更新しないため、
 // 基準側が実際の現在地から乖離している場合は正常な測位が延々と弾かれ、位置が
@@ -281,7 +287,11 @@ export const setLocation = (location: Location.LocationObject) => {
     const skipPrev = store.get(lastSkipSmoothingLocationAtom);
     if (
       skipPrev != null &&
-      isImplausibleJump(skipPrev, location, MAX_PLAUSIBLE_SUBWAY_SPEED) &&
+      isImplausibleJump(
+        skipPrev,
+        location,
+        MAX_PLAUSIBLE_SKIP_SMOOTHING_SPEED
+      ) &&
       // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま復帰
       // できなくなるのを避けるため、上限に達したら棄却せず基準を張り直す。
       !registerSpeedRejection(location.timestamp, MIN_SPEED_REJECTION_STREAK_MS)

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -21,18 +21,22 @@ const MAX_PLAUSIBLE_SUBWAY_SPEED = 33;
 
 // 速度フィルタが連続して棄却できる回数の上限。棄却しても基準座標は更新しないため、
 // 基準側が実際の現在地から乖離している場合は正常な測位が延々と弾かれ、位置が
-// 永久に凍結する。この回数に達し、かつMIN_SPEED_REJECTION_STREAK_MSぶんの時間が
-// 経っていれば「基準の方が誤っている」と判断し、届いた測位で基準を張り直す。
+// 永久に凍結する。この回数に達したら「基準の方が誤っている」と判断し、届いた
+// 測位で基準を張り直す(スキップ経路のみMIN_SPEED_REJECTION_STREAK_MSも課す)。
 const MAX_CONSECUTIVE_SPEED_REJECTIONS = 5;
 
-// 連続棄却で基準を張り直すまでに最低限必要な経過時間(ms)。
-// 回数だけを条件にすると、ワープ対策の粘り強さが測位の配信間隔に依存してしまう。
+// スムージングスキップ経路(地下鉄)で基準を張り直すまでに最低限必要な経過時間(ms)。
+// この経路は回数だけを条件にすると、ワープ耐性が測位の配信間隔に反比例してしまう。
 // iOSはtimeIntervalが効かずdistanceInterval基準で概ね1Hz配信されるため5回=約5秒で
 // 基準を明け渡すのに対し、Androidは10秒間隔なので約50秒粘る。同じ「配信間隔で
-// 保護の強さが変わる」問題はEMAのα側では正規化済み(LEGACY_ALPHA_INTERVAL_SEC)で、
-// ここも回数と経過時間の両方を満たしたときだけ張り直すことで間隔に依存させない。
-// 誤測位が数秒だけ固まって届くケース(地下鉄のWi-Fi/基地局測位)で基準を奪われない
-// 程度に長く、基準側が本当に誤っていたときの凍結が長引かない程度に短い値を採る。
+// 保護の強さが変わる」問題はEMAのα側では正規化済み(LEGACY_ALPHA_INTERVAL_SEC)。
+//
+// 本線経路にはこの条件を掛けない。あちらの閾値は360km/hで、超えるのは基準側が
+// 誤っているときだけなので、#6898 は「5サンプルで即座に張り直す」ことで新幹線速度
+// での現在地凍結を解消している。ここに経過時間を足すと凍結時間が配信の速い端末ほど
+// 延び(1Hzなら5秒→20秒 ≒ 320km/hで1.8km)、その修正を打ち消してしまう。
+// スキップ経路の閾値は120km/hで、誤測位のクラスタが数秒続く程度では基準を
+// 明け渡さないことのほうが重要なため、こちらにだけ課す。
 const MIN_SPEED_REJECTION_STREAK_MS = 20_000;
 
 // 基準座標がこれ以上古い場合、EMAの基準としては意味を持たないため、速度フィルタを
@@ -200,8 +204,12 @@ const resetSpeedRejectionStreak = () => {
 };
 
 // 速度フィルタによる棄却を記録し、基準を張り直すべきか(=基準側が誤っていると
-// 判断すべきか)を返す。棄却が規定回数かつ規定時間続いたときにだけ真を返す。
-const registerSpeedRejection = (timestampMs: number): boolean => {
+// 判断すべきか)を返す。棄却が規定回数に達し、かつ経過時間の下限(minStreakMs、
+// 本線経路は0)を満たしたときにだけ真を返す。
+const registerSpeedRejection = (
+  timestampMs: number,
+  minStreakMs: number
+): boolean => {
   // 連続棄却の開始時、および時計の巻き戻りで経過時間が測れなくなった場合は数え直す
   if (
     consecutiveSpeedRejections === 0 ||
@@ -214,8 +222,7 @@ const registerSpeedRejection = (timestampMs: number): boolean => {
 
   return (
     consecutiveSpeedRejections >= MAX_CONSECUTIVE_SPEED_REJECTIONS &&
-    timestampMs - speedRejectionStreakStartedAtMs >=
-      MIN_SPEED_REJECTION_STREAK_MS
+    timestampMs - speedRejectionStreakStartedAtMs >= minStreakMs
   );
 };
 
@@ -277,7 +284,7 @@ export const setLocation = (location: Location.LocationObject) => {
       isImplausibleJump(skipPrev, location, MAX_PLAUSIBLE_SUBWAY_SPEED) &&
       // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま復帰
       // できなくなるのを避けるため、上限に達したら棄却せず基準を張り直す。
-      !registerSpeedRejection(location.timestamp)
+      !registerSpeedRejection(location.timestamp, MIN_SPEED_REJECTION_STREAK_MS)
     ) {
       store.set(accuracyHistoryAtom, updatedHistory);
       return;
@@ -306,8 +313,9 @@ export const setLocation = (location: Location.LocationObject) => {
   // 物理的にありえない速度の場合は座標を棄却し、前回値を維持する
   if (isImplausibleJump(rawPrev, location, MAX_PLAUSIBLE_SPEED)) {
     // 棄却が続くのは基準側が誤っている可能性が高い。位置が凍結したまま
-    // 復帰できなくなるのを避けるため、上限に達したら基準を張り直す。
-    if (registerSpeedRejection(location.timestamp)) {
+    // 復帰できなくなるのを避けるため、上限に達したら即座に基準を張り直す
+    // (#6898: 新幹線速度での現在地凍結の解消。経過時間の条件は課さない)。
+    if (registerSpeedRejection(location.timestamp, 0)) {
       resyncLocationReference(location, updatedHistory);
       return;
     }


### PR DESCRIPTION
## 概要

地下鉄走行中、特に iPhone で現在地が無関係な駅へワープする問題を修正する。

`setLocation` の「地下鉄かつ精度が不安定なときはスムージングをスキップする」経路が、ワープ対策の速度フィルタごと素通しになっていた。地下鉄では GPS が届かず Wi-Fi / 基地局測位へ落ちるため、`MAX_PERMIT_ACCURACY` を余裕で通るもっともらしい精度のまま、数百 m 〜数 km 離れた別の駅付近の座標が届く。それが無検査で `locationAtom` に入り、そのまま最寄り駅探索へ流れていた。つまり最もワープしやすい区間でワープ対策だけが無効になっていた。

iOS で目立つのは配信間隔の差による。iOS は `timeInterval` が効かず `distanceInterval` 基準で概ね 1Hz 配信されるため、素通しの誤測位がそのままの頻度で反映される。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- スムージングスキップ経路にも速度フィルタを適用。EMA 基準（`lastFilteredLocationAtom` / `lastRawLocationAtom`）は地上復帰時に `STALE_REFERENCE_MS` で張り直させるため据え置き、速度判定専用の基準 `lastSkipSmoothingLocationAtom` を追加した
- 地上経路で測位を受理する際にもこの基準を揃え、地上から地下鉄へ切り替わった直後の 1 点にもワープ対策が効くようにした
- スキップ経路の速度上限を 180km/h (`MAX_PLAUSIBLE_SKIP_SMOOTHING_SPEED`) とした。既定値 360km/h は新幹線を通すための値で、これをこの経路に当てると隣駅程度（500m〜1km）のワープが数秒で通ってしまう。棄却を保てる時間は「距離 ÷ 上限」なので、500m のワープで 5 秒 → 10 秒になる
- 連続棄却で基準を張り直す条件に「経過時間 20 秒」を追加したが、これはスキップ経路のみに課す。本線経路は #6898 が「5 サンプルで即座に張り直す」ことで新幹線速度での現在地凍結を解消しているため、経過時間を足すと配信の速い端末ほど凍結が延びてその修正を打ち消す（1Hz なら 5 秒 → 20 秒 ≒ 320km/h で 1.8km）
- 棄却の記録（連続回数と開始時刻）を基準ごとに分離した（`SpeedRejectionStreak`）。共有していると、地下鉄経路が 20 秒条件で抑え込んでいる最中に精度が安定して本線経路へ切り替わったとき、持ち越された回数だけで本線経路（経過時間の条件なし）の上限に達し、抑え込んでいたワープがその 1 点目で受理される。リセット範囲は「その呼び出しがどの基準を張り直したか」に対応させている
- `isImplausibleJump` / `registerSpeedRejection` として両経路の共通処理を切り出した。本線経路の判定式（生座標基準・360km/h）は #6898 のまま変更していない

### 速度上限の根拠

判定に使う `lineType` は `stationState.station`、すなわち最後に「到着した」駅のもので、次駅へ到着するまで更新されない（`useRefreshStation`）。地下鉄から直通先へ抜けた区間もまだ Subway 扱いのままこの経路を通るため、上限を地下鉄の営業最高速度（110km/h）基準で置くと直通先の走行を誤棄却する。在来線最速の京成成田スカイアクセス線 160km/h を上回る 180km/h を採った。新幹線は `lineType` が `BulletTrain` なのでこの経路自体に入らない。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 274 suites / 3001 tests 全通過。追加した回帰テスト:

- スムージングスキップ中でもありえない速度のワープを棄却すること、妥当な速度の移動は生座標のまま反映すること
- 隣駅程度（500m）のワープを既定の閾値より長く棄却し続けること
- 地下鉄直通先の在来線速度（160km/h）を誤棄却しないこと（上限値の根拠を固定する）
- 地上から地下鉄へ切り替わった直後の 1 点にもワープ対策が効くこと
- 地下鉄経路の棄却回数が本線経路へ引き継がれないこと（修正前は失敗することを確認済み）
- 本線経路では 1Hz 配信でも凍結が 5 サンプルを超えて続かないこと（#6898 の保証を固定する）

実機検証は未実施。`replay-gpx` は Android 実機向けのため、iPhone での地下鉄実走確認は別途必要。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: #6898（速度フィルタの基準を生座標にした修正。本 PR はその保証を維持する）

## スクリーンショット（任意）

UI 変更なし: `src/store/atoms/**` の測位フィルタのロジック変更のみで、画面表示に変化はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzST2G67yT9ozhzAPQNRAV