### PR TITLE
地下鉄で到着表示が最大90秒遅れるETA棄却のデッドロックを解消

### DIFF
--- a/src/hooks/useEtaAnchor.test.tsx
+++ b/src/hooks/useEtaAnchor.test.tsx
@@ -1,10 +1,12 @@
 import { act, renderHook } from '@testing-library/react-native';
+import type * as Location from 'expo-location';
 import { createStore, Provider } from 'jotai';
 import type React from 'react';
 import type { Station } from '~/@types/graphql';
 import { StopCondition } from '~/@types/graphql';
 import { createStation } from '~/utils/test/factories';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
+import { locationAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -14,6 +16,20 @@ import { useEtaAnchor } from './useEtaAnchor';
 
 // AT_STATION の定期更新周期(フック内部定数と同じ5秒)。
 const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
+
+// 受理済み測位。observedAtMs はこの timestamp を基準にする
+const makeLocation = (timestamp: number): Location.LocationObject => ({
+  coords: {
+    latitude: 35.0,
+    longitude: 139.0,
+    accuracy: 20,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    speed: null,
+  },
+  timestamp,
+});
 
 const stationA = createStation(1);
 const passStation = createStation(2, { stopCondition: StopCondition.Not });
@@ -25,11 +41,21 @@ const renderWithStore = (
     arrived = true,
     station = stationA as Station | null,
     selectedBound = boundStation as Station | null,
+    locationTimestamp,
+  }: {
+    arrived?: boolean;
+    station?: Station | null;
+    selectedBound?: Station | null;
+    /** 受理済み測位の時刻。省略時は測位がまだ無い状態 */
+    locationTimestamp?: number;
   } = {}
 ) => {
   store.set(arrivedAtom, arrived);
   store.set(stationAtom, station);
   store.set(selectedBoundAtom, selectedBound);
+  if (locationTimestamp != null) {
+    store.set(locationAtom, makeLocation(locationTimestamp));
+  }
 
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <Provider store={store}>{children}</Provider>
@@ -47,28 +73,108 @@ describe('useEtaAnchor', () => {
     jest.useRealTimers();
   });
 
-  it('到着中は AT_STATION が記録され、時間経過で observedAtMs が更新される', () => {
+  it('到着中は AT_STATION が記録され、新しい測位を受理するたびに observedAtMs が追随する', () => {
     jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const store = createStore();
 
-    renderWithStore(store, { arrived: true, station: stationA });
+    renderWithStore(store, {
+      arrived: true,
+      station: stationA,
+      locationTimestamp: 999_000,
+    });
 
+    // 打刻は端末時計ではなく受理済み測位の時刻で行う(棄却判定がGPSの時刻軸で回るため)
     expect(store.get(etaAnchorAtom)).toEqual({
       stationId: stationA.id,
       kind: 'AT_STATION',
-      observedAtMs: 1_000_000,
+      observedAtMs: 999_000,
     });
 
-    // 5秒経過。arrived/stationは不変だが、useIntervalの定期更新でobservedAtMsが進む
+    // 5秒経過。arrived/stationは不変だが、到着を確認し続ける測位が受理されている間は
+    // その測位の時刻までobservedAtMsを追随させる
     jest.spyOn(Date, 'now').mockReturnValue(1_005_000);
     act(() => {
+      store.set(locationAtom, makeLocation(1_004_000));
       jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
     });
 
     expect(store.get(etaAnchorAtom)).toEqual({
       stationId: stationA.id,
       kind: 'AT_STATION',
-      observedAtMs: 1_005_000,
+      observedAtMs: 1_004_000,
+    });
+  });
+
+  // 受理済み測位が無い間にDate.now()でフォールバック打刻すると、端末時計軸のアンカーが
+  // でき、初回測位が届いても下の単調ガードで打ち直されない。棄却判定はGPS軸なので
+  // ずれぶん仮想時計が遅れ、DWELLINGに張り付いて凍結が再発する。
+  it('受理済み測位が無い間はアンカーを記録しない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_200_000);
+    const store = createStore();
+
+    renderWithStore(store, { arrived: true, station: stationA });
+    expect(store.get(etaAnchorAtom)).toBeNull();
+
+    // 初回測位が届いたら、その測位の時刻で記録される
+    act(() => {
+      store.set(locationAtom, makeLocation(1_199_000));
+      jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
+    });
+
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'AT_STATION',
+      observedAtMs: 1_199_000,
+    });
+  });
+
+  // Androidのfused providerはキャッシュ済みの古いfixを返すことがある。基準時刻が巻き戻ると
+  // 仮想時計も巻き戻り、一度広がった許容が縮んで棄却が復活する。
+  it('アンカーより古い測位では observedAtMs を巻き戻さない', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_300_000);
+    const store = createStore();
+
+    renderWithStore(store, {
+      arrived: true,
+      station: stationA,
+      locationTimestamp: 1_300_000,
+    });
+    expect(store.get(etaAnchorAtom)?.observedAtMs).toBe(1_300_000);
+
+    act(() => {
+      store.set(locationAtom, makeLocation(1_290_000));
+      jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
+    });
+
+    expect(store.get(etaAnchorAtom)?.observedAtMs).toBe(1_300_000);
+  });
+
+  // 回帰: 無条件にDate.now()で打ち直すと、ETAの進行量上限(#6939)が測位を棄却して位置が
+  // 凍結した際にarrivedが到着駅で張り付き、基準時刻も一緒に進むため仮想時計が止まる。
+  // DWELLINGのまま許容が広がらず、棄却が上限時間(90秒)まで続いて到着表示が遅れた。
+  it('測位が受理されなくなったら observedAtMs を進めない(仮想時計を止めない)', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_100_000);
+    const store = createStore();
+
+    renderWithStore(store, {
+      arrived: true,
+      station: stationA,
+      locationTimestamp: 1_100_000,
+    });
+    expect(store.get(etaAnchorAtom)?.observedAtMs).toBe(1_100_000);
+
+    // 位置が凍結している(locationAtomが更新されない)まま時間だけ経過する
+    for (let i = 1; i <= 6; i += 1) {
+      jest.spyOn(Date, 'now').mockReturnValue(1_100_000 + i * 5_000);
+      act(() => {
+        jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS);
+      });
+    }
+
+    expect(store.get(etaAnchorAtom)).toEqual({
+      stationId: stationA.id,
+      kind: 'AT_STATION',
+      observedAtMs: 1_100_000,
     });
   });
 
