### PR TITLE
行き先ナンバリングが消える駅番号indexの取り違えを修正

### DIFF
--- a/src/hooks/useStationNumberIndexFunc.test.ts
+++ b/src/hooks/useStationNumberIndexFunc.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react-native';
+import type { LineSymbol } from '~/@types/graphql';
+import {
+  createLine,
+  createStation,
+  createStationNumber,
+} from '~/utils/test/factories';
+import { useStationNumberIndexFunc } from './useStationNumberIndexFunc';
+
+const createLineSymbol = (symbol: string): LineSymbol => ({
+  __typename: 'LineSymbol',
+  color: '#123456',
+  shape: 'ROUND',
+  symbol,
+});
+
+describe('useStationNumberIndexFunc', () => {
+  it('lineを渡さない場合は先頭の駅番号を指す', () => {
+    const { result } = renderHook(() => useStationNumberIndexFunc());
+    const station = createStation(1, {
+      stationNumbers: [
+        createStationNumber('TS', 'TS-30'),
+        createStationNumber('TI', 'TI-10'),
+      ],
+    });
+
+    expect(result.current(station)).toBe(0);
+  });
+
+  it('路線の記号に一致する駅番号の位置を返す', () => {
+    const { result } = renderHook(() => useStationNumberIndexFunc());
+    const station = createStation(1, {
+      stationNumbers: [
+        createStationNumber('JY', 'JY-01'),
+        createStationNumber('JK', 'JK-26'),
+      ],
+    });
+    const line = createLine(1, { lineSymbols: [createLineSymbol('JK')] });
+
+    expect(result.current(station, line)).toBe(1);
+  });
+
+  // 東武スカイツリーラインの lineSymbols は [TI, TS] だが、東武動物公園の
+  // stationNumbers は [TS-30] のみ。lineSymbols 側の位置(1)を返すと存在しない
+  // 駅番号を引いてナンバリングが消えるため、stationNumbers 側の位置を返す。
+  it('lineSymbolsとstationNumbersの数が揃っていなくても駅番号を引ける', () => {
+    const { result } = renderHook(() => useStationNumberIndexFunc());
+    const station = createStation(1, {
+      stationNumbers: [createStationNumber('TS', 'TS-30')],
+    });
+    const line = createLine(1, {
+      lineSymbols: [createLineSymbol('TI'), createLineSymbol('TS')],
+    });
+
+    expect(result.current(station, line)).toBe(0);
+  });
+
+  it('一致する記号がない場合は先頭の駅番号にフォールバックする', () => {
+    const { result } = renderHook(() => useStationNumberIndexFunc());
+    const station = createStation(1, {
+      stationNumbers: [createStationNumber('TS', 'TS-30')],
+    });
+    const line = createLine(1, { lineSymbols: [createLineSymbol('H')] });
+
+    expect(result.current(station, line)).toBe(0);
+  });
+
+  it('駅番号がない場合は0を返す', () => {
+    const { result } = renderHook(() => useStationNumberIndexFunc());
+    const station = createStation(1, { stationNumbers: [] });
+    const line = createLine(1, { lineSymbols: [createLineSymbol('H')] });
+
+    expect(result.current(station, line)).toBe(0);
+    expect(result.current(undefined, line)).toBe(0);
+  });
+});

