### PR TITLE
ビルドワークフローにSENTRY_DSNを渡してCI製ビルドから例外が送信されない問題を修正

### DIFF
--- a/.github/workflows/build_android_canary.yml
+++ b/.github/workflows/build_android_canary.yml
@@ -7,6 +7,7 @@ env:
   DEV_WORKER_API_URL: "${{ secrets.DEV_WORKER_API_URL }}"
   ENABLE_EXPERIMENTAL_TELEMETRY: "${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}"
   EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: "${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}"
+  SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
 
 on:
   push:
@@ -118,6 +119,7 @@ jobs:
             STAGING_API_URL
             DEV_ROUTE_RESOLVER_API_URL
             DEV_WORKER_API_URL
+            SENTRY_DSN
           )
 
           for variable_name in "${required_variables[@]}"; do

--- a/.github/workflows/build_android_production.yml
+++ b/.github/workflows/build_android_production.yml
@@ -7,6 +7,7 @@ env:
   PRODUCTION_WORKER_API_URL: "${{ secrets.PRODUCTION_WORKER_API_URL }}"
   ENABLE_EXPERIMENTAL_TELEMETRY: "${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}"
   EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: "${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}"
+  SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
 
 on:
   push:
@@ -118,6 +119,7 @@ jobs:
             PRODUCTION_API_URL
             PRODUCTION_ROUTE_RESOLVER_API_URL
             PRODUCTION_WORKER_API_URL
+            SENTRY_DSN
           )
 
           for variable_name in "${required_variables[@]}"; do

--- a/.github/workflows/build_ios_canary.yml
+++ b/.github/workflows/build_ios_canary.yml
@@ -7,6 +7,7 @@ env:
   DEV_WORKER_API_URL: "${{ secrets.DEV_WORKER_API_URL }}"
   ENABLE_EXPERIMENTAL_TELEMETRY: "${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}"
   EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: "${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}"
+  SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
 
 on:
   push:
@@ -89,6 +90,7 @@ jobs:
             STAGING_API_URL
             DEV_ROUTE_RESOLVER_API_URL
             DEV_WORKER_API_URL
