### PR TITLE
精度劣化による強制未到着を発車とみなさないようにしてETAアンカーの誤記録を防ぐ

### DIFF
--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -1,10 +1,15 @@
 import { act, renderHook } from '@testing-library/react-native';
+import type * as Location from 'expo-location';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
 import { StopCondition } from '~/@types/graphql';
 import { createStation } from '~/utils/test/factories';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
+import {
+  locationAccuracyOutlierAtom,
+  locationAtom,
+} from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -100,6 +105,88 @@ describe('useEtaAnchor', () => {
       stationId: stationA.id,
       kind: 'DEPARTED',
       observedAtMs: 2_001_000,
+    });
+  });
+
+  // 回帰: 地下鉄の駅で精度が落ちると useRefreshStation が現在位置を信用できないと判断して
+  // arrived を false へ倒すため、停車したままでも「発車」として記録されていた。そこから
+  // ETA仮想時計が走り出し、以降の推定が「もう発車したはず」の側へずれる。
+  it('精度の外れ値でarrivedがfalseになった場合はDEPARTEDを記録しない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_000_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
+
+    jest.spyOn(Date, 'now').mockReturnValue(3_001_000);
+    act(() => {
+      // 継続測位が最大許容精度超で棄却された状態
+      store.set(locationAccuracyOutlierAtom, true);
+      store.set(arrivedAtom, false);
+    });
+
+    // 発車していないのでアンカーは直前のAT_STATIONのまま
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'AT_STATION',
+      observedAtMs: 3_000_000,
+    });
+  });
+
+  it('最大許容精度を超える測位を保持している場合もDEPARTEDを記録しない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(4_000_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+
+    jest.spyOn(Date, 'now').mockReturnValue(4_001_000);
+    act(() => {
+      // ワンショット取得・手動選択で粗い精度の測位がlocationAtomへ入った状態
+      store.set(locationAtom, {
+        coords: {
+          latitude: 35,
+          longitude: 139,
+          accuracy: 5_000,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          speed: 0,
+        },
+        timestamp: 4_001_000,
+      } as Location.LocationObject);
+      store.set(arrivedAtom, false);
+    });
+
+    expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
+  });
+
+  it('測位が信用できる状態での発車は従来どおりDEPARTEDを記録する', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(5_000_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+
+    jest.spyOn(Date, 'now').mockReturnValue(5_001_000);
+    act(() => {
+      store.set(locationAtom, {
+        coords: {
+          latitude: 35,
+          longitude: 139,
+          accuracy: 30,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          speed: 0,
+        },
+        timestamp: 5_001_000,
+      } as Location.LocationObject);
+      store.set(arrivedAtom, false);
+    });
+
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'DEPARTED',
+      observedAtMs: 5_001_000,
     });
   });
 

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -1,12 +1,15 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
+import { locationAccuracyOutlierAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
   stationAtom,
 } from '../store/atoms/station';
+import { locationAccuracyAtom } from '../store/selectors/location';
 import getIsPass from '../utils/isPass';
+import { isLocationUntrustworthy } from '../utils/locationTrust';
 import { useInterval } from './useInterval';
 
 // AT_STATION の observedAtMs 更新周期。arrived/station が変化しない間も
