### PR TITLE
ストア版と同居できるAndroidのlocalビルドバリアントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,19 @@ Before you begin, ensure you have met the following requirements:
    cd MobileApp
    ```
 
-2. Install dependencies:
+2. Check out the font submodule (maintainers only):
+   ```bash
+   git submodule update --init --recursive
+   ```
+
+   The station numbering icons and the LED theme use commercially licensed
+   typefaces, so they are kept in a private submodule (`android/app/src/main/assets/fonts`,
+   `ios/Fonts`) that cannot be redistributed. The app builds and runs without it —
+   those glyphs simply fall back to the system font — so outside contributors can
+   skip this step and should expect the numbering to render in a different
+   typeface than the released builds.
+
+3. Install dependencies:
    ```bash
    npm install
    ```
@@ -96,7 +108,14 @@ npm run start
 
 - **iOS**: `npm run ios`
 - **Android**: `npm run android`
+- **Android (local-only variant)**: `npm run android:local`
 - **Web**: `npm run web`
+
+`npm run android` installs the `dev` flavor (`me.tinykitten.trainlcd.dev`), which is the
+same application ID as the Canary build distributed through the stores, so it replaces an
+installed Canary build. `npm run android:local` installs the `local` flavor
+(`me.tinykitten.trainlcd.local`, shown as **TrainLCD Local**) instead, which coexists with
+both store builds. It points at the same staging backends as Canary.
 
 ## Download
 
@@ -145,6 +164,7 @@ utils/                 # Tooling scripts and codegen helpers
 
 - `npm run start` - Start the Expo development server
 - `npm run android` / `npm run ios` - Build and launch native binaries
+- `npm run android:local` - Build and launch the Android `local` flavor, which can be installed alongside the store builds
 - `npm run web` - Serve the Expo web build
 - `npm run lint` - Run Biome linter
 - `npm run format` - Format code with Biome

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,14 +31,21 @@ react {
     //   ここに挙げたバリアントは JS バンドルとアセットの同梱をスキップし、Metro から
     //   JS を読み込む。判定はバリアント名の完全一致（大文字小文字は無視）で行われる。
     //   RN の既定値は ["debug", "debugOptimized"] だが、本プロジェクトは
-    //   flavorDimensions "environment" を持つためバリアント名が devDebug / prodDebug
-    //   （および RN プラグインが自動生成する build type の devDebugOptimized /
-    //   prodDebugOptimized）となり、既定リストに一致しない。明示しないと debug ビルドでも
+    //   flavorDimensions "environment" を持つためバリアント名が devDebug / prodDebug /
+    //   localDebug（および RN プラグインが自動生成する build type の devDebugOptimized /
+    //   prodDebugOptimized / localDebugOptimized）となり、既定リストに一致しない。明示しないと debug ビルドでも
     //   createBundle<Variant>JsAndAssets が走って JS が APK に焼き込まれ、Metro に接続されず
     //   Fast Refresh も CDP デバッガも使えなくなる。
     //   配布ビルドは EAS / CI とも bundleDevRelease / bundleProdRelease（Release バリアント）
     //   を使うため、このリストの影響を受けない。
-    debuggableVariants = ["devDebug", "prodDebug", "devDebugOptimized", "prodDebugOptimized"]
+    debuggableVariants = [
+        "devDebug",
+        "prodDebug",
+        "localDebug",
+        "devDebugOptimized",
+        "prodDebugOptimized",
+        "localDebugOptimized",
+    ]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
@@ -159,6 +166,17 @@ android {
         }
         prod {
             dimension "environment"
+            versionCode 100000753
+            versionName "10.15.0"
+        }
+        // ストア配信する dev (Canary) と applicationId を分けた、ローカル検証専用のフレーバー。
+        // ストアの Canary 版を消さずに同居させるためだけに存在し、配信には使わない
+        // (EAS / CI はいずれも devRelease / prodRelease を名指しするのでここは参照されない)。
+        // アイコン・スプラッシュは main を継承し、背景色と表示名・スキームだけ src/local/res で上書きする
+        local {
+            dimension "environment"
+            applicationId "me.tinykitten.trainlcd.local"
+            versionNameSuffix "-local"
             versionCode 100000753
             versionName "10.15.0"
         }

--- a/android/app/src/local/res/values/ic_launcher_background.xml
+++ b/android/app/src/local/res/values/ic_launcher_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- アダプティブアイコンの前景は main (本番と同じロゴ) を継承するため、
+         ランチャー上で本番・Canary と区別できるよう背景色だけローカル版用に変える -->
+    <color name="ic_launcher_background">#C8E6C9</color>
+</resources>

--- a/android/app/src/local/res/values/strings.xml
+++ b/android/app/src/local/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+  <!-- ストアの Canary 版と同居させるため、表示名もディープリンクのスキームも dev と分ける。
+       ここで上書きしない文字列は main から継承する -->
+  <string name="app_name">TrainLCD Local</string>
+  <string name="app_scheme">trainlcd-local</string>
+</resources>

--- a/android/wearable/build.gradle.kts
+++ b/android/wearable/build.gradle.kts
@@ -93,6 +93,16 @@ android {
       versionCode = 100000754
       versionName = "10.15.0"
     }
+    // :app の local フレーバーと対になるローカル検証専用フレーバー。Wear の Data Layer は
+    // applicationId が一致する場合しか疎通しないため、:app を .local にしたときは
+    // :wearable も同じ suffix を付けないと Wear 連携だけ無反応になる。配信には使わない
+    create("local") {
+      dimension = "environment"
+      applicationIdSuffix = ".local"
+      versionNameSuffix = "-local"
+      versionCode = 100000754
+      versionName = "10.15.0"
+    }
   }
 
   compileOptions {

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,9 @@
-const IS_DEV = process.env.APP_VARIANT === 'dev';
+// 'dev' はストア配信する Canary、'local' は android/app/build.gradle の local フレーバー
+// （ストアの Canary 版を消さずに同居させるローカル検証専用ビルド）。local は Android 限定で
+// iOS には対応するターゲットが無いため、iOS 側の識別子は Canary と同じものを使う。
+// 外部参照先も Canary に合わせる方針なので、判定は IS_DEV 側にまとめる（src/utils/isDevApp.ts）
+const IS_LOCAL = process.env.APP_VARIANT === 'local';
+const IS_DEV = process.env.APP_VARIANT === 'dev' || IS_LOCAL;
 
 export default {
   name: 'TrainLCD',
@@ -60,7 +65,11 @@ export default {
     supportsTablet: true,
   },
   android: {
-    package: IS_DEV ? 'me.tinykitten.trainlcd.dev' : 'me.tinykitten.trainlcd',
+    package: IS_LOCAL
+      ? 'me.tinykitten.trainlcd.local'
+      : IS_DEV
+        ? 'me.tinykitten.trainlcd.dev'
+        : 'me.tinykitten.trainlcd',
     permissions: [],
     versionCode: 100000753,
   },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,56 @@ CLAUDE.md「Security & Configuration Guardrails」に従い、依存更新後に
 
 新しいエントリを上に追加する。
 
+## 2026-09-12 — ストア版と同居できる Android の `local` ビルドバリアントを追加
+
+対象バージョン: v10.15.0
+
+### 内容
+
+- ローカル検証は `npm run android`（`dev` フレーバー）で行っていたが、`dev` の
+  applicationId `me.tinykitten.trainlcd.dev` はストア配信している Canary 版と同じため、
+  検証のたびにストアの Canary 版を削除する必要があった。
+- `android/app/build.gradle` に `local` フレーバー（applicationId
+  `me.tinykitten.trainlcd.local`、表示名 `TrainLCD Local`、スキーム `trainlcd-local`）を追加し、
+  `npm run android:local` で導入できるようにした。ストアの本番版・Canary 版と同時に
+  インストールできるため、検証のための再ビルド・再インストールが不要になる。
+- `react { debuggableVariants }` に `localDebug` / `localDebugOptimized` を追加した。ここに
+  挙げないと debug ビルドでも JS が APK へ焼き込まれ、Metro に繋がらず Fast Refresh も
+  CDP デバッガも使えなくなる（2026-08-28 のエントリを参照）。
+- アイコンとスプラッシュは `src/main` を継承し、`src/local/res` では表示名・スキームと
+  アダプティブアイコンの背景色（`#C8E6C9`）だけを上書きする。画像を追加せずに、白背景の
+  本番版・Canary 版とランチャー上で見分けられるようにするため。
+- `:wearable` にも同じ `local` フレーバーを追加した。Wear OS の Data Layer は
+  applicationId が一致する場合のみ疎通するため、`:app` だけ `.local` にすると
+  ローカルビルドでのみ Wear 連携が無反応になる。
+- 外部参照先は Canary に合わせる。`src/utils/isDevApp.ts` は `__DEV__` でも true になるが、
+  `localRelease` を焼いたときに本番 API やテレメトリーへ向かないよう、bundleId でも
+  `me.tinykitten.trainlcd.local` を dev 扱いにした。
+- `scripts/bump-version.js` が `local` フレーバーの `versionCode` / `versionName` も
+  dev・prod と同じ値へ追従させる。配信しないフレーバーだが、アプリ内のバージョン表示が
+  ずれると検証中の版を取り違えるため。
+- EAS / GitHub Actions はいずれも `bundleDevRelease` / `bundleProdRelease` を名指ししており、
+  配信ビルドはこの追加の影響を受けない。
+- 実機検証中に、非公開フォントサブモジュール（`android/app/src/main/assets/fonts`）が
+  未初期化のワークツリーではナンバリングや LED テーマのフォントが無言でシステムフォントへ
+  フォールバックすることが分かった。フレーバーとは無関係で `npm run android` でも同じように
+  起きるため、README の Installation に `git submodule update --init --recursive` の手順を追加した。
+
+### 検証結果
+
+Linux ホストで Gradle の構成と成果物を確認した（実機インストールは未実施）。
+
+- `./gradlew :app:assembleLocalDebug --dry-run` が成功し、タスクグラフに
+  `createBundleLocalDebugJsAndAssets` が現れない（`devDebug` と同じく JS は Metro から読む）。
+- `./gradlew :app:processLocalDebugManifest :app:mergeLocalDebugResources` の成果物が
+  `package="me.tinykitten.trainlcd.local"` / `android:versionName="10.15.0-local"` /
+  `app_name=TrainLCD Local` / `app_scheme=trainlcd-local` /
+  `ic_launcher_background=#C8E6C9` になっていること。
+- `./gradlew :wearable:processLocalDebugManifest` の成果物が
+  `package="me.tinykitten.trainlcd.local"` になっていること。
+- `npm run lint` / `npm test` / `npm run typecheck`。
+
+
 ## 2026-08-28 — `npm run android` がアプリ起動段階で失敗する不具合を修正
 
 対象バージョン: v10.13.1

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "expo start",
     "android": "cross-env APP_VARIANT=dev expo run:android -- --variant devDebug --app-id me.tinykitten.trainlcd.dev",