+            SENTRY_DSN
           )
 
           required_variables+=(

--- a/.github/workflows/build_ios_production.yml
+++ b/.github/workflows/build_ios_production.yml
@@ -7,6 +7,7 @@ env:
   PRODUCTION_WORKER_API_URL: "${{ secrets.PRODUCTION_WORKER_API_URL }}"
   ENABLE_EXPERIMENTAL_TELEMETRY: "${{ secrets.ENABLE_EXPERIMENTAL_TELEMETRY }}"
   EXPERIMENTAL_TELEMETRY_ENDPOINT_URL: "${{ secrets.EXPERIMENTAL_TELEMETRY_ENDPOINT_URL }}"
+  SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
 
 on:
   push:
@@ -89,6 +90,7 @@ jobs:
             PRODUCTION_API_URL
             PRODUCTION_ROUTE_RESOLVER_API_URL
             PRODUCTION_WORKER_API_URL
+            SENTRY_DSN
           )
 
           required_variables+=(

--- a/docs/android-build-workflows.md
+++ b/docs/android-build-workflows.md
@@ -33,6 +33,7 @@ Configure these GitHub Actions secrets:
 | `EXPERIMENTAL_TELEMETRY_ENDPOINT_URL` | Telemetry endpoint |
 | `EXPERIMENTAL_TELEMETRY_TOKEN` | Telemetry authentication token |
 | `FONTS_SSH_KEY` | Fonts submodule SSH private key |
+| `SENTRY_DSN` | Sentry runtime DSN (required; the build fails when unset) |
 | `SENTRY_PROPERTIES_BASE64` | Base64-encoded `sentry.properties` |
 | `RELEASE_KEYSTORE` | Base64-encoded Android release keystore |
 | `KEYSTORE_PASSWORD` | Release keystore password |

--- a/docs/ios-build-workflows.md
+++ b/docs/ios-build-workflows.md
@@ -34,6 +34,7 @@ Configure these GitHub Actions secrets:
 | `EXPERIMENTAL_TELEMETRY_ENDPOINT_URL` | Telemetry endpoint |
 | `EXPERIMENTAL_TELEMETRY_TOKEN` | Telemetry authentication token |
 | `FONTS_SSH_KEY` | Fonts submodule SSH private key |
+| `SENTRY_DSN` | Sentry runtime DSN (required; the build fails when unset) |
 | `SENTRY_PROPERTIES_BASE64` | Base64-encoded `sentry.properties` |
 | `APP_STORE_CONNECT_API_ISSUER_ID` | App Store Connect API issuer ID |
 | `APP_STORE_CONNECT_API_KEY_ID` | App Store Connect API key ID |


### PR DESCRIPTION
## 概要

GitHub Actions でビルドしたアプリから Sentry へ例外が一切送信されていない状態を修正する。

`SENTRY_DSN` は `index.js` で `react-native-dotenv` 経由でビルド時にインライン展開されるが、ビルドワークフローの `env:` に定義されていなかった。`react-native-dotenv` は `allowUndefined: true` が既定（`node_modules/react-native-dotenv/index.js:70`）なので、未定義でもビルドは成功し `Sentry.init({ dsn: undefined })` として焼き込まれる。エラーも警告も出ないまま送信だけが止まる。

EAS から GitHub Actions へ移行した際（#6446 / #6508）、旧ワークフローにあった `.env.local` をまるごと復元するステップが個別の環境変数列挙へ置き換わり、その列挙から `SENTRY_DSN` が漏れたことが原因。

### 影響範囲

Sentry のリリース別イベントを確認したところ、本番は `10.10.0` を最後にイベントが途絶えており、`10.11.0` 以降の 4 リリース分が 1 件も届いていない。canary も同様で、届いているイベントはローカルビルド（`.env.local` あり）由来のものだけだった。つまり CI 経由で配信したビルドはすべて監視が効いていない状態だった。

`SENTRY_DSN` は GitHub Secrets に登録済み（2026-08-03）で、ワークフローから参照されていなかっただけ。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `build_ios_production.yml` / `build_ios_canary.yml` / `build_android_production.yml` / `build_android_canary.yml` の `env:` に `SENTRY_DSN` を追加
- 同 4 ファイルの `Validate build environment` の必須変数リストにも `SENTRY_DSN` を追加し、未設定ならビルドが失敗するようにした
- `docs/ios-build-workflows.md` / `docs/android-build-workflows.md` の Secret 表に `SENTRY_DSN` を追記

### 必須化した理由

今回の不具合は「検証ステップが `SENTRY_DSN` を見ていなかったため、4 リリースにわたって無言で壊れ続けた」というもの。`env:` への追加だけでは同じ形の再発を防げないため、必須変数として扱う。監視が死んだまま出荷される事故を構造的に防ぐ側に倒した。

### リグレッションリスクと緩和策

| リスク | 評価・緩和策 |
| --- | --- |
| 必須化により Secret 未設定でリリースが止まる | `SENTRY_DSN` は登録済みのため現状では落ちない。落ちる場合は Secret の欠落そのものが問題であり、無言で監視を失うより早期に検知できる方が望ましい |
| アプリ挙動への影響 | `src/**` に変更は無く、ビルド時に埋め込まれる DSN が `undefined` から実値に変わるだけ。Sentry SDK の初期化経路自体は従来どおり |
| DSN の露出 | 値は Secrets 経由で渡され、ワークフロー定義には現れない。クライアント用 DSN はもともとアプリバイナリに埋め込まれる性質のもので、今回新たに秘匿性が下がる箇所は無い |

## テスト

- [ ] `npm run lint` が通ること
- [ ] `npm test` が通ること
- [ ] `npm run typecheck` が通ること

省略: `src/**` に変更が無く、これらを実行する意味が無いため。代わりに以下を実施した。

- 4 ワークフローの YAML パースと、`env.SENTRY_DSN` が `${{ secrets.SENTRY_DSN }}` に解決されることを確認
- `markdownlint-cli2 docs/ios-build-workflows.md docs/android-build-workflows.md` → 0 issues

なお、この修正が実際に効いたかどうかは**マージ後に CI でビルドしたバイナリから Sentry にイベントが届くか**でしか確認できない。次のリリース後に Sentry のリリース別イベントを確認する必要がある。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: `.github/workflows/**` と `docs/**` のみの変更で、アプリの画面には影響しません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqiR5hU3HTFnN5PXNKKp3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Android・iOSのCanaryおよび本番ビルドで、エラー監視サービスの接続設定が必須になりました。
  * 接続設定が未登録の場合、ビルド時に検証エラーとなります。

* **ドキュメント**
  * Android・iOSのビルド手順に、必要な接続設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->