### PR TITLE
ポートレートのステート表示を省略せず全文出す

### DIFF
--- a/src/components/PortraitMain.test.tsx
+++ b/src/components/PortraitMain.test.tsx
@@ -517,6 +517,41 @@ describe('PortraitMain', () => {
     expect(getByText('nowStoppingAtEn')).toBeTruthy();
   });
 
+  it('終着駅の state は改行を空白に畳んで全文を1行で出す', () => {
+    mockedUseHeaderCommonData.mockReturnValue({
+      ...commonData,
+      // 横画面ヘッダーの2行組みをそのまま渡すと、1行表示では2行目が省略記号になる
+      stateText: 'まもなく\n終点',
+      headerState: 'ARRIVING',
+    });
+
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    expect(getByTestId('portrait-state-text').props.children).toBe(
+      'まもなく 終点'
+    );
+  });
+
+  it('state は行内で縮めず、省略記号を出さない', () => {
+    mockedUseHeaderCommonData.mockReturnValue({
+      ...commonData,
+      stateText: 'nowStoppingAtEn',
+      headerState: 'CURRENT_EN',
+    });
+
+    const { getByTestId } = renderWithStations([
+      buildStation(1, '品川', StopCondition.All, 'JY-25'),
+    ]);
+
+    const stateText = getByTestId('portrait-state-text');
+    // 縮まなければ numberOfLines={1} でも末尾が省略されない。
+    // 長い駅名と競合したときに縮むのは隣の cardHeadMeta 側。
+    expect(StyleSheet.flatten(stateText.props.style).flexShrink).toBe(0);
+    expect(stateText.props.numberOfLines).toBe(1);
+  });
+
   it('上端は Dynamic Island、下端はホームインジケータと被らないようセーフエリア分の余白を取る', () => {
     const { getByTestId } = renderWithStations([
       buildStation(1, '品川', StopCondition.All, 'JY-25'),

--- a/src/components/PortraitMain.tsx
+++ b/src/components/PortraitMain.tsx
@@ -146,20 +146,26 @@ const departedTrackColor = (accent: string, background: string): string => {
   }
 };
 
+// 終着駅の state は横画面ヘッダーの2行組み(例: 「まもなく\n終点」)を前提に
+// 改行を含む。ポートレートの state は高さ固定の1行なので、改行をそのまま渡すと
+// 2行目が省略記号に化けて「終点」が読めなくなる。空白に畳んで全文を1行で出す。
+const flattenStateText = (stateText: string): string =>
+  stateText.replaceAll('\n', ' ');
+
 // 停車中(CURRENT)の state は共有の useHeaderStateText では日本語以外が空になる
 // (ヘッダーは駅名のみ表示する仕様)。ポートレートでは各言語の「ただいま停車中」を
 // 補完して、停車中でも英中韓の state を表示する。
 const resolveStateText = (stateText: string, headerState: string): string => {
   if (stateText) {
-    return stateText;
+    return flattenStateText(stateText);
   }
   switch (headerState) {
     case 'CURRENT_EN':
-      return translate('nowStoppingAtEn');
+      return flattenStateText(translate('nowStoppingAtEn'));
     case 'CURRENT_ZH':
-      return translate('nowStoppingAtZh');
+      return flattenStateText(translate('nowStoppingAtZh'));
     case 'CURRENT_KO':
-      return translate('nowStoppingAtKo');
+      return flattenStateText(translate('nowStoppingAtKo'));
     default:
       return stateText;
   }
@@ -320,9 +326,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  // 状態テキストも言語切り替えで内容が変わるため高さを固定する
+  // 状態テキストも言語切り替えで内容が変わるため高さを固定する。
+  // 「まもなく」などの state は行の主役なので縮めない。長い駅名と競合したときは
+  // 隣の cardHeadMeta 側が縮む(そちらは頭を省略して次駅を残す作り)。
   stateText: {
-    flexShrink: 1,
+    flexShrink: 0,
     fontSize: RFValue(11),
     fontWeight: 'bold',
     height: RFValue(17),
@@ -1666,6 +1674,7 @@ const PortraitMain: React.FC<Props> = ({ onPress, onTransferPress }) => {
           <View style={styles.cardHeadRow}>
             <Typography
               numberOfLines={1}
+              testID="portrait-state-text"
               style={[styles.stateText, { color: accentColor }]}
             >
               {displayStateText}


### PR DESCRIPTION
## 概要

ポートレートのステート表示（「まもなく」など）が三点リーダーで省略されることがあったので、常に全文を出すようにしました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

省略が起きていた原因は 2 つあり、両方に手を入れています。

- **改行**: `useHeaderStateText` が返す state は横画面ヘッダーの 2 行組みを前提に改行を含みます（`まもなく\n終点` / `つぎは\nしゅうてん` / `Soon\nLast Stop` / `下一站是\n终点站` など）。ポートレートの state は `numberOfLines={1}` かつ高さ固定の 1 行なので、2 行目が落ちて `まもなく…` になっていました。`flattenStateText()` を追加し、`resolveStateText` の全経路で改行を半角空白へ畳んで 1 行に収めます。行の高さを固定している既存の意図（言語切り替えでカードの高さが動かないようにする）はそのまま維持しています。
- **横方向**: `styles.stateText` が `flexShrink: 1` だったため、同じ行の `cardHeadMeta`（起点・次駅）と競合したときに state 側も縮んで末尾が省略され得ました。state は行の主役なので `flexShrink: 0` にし、縮むのは隣の `cardHeadMeta` 側（元々 `ellipsizeMode="head"` で頭を削り次駅を残す作り）に寄せています。最長ケース（`Now stopping at` / `下一站是 终点站`）でも `RFValue(11)` で 110pt 程度なのでカード幅に収まり、はみ出しは起きません。
- 同じ `styles.stateText` を使う「のりかえ」オーバーレイの見出しにも同じ扱いが及びます（短い語なので見た目の変化はありません）。
- 回帰テストを 2 件追加（改行を畳んで全文表示すること / `flexShrink: 0` で縮まないこと）。変更前のコードでは両方 fail することを確認済みです。

## テスト

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること
- [x] `npm run typecheck` が通ること

`npm run lint`（747 ファイル・指摘なし）、`npm test`（279 suites / 3028 tests 全て pass）、`npm run typecheck`（エラーなし）をローカルで実行しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

### React Native Web (Chromium) / PortraitMain をモックデータで描画したハーネス

画像は資材ブランチ `assets/pr-screenshots` に置いてあります（本文への埋め込みは、このセッションの投稿経路が画像 URL を無効化するため断念しました。下の URL をブラウザで開いてください）。

https://github.com/TrainLCD/MobileApp/blob/assets/pr-screenshots/claude_portrait-state-display-full-23ke33-d61887d/36fd45023976-portrait-state-after.png

内容: 修正後のポートレート表示。中央線（JC・SQUARE ナンバリング）の終着「東京」へ接近中で、state が「まもなく 終点」と省略されずに 1 行で出ています。実機ではなく、`PortraitMain` を react-native-web + Chromium でモックデータのまま描画したハーネスの出力です。

なお **Before の画像はありません**。react-native-web は文字列中の改行を空白へ畳むため、修正前のコードで撮っても同じ絵になります（実際にバイト単位で一致することを確認しました）。`\n` を強制改行として扱い `numberOfLines={1}` で 2 行目を落とすのはネイティブ側の挙動で、web では再現できません。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nthn3xqvpL8ufsJhmbo4hh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **不具合修正**
  - ポートレート表示で、終着駅などの複数行テキストを空白区切りの1行で表示するよう改善しました。
  - 英語・中国語・韓国語の停車中テキストにも同様の表示調整を適用しました。
  - 長い状態テキストを縮小せず、末尾を省略記号なしで表示するよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
