### PR TITLE
ETAが許す進行量を超える測位を棄却して地下鉄で無関係な駅へ飛ぶのを防ぐ

### DIFF
--- a/src/store/atoms/location.etaBound.test.ts
+++ b/src/store/atoms/location.etaBound.test.ts
@@ -1,0 +1,123 @@
+import type * as Location from 'expo-location';
+import { LineType, type Station } from '~/@types/graphql';
+import { store } from '..';
+import { etaAnchorAtom, etaStopsAtom } from './etaFallback';
+import { locationAtom, resetLocationState, setLocation } from './location';
+import stationState from './station';
+
+// ETA補助は既定で無効(remoteConfigのフォールバックがfalse)なので、有効な場合の挙動を測る
+jest.mock('~/lib/remoteConfig', () => ({
+  isEtaAssistEnabled: () => true,
+  getEtaFallbackArrivalConfirmMarginSec: () => 30,
+  getMaxPermitAccuracy: () => 1500,
+  isForceNotArrivedOnLowAccuracyEnabled: () => true,
+}));
+
+const METERS_PER_DEG_LAT = 111_320;
+const STATION_INTERVAL_M = 1_100;
+
+// 1.1km間隔で南北に並ぶ10駅の路線
+const stations: Station[] = Array.from(
+  { length: 10 },
+  (_, i) =>
+    ({
+      id: i + 1,
+      latitude: 35.0 + (i * STATION_INTERVAL_M) / METERS_PER_DEG_LAT,
+      longitude: 139.0,
+    }) as Station
+);
+
+const makeLocation = (
+  lat: number,
+  timestamp: number,
+  accuracy = 300
+): Location.LocationObject => ({
+  coords: {
+    latitude: lat,
+    longitude: 139.0,
+    accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: null,
+  },
+  timestamp,
+});
+
+const setupRoute = () => {
+  store.set(stationState, {
+    arrived: true,
+    approaching: false,
+    station: { line: { lineType: LineType.Subway } } as Station,
+    stations,
+    stationsCache: [],
+    pendingStation: null,
+    pendingStations: [],
+    selectedDirection: null,
+    selectedBound: null,
+    wantedDestination: null,
+  });
+  // 2分間隔で停車していく想定のETA
+  store.set(
+    etaStopsAtom,
+    stations.map((s, i) => ({
+      stationId: s.id as number,
+      cumulativeMinutes: i * 2,
+      departureCumulativeMinutes: i * 2 + 0.5,
+    }))
+  );
+};
+
+describe('ETAの進行量上限による棄却', () => {
+  beforeEach(() => {
+    resetLocationState();
+    setupRoute();
+  });
+
+  it('ETAが示す進行量を大きく超える測位は反映しない', () => {
+    const t0 = 1_000_000;
+    // 2駅目を発車した直後
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+
+    // まず2駅目付近の測位で基準を作る
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+    const before = store.get(locationAtom)?.coords.latitude;
+
+    // 10秒後、6駅目付近(=4駅先)の座標が届く
+    setLocation(makeLocation(stations[5].latitude as number, t0 + 11_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(before);
+  });
+
+  it('ETAが示す進行量の範囲内なら反映する', () => {
+    const t0 = 2_000_000;
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+
+    // 10秒後、3駅目付近(=次の停車駅)の座標が届く
+    const next = stations[2].latitude as number;
+    setLocation(makeLocation(next, t0 + 11_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(next);
+  });
+
+  it('アンカーが無い場合は判定せず従来どおり反映する', () => {
+    const t0 = 3_000_000;
+    store.set(etaAnchorAtom, null);
+
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+    const far = stations[5].latitude as number;
+    setLocation(makeLocation(far, t0 + 11_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(far);
+  });
+});

--- a/src/store/atoms/location.etaBound.test.ts
+++ b/src/store/atoms/location.etaBound.test.ts
@@ -5,9 +5,11 @@ import { etaAnchorAtom, etaStopsAtom } from './etaFallback';
 import { locationAtom, resetLocationState, setLocation } from './location';
 import stationState from './station';
 
-// ETA補助は既定で無効(remoteConfigのフォールバックがfalse)なので、有効な場合の挙動を測る
+// ETA補助は既定で無効(remoteConfigのフォールバックがfalse)なので、有効な場合の挙動を測る。
+// 無効時に一切干渉しないことも確認するため、フラグで切り替えられるようにする。
+let mockEtaAssistEnabled = true;
 jest.mock('~/lib/remoteConfig', () => ({
-  isEtaAssistEnabled: () => true,
+  isEtaAssistEnabled: () => mockEtaAssistEnabled,
   getEtaFallbackArrivalConfirmMarginSec: () => 30,
   getMaxPermitAccuracy: () => 1500,
   isForceNotArrivedOnLowAccuracyEnabled: () => true,
@@ -70,6 +72,7 @@ const setupRoute = () => {
 
 describe('ETAの進行量上限による棄却', () => {
   beforeEach(() => {
+    mockEtaAssistEnabled = true;
     resetLocationState();
     setupRoute();
   });
@@ -108,6 +111,101 @@ describe('ETAの進行量上限による棄却', () => {
     setLocation(makeLocation(next, t0 + 11_000));
 
     expect(store.get(locationAtom)?.coords.latitude).toBe(next);
+  });
+
+  // 回帰: 上限時間の打ち切りが「1件だけ受理して棄却を再開する」実装だと、
+  // 範囲外の測位が90秒に1件しか通らず、位置が実質凍結したままになる。
+  it('上限時間を過ぎたら棄却を打ち切り、その後の範囲外測位も続けて反映する', () => {
+    const t0 = 4_000_000;
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+
+    const far = stations[5].latitude as number;
+    // 範囲外の測位が届き続ける
+    setLocation(makeLocation(far, t0 + 11_000));
+    expect(store.get(locationAtom)?.coords.latitude).not.toBe(far);
+
+    // 上限(90秒)到達で打ち切り、受理する
+    setLocation(makeLocation(far, t0 + 11_000 + 90_000));
+    expect(store.get(locationAtom)?.coords.latitude).toBe(far);
+
+    // 打ち切り後は、直後の範囲外測位も続けて反映される
+    const farther = stations[6].latitude as number;
+    setLocation(makeLocation(farther, t0 + 11_000 + 91_000));
+    expect(store.get(locationAtom)?.coords.latitude).toBe(farther);
+  });
+
+  it('打ち切り後に範囲内の測位が届いたら、再び範囲外を棄却する', () => {
+    const t0 = 5_000_000;
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+
+    const far = stations[5].latitude as number;
+    setLocation(makeLocation(far, t0 + 11_000));
+    setLocation(makeLocation(far, t0 + 11_000 + 90_000));
+    expect(store.get(locationAtom)?.coords.latitude).toBe(far);
+
+    // 範囲内へ戻る(ETAを再び信用できる状態)
+    const inRange = stations[2].latitude as number;
+    setLocation(makeLocation(inRange, t0 + 11_000 + 91_000));
+    expect(store.get(locationAtom)?.coords.latitude).toBe(inRange);
+
+    // 再び範囲外が届いたら棄却する
+    setLocation(
+      makeLocation(stations[6].latitude as number, t0 + 11_000 + 92_000)
+    );
+    expect(store.get(locationAtom)?.coords.latitude).toBe(inRange);
+  });
+
+  it('打ち切り後でもアンカーが張り直されたら再び棄却する', () => {
+    const t0 = 6_000_000;
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+
+    const far = stations[5].latitude as number;
+    setLocation(makeLocation(far, t0 + 11_000));
+    setLocation(makeLocation(far, t0 + 11_000 + 90_000));
+    expect(store.get(locationAtom)?.coords.latitude).toBe(far);
+
+    // 次の駅へ到着してアンカーが張り直された
+    store.set(etaAnchorAtom, {
+      stationId: 3,
+      kind: 'AT_STATION',
+      observedAtMs: t0 + 11_000 + 91_000,
+    });
+    const held = store.get(locationAtom)?.coords.latitude;
+    setLocation(
+      makeLocation(stations[8].latitude as number, t0 + 11_000 + 92_000)
+    );
+    expect(store.get(locationAtom)?.coords.latitude).toBe(held);
+  });
+
+  it('ETA補助が無効なら判定せず従来どおり反映する', () => {
+    mockEtaAssistEnabled = false;
+    const t0 = 7_000_000;
+    store.set(etaAnchorAtom, {
+      stationId: 2,
+      kind: 'DEPARTED',
+      observedAtMs: t0,
+    });
+
+    setLocation(makeLocation(stations[1].latitude as number, t0 + 1_000));
+    const far = stations[5].latitude as number;
+    setLocation(makeLocation(far, t0 + 11_000));
+
+    expect(store.get(locationAtom)?.coords.latitude).toBe(far);
   });
 
   it('アンカーが無い場合は判定せず従来どおり反映する', () => {

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -129,7 +129,7 @@ export const resetLocationState = () => {
   store.set(lastRawLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
   consecutiveSpeedRejections = 0;
-  etaBoundHoldStartedAtMs = 0;
+  resetEtaBoundHold();
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -170,6 +170,17 @@ const ETA_BOUND_MAX_HOLD_MS = 90_000;
 
 let etaBoundHoldStartedAtMs = 0;
 
+// 上限時間に達して「ETA側が誤っている」と判断した状態。値は判断した時点のETAの文脈
+// (アンカー駅・種別・対象駅)で、同じ文脈が続くあいだは棄却を再開しない。
+// 1件だけ受理して棄却を再開すると、範囲外の測位が上限時間ごとに1件しか通らず、
+// 位置が実質凍結したままになる(=保険が機能しない)。
+let etaBoundBypassedContext: string | null = null;
+
+const resetEtaBoundHold = () => {
+  etaBoundHoldStartedAtMs = 0;
+  etaBoundBypassedContext = null;
+};
+
 /**
  * ETAが許す進行量を超えた測位か。超えていれば受理せず、位置を据え置く。
  * ETAは位置を進めない(#6369の方針)ので、棄却にのみ使う。
@@ -178,11 +189,19 @@ const isImplausibleByEta = (location: Location.LocationObject): boolean => {
   const anchor = store.get(etaAnchorAtom);
   const phase = getEtaPhaseNow(location.timestamp);
   if (!anchor || !phase) {
-    etaBoundHoldStartedAtMs = 0;
+    resetEtaBoundHold();
     return false;
   }
   const targetStationId =
     phase.kind === 'DWELLING' ? phase.stationId : phase.targetStationId;
+
+  // アンカーが張り直された(次駅へ到着した等)ならETAは新しい観測に基づくので、
+  // 打ち切り状態を解除して再び信用する。
+  const context = `${anchor.stationId}:${anchor.kind}:${targetStationId}`;
+  if (etaBoundBypassedContext !== null && etaBoundBypassedContext !== context) {
+    resetEtaBoundHold();
+  }
+
   const beyond = isBeyondEtaProgress({
     stations: store.get(stationState).stations,
     anchorStationId: anchor.stationId,
@@ -192,7 +211,11 @@ const isImplausibleByEta = (location: Location.LocationObject): boolean => {
     toleranceStations: ETA_BOUND_TOLERANCE_STATIONS,
   });
   if (!beyond) {
-    etaBoundHoldStartedAtMs = 0;
+    // 範囲内の測位が届いた＝ETAと実測が再び噛み合った
+    resetEtaBoundHold();
+    return false;
+  }
+  if (etaBoundBypassedContext === context) {
     return false;
   }
   if (
@@ -202,6 +225,7 @@ const isImplausibleByEta = (location: Location.LocationObject): boolean => {
     etaBoundHoldStartedAtMs = location.timestamp;
   }
   if (location.timestamp - etaBoundHoldStartedAtMs >= ETA_BOUND_MAX_HOLD_MS) {
+    etaBoundBypassedContext = context;
     etaBoundHoldStartedAtMs = 0;
     return false;
   }

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -3,7 +3,10 @@ import getDistance from 'geolib/es/getDistance';
 import { atom } from 'jotai';
 import { LineType } from '~/@types/graphql';
 import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
+import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
+import { isBeyondEtaProgress } from '~/utils/etaProgressBound';
 import { store } from '..';
+import { etaAnchorAtom } from './etaFallback';
 import stationState from './station';
 
 const MAX_ACCURACY_HISTORY = 12;
@@ -126,6 +129,7 @@ export const resetLocationState = () => {
   store.set(lastRawLocationAtom, null);
   store.set(locationAccuracyOutlierAtom, false);
   consecutiveSpeedRejections = 0;
+  etaBoundHoldStartedAtMs = 0;
 };
 
 // ワープ対策フィルタによる棄却有無を記録する。handleTrackingLocationから
@@ -157,6 +161,53 @@ const resyncLocationReference = (
   consecutiveSpeedRejections = 0;
 };
 
+// ETAの進行量上限から外れた測位を、何駅ぶんまで許容するか。
+// ETAは停車時間や加減速の見積もりぶん実際とずれるので、隣駅1つぶんの余裕を持たせる。
+const ETA_BOUND_TOLERANCE_STATIONS = 1;
+
+// ETAによる棄却を続けてよい上限(ms)。ETA側が誤っている場合に位置が凍結し続けないための保険。
+const ETA_BOUND_MAX_HOLD_MS = 90_000;
+
+let etaBoundHoldStartedAtMs = 0;
+
+/**
+ * ETAが許す進行量を超えた測位か。超えていれば受理せず、位置を据え置く。
+ * ETAは位置を進めない(#6369の方針)ので、棄却にのみ使う。
+ */
+const isImplausibleByEta = (location: Location.LocationObject): boolean => {
+  const anchor = store.get(etaAnchorAtom);
+  const phase = getEtaPhaseNow(location.timestamp);
+  if (!anchor || !phase) {
+    etaBoundHoldStartedAtMs = 0;
+    return false;
+  }
+  const targetStationId =
+    phase.kind === 'DWELLING' ? phase.stationId : phase.targetStationId;
+  const beyond = isBeyondEtaProgress({
+    stations: store.get(stationState).stations,
+    anchorStationId: anchor.stationId,
+    targetStationId,
+    latitude: location.coords.latitude,
+    longitude: location.coords.longitude,
+    toleranceStations: ETA_BOUND_TOLERANCE_STATIONS,
+  });
+  if (!beyond) {
+    etaBoundHoldStartedAtMs = 0;
+    return false;
+  }
+  if (
+    etaBoundHoldStartedAtMs === 0 ||
+    location.timestamp < etaBoundHoldStartedAtMs
+  ) {
+    etaBoundHoldStartedAtMs = location.timestamp;
+  }
+  if (location.timestamp - etaBoundHoldStartedAtMs >= ETA_BOUND_MAX_HOLD_MS) {
+    etaBoundHoldStartedAtMs = 0;
+    return false;
+  }
+  return true;
+};
+
 // 受理した測位が反映される唯一の入口。継続測位の正常系に加え、ワンショット取得や
 // 手動選択(StationSearchModal/useInitialNearbyStation/Privacy等)もここを通る。
 export const setLocation = (location: Location.LocationObject) => {
@@ -182,6 +233,12 @@ export const setLocation = (location: Location.LocationObject) => {
   const currentLineType = store.get(stationState).station?.line?.lineType;
   const skipSmoothing =
     currentLineType === LineType.Subway && !isAccuracyStable(updatedHistory);
+
+  // ETAが許す進行量を超えた測位は、どちらの経路へも通さない
+  if (isImplausibleByEta(location)) {
+    store.set(accuracyHistoryAtom, updatedHistory);
+    return;
+  }
 
   // スムージングスキップ時はフィルタ・スムージングを全てスキップする
   // UIには生の座標を反映するが、EMA基準(lastFilteredLocationAtom)も速度フィルタ基準

--- a/src/utils/etaProgressBound.test.ts
+++ b/src/utils/etaProgressBound.test.ts
@@ -1,0 +1,148 @@
+import type { Station } from '~/@types/graphql';
+import { isBeyondEtaProgress } from './etaProgressBound';
+
+// 経度0.01度 ≒ 900m。駅を南北に約1.1kmずつ並べた直線路線を用意する。
+const makeStations = (count: number): Station[] =>
+  Array.from(
+    { length: count },
+    (_, i) =>
+      ({
+        id: i + 1,
+        latitude: 35.0 + i * 0.01,
+        longitude: 139.0,
+      }) as Station
+  );
+
+const stations = makeStations(10);
+
+// 指定した駅のすぐ近く(約50m)の座標
+const near = (idx: number) => ({
+  latitude: (stations[idx].latitude as number) + 0.00045,
+  longitude: stations[idx].longitude as number,
+});
+
+describe('isBeyondEtaProgress', () => {
+  const base = {
+    stations,
+    toleranceStations: 1,
+  };
+
+  it('ETAの対象駅の手前にいる測位は許容する', () => {
+    // 駅2を発車し駅3へ向かっている推定。実際は駅2と駅3の間
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 3,
+        targetStationId: 4,
+        ...near(2),
+      })
+    ).toBe(false);
+  });
+
+  it('対象駅の1駅先までは許容する(ETAの見積もり誤差ぶん)', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 3,
+        targetStationId: 4,
+        ...near(4),
+      })
+    ).toBe(false);
+  });
+
+  it('対象駅の2駅以上先を指す測位は棄却する', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 3,
+        targetStationId: 4,
+        ...near(5),
+      })
+    ).toBe(true);
+  });
+
+  it('アンカーより後方へ大きく外れた測位も棄却する', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 5,
+        targetStationId: 6,
+        ...near(2),
+      })
+    ).toBe(true);
+  });
+
+  // 進行方向はアンカー→対象駅の並びから決まるので、逆向きでも同じ基準になること。
+  // アンカーidx5→対象idx4(降順)なら、idx3までが許容・idx2からが棄却で、
+  // 昇順(アンカーidx2→対象idx3で、idx4まで許容・idx5から棄却)と対称。
+  it('インデックスが降順に進む向きでも同じ基準で判定する', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 6,
+        targetStationId: 5,
+        ...near(2),
+      })
+    ).toBe(true);
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 6,
+        targetStationId: 5,
+        ...near(3),
+      })
+    ).toBe(false);
+  });
+
+  it('停車推定(アンカーと対象が同一駅)では前後1駅までを許容する', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 4,
+        targetStationId: 4,
+        ...near(4),
+      })
+    ).toBe(false);
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 4,
+        targetStationId: 4,
+        ...near(5),
+      })
+    ).toBe(true);
+  });
+
+  it('アンカー駅または対象駅が路線の駅一覧に無い場合は判定しない', () => {
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 999,
+        targetStationId: 4,
+        ...near(9),
+      })
+    ).toBe(false);
+    expect(
+      isBeyondEtaProgress({
+        ...base,
+        anchorStationId: 3,
+        targetStationId: 999,
+        ...near(9),
+      })
+    ).toBe(false);
+  });
+
+  it('座標を持たない駅しか無い場合は判定しない', () => {
+    const noCoords = [{ id: 1 } as Station, { id: 2 } as Station];
+    expect(
+      isBeyondEtaProgress({
+        stations: noCoords,
+        anchorStationId: 1,
+        targetStationId: 2,
+        latitude: 35.0,
+        longitude: 139.0,
+        toleranceStations: 1,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/etaProgressBound.ts
+++ b/src/utils/etaProgressBound.ts
@@ -1,0 +1,68 @@
+import getDistance from 'geolib/es/getDistance';
+import type { Station } from '~/@types/graphql';
+
+/**
+ * ETA仮想時計が示す進行状況から見て、届いた測位が「そこまで進んでいるはずがない」位置かを
+ * 判定する純関数。
+ *
+ * ETAは駅間距離と車両性能から算出される(StationAPIのTrainRouteSegmentが
+ * distanceFromPrevious / maxSpeed / maxAcceleration / maxDeceleration を持つ)ため、
+ * 「どこにいるか」より「どこまでは進めないか」の方が信頼できる。遅延も停車時間の伸びも
+ * 列車を遅くする方向にしか働かないので、上限としては破られない。
+ *
+ * 位置を進めるためには使わない。ETAが位置・到着・接近を駆動しない方針(#6369)は維持し、
+ * ここでの用途は棄却のみ。ETAが誤っていても、位置が据え置かれる以上の影響は出ない。
+ */
+export const isBeyondEtaProgress = ({
+  stations,
+  anchorStationId,
+  targetStationId,
+  latitude,
+  longitude,
+  toleranceStations,
+}: {
+  stations: Station[];
+  anchorStationId: number;
+  targetStationId: number;
+  latitude: number;
+  longitude: number;
+  toleranceStations: number;
+}): boolean => {
+  const anchorIdx = stations.findIndex((s) => s.id === anchorStationId);
+  const targetIdx = stations.findIndex((s) => s.id === targetStationId);
+  if (anchorIdx === -1 || targetIdx === -1) {
+    return false;
+  }
+
+  let fixIdx = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  stations.forEach((s, i) => {
+    const lat = s.latitude;
+    const lon = s.longitude;
+    if (lat == null || lon == null) {
+      return;
+    }
+    const d = getDistance(
+      { latitude: lat, longitude: lon },
+      { latitude, longitude }
+    );
+    if (d < bestDistance) {
+      bestDistance = d;
+      fixIdx = i;
+    }
+  });
+  if (fixIdx === -1) {
+    return false;
+  }
+
+  // 進行方向はETA側の並び(アンカー→対象駅)から決める。
+  const direction = Math.sign(targetIdx - anchorIdx);
+  if (direction === 0) {
+    // アンカー駅で停車中の推定。前後どちらへもtolerance以上離れていたら説明できない。
+    return Math.abs(fixIdx - anchorIdx) > toleranceStations;
+  }
+
+  const progress = (fixIdx - anchorIdx) * direction;
+  const limit = (targetIdx - anchorIdx) * direction + toleranceStations;
+  return progress > limit || progress < -toleranceStations;
+};


### PR DESCRIPTION
## 概要

地下鉄走行中に現在地が数駅先の無関係な駅へ飛ぶ問題を修正する。

地下鉄では GPS が届かず Wi-Fi / 基地局測位へ落ちるため、**もっともらしい精度（65m 程度）のまま、数駅離れた駅付近の座標が数十秒にわたって届き続ける**ことがある。この誤測位は単発のスパイクではなくクラスタなので、既存の速度フィルタ（前回座標からの見かけ速度が閾値超なら棄却）では原理的に止められない。

### 速度フィルタで止められない理由（計測済み）

1Hz 配信では 1 サンプルあたりの変位がノイズ支配になる。地下鉄の σ=65〜400m に対し「500m のワープ」は 1〜2σ の範囲に収まり、**単発の変位を見る限りワープとノイズは統計的に区別できない**。実際、実走行ログ（`assets/gpx/SampleJY.gpx`、外部ツールで記録した山手線の実ログ）には見かけ速度 50m/s 超の区間が 30 件（最大 494km/h 相当）含まれており、これはノイズである。閾値を絞れば通常走行の測位まで棄却して表示が凍結し、緩めればワープが通る。

そこで、単発の変位ではなく **ETA が許す進行量の上限**で判定する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/utils/etaProgressBound.ts` を新設。ETA 仮想時計が示す対象駅とアンカー駅から進行方向を決め、届いた測位の最寄り駅がその範囲を `toleranceStations` 以上超えていれば「そこまで進めるはずがない」と判定する純関数 `isBeyondEtaProgress`
- `setLocation` で、この判定に掛かった測位を受理せず位置を据え置く（スキップ経路・本線経路の両方に適用）
- 許容は前後 1 駅（`ETA_BOUND_TOLERANCE_STATIONS`）
- ETA 側が誤っている場合に位置が凍結し続けないための保険として、棄却が 90 秒（`ETA_BOUND_MAX_HOLD_MS`）続いたら打ち切る。打ち切りは **1 件の例外ではなく継続する状態**で、同じ ETA の文脈（アンカー駅・種別・対象駅）が続くあいだは棄却を再開しない。解除条件は「範囲内の測位が届いた」「アンカーが張り直された」「`resetLocationState`」の 3 つ

### なぜ ETA を上限として使えるか

ETA は StationAPI が駅間距離と車両性能（`TrainRouteSegment` の `distanceFromPrevious` / `maxSpeed` / `maxAcceleration` / `maxDeceleration`）から算出する運動学モデルで、経過時間からの外挿ではない。**遅延も停車時間の伸びも列車を遅くする方向にしか働かない**ため、「ここまでしか進んでいないはず」という上限としては破られない。ノイズの大きさに依存しないので、σ が大きい地下鉄でも判定できる。

### #6369 の方針との関係

ETA が位置・到着・接近を駆動しない方針（#6369 で R2 を撤去した理由）は維持する。本 PR の用途は棄却のみで、ETA が位置を進めることはない。ETA が誤っていても、位置が据え置かれる以上の影響は出ない（上記の打ち切りで最大 90 秒）。

## 計測

`assets/gpx/KeioSpecialExpress.gpx`（10駅・駅間中央値 3.3km・非環状）を 1Hz で実パイプラインへ流し、σ=精度 のノイズを全区間に乗せたうえで、途中 30 秒だけ「N 駅先の駅に貼り付いた誤測位」を注入した。

| 条件 | | 誤った駅を表示 | 最大ずれ | 注入後の残存 |
| --- | --- | --- | --- | --- |
| 精度65m・2駅先 | dev | 33s | 2駅 | 6s |
| | 本PR | **3s** | **1駅** | 3s |
| 精度65m・5駅先 | dev | 33s | 5駅 | 6s |
| | 本PR | **3s** | **1駅** | 3s |
| 精度300m・5駅先 | dev | 39s | 5駅 | 9s |
| | 本PR | **9s** | **1駅** | 9s |

ワープ距離に依存せず最大ずれが 1 駅に収まる。残る 1 駅ぶんは「誤測位を据え置いている間に列車が進んだぶん」で、誤った駅へ飛んだものではない。

通常走行（ワープ注入なし）での副作用:

| 精度 | dev | 本PR |
| --- | --- | --- |
| 65m | 棄却による凍結 787s / 最長3s | **787s / 最長3s（増加なし）** |
| 300m | 0s | **0s（増加なし）** |

65m 側の 787s は dev が元から持つ速度フィルタによるもので、ETA 上限は 1 件も棄却を足していない。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 276 suites / 3006 tests 全通過。追加したテスト 15 件:

`src/utils/etaProgressBound.test.ts`（8件）

- 対象駅の手前にいる測位は許容する / 対象駅の1駅先までは許容する / 2駅以上先は棄却する
- アンカーより後方へ大きく外れた測位も棄却する
- インデックスが降順に進む向きでも同じ基準で判定する
- 停車推定（アンカーと対象が同一駅）では前後1駅までを許容する
- アンカー駅または対象駅が駅一覧に無い場合は判定しない / 座標を持たない駅しか無い場合は判定しない

`src/store/atoms/location.etaBound.test.ts`（7件、`setLocation` 経由）

- ETA が示す進行量を大きく超える測位は反映しない / 範囲内なら反映する
- 上限時間を過ぎたら棄却を打ち切り、その後の範囲外測位も続けて反映する（回帰）
- 打ち切り後に範囲内の測位が届いたら、再び範囲外を棄却する
- 打ち切り後でもアンカーが張り直されたら再び棄却する
- ETA 補助が無効なら判定せず従来どおり反映する / アンカーが無い場合も同様

実機検証は未実施。`replay-gpx` は Android 実機向けのため、iPhone での地下鉄実走確認は別途必要。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: #6936（速度フィルタで解決しようとして計測で否定された先行アプローチ。クローズ済み）、#6369（ETA の役割を GPS の補助に限定した PR）

## スクリーンショット（任意）

UI 変更なし: `src/store/atoms/**` と `src/utils/**` の測位フィルタのみの変更で、画面レイアウトに変化はありません（表示される駅名が正しくなるという挙動の変化はあり、上の計測表がその内容です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzST2G67yT9ozhzAPQNRAV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ETA（到着予測）に基づき、進行上限を超えた、または逆方向に外れた測位情報を一時的に反映しないよう改善しました。
  - 測位の保留が90秒続くと、同じETA状況では範囲外の測位情報も反映します。
  - 許容範囲への復帰やETAアンカーの更新により、測位の保留を再開します。
  - ETAアンカーや必要な駅情報がない場合は、従来どおり測位情報を処理します。
  - 位置情報のリセット時に、ETAに関する保留状態もリセットされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->