### PR TITLE
ETA補助を有効にした状態でassets/gpx配下の全GPXを測位パイプラインへ流す回帰テストを追加

### DIFF
--- a/docs/location-simulation.md
+++ b/docs/location-simulation.md
@@ -180,6 +180,37 @@ T は旧実装の固定 α が 1 秒間隔で持っていた遅れ時間なの�
 流して検証している (`assets/gpx/KatamachiRapid.gpx` は駅間 2.3km・95km/h と、到着圏が
 最小クランプに張り付く最も不利な条件)。
 
+## Jest から GPX を流すテスト
+
+GPX は Xcode / adb だけでなく Jest からも参照する。`src/store/atoms/location.ts` の
+`setLocation` へ直接流し込めるので、速度フィルタ・EMA・基準の張り直しまで含んだ
+測位パイプライン全体を CI で回帰させられる。
+
+| テスト | 対象 | 使う GPX |
+| ---- | ---- | ---- |
+| `src/store/atoms/location.gpxLag.test.ts` | EMA の追従遅れが「次は」「まもなく」「到着」の切り替わり位置をどれだけ後ろへずらすか | 4 本 (新幹線を除く) |
+| `src/store/atoms/location.gpxEtaAssist.test.ts` | `eta_assist_enabled = true` のときに ETA 補助が走行結果を変えないこと | `assets/gpx` 配下の全 GPX |
+
+ETA 補助 (`eta_assist_enabled`) がパイプラインへ介入する経路は 2 つある。
+
+- ETA が許す進行量を超えた測位の棄却 (`store/atoms/location.ts`)
+- 精度劣化時に ETA が同じ駅の停車を示すときだけ到着圏を緩和する R1 (`hooks/useRefreshStation.ts`)
+
+どちらもサーバー配信のフラグ 1 つで全ユーザーへ有効化されるため、有効化の前提は
+「正常な走行では何も変えない」ことになる。`location.gpxEtaAssist.test.ts` は各 GPX を
+フラグ ON / OFF で 2 回流し、平滑後の軌跡・位置を据え置いた回数・到着検知位置が
+一致することを確かめる。ETA の停車時刻は GPX 自身の時刻表から作るので、ETA どおりに
+走る列車のモデルになる。棄却が実際に働く側の挙動は合成データで
+`src/store/atoms/location.etaBound.test.ts` が受け持つ。
+
+GPX の解析・停車駅の検出・真の位置の補間は `src/utils/test/gpxTrack.ts` にまとめてある。
+停車駅は速度がほぼ 0 の区間から検出するが、生成した GPX は始発駅の停車時間を書き出さず
+(1 点目から発車する)、終着駅では減速しきった時点でトラックが終わるため、停車時間の
+下限では始発駅・終着駅を拾えない。先頭・末尾で静止しているトラックはその点が
+始発駅・終着駅なので、停車時間に関わらず停車として扱う。
+`location.gpxLag.test.ts` は始発駅・終着駅を含めない検出を自前に持っており、区間長の
+中央値がこの扱いで変わるため共通化していない。
+
 ## 検証できること・できないこと
 
 | 条件 | GPX (iOS シミュレータ) | GPX (Android) | 実乗車 |