+    "android:local": "cross-env APP_VARIANT=local expo run:android -- --variant localDebug --app-id me.tinykitten.trainlcd.local",
     "ios": "npm run ios:frameworks && cross-env APP_VARIANT=dev expo run:ios",
     "ios:frameworks": "node scripts/fetch-voicevox-frameworks.mjs",
     "web": "expo start --web",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -200,14 +200,18 @@ const replaceFlavorStringSetting = (source, flavor, key, value) => {
 const updateAndroidBuildGradle = (filePath, versionCode, versionName) => {
   let content = fs.readFileSync(filePath, 'utf8');
 
-  // productFlavors内のdev/prodのversionCodeを更新
+  // productFlavors内のdev/prod/localのversionCodeを更新。
+  // local は配信しないフレーバーだが、アプリ内のバージョン表示が dev とずれると
+  // ローカル検証で見ている版を取り違えるため、同じ値に追従させる。
   content = replaceFlavorNumericSetting(content, 'dev', 'versionCode', versionCode);
   content = replaceFlavorNumericSetting(content, 'prod', 'versionCode', versionCode);
+  content = replaceFlavorNumericSetting(content, 'local', 'versionCode', versionCode);
 
   // versionNameを更新（versionNameが指定された場合のみ）
   if (versionName) {
     content = replaceFlavorStringSetting(content, 'dev', 'versionName', versionName);
     content = replaceFlavorStringSetting(content, 'prod', 'versionName', versionName);
+    content = replaceFlavorStringSetting(content, 'local', 'versionName', versionName);
   }
 
   fs.writeFileSync(filePath, content);
@@ -241,10 +245,12 @@ const updateWearableBuildGradle = (filePath, versionCode, versionName) => {
 
   content = replaceKtsFlavorNumericSetting(content, 'dev', 'versionCode', versionCode);
   content = replaceKtsFlavorNumericSetting(content, 'prod', 'versionCode', versionCode);
+  content = replaceKtsFlavorNumericSetting(content, 'local', 'versionCode', versionCode);
 
   if (versionName) {
     content = replaceKtsFlavorStringSetting(content, 'dev', 'versionName', versionName);
     content = replaceKtsFlavorStringSetting(content, 'prod', 'versionName', versionName);
+    content = replaceKtsFlavorStringSetting(content, 'local', 'versionName', versionName);
   }
 
   fs.writeFileSync(filePath, content);

--- a/scripts/bump-version.test.js
+++ b/scripts/bump-version.test.js
@@ -34,6 +34,13 @@ const appBuildGradleTemplate = (versionCode, versionName) => `android {
             versionCode ${versionCode}
             versionName "${versionName}"
         }
+        local {
+            dimension "environment"
+            applicationId "me.tinykitten.trainlcd.local"
+            versionNameSuffix "-local"
+            versionCode ${versionCode}
+            versionName "${versionName}"
+        }
     }
 }
 `;
@@ -49,6 +56,13 @@ const wearableBuildGradleTemplate = (versionCode, versionName) => `android {
     }
     create("prod") {
       dimension = "environment"
+      versionCode = ${versionCode}
+      versionName = "${versionName}"
+    }
+    create("local") {
+      dimension = "environment"
+      applicationIdSuffix = ".local"
+      versionNameSuffix = "-local"
       versionCode = ${versionCode}
       versionName = "${versionName}"
     }
@@ -124,6 +138,30 @@ const readAppVersionCode = (root) => {
   return Number(/prod\s*\{[\s\S]*?versionCode\s+(\d+)/m.exec(content)[1]);
 };
 
+const readAppFlavorVersion = (root, flavor) => {
+  const content = fs.readFileSync(
+    path.join(root, 'android', 'app', 'build.gradle'),
+    'utf8'
+  );
+  const block = new RegExp(
+    `${flavor}\\s*\\{[\\s\\S]*?versionCode\\s+(\\d+)[\\s\\S]*?versionName\\s+"([^"]*)"`,
+    'm'
+  ).exec(content);
+  return { versionCode: Number(block[1]), versionName: block[2] };
+};
+
+const readWearableFlavorVersion = (root, flavor) => {
+  const content = fs.readFileSync(
+    path.join(root, 'android', 'wearable', 'build.gradle.kts'),
+    'utf8'
+  );
+  const block = new RegExp(
+    `create\\("${flavor}"\\)\\s*\\{[\\s\\S]*?versionCode\\b\\s*=\\s*(\\d+)[\\s\\S]*?versionName\\b\\s*=\\s*"([^"]*)"`,
+    'm'
+  ).exec(content);
+  return { versionCode: Number(block[1]), versionName: block[2] };
+};
+
 const readWearableVersionCode = (root) => {
   const content = fs.readFileSync(
     path.join(root, 'android', 'wearable', 'build.gradle.kts'),
@@ -186,6 +224,32 @@ describe('bump-version.js の Android versionCode 採番', () => {
       ])
     ).toThrow();
     expect(readAppVersionCode(root)).toBe(100000586);
+  });
+
+  // ローカル検証専用の local フレーバーは配信しないが、バージョン表示が dev とずれると
+  // 検証中の版を取り違えるため、bump のたびに同じ値へ追従させている。
+  it('配信しない local フレーバーも dev / prod と同じ版へ追従する', () => {
+    const root = createWorkspace({
+      version: '10.12.1',
+      appVersionCode: 100000586,
+    });
+
+    runBump(root, ['patch']);
+
+    expect(readAppFlavorVersion(root, 'local')).toEqual(
+      readAppFlavorVersion(root, 'dev')
+    );
+    expect(readAppFlavorVersion(root, 'local')).toEqual({
+      versionCode: 100000588,
+      versionName: '10.12.2',
+    });
+    expect(readWearableFlavorVersion(root, 'local')).toEqual(
+      readWearableFlavorVersion(root, 'dev')
+    );
+    expect(readWearableFlavorVersion(root, 'local')).toEqual({
+      versionCode: 100000589,
+      versionName: '10.12.2',
+    });
   });
 
   it('据え置き指定では :app < :wearable のままでも失敗しない', () => {

--- a/src/constants/ident.ts
+++ b/src/constants/ident.ts
@@ -1,2 +1,6 @@
 export const DEV_APP_BUNDLE_IDENTIFIER = 'me.tinykitten.trainlcd.dev';
 export const DEV_CLIP_BUNDLE_IDENTIFIER = 'me.tinykitten.trainlcd.dev.Clip';
+// ローカル検証専用の Android ビルド（android/app/build.gradle の local フレーバー）。
+// ストア配信の Canary と applicationId を分けただけの同じ検証用ビルドなので、
+// 参照する外部サービスは Canary に合わせる
+export const LOCAL_APP_BUNDLE_IDENTIFIER = 'me.tinykitten.trainlcd.local';

--- a/src/utils/isDevApp.test.ts
+++ b/src/utils/isDevApp.test.ts
@@ -1,0 +1,47 @@
+import { getBundleId } from 'react-native-device-info';
+
+jest.mock('react-native-device-info', () => ({
+  getBundleId: jest.fn(() => 'me.tinykitten.trainlcd'),
+}));
+
+const mockedGetBundleId = jest.mocked(getBundleId);
+
+// isDevApp は import 時に評価される定数のため、bundleId を差し替えてから読み直す。
+// __DEV__ は debug ビルド相当で常に true になり bundleId 側の分岐を隠してしまうので、
+// リリースビルド相当（false）に落として判定する
+const loadIsDevApp = (bundleId: string) => {
+  mockedGetBundleId.mockReturnValue(bundleId);
+  const globalWithDev = globalThis as unknown as { __DEV__: boolean };
+  const originalDev = globalWithDev.__DEV__;
+  globalWithDev.__DEV__ = false;
+  let isDevApp = false;
+  try {
+    jest.isolateModules(() => {
+      isDevApp = require('./isDevApp').isDevApp;
+    });
+  } finally {
+    globalWithDev.__DEV__ = originalDev;
+  }
+  return isDevApp;
+};
+
+describe('isDevApp', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Canary 版を dev 扱いする', () => {
+    expect(loadIsDevApp('me.tinykitten.trainlcd.dev')).toBe(true);
+    expect(loadIsDevApp('me.tinykitten.trainlcd.dev.Clip')).toBe(true);
+  });
+
+  // local フレーバーは Canary と applicationId を分けただけの検証用ビルドなので、
+  // 参照する外部サービスは Canary と揃える。localRelease を焼いても本番へ向かせない
+  it('ローカル検証用フレーバーを dev 扱いする', () => {
+    expect(loadIsDevApp('me.tinykitten.trainlcd.local')).toBe(true);
+  });
+
+  it('本番版は dev 扱いしない', () => {
+    expect(loadIsDevApp('me.tinykitten.trainlcd')).toBe(false);
+  });
+});

