### PR TITLE
よくある質問をアプリ内ブラウザで開き設定画面の項目に外部リンクの印を付ける

### DIFF
--- a/src/components/NewReportModal.test.tsx
+++ b/src/components/NewReportModal.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
 import type React from 'react';
-import { Linking, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { FAQ_URL } from '~/constants';
 import NewReportModal from './NewReportModal';
 
@@ -13,6 +13,10 @@ jest.mock('@expo/vector-icons', () => {
 jest.mock('jotai', () => ({
   useAtomValue: jest.fn(() => false),
   atom: jest.fn((initialValue) => initialValue),
+}));
+
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
 }));
 
 jest.mock('@gorhom/portal', () => ({
@@ -28,6 +32,7 @@ jest.mock('~/utils/dialogPresentation', () => ({
 }));
 
 const { showDialog } = jest.requireMock('~/utils/dialogPresentation');
+const { openBrowserAsync } = jest.requireMock('expo-web-browser');
 const { useAtomValue } = jest.requireMock('jotai');
 
 const defaultProps = {
@@ -73,15 +78,15 @@ describe('NewReportModal', () => {
 
   // 「動かない」系の報告は原因が非対応環境であることがあり、その判定はアプリ側では
   // 行えないため、送信前にFAQへ誘導できることを固定する
-  it('FAQリンクをタップするとよくある質問を開く', () => {
-    const openURL = jest
-      .spyOn(Linking, 'openURL')
-      .mockResolvedValue(undefined as never);
+  // 外部ブラウザへ飛ばすと入力中の本文を残したままアプリを離れることになるため、
+  // アプリ内ブラウザで開くことも併せて固定する
+  it('FAQリンクをタップするとよくある質問をアプリ内ブラウザで開く', () => {
+    openBrowserAsync.mockResolvedValue(undefined);
     const { getByText } = renderModal();
 
     fireEvent.press(getByText('reportFaqLink'));
 
-    expect(openURL).toHaveBeenCalledWith(FAQ_URL);
+    expect(openBrowserAsync).toHaveBeenCalledWith(FAQ_URL);
   });
 
   // 押せることがリンク語自体から分かる必要があるため、下線とアクセント色を固定する
@@ -124,9 +129,7 @@ describe('NewReportModal', () => {
   });
 
   it('よくある質問を開けなくても送信フローを妨げない', async () => {
-    const openURL = jest
-      .spyOn(Linking, 'openURL')
-      .mockRejectedValue(new Error('cannot open'));
+    openBrowserAsync.mockRejectedValue(new Error('cannot open'));
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const onSubmit = jest.fn();
     const { getByText, input } = renderModal({ onSubmit });
@@ -136,7 +139,7 @@ describe('NewReportModal', () => {
       await Promise.resolve();
     });
 
-    expect(openURL).toHaveBeenCalledWith(FAQ_URL);
+    expect(openBrowserAsync).toHaveBeenCalledWith(FAQ_URL);
     expect(warn).toHaveBeenCalled();
 
     // 警告が出たことだけでは「送信を妨げない」の保証にならないため、

--- a/src/components/NewReportModal.tsx
+++ b/src/components/NewReportModal.tsx
@@ -1,10 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
+import * as WebBrowser from 'expo-web-browser';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Keyboard,
-  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -239,8 +239,10 @@ const NewReportModal: React.FC<Props> = ({
   // 「動かない」系の報告は原因が非対応環境(GNSS非搭載端末など)であることがあり、
   // その判定はアプリ側では行えないため、FAQへ誘導する。導線は進捗表示と注意書きの間に
   // 置き、書き終えて送信を判断する位置で注意書きと一緒に目に入るようにしている。
+  // 外部ブラウザへ遷移すると入力中の本文を残したままアプリを離れることになるため、
+  // アプリ内ブラウザで開き、閉じればそのまま書き続けられるようにする。
   const handleOpenFaq = useCallback(() => {
-    Linking.openURL(FAQ_URL).catch((error) => {
+    WebBrowser.openBrowserAsync(FAQ_URL).catch((error) => {
       console.warn('よくある質問を開けませんでした:', error);
     });
   }, []);

--- a/src/screens/AppSettings.test.tsx
+++ b/src/screens/AppSettings.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
-import { Linking, View } from 'react-native';
+import {
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from '@testing-library/react-native';
+import { View } from 'react-native';
+import { CardChevron } from '~/components/CardChevron';
 import type {
   WalkthroughStep,
   WalkthroughStepId,
@@ -17,14 +23,26 @@ jest.mock('react-native-app-clip', () => ({
   isClip: () => false,
 }));
 
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+const { openBrowserAsync } = jest.requireMock('expo-web-browser');
+
 jest.mock('expo-linear-gradient', () => {
   const { View: RNView } = require('react-native');
   return { LinearGradient: RNView };
 });
 
-jest.mock('@expo/vector-icons', () => ({
-  Ionicons: () => null,
-}));
+// 末尾の印がシェブロンか外部リンクかをテストから判別できるよう、name を props に残す
+jest.mock('@expo/vector-icons', () => {
+  const { View: RNView } = require('react-native');
+  const ReactMock = require('react');
+  return {
+    Ionicons: (props: { name: string }) =>
+      ReactMock.createElement(RNView, props),
+  };
+});
 
 jest.mock('react-native-safe-area-context', () => {
   const { View: RNView } = require('react-native');
@@ -149,17 +167,39 @@ describe('AppSettingsScreen', () => {
     expect(new Set(radii).size).toBe(1);
   });
 
-  // 非対応環境(GNSS非搭載端末など)はアプリ側で判定できないため、FAQへの導線を常設する
-  it('「アプリについて」のFAQ項目からよくある質問を開く', async () => {
-    const openURL = jest
-      .spyOn(Linking, 'openURL')
-      .mockResolvedValue(undefined as never);
+  // 非対応環境(GNSS非搭載端末など)はアプリ側で判定できないため、FAQへの導線を常設する。
+  // 外部ブラウザへ飛ばすと設定画面から離脱するため、アプリ内ブラウザで開くことも固定する
+  it('「アプリについて」のFAQ項目からよくある質問をアプリ内ブラウザで開く', async () => {
+    openBrowserAsync.mockResolvedValue(undefined);
     const { getByText } = render(<AppSettingsScreen />);
 
     await waitFor(() => expect(getByText('faq')).toBeTruthy());
     fireEvent.press(getByText('faq'));
 
-    expect(openURL).toHaveBeenCalledWith(FAQ_URL);
+    expect(openBrowserAsync).toHaveBeenCalledWith(FAQ_URL);
+  });
+
+  // Webページを開く項目と画面遷移する項目が同じシェブロンだと、押すまで
+  // アプリ内ブラウザが開くことが分からないため、末尾の印を出し分ける
+  it('FAQ項目の末尾は外部リンクの印で、他の項目はシェブロンのままになる', async () => {
+    const { getByLabelText } = render(<AppSettingsScreen />);
+
+    await waitFor(() => expect(getByLabelText('faq')).toBeTruthy());
+
+    // UNSAFE_queryAllByProps は同じ要素をコンポジット・ホスト双方で拾うため、
+    // 件数ではなく有無で判定する
+    const faqRow = within(getByLabelText('faq'));
+    expect(
+      faqRow.UNSAFE_queryAllByProps({ name: 'open-outline' }).length
+    ).toBeGreaterThan(0);
+    expect(faqRow.UNSAFE_queryAllByType(CardChevron)).toHaveLength(0);
+
+    // 同じ「アプリについて」セクション内の画面遷移項目は従来どおりであること
+    const licenseRow = within(getByLabelText('license'));
+    expect(
+      licenseRow.UNSAFE_queryAllByProps({ name: 'open-outline' })
+    ).toHaveLength(0);
+    expect(licenseRow.UNSAFE_queryAllByType(CardChevron)).toHaveLength(1);
   });
 
   it('スポットライト対象がないステップでは切り抜きを設定しない', async () => {

--- a/src/screens/AppSettings.tsx
+++ b/src/screens/AppSettings.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
+import * as WebBrowser from 'expo-web-browser';
 import { useAtomValue } from 'jotai';
 import { lighten } from 'polished';
 import React, {
@@ -11,7 +12,6 @@ import React, {
   useState,
 } from 'react';
 import {
-  Linking,
   Platform,
   Animated as RNAnimated,
   StyleSheet,
@@ -188,7 +188,25 @@ const SettingsItem = ({
         </View>
       ) : null}
 
-      <CardChevron stroke={isLEDTheme || colors.isDark ? 'white' : 'black'} />
+      {/*
+        FAQ はアプリ内ブラウザで Web ページを開く項目で、アプリ内の別画面へ進む
+        他の項目とは遷移先の種類が違う。同じシェブロンのままでは押すまで区別が
+        つかないため、末尾の印を外部リンクのものに差し替えて事前に知らせる。
+      */}
+      {item.id === SETTING_ITEM_ID_MAP.about_app_faq ? (
+        // size 24 では実描画が 19.3dp になり、隣のシェブロン(実測 16.7dp)より
+        // 一回り大きく見えるため、高さが揃う 20 にしている。CardChevron は
+        // 24dp の枠内でパスが右に 8dp 余白を持つ一方こちらは枠いっぱいに描かれ、
+        // そのままだと視覚的な右端が 4dp 外へ出るため marginRight で吸収する
+        <Ionicons
+          name="open-outline"
+          size={20}
+          color={isLEDTheme || colors.isDark ? 'white' : 'black'}
+          style={{ marginRight: 4 }}
+        />
+      ) : (
+        <CardChevron stroke={isLEDTheme || colors.isDark ? 'white' : 'black'} />
+      )}
     </TouchableOpacity>
   );
 };
@@ -410,8 +428,11 @@ const AppSettingsScreen: React.FC = () => {
         id: SETTING_ITEM_ID_MAP.about_app_faq,
         title: translate('faq'),
         color: '#5AC8FA',
+        // 外部ブラウザへ遷移すると設定画面から離脱してしまうため、
+        // プライバシーポリシー(src/screens/Privacy.tsx)と同じくアプリ内ブラウザで開き、
+        // 閉じれば元の位置に戻れるようにする。
         onPress: () => {
-          Linking.openURL(FAQ_URL).catch((error) => {
+          WebBrowser.openBrowserAsync(FAQ_URL).catch((error) => {
             console.warn('よくある質問を開けませんでした:', error);
           });
         },


### PR DESCRIPTION
## 概要

設定画面の「よくある質問」をタップすると、予告なく外部ブラウザへ遷移してアプリから離脱していました。アプリ内ブラウザ（`expo-web-browser`）で開くよう変更し、あわせて行末の印を外部リンクのものに差し替えて、押す前に Web ページが開くと分かるようにしました。

フィードバックモーダルの FAQ 導線（#6943 で同時に追加されたもの）も同じ実装だったため、作法を揃えています。こちらは入力途中の本文を抱えたままアプリを離脱する形になっており、影響がより大きい箇所でした。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/screens/AppSettings.tsx`: FAQ 項目の遷移を `Linking.openURL` から `WebBrowser.openBrowserAsync` に変更
- `src/screens/AppSettings.tsx`: FAQ 項目のみ行末のアクセサリを `CardChevron` から Ionicons `open-outline` に差し替え
- `src/components/NewReportModal.tsx`: FAQ リンクを同じくアプリ内ブラウザで開くよう変更
- `src/screens/AppSettings.test.tsx` / `src/components/NewReportModal.test.tsx`: アプリ内ブラウザで開くこと、および FAQ 行だけがアクセサリを出し分けることを固定

### 実装の根拠

- アプリ内ブラウザ化は `src/screens/Privacy.tsx:154` がプライバシーポリシーで既に採っている作法に合わせたもので、FAQ だけが `Linking.openURL` で割れていた状態を揃えています。ネイティブ側の追加作業はありません（`expo-web-browser` は既存依存）。
- アイコンの `size` は 20 です。24 では実描画が 19.3dp となり、隣接するシェブロン（実測 16.7dp）より一回り大きく見えたため、実機実測で高さが揃う値を採りました。
- `CardChevron` は Svg 24dp の枠内でパスが右に 8dp の余白を持つ設計のため、枠いっぱいに描かれる Ionicons とはそのままだと視覚的な右端が 4dp ずれます。`marginRight: 4` で吸収しています。

実機（Galaxy SCG13、1080×2340 @480dpi、1dp = 3px）での実測値:

| アクセサリ | 高さ | 右端 x |
| ---- | ---- | ---- |
| `open-outline`（調整前 size 24） | 58px | 928 |
| `open-outline`（調整後 size 20 + marginRight 4） | 49px | 916 |
| `CardChevron`（比較対象） | 50px | 915 |

## テスト

実機（Galaxy SCG13）で以下を確認しました。

- 設定画面 →「よくある質問」タップ → `com.android.chrome/...CustomTabActivity` が前面に来ること（`dumpsys activity activities` で確認）＝アプリ内ブラウザで開くこと
- FAQ ページが正常に表示されること
- 閉じるボタン（×）で `me.tinykitten.trainlcd.dev/MainActivity` に復帰し、**設定画面のスクロール位置が保持される**こと
- 戻るキーでも同様にアプリへ復帰すること

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy SCG13（実機）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_settings-faq-in-app-browser-5d0996cc/0fdd51b43d0c-evidence.png" width="640" alt="左: 設定画面のアプリについてセクション、右: タップ後のアプリ内ブラウザ" />

左: 変更後の設定画面（FAQ 行が外部リンクの印、ライセンス行はシェブロンのまま）／右: タップ後に開くアプリ内ブラウザ

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_settings-faq-in-app-browser-5d0996cc/0640b36b70dd-after_final.png" width="480" alt="FAQ行とライセンス行のアクセサリ拡大" />

アクセサリ部分の拡大。外部リンクの印とシェブロンの高さ・右端が揃っていることが分かります

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YutxZAqkKyfiDREtqHrf2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - FAQリンクをアプリ内ブラウザで開けるようになりました。
  - FAQ閲覧後、設定画面へ戻りやすくなりました。
  - FAQ項目に外部リンクアイコンを表示するよう変更しました。
- **改善**
  - FAQを開けない場合も警告を表示し、その後の送信フローを継続できるようになりました。
- **テスト**
  - FAQのブラウザ起動、アイコン表示、エラー時の動作に関する検証を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->