--- a/docs/location-simulation.md
+++ b/docs/location-simulation.md
@@ -186,10 +186,10 @@ GPX は Xcode / adb だけでなく Jest からも参照する。`src/store/atom
 `setLocation` へ直接流し込めるので、速度フィルタ・EMA・基準の張り直しまで含んだ
 測位パイプライン全体を CI で回帰させられる。
 
-| テスト | 対象 | 使う GPX |
+| テスト (`src/store/atoms/`) | 対象 | 使う GPX |
 | ---- | ---- | ---- |
-| `src/store/atoms/location.gpxLag.test.ts` | EMA の追従遅れが「次は」「まもなく」「到着」の切り替わり位置をどれだけ後ろへずらすか | 4 本 (新幹線を除く) |
-| `src/store/atoms/location.gpxEtaAssist.test.ts` | `eta_assist_enabled = true` のときに ETA 補助が走行結果を変えないこと | `assets/gpx` 配下の全 GPX |
+| `location.gpxLag.test.ts` | EMA の追従遅れが表示の切り替わり位置をどれだけ後ろへずらすか | 4 本 (新幹線を除く) |
+| `location.gpxEtaAssist.test.ts` | ETA 補助を有効にしても走行結果が変わらないこと | 全 GPX |
 
 ETA 補助 (`eta_assist_enabled`) がパイプラインへ介入する経路は 2 つある。
 

--- a/src/store/atoms/location.gpxEtaAssist.test.ts
+++ b/src/store/atoms/location.gpxEtaAssist.test.ts
@@ -1,0 +1,370 @@
+/**
+ * eta_assist_enabled = true を前提に、assets/gpx 配下の**全**GPXを setLocation の実パイプラインへ
+ * 流し、ETA補助を有効化しても走行結果が変わらないことを確かめる。
+ *
+ * ETA補助にはパイプラインへ介入する経路が2つある。
+ *   - ETAが許す進行量を超えた測位の棄却 (#6939 / store/atoms/location.ts)
+ *   - 精度劣化時にETAが同じ駅の停車を示すときだけ到着圏を緩和するR1 (hooks/useRefreshStation.ts)
+ * どちらもサーバー配信のマスタースイッチ一つで全ユーザーへ有効化されるため、
+ * 「正常な走行では何も変えない」ことが有効化の前提条件になる。棄却が働く側の挙動は
+ * 合成データで location.etaBound.test.ts が受け持つので、ここでは実トラックでの
+ * 非干渉性（平滑後の軌跡と到着検知位置がフラグON/OFFで一致すること）を測る。
+ *
+ * アンカー(etaAnchorAtom)はGPSの到着・発車検知に追従する閉ループにしている。
+ * useRefreshStation の到着判定(R1の緩和を含む)と useEtaAnchor の打刻を最小構成で
+ * 再現することで、ETAの仮想時計が本番と同じ経路で進む。
+ *
+ * 経路(stationState.stations)はGPXから検出した停車駅だけで構成する。本番の stations は
+ * 通過駅も含むので進行量の刻みは本番のほうが細かく、同じ距離のずれでも本番は
+ * ここより棄却が起きやすい側に寄る。
+ */
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { LineType, type Station } from '~/@types/graphql';
+import {
+  ARRIVED_MAX_THRESHOLD,
+  ARRIVED_MIN_THRESHOLD,
+  BAD_ACCURACY_THRESHOLD,
+} from '~/constants/threshold';
+import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
+import {
+  clamp,
+  findStops,
+  GPX_DIR,
+  METERS_PER_DEG_LAT,
+  makeNoise,
+  median,
+  parseGpx,
+  type TrackPoint,
+  type TrackStop,
+  toLocation,
+  trackDistance,
+  truthAt,
+} from '~/utils/test/gpxTrack';
+import { store } from '..';
+import { etaAnchorAtom, etaStopsAtom } from './etaFallback';
+import { locationAtom, resetLocationState, setLocation } from './location';
+import stationState from './station';
+
+// ETA補助は既定で無効(remoteConfigのフォールバックがfalse)なので、有効・無効を
+// 切り替えられるようにしてフラグ間の差分を測る。
+let mockEtaAssistEnabled = true;
+jest.mock('~/lib/remoteConfig', () => ({
+  isEtaAssistEnabled: () => mockEtaAssistEnabled,
+  getEtaFallbackArrivalConfirmMarginSec: () => 30,
+  getMaxPermitAccuracy: () => 1500,
+  isForceNotArrivedOnLowAccuracyEnabled: () => true,
+}));
+
+// useRefreshStation のプライベート定数と同値。到着圏へ加える精度ボーナスの上限(m)と、
+// R1が効くときだけ使う緩和上限(m)。
+const MAX_ACCURACY_BONUS = 150;
+const ETA_ARRIVED_BONUS_CAP = 500;
+
+type Condition = {
+  label: string;
+  accuracy: number;
+  intervalMs: number;
+  /** 入力座標へ乗せる正規分布ノイズのσ(m)。0でノイズなし */
+  noiseSigma: number;
+};
+
+// gpxLag と同じ精度・間隔の帯に加え、ETA補助が実際に分岐へ入る帯を含める。
+// R1は精度がBAD_ACCURACY_THRESHOLD(200m)を超える帯でしか評価されず、さらに到着圏を
+// 実際に広げるのは通常の精度ボーナス上限(150m)を超える精度、つまり300m超の帯だけ
+// (ボーナスは accuracy*0.5 で、R1の上限は500m)。600mはMAX_PERMIT_ACCURACY(1500m)の
+// 範囲内なので、フィルタを通ってsetLocationまで届く現実的な値。
+const CONDITIONS: Condition[] = [
+  { label: ' 30m/ 5s', accuracy: 30, intervalMs: 5_000, noiseSigma: 0 },
+  { label: ' 30m/10s', accuracy: 30, intervalMs: 10_000, noiseSigma: 0 },
+  { label: ' 60m/10s', accuracy: 60, intervalMs: 10_000, noiseSigma: 0 },
+  { label: '250m/10s', accuracy: 250, intervalMs: 10_000, noiseSigma: 0 },
+  { label: '600m/10s', accuracy: 600, intervalMs: 10_000, noiseSigma: 0 },
+  {
+    label: '250m/10s σ250m',
+    accuracy: 250,
+    intervalMs: 10_000,
+    noiseSigma: 250,
+  },
+];
+
+const GPX_FILES = readdirSync(join(process.cwd(), GPX_DIR))
+  .filter((f) => f.endsWith('.gpx'))
+  .sort();
+
+const stationIdOf = (stopIndex: number) => stopIndex + 1;
+
+/** 検出した停車駅を、そのまま経路上の駅として扱う */
+const buildStations = (stops: TrackStop[]): Station[] =>
+  stops.map(
+    (s, i) =>
+      ({
+        id: stationIdOf(i),
+        latitude: s.anchor.lat,
+        longitude: s.anchor.lon,
+      }) as Station
+  );
+
+const setupRoute = (stops: TrackStop[]) => {
+  store.set(stationState, {
+    arrived: true,
+    approaching: false,
+    // 地下鉄はスムージング自体をスキップするため、地上路線として流す
+    station: { line: { lineType: LineType.Normal } } as Station,
+    stations: buildStations(stops),
+    stationsCache: [],
+    pendingStation: null,
+    pendingStations: [],
+    selectedDirection: null,
+    selectedBound: null,
+    wantedDestination: null,
+  });
+  // ETAはGPX自身の時刻表(=ETA通りに走る列車)から作る。ETAが実際より遅い側へ
+  // 外れた場合の棄却は location.etaBound.test.ts が受け持つ。
+  const t0 = stops[0].departAt;
+  store.set(
+    etaStopsAtom,
+    stops.map((s, i) => ({
+      stationId: stationIdOf(i),
+      cumulativeMinutes: (s.arriveAt - t0) / 60_000,
+      departureCumulativeMinutes: (s.departAt - t0) / 60_000,
+    }))
+  );
+};
+
+type ReplayResult = {
+  /** 平滑後の軌跡 */
+  samples: TrackPoint[];
+  /** 停車駅ごとの「到着検知が初めて成立した時点で駅まであと何m」。未検知はnull */
+  firstDetection: (number | null)[];
+  /** 測位が反映されず位置が据え置かれたサンプル数(速度フィルタ or ETA上限) */
+  heldSamples: number;
+  /** R1(ETA確認による到着圏緩和)が実際に到着圏を広げたサンプル数 */
+  r1Activations: number;
+  /**
+   * ETA仮想時計がフェーズを返せたサンプル数。ETA補助が有効なら（アンカーと停車駅リストが
+   * 揃っている＝棄却判定が実際に評価される）ほぼ全サンプルで非nullになる。ETAの配線が
+   * 抜けたまま「差分なし」を確認してしまう空振りを防ぐための計測。
+   */
+  etaPhaseSamples: number;
+};
+
+const replay = (
+  track: TrackPoint[],
+  stops: TrackStop[],
+  { accuracy, intervalMs, noiseSigma }: Condition
+): ReplayResult => {
+  resetLocationState();
+  store.set(etaAnchorAtom, null);
+
+  const noise = makeNoise(0x5eed);
+  const samples: TrackPoint[] = [];
+  const firstDetection: (number | null)[] = stops.map(() => null);
+  let heldSamples = 0;
+  let r1Activations = 0;
+  let etaPhaseSamples = 0;
+  // 最後に到着と判定した停車駅(useRefreshStationのstation相当)。始発駅から始まる。
+  let arrivedIdx = 0;
+  let prevArrived = false;
+
+  for (let t = track[0].t; t <= track[track.length - 1].t; t += intervalMs) {
+    const truth = truthAt(track, t);
+    const input =
+      noiseSigma > 0
+        ? {
+            t,
+            lat: truth.lat + (noise() * noiseSigma) / METERS_PER_DEG_LAT,
+            lon:
+              truth.lon +
+              (noise() * noiseSigma) /
+                (METERS_PER_DEG_LAT * Math.cos((truth.lat * Math.PI) / 180)),
+          }
+        : truth;
+
+    const before = store.get(locationAtom);
+    setLocation(toLocation(input, accuracy));
+    const cur = store.get(locationAtom);
+    if (!cur) {
+      continue;
+    }
+    if (cur === before) {
+      heldSamples += 1;
+    }
+    const pos = { t, lat: cur.coords.latitude, lon: cur.coords.longitude };
+    samples.push(pos);
+
+    // ETA仮想時計のフェーズ。無効時はnullを返す(getEtaPhaseNowがフラグを見る)。
+    // 本番は Date.now() で評価するが、ここではGPXの時刻で仮想時計を回す。
+    const phase = getEtaPhaseNow(t);
+    if (phase) {
+      etaPhaseSamples += 1;
+    }
+
+    // --- useRefreshStation の到着判定(最小構成) ---
+    let nearestIdx = 0;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    stops.forEach((s, i) => {
+      const d = trackDistance(pos, s.anchor);
+      if (d < nearestDistance) {
+        nearestDistance = d;
+        nearestIdx = i;
+      }
+    });
+
+    // useThreshold: 「最後に到着した駅→次の停車駅」の駅間距離から到着圏を決める
+    const nextIdx = Math.min(arrivedIdx + 1, stops.length - 1);
+    const between = trackDistance(
+      stops[arrivedIdx].anchor,
+      stops[nextIdx].anchor
+    );
+    const arrivedThreshold = clamp(
+      between / 4,
+      ARRIVED_MIN_THRESHOLD,
+      ARRIVED_MAX_THRESHOLD
+    );
+    let arrivedRadius =
+      arrivedThreshold + Math.min(accuracy * 0.5, MAX_ACCURACY_BONUS);
+
+    // R1: 精度劣化時、ETAが最寄り停車駅での停車を示すときだけ到着圏を広げる
+    if (mockEtaAssistEnabled && accuracy > BAD_ACCURACY_THRESHOLD) {
+      const anchor = store.get(etaAnchorAtom);
+      if (anchor?.kind === 'DEPARTED') {
+        if (
+          phase?.kind === 'DWELLING' &&
+          phase.stationId === stationIdOf(nearestIdx)
+        ) {
+          const relaxed =
+            arrivedThreshold + Math.min(accuracy * 0.5, ETA_ARRIVED_BONUS_CAP);
+          if (relaxed > arrivedRadius) {
+            r1Activations += 1;
+          }
+          arrivedRadius = relaxed;
+        }
+      }
+    }
+
+    const arrived = nearestDistance <= arrivedRadius;
+    if (arrived && firstDetection[nearestIdx] === null) {
+      // 検知時点の「真の」列車位置で測る(平滑後の座標ではなく実際の駅までの距離)
+      firstDetection[nearestIdx] = trackDistance(
+        truthAt(track, t),
+        stops[nearestIdx].anchor
+      );
+    }
+
+    // --- useEtaAnchor の打刻 ---
+    if (arrived) {
+      store.set(etaAnchorAtom, {
+        stationId: stationIdOf(nearestIdx),
+        kind: 'AT_STATION',
+        observedAtMs: t,
+      });
+      arrivedIdx = nearestIdx;
+    } else if (prevArrived) {
+      store.set(etaAnchorAtom, {
+        stationId: stationIdOf(arrivedIdx),
+        kind: 'DEPARTED',
+        observedAtMs: t,
+      });
+    }
+    prevArrived = arrived;
+  }
+
+  return {
+    samples,
+    firstDetection,
+    heldSamples,
+    r1Activations,
+    etaPhaseSamples,
+  };
+};
+
+/** 2つの軌跡が初めて食い違うindex。一致していれば-1 */
+const divergenceIndex = (a: TrackPoint[], b: TrackPoint[]): number => {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    if (a[i].t !== b[i].t || a[i].lat !== b[i].lat || a[i].lon !== b[i].lon) {
+      return i;
+    }
+  }
+  return a.length === b.length ? -1 : len;
+};
+
+const detectedCount = (detections: (number | null)[]) =>
+  detections.filter((d) => d !== null).length;
+
+describe('eta_assist_enabled=true でGPXを実パイプラインへ流したときの非干渉性', () => {
+  it.each(GPX_FILES)('%s: ETA補助の有効・無効で走行結果が一致する', (file) => {
+    const track = parseGpx(join(GPX_DIR, file));
+    expect(track.length).toBeGreaterThan(100);
+    const stops = findStops(track);
+    expect(stops.length).toBeGreaterThan(1);
+    setupRoute(stops);
+
+    // 終着駅で静止したままトラックが終わるか(生成GPXは終着駅の停車時間を持たない)
+    const endsAtStop =
+      stops[stops.length - 1].departAt === track[track.length - 1].t;
+
+    const lines: string[] = [`\n■ ${file}  停車=${stops.length}`];
+    lines.push(
+      '  精度/間隔       | 据え置き ON/OFF | R1発動 | 到着検知中央値 ON/OFF | 検知駅数 | 検知前倒し(最大)'
+    );
+
+    for (const cond of CONDITIONS) {
+      mockEtaAssistEnabled = true;
+      const on = replay(track, stops, cond);
+      mockEtaAssistEnabled = false;
+      const off = replay(track, stops, cond);
+
+      // ETAの配線が生きていること(=棄却判定が毎サンプル実際に評価されていること)。
+      // これが無いと、ETAが不発のまま「差分なし」を確認する空振りになる。
+      expect(on.etaPhaseSamples).toBeGreaterThan(on.samples.length * 0.8);
+      expect(off.etaPhaseSamples).toBe(0);
+
+      // ETA上限が1点でも棄却すれば、以降の平滑後座標が分岐する
+      expect(divergenceIndex(on.samples, off.samples)).toBe(-1);
+      expect(on.heldSamples).toBe(off.heldSamples);
+      // 到着を検知できた駅数。取りこぼしはETA以前の問題として検出する。
+      // ただし精度劣化帯(固定α=0.3)は追従遅れが大きく、停車時間を持たない終着駅では
+      // 遅れが解けないままトラックが終わるため検知できないことがある。
+      const undetectableTerminal =
+        endsAtStop && cond.accuracy > BAD_ACCURACY_THRESHOLD ? 1 : 0;
+      expect(detectedCount(on.firstDetection)).toBe(
+        stops.length - undetectableTerminal
+      );
+      // ETA補助は到着圏を広げる側にしか働かないため、検知が遅れてはならない
+      on.firstDetection.forEach((d, i) => {
+        const o = off.firstDetection[i];
+        if (o === null) {
+          return;
+        }
+        expect(d).not.toBeNull();
+        expect(d as number).toBeGreaterThanOrEqual(o - 0.5);
+      });
+
+      const onDetections = on.firstDetection.filter(
+        (d): d is number => d !== null
+      );
+      const offDetections = off.firstDetection.filter(
+        (d): d is number => d !== null
+      );
+      // ETA有効時に到着検知が何m手前へ動いたか(最大)。0なら検知位置は完全一致。
+      const maxDetectionGain = Math.max(
+        0,
+        ...on.firstDetection.map((d, i) => {
+          const o = off.firstDetection[i];
+          return d === null || o === null ? 0 : d - o;
+        })
+      );
+      lines.push(
+        `  ${cond.label.padEnd(15)} | ` +
+          `${`${on.heldSamples}/${off.heldSamples}`.padStart(15)} | ` +
+          `${String(on.r1Activations).padStart(6)} | ` +
+          `${`${median(onDetections).toFixed(0)}m/${median(offDetections).toFixed(0)}m 手前`.padStart(21)} | ` +
+          `${`${detectedCount(on.firstDetection)}/${detectedCount(off.firstDetection)}`.padStart(8)} | ` +
+          `${maxDetectionGain.toFixed(1)}m`
+      );
+    }
+    console.log(lines.join('\n'));
+  });
+});

--- a/src/utils/test/gpxTrack.ts
+++ b/src/utils/test/gpxTrack.ts
@@ -1,0 +1,151 @@
+/**
+ * assets/gpx のGPXをテストから読み、走行トラックとして扱うためのユーティリティ。
+ * 測位パイプライン(store/atoms/location)へGPXを流すテストが共用する。
+ * ストアやReactへは依存させず、純粋な解析・幾何計算だけを持たせる。
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type * as Location from 'expo-location';
+import getPreciseDistance from 'geolib/es/getPreciseDistance';
+
+export type TrackPoint = { t: number; lat: number; lon: number };
+
+/** 速度がほぼ0の区間から検出した「駅での停車」 */
+export type TrackStop = {
+  anchor: TrackPoint;
+  arriveAt: number;
+  departAt: number;
+};
+
+/** GPXのディレクトリ(リポジトリルート起点) */
+export const GPX_DIR = 'assets/gpx';
+
+export const parseGpx = (relPath: string): TrackPoint[] => {
+  const xml = readFileSync(join(process.cwd(), relPath), 'utf8');
+  const points: TrackPoint[] = [];
+  // trkpt / wpt のどちらの形式でも読む(実走ログと生成物で異なる)
+  const re =
+    /<(?:wpt|trkpt)\s+lat="([-\d.]+)"\s+lon="([-\d.]+)"[^>]*>[\s\S]*?<time>([^<]+)<\/time>/g;
+  let m = re.exec(xml);
+  while (m !== null) {
+    points.push({ lat: Number(m[1]), lon: Number(m[2]), t: Date.parse(m[3]) });
+    m = re.exec(xml);
+  }
+  return points.sort((a, b) => a.t - b.t);
+};
+
+export const trackDistance = (
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number }
+): number =>
+  getPreciseDistance(
+    { latitude: a.lat, longitude: a.lon },
+    { latitude: b.lat, longitude: b.lon },
+    0.1
+  );
+
+/** 真のトラックを線形補間して任意時刻の位置を返す */
+export const truthAt = (track: TrackPoint[], t: number): TrackPoint => {
+  if (t <= track[0].t) return track[0];
+  const last = track[track.length - 1];
+  if (t >= last.t) return last;
+  let lo = 0;
+  let hi = track.length - 1;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (track[mid].t <= t) lo = mid;
+    else hi = mid;
+  }
+  const a = track[lo];
+  const b = track[hi];
+  const r = (t - a.t) / (b.t - a.t);
+  return {
+    t,
+    lat: a.lat + (b.lat - a.lat) * r,
+    lon: a.lon + (b.lon - a.lon) * r,
+  };
+};
+
+/**
+ * 速度がほぼ0の区間を「駅での停車」として抽出する。
+ *
+ * 途中駅は停車時間(MIN_DWELL_MS)で拾うが、始発駅と終着駅は拾えない。
+ * scripts/generate-location-gpx.mjs は始発駅の停車時間を書き出さず(1点目から発車する)、
+ * 終着駅では減速しきった時点でトラックが終わるためどちらも停車時間が下限に届かない。
+ * トラックの先頭・末尾で静止している場合はその点が始発駅・終着駅なので、停車時間の
+ * 下限に関わらず停車として扱う。実走行ログのように走行中から記録が始まる(終わる)
+ * トラックでは先頭・末尾が静止区間にならないため、駅でない点を拾うことはない。
+ */
+export const findStops = (track: TrackPoint[]): TrackStop[] => {
+  const STOP_SPEED = 1.5; // m/s
+  const MIN_DWELL_MS = 15_000;
+  const runs: { start: number; end: number }[] = [];
+  let runStart: number | null = null;
+  for (let i = 1; i < track.length; i += 1) {
+    const dt = (track[i].t - track[i - 1].t) / 1000;
+    const v = dt > 0 ? trackDistance(track[i - 1], track[i]) / dt : 0;
+    if (v < STOP_SPEED) {
+      if (runStart === null) runStart = i - 1;
+    } else if (runStart !== null) {
+      runs.push({ start: runStart, end: i - 1 });
+      runStart = null;
+    }
+  }
+  if (runStart !== null) {
+    runs.push({ start: runStart, end: track.length - 1 });
+  }
+
+  return runs
+    .filter(
+      (r) =>
+        r.start === 0 ||
+        r.end === track.length - 1 ||
+        track[r.end].t - track[r.start].t >= MIN_DWELL_MS
+    )
+    .map((r) => ({
+      anchor: track[(r.start + r.end) >> 1],
+      arriveAt: track[r.start].t,
+      departAt: track[r.end].t,
+    }));
+};
+
+export const toLocation = (
+  p: TrackPoint,
+  accuracy: number
+): Location.LocationObject => ({
+  coords: {
+    latitude: p.lat,
+    longitude: p.lon,
+    accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: null,
+  },
+  timestamp: p.t,
+});
+
+/** 再現性のある擬似乱数（測位ノイズの注入に使う） */
+export const makeNoise = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  const next = () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+  // Box-Muller法で標準正規分布へ変換する
+  return () => {
+    const u = Math.max(next(), Number.EPSILON);
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * next());
+  };
+};
+
+export const METERS_PER_DEG_LAT = 111_132;
+
+export const median = (values: number[]): number => {
+  if (values.length === 0) return Number.NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+};
+
+export const clamp = (v: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, v));


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

`eta_assist_enabled: true`（ETA補助がサーバー配信のマスタースイッチで有効になった状態）を前提に、`assets/gpx` 配下の**全** GPX を `setLocation` の実パイプラインへ流す回帰テストを追加した。ETA補助はフラグ 1 つで全ユーザーへ効くため、「正常な走行では測位も到着検知も何も変えない」ことが有効化の前提条件になる。それを実トラック上で固定する。

既存の `location.gpxLag.test.ts` は ETA補助が無効（`remoteConfig` のフォールバックが `false`）のまま 4 本の GPX でしか走っておらず、`SampleTohokuShinkansen.gpx` は停車検出が 1 駅しか拾えないため対象外だった。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

アプリのコード（挙動）は変更していない。追加したのはテストとテスト用ユーティリティで、`docs/` はその説明。

## 変更内容

<!-- 変更の詳細を記述してください -->

- `src/store/atoms/location.gpxEtaAssist.test.ts` を追加。`assets/gpx` を `readdirSync` で列挙するので、GPX を足せば自動的に対象へ入る。各トラックを精度・配信間隔・ノイズの 6 条件 × フラグ ON/OFF で流し、平滑後の軌跡・位置を据え置いた回数・到着検知位置が一致することを確かめる。
- `etaAnchorAtom` は GPS の到着・発車検知に追従する閉ループにし、`useRefreshStation` の到着判定（R1 の到着圏緩和込み）と `useEtaAnchor` の打刻を最小構成で再現している。ETA の停車時刻は GPX 自身の時刻表から作るので「ETA どおりに走る列車」のモデルになる。
- ETA の配線が生きていること（仮想時計が全サンプルの 80% 超でフェーズを返し、無効時は 0 件）も assert し、ETA が不発のまま「差分なし」を確認する空振りを防いでいる。
- `src/utils/test/gpxTrack.ts` を追加（GPX 解析・停車駅検出・真位置の線形補間）。生成 GPX は始発駅の停車時間を書き出さず、終着駅も減速しきった直後にトラックが終わるため、停車時間の下限では両端を拾えない。先頭・末尾で静止しているトラックはその点が始発駅・終着駅なので停車として扱う。これで新幹線も 3 駅（盛岡・一ノ関・仙台）の経路として流せる。実走行ログは走行中から記録が始まるので、駅でない点を拾うことはない。
- `docs/location-simulation.md` に「Jest から GPX を流すテスト」節を追加。

### 実行結果

5 本 × 6 条件の全 30 ケースでフラグ ON/OFF の差分なし（到着検知の前倒し 0.0m、据え置き回数も一致）。

- ETA の進行量上限は 1 点も棄却していない。アンカーが駅ごとに張り直されるため、ETA どおりに走る列車では進行量が許容（次の停車駅 +1 駅）を超えられない構造になっている。
- R1（到着圏の緩和）が分岐に入るのは精度 300m 超の帯だけ（通常の精度ボーナス上限 150m を `accuracy*0.5` が超える必要がある）。実走ログの 600m 条件で 6 サンプル発動したが、到着検知位置は変えなかった。
- 精度 200m 超の帯で終着駅の検知が 1 駅欠けるのは ETA とは無関係で、固定 α=0.3 の追従遅れが残ったまま（生成 GPX が終着駅の停車時間を持たないため）トラックが終わるからで、テスト側でその条件だけ明示的に除外している。

### このテストが空振りしていないことの確認

「フラグ ON と OFF で結果が一致する」という主張は、**ETA 側が一度も動いていなくても成立してしまう**。アンカーが張られていない・停車駅リストが空・フラグのモックが効いていない、のどれか 1 つでも壊れていれば ON/OFF 両方が「ETA 無効」の状態で走り、当然一致して緑になる。何も検証していないのにパスする状態を潰すため、次の 2 つを行っている。

- **テスト内の assert**: ON 側は ETA 仮想時計が全サンプルの 80% 超でフェーズを返すこと、OFF 側は 0 件であることを確かめる。棄却判定が毎サンプル実際に評価されていたことと、キルスイッチが本当に無効化していることの担保。
- **壊して落ちることの確認（手元のみ・この差分には含まない）**: `src/store/atoms/location.ts` の `ETA_BOUND_TOLERANCE_STATIONS` を一時的に `1` → `-1`（ETA 上限がほぼ何でも棄却する状態）へ改変すると、5 本すべてが平滑後の軌跡の分岐で fail することを確認した。改変は元に戻し、`git diff` が空になることも確認済み。つまり本番挙動が壊れればこのテストは赤くなる。

### 検証範囲外

- 経路 `stationState.stations` は検出した停車駅だけで構成している。本番の `stations` は通過駅も含むので刻みは本番のほうが細かく、同じ距離のずれでも本番は棄却が起きやすい側に寄る。
- 棄却が実際に発動する境界（列車が ETA より 2 駅以上先行し、かつ到着検知を連続で取りこぼすケース）は合成データの `location.etaBound.test.ts` が受け持つ。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 277 suites / 3011 tests すべて green。追加分は `npx jest src/store/atoms/location` で 4 suites / 42 tests green。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

UI変更なし: 追加したのはテスト・テスト用ユーティリティ・ドキュメントのみで、アプリの画面には影響しません

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XAgKfxsnB3USpudL3Bkds

---
_Generated by [Claude Code](https://claude.ai/code/session_011XAgKfxsnB3USpudL3Bkds)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - GPXデータを使った測位シミュレーションの実行手順を追加しました。
  - 速度フィルター、平滑化、基準座標、ETA補助、停車駅検出、位置補間の検証内容を記載しました。

- **テスト**
  - 複数のGPX走行データを用いて、測位結果や到着検知の再現性を検証できるようになりました。
  - 測位ノイズ、精度、測位間隔などの条件を変えた検証に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->