--- a/src/utils/isDevApp.ts
+++ b/src/utils/isDevApp.ts
@@ -2,9 +2,13 @@ import { getBundleId } from 'react-native-device-info';
 import {
   DEV_APP_BUNDLE_IDENTIFIER,
   DEV_CLIP_BUNDLE_IDENTIFIER,
+  LOCAL_APP_BUNDLE_IDENTIFIER,
 } from '../constants';
 
 export const isDevApp =
   (() => getBundleId() === DEV_APP_BUNDLE_IDENTIFIER)() ||
   (() => getBundleId() === DEV_CLIP_BUNDLE_IDENTIFIER)() ||
+  // local フレーバーは debug ビルドが基本で __DEV__ で拾えるが、localRelease を焼いたときに
+  // 本番の API やテレメトリーへ向かないよう bundleId でも Canary 扱いにする
+  (() => getBundleId() === LOCAL_APP_BUNDLE_IDENTIFIER)() ||
   __DEV__;


### PR DESCRIPTION
## 概要

ローカル検証に使っている `npm run android`（`dev` フレーバー）は、ストア配信している Canary 版と applicationId が同じ `me.tinykitten.trainlcd.dev` のため、検証のたびにストアの Canary 版を消す必要がありました。ストア版と同居できる Android 専用の `local` ビルドバリアントを追加し、消して入れ直す往復を無くします。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `android/app/build.gradle` に `local` フレーバーを追加（applicationId `me.tinykitten.trainlcd.local`、表示名 `TrainLCD Local`、スキーム `trainlcd-local`、`versionNameSuffix "-local"`）。`npm run android:local` で導入できる
- `react { debuggableVariants }` に `localDebug` / `localDebugOptimized` を追加。ここに挙げないと debug ビルドでも JS が APK へ焼き込まれ、Metro に繋がらず Fast Refresh も CDP デバッガも使えなくなる（`docs/changelog.md` 2026-08-28 のエントリ参照）
- `android/app/src/local/res` は表示名・スキームとアダプティブアイコンの背景色（`#C8E6C9`）だけを上書きし、アイコン画像とスプラッシュは `src/main` を継承する。画像ファイルを増やさずに、白背景の本番版・Canary 版とランチャー上で見分けられるようにするため
- `:wearable` にも同じ `local` フレーバーを追加。Wear OS の Data Layer は applicationId が一致する場合のみ疎通するため、`:app` だけ `.local` にするとローカルビルドでのみ Wear 連携が無反応になる
- 外部参照先は Canary に揃える。`src/utils/isDevApp.ts` は `__DEV__` でも true になるが、`localRelease` を焼いたときに本番 API やテレメトリーへ向かないよう bundleId でも `me.tinykitten.trainlcd.local` を dev 扱いにした（`src/utils/isDevApp.test.ts` を追加）
- `scripts/bump-version.js` が `local` の `versionCode` / `versionName` も dev・prod と同じ値へ追従させる。配信しないフレーバーだが、アプリ内のバージョン表示がずれると検証中の版を取り違えるため
- README の Installation に、非公開フォントサブモジュール（`git submodule update --init --recursive`）の手順を追加。実機検証中に、未初期化のワークツリーではナンバリングや LED テーマのフォントが無言でシステムフォントへフォールバックすることが分かったため（フレーバーとは無関係で `npm run android` でも同様に起きる）。商用フォントで再配布できない旨と、無くてもビルド自体は通る旨も明記した