@@ -28,6 +31,10 @@ export const useEtaAnchor = (): void => {
   const station = useAtomValue(stationAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
   const setAnchor = useSetAtom(etaAnchorAtom);
+  // 発車の真偽を確かめるために測位の信頼性を見る。座標そのものではなく
+  // 精度と外れ値フラグだけを購読するので、測位のたびに再評価はされない。
+  const isAccuracyOutlier = useAtomValue(locationAccuracyOutlierAtom);
+  const accuracy = useAtomValue(locationAccuracyAtom);
 
   // 直前レンダー時点の arrived/station を保持し、true→false 遷移(=発車)の検出に使う。
   // StrictMode は初回マウント時にeffectを一度余分に再実行するが、このrefは
@@ -61,9 +68,21 @@ export const useEtaAnchor = (): void => {
       prevStation?.id != null &&
       !getIsPass(prevStation)
     ) {
-      // 到着中→非到着への遷移(=発車)を検出した瞬間にだけ一発記録する。ETAは位置を
-      // 駆動せず到着しきい値の緩和(R1)にしか使わないため、仮に静止中の強制未到着で
-      // 記録されても、R1は最寄り駅とETA停車駅が一致するときだけ効き、GPS復帰で自己修復する。
+      // 到着中→非到着への遷移(=発車)を検出した瞬間にだけ一発記録する。
+      //
+      // ただし、この遷移は「発車した」以外の理由でも起きる。地下鉄の駅で精度が落ちると
+      // useRefreshStationが現在位置を信用できないと判断してarrivedをfalseへ倒すため、
+      // 停車したままでも発車として記録されてしまう(#6936の調査で確認)。そこから
+      // ETA仮想時計が走り出すと、以降の推定は「もう発車したはず」の側へずれる。
+      // 測位が信用できない間の遷移は発車の証拠にならないので記録しない。
+      // この場合アンカーは直前のAT_STATIONのまま据え置かれ、精度が回復して次の到着を
+      // 検出した時点で正しく張り直される。
+      if (isLocationUntrustworthy({ isAccuracyOutlier, accuracy })) {
+        prevArrivedRef.current = arrived;
+        prevStationRef.current = station;
+        return;
+      }
+
       setAnchor({
         stationId: prevStation.id,
         kind: 'DEPARTED',
@@ -73,7 +92,7 @@ export const useEtaAnchor = (): void => {
 
     prevArrivedRef.current = arrived;
     prevStationRef.current = station;
-  }, [arrived, station, selectedBound, setAnchor]);
+  }, [arrived, station, selectedBound, setAnchor, isAccuracyOutlier, accuracy]);
 
   // arrived/station が変化しない間も経過時間だけは進むため、数秒おきに
   // observedAtMsを更新し続ける(仮想時計の基準時刻を最新に保つ)

--- a/src/hooks/useRefreshStation.ts
+++ b/src/hooks/useRefreshStation.ts
@@ -4,11 +4,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Station } from '~/@types/graphql';
 import { ARRIVED_GRACE_PERIOD_MS, BAD_ACCURACY_THRESHOLD } from '~/constants';
-import {
-  getMaxPermitAccuracy,
-  isEtaAssistEnabled,
-  isForceNotArrivedOnLowAccuracyEnabled,
-} from '~/lib/remoteConfig';
+import { isEtaAssistEnabled } from '~/lib/remoteConfig';
 import { store } from '~/store';
 import { etaAnchorAtom } from '~/store/atoms/etaFallback';
 import {
@@ -21,6 +17,7 @@ import stationState from '../store/atoms/station';
 import { isJapanese, translate } from '../translation';
 import { getEtaPhaseNow } from '../utils/etaPhaseNow';
 import getIsPass from '../utils/isPass';
+import { isLocationUntrustworthy } from '../utils/locationTrust';
 import sendNotificationAsync from '../utils/native/ios/sensitiveNotificationMoudle';
 import { useApproachingStation } from './useApproachingStation';
 import { useCanGoForward } from './useCanGoForward';
@@ -97,19 +94,9 @@ export const useRefreshStation = (): void => {
     }
 
     // 現在位置を信用できない状況では到着判定の信頼性が担保できないため、
-    // 強制的に未到着(=走行中)とみなす。次の2系統を区別して検査する:
-    //   1. 継続測位: handleTrackingLocationが最大許容精度超の測位を棄却して
-    //      座標を凍結するため、精度悪化はlocationAtom側には現れない。棄却の事実は
-    //      外れ値フラグ(isAccuracyOutlier)から判定する。
-    //   2. ワンショット取得・手動選択: フィルタを経由せず粗い精度の測位がlocationAtomに
-    //      入りうるため、保持している精度を直接検査する。
-    // この強制未到着はRemote Configのフィーチャートグルで無効化でき、無効時は
-    // 精度に依らず通常の到着判定を行う。
-    if (
-      isForceNotArrivedOnLowAccuracyEnabled() &&
-      (isAccuracyOutlier ||
-        (accuracy != null && accuracy > getMaxPermitAccuracy()))
-    ) {
+    // 強制的に未到着(=走行中)とみなす。判定材料とフィーチャートグルの扱いは
+    // isLocationUntrustworthy に集約している(useEtaAnchorと同じ条件を使うため)。
+    if (isLocationUntrustworthy({ isAccuracyOutlier, accuracy })) {
       return false;
     }
 

--- a/src/utils/locationTrust.ts
+++ b/src/utils/locationTrust.ts
@@ -1,0 +1,30 @@
+import {
+  getMaxPermitAccuracy,
+  isForceNotArrivedOnLowAccuracyEnabled,
+} from '~/lib/remoteConfig';
+
+/**
+ * 現在位置を信用できない状態かを返す。
+ *
+ * 判定材料は2系統ある:
+ *   1. 継続測位: handleTrackingLocationが最大許容精度超の測位を棄却して座標を凍結する
+ *      ため、精度悪化はlocationAtom側には現れない。棄却の事実は外れ値フラグから判定する。
+ *   2. ワンショット取得・手動選択: フィルタを経由せず粗い精度の測位がlocationAtomへ
+ *      入りうるため、保持している精度を直接検査する。
+ *
+ * Remote Configのフィーチャートグルで無効化でき、無効時は常にfalse(＝信用する)を返す。
+ *
+ * useRefreshStationの強制未到着と、useEtaAnchorの発車記録の抑止が同じ条件を参照する。
+ * 条件を2箇所へ書くと、片方だけ変わったときに「発車していないのに発車として記録される」
+ * 状態へ戻るため、ここへ集約する。
+ */
+export const isLocationUntrustworthy = ({
+  isAccuracyOutlier,
+  accuracy,
+}: {
+  isAccuracyOutlier: boolean;
+  accuracy: number | null | undefined;
+}): boolean =>
+  isForceNotArrivedOnLowAccuracyEnabled() &&
+  (isAccuracyOutlier ||
+    (accuracy != null && accuracy > getMaxPermitAccuracy()));


### PR DESCRIPTION
## 概要

地下鉄の駅に停車したままでも「発車した」と記録され、ETA 仮想時計がそこから走り出してしまう経路を塞ぐ。

`useRefreshStation` は現在位置を信用できないとき（測位が最大許容精度超で棄却された、または保持している精度が粗い）に `arrived` を強制的に false へ倒す。`useEtaAnchor` は `arrived` の true→false 遷移を発車とみなして `DEPARTED` アンカーを記録するため、**地下鉄の駅で精度が落ちた瞬間に、停車中でも発車として記録される**。

```text
地下鉄駅で停車中に精度が悪化
  → useRefreshStation の強制未到着で isArrived = false
  → stationState.arrived が true→false
  → useEtaAnchor が「発車」とみなして DEPARTED を記録
  → ETA仮想時計がその駅の発車時刻から走り出す
```

この誤記録自体は既知で、#6369（ETA が位置を独占駆動する R2 を撤去した PR）のコメントに「ETAは位置を駆動しないため、仮に静止中の強制未到着で `DEPARTED` が記録されても、R1は最寄り駅とETA停車駅が一致するときだけ効き、GPS復帰で自己修復する」と、**許容する前提**で書かれていた。本 PR はその判断を変更する。理由は2点。

1. アンカーは「GPSで確定した駅イベント」であるべきで、停車中に発車を記録するのは事実に反する。R1 が結果的に無害でも、記録が誤っていること自体は変わらない
2. 測位の妥当性判定に ETA を使う方向（#6936 の調査で、点ごとの速度判定ではノイズとワープを原理的に分離できないことが判明）を検討しており、その場合アンカーの正しさが前提条件になる

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/locationTrust.ts` を新設し、「現在位置を信用できない」条件（フィーチャートグル + 外れ値フラグ + 保持精度）を純関数 `isLocationUntrustworthy` へ集約した
- `useRefreshStation` の強制未到着をこの関数の呼び出しへ置き換えた（判定内容は変更なし）
- `useEtaAnchor` で、`arrived` の true→false 遷移が起きても**測位が信用できない間は `DEPARTED` を記録しない**ようにした。アンカーは直前の `AT_STATION` のまま据え置かれ、精度が回復して次の到着を検出した時点で正しく張り直される
- 条件を2箇所に書くと片方だけ変わったときに元の状態へ戻るため、共通化を同じ変更に含めている

`useEtaAnchor` が新たに購読するのは `locationAccuracyOutlierAtom` と `locationAccuracyAtom`（精度のみの派生 atom）で、座標そのものは購読しない。測位のたびに再評価されることはない（`docs/state-management.md` の方針に沿う）。

## 挙動の変化（レビューで見ていただきたい点）

精度が悪いまま実際に発車した場合、`arrived` はすでに false なので true→false 遷移が起きず、**その区間では `DEPARTED` アンカーが記録されない**。したがって R1（精度劣化時に ETA が同じ駅で停車を示すときだけ到着圏を緩和する補助）は、その区間では発動しない。次の到着を検出した時点で `AT_STATION` が記録され復帰する。

「誤った発車時刻を起点に走るETA」と「アンカーが無い状態」のどちらを選ぶかという判断で、本 PR は後者を採った。R1 は確認的な緩和であり、誤った起点で効くより発動しない方が安全と考えたため。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 274 suites / 2994 tests 全通過。追加した回帰テスト3件:

- 精度の外れ値で `arrived` が false になった場合は `DEPARTED` を記録しない
- 最大許容精度を超える測位を保持している場合も `DEPARTED` を記録しない
- 測位が信用できる状態での発車は従来どおり `DEPARTED` を記録する

前2件がガードを外すと失敗することを確認済み（外した状態で 2 failed / 6 passed、戻すと 8 passed）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: #6369（ETA の R2 撤去。本 PR が変更する「誤記録を許容する」判断の出どころ）、#6936（この経路を発見した調査。現在 Draft）

## スクリーンショット（任意）

UI 変更なし: `src/hooks/**` と `src/utils/**` の状態記録ロジックのみの変更で、画面表示に変化はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzST2G67yT9ozhzAPQNRAV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzST2G67yT9ozhzAPQNRAV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 信頼性の低い測位情報による誤った発車判定を防止しました。
  * 停車中に測位精度が外れ値または許容範囲外となった場合、既存の到着状態を維持します。
  * 信頼できる測位情報に基づく発車判定は、従来どおり記録されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->