--- a/src/hooks/useStationNumberIndexFunc.ts
+++ b/src/hooks/useStationNumberIndexFunc.ts
@@ -4,13 +4,24 @@ import type { Line, Station } from '~/@types/graphql';
 export const useStationNumberIndexFunc = () => {
   const func = useCallback(
     (station: Station | undefined, line?: Line | null) => {
-      return (
-        line?.lineSymbols?.findIndex(({ symbol }) =>
-          station?.stationNumbers?.some(
-            ({ lineSymbol }) => symbol === lineSymbol
-          )
-        ) ?? 0
+      const stationNumbers = station?.stationNumbers;
+      const lineSymbols = line?.lineSymbols;
+
+      if (!stationNumbers?.length || !lineSymbols?.length) {
+        return 0;
+      }
+
+      // lineSymbols(路線が持つ記号の一覧)と stationNumbers(駅が持つ番号の一覧)は
+      // 並びも要素数も揃っていない。東武スカイツリーラインの lineSymbols は
+      // [TI, TS] だが東武動物公園の stationNumbers は [TS-30] だけ、という具合に
+      // ずれるため、返す位置は必ず stationNumbers 側から引く。
+      const index = stationNumbers.findIndex(({ lineSymbol }) =>
+        lineSymbols.some(({ symbol }) => symbol === lineSymbol)
       );
+
+      // 路線の記号を持たない駅(直通先などデータ上の想定外)では番号ごと消さず、
+      // line 未指定時と同じく先頭の番号にフォールバックする。
+      return index < 0 ? 0 : index;
     },
     []
   );


### PR DESCRIPTION
## 概要

乗車直後の行き先表示で、行き先駅のナンバリングが表示されないことがある不具合を修正します。日比谷線から東武スカイツリーライン直通の「東武動物公園ゆき」で再現します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `useStationNumberIndexFunc` が `lineSymbols` 側の index を `stationNumbers` の index として返していたのを、`stationNumbers` 側から引くように修正
- 一致する記号が無い場合は番号ごと消さず、`line` 未指定時と同じく先頭の駅番号にフォールバック
- `src/hooks/useStationNumberIndexFunc.test.ts` を新規追加（これまでテストが無かった）

### 原因

`lineSymbols`（路線が持つ記号の一覧）と `stationNumbers`（駅が持つ番号の一覧）は並びも要素数も一致しませんが、旧実装は前者で得た index をそのまま後者に使っていました。

```ts
line?.lineSymbols?.findIndex(({ symbol }) =>
  station?.stationNumbers?.some(({ lineSymbol }) => symbol === lineSymbol)
) ?? 0
```

StationAPI の実データでは次のようにずれます。

- 東武スカイツリーライン (id: 21002) の `lineSymbols` … `[TI, TS]`
- 東武動物公園 (id: 2100230) の `stationNumbers` … `[TS-30]` のみ

`TS` は `lineSymbols` の 1 番目なので index `1` が返り、`stationNumbers[1]` は `undefined`。その結果 `currentStationNumber` が falsy になり、`PortraitMain` / 各ヘッダーの `currentStationNumber ? ...` が丸ごと落ちてナンバリングが消えていました。

`line` を渡すのは `useNumbering` の firstStop（乗車直後の行き先表示）だけで、他の呼び出しは `line` 未指定 → `?? 0` に落ちるため、この経路でのみ顕在化します。ポートレート固有ではなく、同じ `useHeaderCommonData` を使う横画面ヘッダーでも同条件で発生します。

なお `544d7030` 時点では `stationNumbers` 側から探す正しい形でしたが、`3c33bca9`「クソデカナンバリング記号が出るバグ＆一部路線でナンバリング情報が出ないバグを修正」(2023-08-10) で「駅の `line` ではなく外から渡した `line` を基準にする」よう変えた際に探索対象の配列が入れ替わり、行き先ナンバリングに `line` を渡し始めた `71e5d85b35`「始発表示準備」で表面化しています。「乗車路線の記号で選ぶ」という意図はそのまま維持しています。

### 回帰リスク

`line` 引数を渡す呼び出しは `useNumbering` の firstStop 経路のみで、他（`useTTSText` / `useGetLineMark` / `useRefreshStation` / `useAndroidPictureInPicture` / `useUpdateLiveActivities` / LineBoard 各種）はすべて `line` 未指定です。未指定時は旧実装・新実装ともに `0` を返すため挙動は変わりません。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm test` は 279 suites / 3026 tests すべて成功。新規追加した `useStationNumberIndexFunc.test.ts` で、`lineSymbols` と `stationNumbers` の数が揃わないケース（東武スカイツリーライン / 東武動物公園の実データ形状）を回帰テストとして固定しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UI変更がある場合は、見た目が分かる画像を出所とともに添付してください。実機/シミュレータのスクリーンショット・動画（例: iPhone 15 Pro, Pixel 8）、React Native Web (npm run web) のレンダリング、実装を動かしていないイメージ図のいずれでも構いません。イメージ図の場合はその旨を明記してください。画像を添付しない場合は、この節を空欄にせず「UI変更なし: <根拠>」のように理由を1行で記載してください -->

<!-- create-pr:screenshots:start -->

### T12\_ROW（Android 13 実機）

ポートレートモードで、茅場町から東武動物公園ゆきに乗車した直後（行き先表示）の状態です。同じ画面状態のまま Fast Refresh で実装だけを入れ替えて撮影しています。

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_first-stop-numbering-index-2fa3c7203/2cd1f92dbc24-before-numbering.png" width="320" alt="修正前: 行き先のナンバリングが表示されない" />

修正前: 駅名のみでナンバリングが出ない

<img src="https://raw.githubusercontent.com/TrainLCD/MobileApp/assets/pr-screenshots/fix_first-stop-numbering-index-2fa3c7203/27ed4bc33a0c-after-numbering.png" width="320" alt="修正後: TS-30 のナンバリングが表示される" />

修正後: `TS-30` が駅名の左に表示される

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtuqguKrrrofDLgoSiRQ3N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 路線記号に対応する駅番号が正しく選択されるようになりました。
  - 路線記号が一致しない場合や駅番号・路線が未指定の場合は、先頭の駅番号へフォールバックします。
  - 路線記号と駅番号の件数が一致しない場合を含む、駅番号選択の動作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->