### 回帰リスクと緩和

- EAS / GitHub Actions はいずれも `bundleDevRelease` / `bundleProdRelease` を名指ししているため、配信ビルドはフレーバー追加の影響を受けない
- 既存の `dev` / `prod` フレーバーの定義・リソースには手を入れていない。`local` は `src/local/res` を新設しただけで、`src/dev` / `src/prod` は無変更
- `bump-version.js` は `local` フレーバーが存在しないと例外を投げるため、フレーバー定義とスクリプトがずれた場合はリリース作業の最初で気付ける。追従を固定する回帰テストも追加した

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（278 suites / 3021 tests passed）
- [x] `npm run typecheck` が通ること

Gradle と実機での確認:

- `./gradlew :app:assembleLocalDebug --dry-run` が成功し、タスクグラフに `createBundleLocalDebugJsAndAssets` が現れない（`devDebug` と同じく JS は Metro から読む）
- `:app:processLocalDebugManifest` / `:app:mergeLocalDebugResources` の成果物が `package="me.tinykitten.trainlcd.local"` / `android:versionName="10.15.0-local"` / `app_name=TrainLCD Local` / `app_scheme=trainlcd-local` / `ic_launcher_background=#C8E6C9`
- `:wearable:processLocalDebugManifest` の成果物が `package="me.tinykitten.trainlcd.local"`
- 実機 Galaxy S23 (SCG13 / Android 16) に `app-local-debug.apk` をインストールし、本番版・Canary 版と 3 つ同居することを確認

  ```text
  me.tinykitten.trainlcd             versionName=10.15.0
  me.tinykitten.trainlcd.dev         versionName=10.15.0-dev
  me.tinykitten.trainlcd.local       versionName=10.15.0-local
  ```