@@ -76,30 +182,37 @@ describe('useEtaAnchor', () => {
     jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
     const store = createStore();
 
-    renderWithStore(store, { arrived: true, station: stationA });
+    renderWithStore(store, {
+      arrived: true,
+      station: stationA,
+      locationTimestamp: 2_000_000,
+    });
     expect(store.get(etaAnchorAtom)?.kind).toBe('AT_STATION');
 
+    // 発車を検出した測位の時刻で打刻される(端末時計の2_001_000ではない)
     jest.spyOn(Date, 'now').mockReturnValue(2_001_000);
     act(() => {
+      store.set(locationAtom, makeLocation(2_000_800));
       store.set(arrivedAtom, false);
     });
 
     expect(store.get(etaAnchorAtom)).toEqual({
       stationId: stationA.id,
       kind: 'DEPARTED',
-      observedAtMs: 2_001_000,
+      observedAtMs: 2_000_800,
     });
 
     // 発車後、時間が経過してもDEPARTEDのobservedAtMsは上書きされない
     jest.spyOn(Date, 'now').mockReturnValue(2_010_000);
     act(() => {
+      store.set(locationAtom, makeLocation(2_009_000));
       jest.advanceTimersByTime(AT_STATION_REFRESH_INTERVAL_MS * 2);
     });
 
     expect(store.get(etaAnchorAtom)).toEqual({
       stationId: stationA.id,
       kind: 'DEPARTED',
-      observedAtMs: 2_001_000,
+      observedAtMs: 2_000_800,
     });
   });
 
@@ -107,7 +220,11 @@ describe('useEtaAnchor', () => {
     jest.spyOn(Date, 'now').mockReturnValue(3_000_000);
     const store = createStore();
 
-    renderWithStore(store, { arrived: true, station: passStation });
+    renderWithStore(store, {
+      arrived: true,
+      station: passStation,
+      locationTimestamp: 3_000_000,
+    });
 
     expect(store.get(etaAnchorAtom)).toBeNull();
 
@@ -122,7 +239,11 @@ describe('useEtaAnchor', () => {
     jest.spyOn(Date, 'now').mockReturnValue(3_100_000);
     const store = createStore();
 
-    renderWithStore(store, { arrived: true, station: passStation });
+    renderWithStore(store, {
+      arrived: true,
+      station: passStation,
+      locationTimestamp: 3_100_000,
+    });
     expect(store.get(etaAnchorAtom)).toBeNull();
 
     act(() => {
@@ -136,7 +257,11 @@ describe('useEtaAnchor', () => {
     jest.spyOn(Date, 'now').mockReturnValue(4_000_000);
     const store = createStore();
 
-    renderWithStore(store, { arrived: true, station: stationA });
+    renderWithStore(store, {
+      arrived: true,
+      station: stationA,
+      locationTimestamp: 4_000_000,
+    });
     expect(store.get(etaAnchorAtom)).not.toBeNull();
 
     act(() => {

--- a/src/hooks/useEtaAnchor.ts
+++ b/src/hooks/useEtaAnchor.ts
@@ -1,6 +1,7 @@
-import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useRef } from 'react';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
+import { useCallback, useEffect, useRef } from 'react';
 import { etaAnchorAtom } from '../store/atoms/etaFallback';
+import { locationAtom } from '../store/atoms/location';
 import {
   arrivedAtom,
   selectedBoundAtom,
@@ -9,8 +10,8 @@ import {
 import getIsPass from '../utils/isPass';
 import { useInterval } from './useInterval';
 
-// AT_STATION の observedAtMs 更新周期。arrived/station が変化しない間も
-// ETAフォールバックの仮想時計を進ませるため、定期的に打刻し直す。
+// AT_STATION の observedAtMs 打ち直し周期。arrived/station が変化しない間も
+// 到着を確認し続ける測位は届くため、その時刻までは基準を追随させる。
 const AT_STATION_REFRESH_INTERVAL_MS = 5_000;
 
 /**
@@ -28,6 +29,23 @@ export const useEtaAnchor = (): void => {
   const station = useAtomValue(stationAtom);
   const selectedBound = useAtomValue(selectedBoundAtom);
   const setAnchor = useSetAtom(etaAnchorAtom);
+  const store = useStore();
+
+  // 観測時刻は「最後に受理した測位の時刻」を使う。棄却判定(isImplausibleByEta)は
+  // getEtaPhaseNow(location.timestamp)で測位の時刻軸のまま仮想時計を回すため、基準側を
+  // Date.now()で打つと端末時計とGPS時刻のずれぶん仮想時計が前後し、ずれが遅れ側に出た
+  // 区間では棄却が増える。locationAtomは毎秒更新されるので購読はせず、必要な瞬間に読む。
+  //
+  // 受理済み測位が無い間はアンカーを記録しない。このフックが記録するのは「GPSで確定した
+  // 駅イベント」であり、測位が無ければ確定していない。useRefreshStationは測位が無いとき
+  // arrivedをtrueに倒すので、ここでDate.now()へフォールバックすると端末時計軸のアンカーが
+  // でき、初回測位が届いても下の単調ガード(端末時計 >= GPS時刻)で打ち直されないまま
+  // 軸のずれが固定される。棄却判定はGPS軸なので、そのずれぶん仮想時計が遅れて
+  // DWELLINGに張り付き、Aで直したはずの凍結が最初の駅だけで再発しうる。
+  const getObservedAtMs = useCallback(
+    (): number | null => store.get(locationAtom)?.timestamp ?? null,
+    [store]
+  );
 
   // 直前レンダー時点の arrived/station を保持し、true→false 遷移(=発車)の検出に使う。
   // StrictMode は初回マウント時にeffectを一度余分に再実行するが、このrefは
@@ -49,13 +67,21 @@ export const useEtaAnchor = (): void => {
       return;
     }
 
-    if (arrived && station?.id != null && !getIsPass(station)) {
+    const observedAtMs = getObservedAtMs();
+
+    if (
+      observedAtMs != null &&
+      arrived &&
+      station?.id != null &&
+      !getIsPass(station)
+    ) {
       setAnchor({
         stationId: station.id,
         kind: 'AT_STATION',
-        observedAtMs: Date.now(),
+        observedAtMs,
       });
     } else if (
+      observedAtMs != null &&
       prevArrived &&
       !arrived &&
       prevStation?.id != null &&
@@ -67,29 +93,48 @@ export const useEtaAnchor = (): void => {
       setAnchor({
         stationId: prevStation.id,
         kind: 'DEPARTED',
-        observedAtMs: Date.now(),
+        observedAtMs,
       });
     }
 
     prevArrivedRef.current = arrived;
     prevStationRef.current = station;
-  }, [arrived, station, selectedBound, setAnchor]);
+  }, [arrived, station, selectedBound, setAnchor, getObservedAtMs]);
 
-  // arrived/station が変化しない間も経過時間だけは進むため、数秒おきに
-  // observedAtMsを更新し続ける(仮想時計の基準時刻を最新に保つ)
+  // arrived/station が変化しない間も、到着を確認し続けている測位が届くあいだは
+  // observedAtMsを打ち直す(遅延で停車が伸びてもETAが先へ行かないようにする)。
+  //
+  // ただし打ち直しは「最後に受理した測位の時刻」までに限る。無条件にDate.now()で
+  // 打ち直すと、ETAの進行量上限(#6939)が測位を棄却して位置が凍結したときに、arrivedが
+  // 到着駅でtrueに張り付いたまま基準時刻も一緒に進むため仮想時計が一切進まない。
+  // その間フェーズはDWELLINGに固定され、許容は停車駅1つぶんのまま広がらないので、
+  // 棄却がETA_BOUND_MAX_HOLD_MSに達するまで続く(地下鉄で発車を観測できないまま
+  // 許容外の測位が届いた場合にこの経路へ入る)。受理済み測位の時刻で止めておけば、
+  // 測位が受理されなくなった瞬間から仮想時計が動き出し、ETA側が自力で追いつける。
   useInterval(() => {
     if (
-      selectedBound != null &&
-      arrived &&
-      station?.id != null &&
-      !getIsPass(station)
+      selectedBound == null ||
+      !arrived ||
+      station?.id == null ||
+      getIsPass(station)
     ) {
-      setAnchor({
-        stationId: station.id,
-        kind: 'AT_STATION',
-        observedAtMs: Date.now(),
-      });
+      return;
     }
+    const observedAtMs = getObservedAtMs();
+    if (observedAtMs == null) {
+      return;
+    }
+    const current = store.get(etaAnchorAtom);
+    const isSameAnchor =
+      current?.kind === 'AT_STATION' && current.stationId === station.id;
+    if (isSameAnchor && current.observedAtMs >= observedAtMs) {
+      return;
+    }
+    setAnchor({
+      stationId: station.id,
+      kind: 'AT_STATION',
+      observedAtMs,
+    });
   }, AT_STATION_REFRESH_INTERVAL_MS);
 
   useEffect(() => {

--- a/src/store/atoms/location.etaBound.test.ts
+++ b/src/store/atoms/location.etaBound.test.ts
@@ -218,4 +218,90 @@ describe('ETAの進行量上限による棄却', () => {
 
     expect(store.get(locationAtom)?.coords.latitude).toBe(far);
   });
+
+  // 回帰: 地下鉄の急行は「発車を観測できないまま次の停車駅で測位が復活する」のが普通で、
+  // 許容をindex差で数えていると通過駅ぶんだけ目減りし、正常な測位を上限時間まで弾き続けた。
+  // さらに位置が凍結するとarrivedが到着駅で張り付き、useEtaAnchorの打ち直しで仮想時計まで
+  // 止まるため、DWELLINGの許容から自力で抜けられない(#6939の90秒を毎停車で使い切る)。
+  describe('通過駅を跨ぐ急行', () => {
+    // 停車駅は id 1(idx0) / 5(idx4) / 7(idx6) / 9(idx8)。間は通過駅
+    const expressStopIdx = [0, 4, 6, 8];
+
+    const setupExpressRoute = () => {
+      store.set(
+        etaStopsAtom,
+        expressStopIdx.map((idx, n) => ({
+          stationId: stations[idx].id as number,
+          cumulativeMinutes: n * 3,
+          departureCumulativeMinutes: n * 3 + 0.5,
+        }))
+      );
+    };
+
+    it('停車中のまま発車し、次の停車駅で測位が復活しても棄却しない', () => {
+      const t0 = 6_000_000;
+      setupExpressRoute();
+      // 始発駅(idx0)に到着中。仮想時計は停車中を指したまま
+      store.set(etaAnchorAtom, {
+        stationId: stations[0].id as number,
+        kind: 'AT_STATION',
+        observedAtMs: t0,
+      });
+      setLocation(makeLocation(stations[0].latitude as number, t0));
+
+      // 発車後、トンネルで測位が途切れ、次の停車駅(idx4)で復活する
+      const next = stations[4].latitude as number;
+      setLocation(makeLocation(next, t0 + 10_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(next);
+    });
+
+    // 保険(ETA_BOUND_MAX_HOLD_MS)が停車駅単位の許容でも効くこと。各停側は上の
+    // 「上限時間を過ぎたら棄却を打ち切り」が見ているが、stopStationIdsを渡す経路は
+    // 許容の算出が別分岐なので別に固定する。
+    it('ETA側が大きく誤っていても上限時間で棄却を打ち切る', () => {
+      const t0 = 8_000_000;
+      // 停車駅間を60分と見積もった(実際よりはるかに遅い)ETA。仮想時計が進んでも
+      // 対象駅が追いつかないため、許容内へ入るのは上限時間の打ち切りだけになる
+      store.set(
+        etaStopsAtom,
+        expressStopIdx.map((idx, n) => ({
+          stationId: stations[idx].id as number,
+          cumulativeMinutes: n * 60,
+          departureCumulativeMinutes: n * 60 + 0.5,
+        }))
+      );
+      store.set(etaAnchorAtom, {
+        stationId: stations[0].id as number,
+        kind: 'AT_STATION',
+        observedAtMs: t0,
+      });
+      setLocation(makeLocation(stations[0].latitude as number, t0));
+      const before = store.get(locationAtom)?.coords.latitude;
+
+      // 3つ先の停車駅(idx8)。対象駅(idx4)の次の停車駅(idx6)より先なので棄却される
+      const far = stations[8].latitude as number;
+      setLocation(makeLocation(far, t0 + 10_000));
+      expect(store.get(locationAtom)?.coords.latitude).toBe(before);
+
+      setLocation(makeLocation(far, t0 + 10_000 + 90_000));
+      expect(store.get(locationAtom)?.coords.latitude).toBe(far);
+    });
+
+    it('2つ先の停車駅を指す測位は棄却する', () => {
+      const t0 = 7_000_000;
+      setupExpressRoute();
+      store.set(etaAnchorAtom, {
+        stationId: stations[0].id as number,
+        kind: 'AT_STATION',
+        observedAtMs: t0,
+      });
+      setLocation(makeLocation(stations[0].latitude as number, t0));
+      const before = store.get(locationAtom)?.coords.latitude;
+
+      setLocation(makeLocation(stations[6].latitude as number, t0 + 10_000));
+
+      expect(store.get(locationAtom)?.coords.latitude).toBe(before);
+    });
+  });
 });

--- a/src/store/atoms/location.ts
+++ b/src/store/atoms/location.ts
@@ -6,7 +6,7 @@ import { BAD_ACCURACY_THRESHOLD } from '~/constants/threshold';
 import { getEtaPhaseNow } from '~/utils/etaPhaseNow';
 import { isBeyondEtaProgress } from '~/utils/etaProgressBound';
 import { store } from '..';
-import { etaAnchorAtom } from './etaFallback';
+import { etaAnchorAtom, etaStopsAtom } from './etaFallback';
 import stationState from './station';
 
 const MAX_ACCURACY_HISTORY = 12;
@@ -161,8 +161,9 @@ const resyncLocationReference = (
   consecutiveSpeedRejections = 0;
 };
 
-// ETAの進行量上限から外れた測位を、何駅ぶんまで許容するか。
-// ETAは停車時間や加減速の見積もりぶん実際とずれるので、隣駅1つぶんの余裕を持たせる。
+// ETAの進行量上限から外れた測位を、何駅ぶんまで許容するか。単位は「停車駅」で、
+// 通過駅は数に入れない(isBeyondEtaProgressにstopStationIdsを渡す)。
+// ETAは停車時間や加減速の見積もりぶん実際とずれるので、隣の停車駅1つぶんの余裕を持たせる。
 const ETA_BOUND_TOLERANCE_STATIONS = 1;
 
 // ETAによる棄却を続けてよい上限(ms)。ETA側が誤っている場合に位置が凍結し続けないための保険。
@@ -209,6 +210,9 @@ const isImplausibleByEta = (location: Location.LocationObject): boolean => {
     latitude: location.coords.latitude,
     longitude: location.coords.longitude,
     toleranceStations: ETA_BOUND_TOLERANCE_STATIONS,
+    // 許容は停車駅単位で数える。stationsは通過駅を含むため、ETA側の停車駅リストを
+    // 渡さないと急行の通過駅ぶんだけ許容が目減りする。
+    stopStationIds: store.get(etaStopsAtom).map((s) => s.stationId),
   });
   if (!beyond) {
     // 範囲内の測位が届いた＝ETAと実測が再び噛み合った

--- a/src/utils/etaProgressBound.test.ts
+++ b/src/utils/etaProgressBound.test.ts
@@ -145,4 +145,112 @@ describe('isBeyondEtaProgress', () => {
       })
     ).toBe(false);
   });
+
+  // 通過駅を含む路線では許容を「停車駅いくつぶん」で数える。index差のまま数えると、
+  // 急行が次の停車駅まで進んだだけの正常な測位を棄却する(#6939の上限時間まで凍結する)。
+  describe('通過駅がある場合(stopStationIds)', () => {
+    // 停車駅は 1(idx0) / 5(idx4) / 7(idx6) / 9(idx8)。間は通過駅
+    const stopStationIds = [1, 5, 7, 9];
+
+    it('停車推定でも次の停車駅までは許容する(通過駅ぶんは数えない)', () => {
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 1,
+          targetStationId: 1,
+          ...near(4),
+        })
+      ).toBe(false);
+    });
+
+    it('停車推定で2つ先の停車駅は棄却する', () => {
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 1,
+          targetStationId: 1,
+          ...near(6),
+        })
+      ).toBe(true);
+    });
+
+    it('走行中は対象駅の次の停車駅までを許容する', () => {
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 1,
+          targetStationId: 5,
+          ...near(6),
+        })
+      ).toBe(false);
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 1,
+          targetStationId: 5,
+          ...near(8),
+        })
+      ).toBe(true);
+    });
+
+    it('後方側も停車駅単位で数える', () => {
+      // アンカー(idx4)の1つ前の停車駅はidx0なので、その手前まで戻った測位は棄却する
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 5,
+          targetStationId: 7,
+          ...near(0),
+        })
+      ).toBe(false);
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds,
+          anchorStationId: 7,
+          targetStationId: 9,
+          ...near(0),
+        })
+      ).toBe(true);
+    });
+
+    it('全駅停車(停車駅リストが全駅)ならindex差で数えるのと同じ結果になる', () => {
+      const allStops = stations.map((st) => st.id as number);
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds: allStops,
+          anchorStationId: 3,
+          targetStationId: 4,
+          ...near(5),
+        })
+      ).toBe(true);
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds: allStops,
+          anchorStationId: 3,
+          targetStationId: 4,
+          ...near(4),
+        })
+      ).toBe(false);
+    });
+
+    it('進行方向に停車駅が無い(終端・ETA区間の外)場合は端まで許容する', () => {
+      expect(
+        isBeyondEtaProgress({
+          ...base,
+          stopStationIds: [1, 5],
+          anchorStationId: 5,
+          targetStationId: 5,
+          ...near(9),
+        })
+      ).toBe(false);
+    });
+  });
 });

--- a/src/utils/etaProgressBound.ts
+++ b/src/utils/etaProgressBound.ts
@@ -2,6 +2,37 @@ import getDistance from 'geolib/es/getDistance';
 import type { Station } from '~/@types/graphql';
 
 /**
+ * indexから direction 方向へ「停車駅」を count 個ぶん進んだindexを返す。
+ *
+ * その方向に停車駅が足りない場合(終端、あるいはETA区間の外へ抜ける通し運転)は
+ * 配列端のindexを返す。ETAが説明できない範囲まで棄却するのは正しくないため、
+ * 足りない側は許容を広げる方向へ倒す。
+ */
+const advanceByStops = (
+  length: number,
+  from: number,
+  direction: 1 | -1,
+  count: number,
+  isStopAt: (index: number) => boolean
+): number => {
+  if (count <= 0) {
+    return from;
+  }
+  let remaining = count;
+  let last = from;
+  for (let i = from + direction; i >= 0 && i < length; i += direction) {
+    last = i;
+    if (isStopAt(i)) {
+      remaining -= 1;
+      if (remaining === 0) {
+        return i;
+      }
+    }
+  }
+  return last;
+};
+
+/**
  * ETA仮想時計が示す進行状況から見て、届いた測位が「そこまで進んでいるはずがない」位置かを
  * 判定する純関数。
  *
@@ -20,6 +51,7 @@ export const isBeyondEtaProgress = ({
   latitude,
   longitude,
   toleranceStations,
+  stopStationIds,
 }: {
   stations: Station[];
   anchorStationId: number;
@@ -27,6 +59,11 @@ export const isBeyondEtaProgress = ({
   latitude: number;
   longitude: number;
   toleranceStations: number;
+  /**
+   * 停車駅のID(ETAのstops)。許容を「停車駅いくつぶん」で数えるために使う。
+   * 省略時・空の場合は stations の全駅を停車駅として数える(=index差そのまま)。
+   */
+  stopStationIds?: readonly number[];
 }): boolean => {
   const anchorIdx = stations.findIndex((s) => s.id === anchorStationId);
   const targetIdx = stations.findIndex((s) => s.id === targetStationId);
@@ -55,14 +92,61 @@ export const isBeyondEtaProgress = ({
     return false;
   }
 
+  // 許容は「停車駅いくつぶん」で数える。stations は通過駅も含むので、index差のまま
+  // 数えると急行の通過駅ぶんだけ許容が目減りし、次の停車駅で測位が復活しただけでも
+  // 棄却される(副都心線の急行は池袋→新宿三丁目がindex差4で、許容1駅では必ず外れる)。
+  // 地下鉄では発車を観測できず、次の測位が次の停車駅まで届かないことが普通にあるため、
+  // ここが目減りすると正常な測位を上限時間まで弾き続けることになる。
+  const stopIds =
+    stopStationIds && stopStationIds.length > 0
+      ? new Set(stopStationIds)
+      : null;
+  const isStopAt = (index: number): boolean => {
+    if (stopIds == null) {
+      return true;
+    }
+    const id = stations[index]?.id;
+    return id != null && stopIds.has(id);
+  };
+
   // 進行方向はETA側の並び(アンカー→対象駅)から決める。
   const direction = Math.sign(targetIdx - anchorIdx);
   if (direction === 0) {
-    // アンカー駅で停車中の推定。前後どちらへもtolerance以上離れていたら説明できない。
-    return Math.abs(fixIdx - anchorIdx) > toleranceStations;
+    // アンカー駅で停車中の推定。前後どちらへも停車駅tolerance個ぶん以上離れていたら
+    // 説明できない。
+    const aheadIdx = advanceByStops(
+      stations.length,
+      anchorIdx,
+      1,
+      toleranceStations,
+      isStopAt
+    );
+    const behindIdx = advanceByStops(
+      stations.length,
+      anchorIdx,
+      -1,
+      toleranceStations,
+      isStopAt
+    );
+    return fixIdx > aheadIdx || fixIdx < behindIdx;
   }
 
+  const aheadLimitIdx = advanceByStops(
+    stations.length,
+    targetIdx,
+    direction > 0 ? 1 : -1,
+    toleranceStations,
+    isStopAt
+  );
+  const behindLimitIdx = advanceByStops(
+    stations.length,
+    anchorIdx,
+    direction > 0 ? -1 : 1,
+    toleranceStations,
+    isStopAt
+  );
   const progress = (fixIdx - anchorIdx) * direction;
-  const limit = (targetIdx - anchorIdx) * direction + toleranceStations;
-  return progress > limit || progress < -toleranceStations;
+  const limit = (aheadLimitIdx - anchorIdx) * direction;
+  const behindLimit = (behindLimitIdx - anchorIdx) * direction;
+  return progress > limit || progress < behindLimit;
 };


### PR DESCRIPTION
## 概要

#6939 で入れた「ETA が許す進行量を超えた測位の棄却」が、地下鉄で到着表示を最大 90 秒遅らせていた問題を修正する。実走では東京メトロ副都心線（急行）で顕著だった。

原因は 2 つあり、どちらも「棄却が `ETA_BOUND_MAX_HOLD_MS`（90 秒）の打ち切りまで続く」状態を作る。

**1. アンカーの再打刻が ETA 仮想時計を止める**

`useEtaAnchor` は `arrived === true` のあいだ 5 秒ごとに無条件で `observedAtMs = Date.now()` を打ち直していた。ETA ゲートが測位を棄却して `locationAtom` が凍結すると、`arrived` は到着駅で true に張り付く（`useRefreshStation` の到着圏判定は凍結座標をそのまま見る）ため、基準時刻も一緒に進み、`estimateEtaPhase` の仮想時計 `m = base + (now - observedAtMs)` が**一切進まない**。フェーズは `DWELLING` に固定され、`isBeyondEtaProgress` の `direction === 0` 枝（許容 1 駅）から自力で抜けられない。解除条件（範囲内の測位が届く／アンカーが張り直される）はどちらも「位置が進むこと」が前提なので、ゲートの入力がゲート自身の出力の下流にある循環になっていた。

**2. 許容を通過駅込みの index 差で数えていた**

`isBeyondEtaProgress` は `stationState.stations`（通過駅を含む全駅）の index 差で許容 1 駅を数えていた。副都心線の急行は池袋→新宿三丁目が index 差 4 なので、**次の停車駅で測位が復活しただけの正常な測位でも必ず許容から外れる**。地下鉄では発車を観測できず、次の測位が次の停車駅まで届かないことが普通にあるため、ここが目減りすると正常な測位を打ち切りまで弾き続ける。

`#6939` が根拠にしていた「ETA は遅くなる方向にしか働かない＝上限としては破られない」は、仮想時計が**進む**前提の議論で、1 の再打刻で止まっているあいだは成立しない。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `src/hooks/useEtaAnchor.ts`: `AT_STATION` の `observedAtMs` の打ち直しを「最後に受理した測位のタイムスタンプ」までに限定。測位が受理されなくなった瞬間から仮想時計が動き出し、ETA 側が自力で追いつけるようにする
- 同: 打刻の時刻軸を `Date.now()` から `location.timestamp` へ寄せた。棄却判定は `getEtaPhaseNow(location.timestamp)` で測位の時刻軸のまま仮想時計を回すため、基準を端末時計で打つとずれぶん仮想時計が前後し、遅れ側に出た区間で棄却が増える（既存の軸混在の解消）
- 同: 受理済み測位が無いあいだはアンカーを記録しない。`useRefreshStation` は測位が無いとき `arrived` を true に倒すので、`Date.now()` でフォールバック打刻すると端末時計軸のアンカーができ、初回測位が届いても単調ガードで打ち直されないまま軸のずれが固定される（1 と同じ凍結が最初の駅で再発しうる）
- `src/utils/etaProgressBound.ts`: 許容を「停車駅いくつぶん」で数えるよう `stopStationIds` を受け取る。`advanceByStops` で通過駅を数に入れずに前後へ走査する。省略時・空の場合は全駅を停車駅として数える（= 従来の index 差と完全に同一）
- `src/store/atoms/location.ts`: `etaStopsAtom` の停車駅 ID を `isBeyondEtaProgress` へ渡す。`ETA_BOUND_TOLERANCE_STATIONS` の単位が「停車駅」になった旨をコメントに追記
- テスト追加: 通過駅ありの許容計算 6 件（`etaProgressBound.test.ts`）、急行での回帰 3 件（`location.etaBound.test.ts`）、アンカー打刻の契約 3 件（`useEtaAnchor.test.tsx`）

`ETA_BOUND_MAX_HOLD_MS`（90 秒）自体は変更していない。この保険の出番が減ったので、短縮するかは実走確認のあとで判断する。

### 過去の意思決定との関係

- `useEtaAnchor` の無条件な `Date.now()` 打ち直しは、ETA が状態を駆動していた時代（#6366 の R2）の「`arrived` が true のあいだは停車中」という前提に基づく。ETA が棄却専用になった #6939 以降は「受理済み測位がある間だけ停車を確認できている」と読み替えるのが妥当で、その前提変更をコメントに残した
- `ETA_BOUND_TOLERANCE_STATIONS = 1`（#6939）は値を変えていない。単位を「路線の駅」から「停車駅」へ変えており、各停では従来と完全に同じ判定、急行では通過駅ぶんだけ許容が広がる
- 既存テストの書き換えは `useEtaAnchor.test.tsx` の 1 件（「時間経過で `observedAtMs` が更新される」→「新しい測位を受理するたびに追随する」）。無条件更新の保証は今回意図的に捨てたもので、代わりに「受理が止まったら進めない」を回帰テストで固定した。それ以外の既存テストは 1 件も緩めていない

## テスト

計測: 9 駅・駅間 1.1km・地下鉄・精度 65m の合成トラックに、副都心線の急行を模した停車パターン（idx0 → 4 → 6 → 8）を与え、「到着中のまま発車し、次の測位が次の停車駅で復活する」状況を 10 秒刻みで流して、測位が受理されるまでの経過時間を測った。

| ケース | 修正前 | 修正後 |
| --- | --- | --- |
| 停車中のまま発車 → 次の停車駅（index 差 4）で測位復活 | 100s | **10s（最初の測位で受理）** |
| 停車中のまま発車 → 2 停車駅先で測位復活 | 100s | **30s（停車時間ぶんで仮想時計が追いつく）** |
| 各停・次駅で測位（正常系） | 棄却なし | 棄却なし |
| 各停・2 駅先へのワープ（#6939 が防いだケース） | 棄却 | **棄却（維持）** |

`src/store/atoms/location.gpxEtaAssist.test.ts`（`assets/gpx` の全トラックを実パイプラインへ流し、ETA 補助の ON/OFF で平滑後の軌跡と到着検知位置が完全一致することを要求する非干渉性テスト）も通っているため、通常走行への影響は無い。

実機検証は未実施。iPhone での地下鉄実走確認（特に副都心線の急行）は別途必要。

- [x] `npm run lint` が通ること
- [x] `npm test` が通ること（279 suites / 3040 tests）
- [x] `npm run typecheck` が通ること

### 回帰リスク

- **急行で許容が広がる**: 停車推定中に「次の停車駅」までの測位を受理するため、その範囲のワープは通る。通過駅を跨ぐ許容は「その列車が実際に到達しうる次の停車駅まで」なので、物理的な上限としては破られていない。許容の計算そのものは全駅停車の路線（大江戸線など）では従来と完全に同一（`isStopAt` が常に true で index 差の計算に一致。`etaProgressBound.test.ts` で固定）
- **棄却を続ける時間が短くなるケースがある**: 全駅停車・駅間 900m・駅間 2 分の路線で「到着中表示のままワープ測位が届き続ける」状況を流した計測。1 駅先は従来どおり許容内（受理まで 5s。ここは ETA ではなく速度フィルタの連続棄却 5 回で抜ける）、3 駅先以上は変化なし（90 秒の打ち切りが効く）。**2 駅先だけ 91s → 29s に短くなる**。29s は ETA データ上の停車時間（`MIN_DWELL_MIN` = 0.5 分）の経過で仮想時計が `RUNNING` へ移り、許容が「次駅 + 1 駅」に広がるためで、ETA を上限として使うモデルが本来許す範囲。従来の 91s は仮想時計が止まっていたため許容が広がらず打ち切りまで粘っていた副作用側の数字。単発のクラスタから「停車中に GPS がワープした」と「発車したが観測できていない」は区別できないため、ここは原理的なトレードオフになる。なお正常走行中（測位が受理され続けている間）は打刻が追随して仮想時計はほぼ止まるので、その間の棄却は従来どおり効く
- **ETA 仮想時計が進むようになる副作用**: 測位が全く来ない長時間停車では仮想時計が進み、ahead 側の許容が時間とともに広がる。これは ETA を上限として使う #6939 本来のモデルどおりの挙動
- **時刻軸の変更**: `location.timestamp` が端末時計より古い（Android の fused provider がキャッシュ済み fix を返す）場合、仮想時計は先へ進む＝許容が広がる方向にしか倒れない。巻き戻りは単調ガードで防いでいる
- 環状線で配列の継ぎ目を跨ぐ区間は index が不連続なため #6939 時点から棄却されうるが、本 PR は継ぎ目を広げも狭めもしない（別途調査が必要）

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

参考: #6939（本 PR が修正する棄却ゲートを入れた PR）、#6369 / #6366（ETA の役割を GPS の補助に限定した経緯）

## スクリーンショット（任意）

<!-- create-pr:screenshots:start -->

UI 変更なし: `src/hooks/**` / `src/utils/**` / `src/store/atoms/**` の測位フィルタのみの変更で、画面レイアウトに変化はありません（到着表示のタイミングが正しくなる挙動の変化はあり、上の計測表がその内容です）。

<!-- create-pr:screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJbrKm4zHvFfiF959yYcDQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ETAアンカーの時刻判定を、端末時計ではなく受理済みの測位時刻に基づくよう改善しました。
  - 測位情報がない場合や古い測位情報を受信した場合に、アンカー時刻が不適切に作成・更新されないようにしました。
  - ETAの進行範囲を通過駅ではなく停車駅単位で判定し、急行運転などでも測位の受理精度を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