- `trainlcd-local://` のディープリンクで走行画面まで到達し、Metro 接続・Fast Refresh・CDP デバッガが使えることを確認

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### Galaxy S23 (SCG13) 実機

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_android-local-build-variant-4abb4fc99/0c8a5948bb1c-pr_device.png" width="320" alt="local版を実機で起動した走行画面" />

local 版を Metro 接続で起動し、山手線の走行画面まで到達。JT03（角型 = FrutigerNeueLTPro）/ KK01（丸型 = FuturaLTPro）のナンバリングが正しいフォントで描画されている

### 合成図（実機ランチャーのキャプチャではありません）

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/feature_android-local-build-variant-4abb4fc99/050ae27f98e4-icon_compare.png" width="480" alt="本番・Canary・Localのランチャーアイコン比較" />

左から本番（白背景）/ Canary（白背景）/ Local（`#C8E6C9`）。リポジトリのアイコンリソースから合成したもので、ランチャー実画面のキャプチャではありません

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZjNCYFFYPQd3ZHtrPhdaC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Android に、本番版と併存できるローカル検証用ビルドを追加しました。
  - ローカル版専用のアプリ名、アイコン背景、アプリID、ディープリンクスキームを設定しました。
  - Wear OS にもローカル版ビルドを追加しました。
  - ローカル版を起動する `android:local` スクリプトを追加しました。

- **ドキュメント**
  - ローカル版のセットアップ手順、利用条件、接続先、フォント取得手順をREADMEに追加しました。
  - 変更履歴を更新しました。

- **改善**
  - ローカル版を開発アプリとして正しく判定し、バージョン更新の対象に含めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->